### PR TITLE
Add debug-only analytics layer for game balancing (#289)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,7 @@ All formulas live in `BalanceConfig.cs`. Caps are enforced via `StatConstants`:
 Design docs under `PitHero/docs/` (kept as standalone references — don't duplicate their content into agent files or skills):
 
 **Balance / data:**
+- `PitHero/docs/AnalyticsSchema.md` — debug-only balance analytics: JSONL event schema, output location, interpretation caveats
 - `PitHero/docs/EquipmentBalanceGuide.md`
 - `PitHero/docs/MonsterBalanceGuide.md`
 - `PitHero/docs/JobStatCurves.md`

--- a/PitHero.Tests/AnalyticsJsonLineBuilderTests.cs
+++ b/PitHero.Tests/AnalyticsJsonLineBuilderTests.cs
@@ -1,0 +1,153 @@
+#if DEBUG
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Services.Analytics;
+using System;
+using System.Text;
+using System.Text.Json;
+
+namespace PitHero.Tests
+{
+    /// <summary>Tests for the AOT-safe JSONL writer used by the analytics service (issue #289).</summary>
+    [TestClass]
+    public class AnalyticsJsonLineBuilderTests
+    {
+        private static (StringBuilder sb, JsonLineBuilder json) CreateBuilder()
+        {
+            var sb = new StringBuilder(256);
+            return (sb, new JsonLineBuilder(sb));
+        }
+
+        [TestMethod]
+        public void SimpleEvent_ProducesValidJsonLine()
+        {
+            var (sb, json) = CreateBuilder();
+            json.BeginEvent();
+            json.Field("e", "test_event");
+            json.Field("count", 42);
+            json.Field("ratio", 1.5f);
+            json.Field("flag", true);
+            json.EndEvent();
+
+            var line = sb.ToString();
+            Assert.IsTrue(line.EndsWith("\n"));
+
+            using var doc = JsonDocument.Parse(line);
+            Assert.AreEqual("test_event", doc.RootElement.GetProperty("e").GetString());
+            Assert.AreEqual(42, doc.RootElement.GetProperty("count").GetInt32());
+            Assert.AreEqual(1.5, doc.RootElement.GetProperty("ratio").GetDouble(), 0.0001);
+            Assert.IsTrue(doc.RootElement.GetProperty("flag").GetBoolean());
+        }
+
+        [TestMethod]
+        public void StringEscaping_HandlesSpecialCharacters()
+        {
+            var (sb, json) = CreateBuilder();
+            json.BeginEvent();
+            json.Field("name", "Sword \"of\" Doom\\Slash");
+            json.Field("multi", "line1\nline2\ttabbed\rreturn");
+            json.Field("control", "lowchar");
+            json.EndEvent();
+
+            using var doc = JsonDocument.Parse(sb.ToString());
+            Assert.AreEqual("Sword \"of\" Doom\\Slash", doc.RootElement.GetProperty("name").GetString());
+            Assert.AreEqual("line1\nline2\ttabbed\rreturn", doc.RootElement.GetProperty("multi").GetString());
+            Assert.AreEqual("lowchar", doc.RootElement.GetProperty("control").GetString());
+        }
+
+        [TestMethod]
+        public void NullString_WritesJsonNull()
+        {
+            var (sb, json) = CreateBuilder();
+            json.BeginEvent();
+            json.Field("item", (string)null);
+            json.EndEvent();
+
+            using var doc = JsonDocument.Parse(sb.ToString());
+            Assert.AreEqual(JsonValueKind.Null, doc.RootElement.GetProperty("item").ValueKind);
+        }
+
+        [TestMethod]
+        public void NestedObjectsAndArrays_ProduceValidJson()
+        {
+            var (sb, json) = CreateBuilder();
+            json.BeginEvent();
+            json.Field("e", "party_snapshot");
+            json.BeginArray("members");
+            json.BeginArrayObject();
+            json.Field("name", "Alice");
+            json.BeginArray("skills");
+            json.ArrayStringValue("slash");
+            json.ArrayStringValue("guard");
+            json.EndArray();
+            json.BeginObject("gear");
+            json.Field("weapon", "Bronze Sword");
+            json.EndObject();
+            json.EndObject();
+            json.BeginArrayObject();
+            json.Field("name", "Bob");
+            json.EndObject();
+            json.EndArray();
+            json.Field("after", 1);
+            json.EndEvent();
+
+            using var doc = JsonDocument.Parse(sb.ToString());
+            var members = doc.RootElement.GetProperty("members");
+            Assert.AreEqual(2, members.GetArrayLength());
+            Assert.AreEqual("Alice", members[0].GetProperty("name").GetString());
+            Assert.AreEqual(2, members[0].GetProperty("skills").GetArrayLength());
+            Assert.AreEqual("slash", members[0].GetProperty("skills")[0].GetString());
+            Assert.AreEqual("Bronze Sword", members[0].GetProperty("gear").GetProperty("weapon").GetString());
+            Assert.AreEqual("Bob", members[1].GetProperty("name").GetString());
+            Assert.AreEqual(1, doc.RootElement.GetProperty("after").GetInt32());
+        }
+
+        [TestMethod]
+        public void TimestampField_ProducesIso8601WithOffset()
+        {
+            var (sb, json) = CreateBuilder();
+            json.BeginEvent();
+            json.TimestampField("t", new DateTime(2026, 7, 9, 18, 30, 5, 123), new TimeSpan(-8, 0, 0));
+            json.EndEvent();
+
+            using var doc = JsonDocument.Parse(sb.ToString());
+            Assert.AreEqual("2026-07-09T18:30:05.123-08:00", doc.RootElement.GetProperty("t").GetString());
+
+            var parsed = DateTimeOffset.Parse(doc.RootElement.GetProperty("t").GetString());
+            Assert.AreEqual(2026, parsed.Year);
+            Assert.AreEqual(123, parsed.Millisecond);
+        }
+
+        [TestMethod]
+        public void TimeField_ProducesPaddedClock()
+        {
+            var (sb, json) = CreateBuilder();
+            json.BeginEvent();
+            json.TimeField("gt", 6, 5);
+            json.EndEvent();
+
+            using var doc = JsonDocument.Parse(sb.ToString());
+            Assert.AreEqual("06:05", doc.RootElement.GetProperty("gt").GetString());
+        }
+
+        [TestMethod]
+        public void MultipleEvents_ProduceOneLineEach()
+        {
+            var (sb, json) = CreateBuilder();
+            for (int i = 0; i < 3; i++)
+            {
+                json.BeginEvent();
+                json.Field("i", i);
+                json.EndEvent();
+            }
+
+            var lines = sb.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            Assert.AreEqual(3, lines.Length);
+            for (int i = 0; i < 3; i++)
+            {
+                using var doc = JsonDocument.Parse(lines[i]);
+                Assert.AreEqual(i, doc.RootElement.GetProperty("i").GetInt32());
+            }
+        }
+    }
+}
+#endif

--- a/PitHero.Tests/AnalyticsServiceTests.cs
+++ b/PitHero.Tests/AnalyticsServiceTests.cs
@@ -1,0 +1,200 @@
+#if DEBUG
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Services;
+using PitHero.Services.Analytics;
+using RolePlayingFramework.Heroes;
+using RolePlayingFramework.Jobs.Primary;
+using RolePlayingFramework.Stats;
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace PitHero.Tests
+{
+    /// <summary>End-to-end tests for the analytics logging service (issue #289).</summary>
+    [TestClass]
+    public class AnalyticsServiceTests
+    {
+        private string _tempDir;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "PitHeroAnalyticsTests_" + Guid.NewGuid().ToString("N"));
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            AnalyticsService.Shutdown();
+            if (Directory.Exists(_tempDir))
+                Directory.Delete(_tempDir, recursive: true);
+        }
+
+        private string[] ReadAllEventLines()
+        {
+            AnalyticsService.Flush();
+            var files = Directory.GetFiles(_tempDir, "session_*.jsonl");
+            Assert.AreEqual(1, files.Length, "Expected exactly one session file");
+            return ReadLinesSharedWithWriter(files[0]);
+        }
+
+        private static string[] ReadLinesSharedWithWriter(string path)
+        {
+            // The service keeps its StreamWriter open, so the reader must allow concurrent write access
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(stream);
+            var content = reader.ReadToEnd();
+            return content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        [TestMethod]
+        public void LogSessionStart_WritesValidEventWithTimestamp()
+        {
+            AnalyticsService.Initialize(_tempDir);
+            AnalyticsService.LogSessionStart("new_game", 100);
+
+            var lines = ReadAllEventLines();
+            Assert.AreEqual(1, lines.Length);
+
+            using var doc = JsonDocument.Parse(lines[0]);
+            Assert.AreEqual("session_start", doc.RootElement.GetProperty("e").GetString());
+            Assert.AreEqual("new_game", doc.RootElement.GetProperty("mode").GetString());
+            Assert.AreEqual(100, doc.RootElement.GetProperty("gold").GetInt32());
+
+            var timestamp = doc.RootElement.GetProperty("t").GetString();
+            Assert.IsFalse(string.IsNullOrEmpty(timestamp));
+            DateTimeOffset.Parse(timestamp); // throws if malformed
+        }
+
+        [TestMethod]
+        public void MultipleEvents_WriteOneValidJsonLineEachInOrder()
+        {
+            AnalyticsService.Initialize(_tempDir);
+            AnalyticsService.LogSessionStart("new_game", 0);
+            AnalyticsService.LogPitGenerated(3, false, 5, 2);
+            AnalyticsService.LogInnSleep(10, 90);
+            AnalyticsService.LogAttack("Hero", "hero", "physical", "Slime", "monster", 7, 20, 13, false);
+            AnalyticsService.LogHeal("Hero", "heal", "Hero", 15, 40);
+            AnalyticsService.LogMercLeft("Boris", "tavern_left");
+
+            var lines = ReadAllEventLines();
+            Assert.AreEqual(6, lines.Length);
+
+            var expectedTypes = new[] { "session_start", "pit_generated", "inn_sleep", "attack", "heal", "merc_left" };
+            for (int i = 0; i < lines.Length; i++)
+            {
+                using var doc = JsonDocument.Parse(lines[i]);
+                Assert.AreEqual(expectedTypes[i], doc.RootElement.GetProperty("e").GetString());
+                Assert.IsFalse(string.IsNullOrEmpty(doc.RootElement.GetProperty("t").GetString()));
+            }
+        }
+
+        [TestMethod]
+        public void LogGoldGained_TracksSessionRunningTotal()
+        {
+            AnalyticsService.Initialize(_tempDir);
+            AnalyticsService.LogSessionStart("new_game", 0);
+            AnalyticsService.LogGoldGained(10, "battle", 10);
+            AnalyticsService.LogGoldGained(25, "sell_item", 30);
+
+            var lines = ReadAllEventLines();
+            using var first = JsonDocument.Parse(lines[1]);
+            using var second = JsonDocument.Parse(lines[2]);
+
+            Assert.AreEqual(10, first.RootElement.GetProperty("sessionTotal").GetInt64());
+            Assert.AreEqual("battle", first.RootElement.GetProperty("source").GetString());
+            Assert.AreEqual(35, second.RootElement.GetProperty("sessionTotal").GetInt64());
+            Assert.AreEqual(30, second.RootElement.GetProperty("currentGold").GetInt32());
+        }
+
+        [TestMethod]
+        public void LogCharacterKilled_WritesFullHeroSnapshotWithKiller()
+        {
+            AnalyticsService.Initialize(_tempDir);
+            var hero = new Hero("TestHero", new Knight(), 5, new StatBlock(6, 4, 7, 2));
+            var enemy = RolePlayingFramework.Enemies.EnemyFactory.Create(RolePlayingFramework.Enemies.EnemyId.Slime, 3);
+
+            AnalyticsService.LogCharacterKilled(hero, enemy);
+
+            var lines = ReadAllEventLines();
+            using var doc = JsonDocument.Parse(lines[0]);
+            var root = doc.RootElement;
+
+            Assert.AreEqual("char_killed", root.GetProperty("e").GetString());
+            Assert.AreEqual("TestHero", root.GetProperty("name").GetString());
+            Assert.AreEqual("hero", root.GetProperty("type").GetString());
+            Assert.AreEqual(5, root.GetProperty("level").GetInt32());
+            Assert.IsTrue(root.GetProperty("maxHP").GetInt32() > 0);
+            Assert.AreEqual(JsonValueKind.Array, root.GetProperty("skills").ValueKind);
+            Assert.AreEqual(JsonValueKind.Object, root.GetProperty("gear").ValueKind);
+
+            var killer = root.GetProperty("killer");
+            Assert.IsFalse(string.IsNullOrEmpty(killer.GetProperty("name").GetString()));
+            Assert.AreEqual(3, killer.GetProperty("level").GetInt32());
+            Assert.IsTrue(killer.GetProperty("maxHP").GetInt32() > 0);
+        }
+
+        [TestMethod]
+        public void DisabledService_WritesNothing()
+        {
+            AnalyticsService.Initialize(_tempDir);
+            AnalyticsService.Enabled = false;
+            AnalyticsService.LogSessionStart("new_game", 0);
+            AnalyticsService.LogInnSleep(10, 90);
+            AnalyticsService.Flush();
+
+            Assert.IsFalse(Directory.Exists(_tempDir), "No output directory should be created when disabled");
+        }
+
+        [TestMethod]
+        public void UninitializedService_DoesNotThrowAndWritesNothing()
+        {
+            AnalyticsService.Shutdown(); // guarantee un-initialized state
+            AnalyticsService.LogInnSleep(10, 90);
+            AnalyticsService.LogGoldGained(5, "battle", 5);
+            AnalyticsService.Flush();
+
+            Assert.IsFalse(Directory.Exists(_tempDir));
+        }
+
+        [TestMethod]
+        public void SessionRestart_RotatesToNewFile()
+        {
+            AnalyticsService.Initialize(_tempDir);
+            AnalyticsService.LogSessionStart("new_game", 0);
+            AnalyticsService.LogInnSleep(10, 90);
+            AnalyticsService.Flush();
+
+            System.Threading.Thread.Sleep(1100); // ensure a distinct per-second filename
+            AnalyticsService.LogSessionStart("load", 50);
+            AnalyticsService.Flush();
+
+            var files = Directory.GetFiles(_tempDir, "session_*.jsonl");
+            Assert.AreEqual(2, files.Length, "A second session should rotate to a new file");
+        }
+
+        [TestMethod]
+        public void Shutdown_FlushesRemainingBufferedEvents()
+        {
+            AnalyticsService.Initialize(_tempDir);
+            AnalyticsService.LogSessionStart("new_game", 0);
+            AnalyticsService.Shutdown();
+
+            var files = Directory.GetFiles(_tempDir, "session_*.jsonl");
+            Assert.AreEqual(1, files.Length);
+            var lines = File.ReadAllLines(files[0]);
+            Assert.AreEqual(1, lines.Length);
+        }
+
+        [TestMethod]
+        public void GameStateService_AddFunds_IncrementsFunds()
+        {
+            var gameState = new GameStateService();
+            gameState.Funds = 10;
+            gameState.AddFunds(25, "battle");
+            Assert.AreEqual(35, gameState.Funds);
+        }
+    }
+}
+#endif

--- a/PitHero/AI/ActivateWizardOrbAction.cs
+++ b/PitHero/AI/ActivateWizardOrbAction.cs
@@ -52,6 +52,8 @@ namespace PitHero.AI
             // Clear all remaining fog first so player sees fully cleared pit
             ClearAllFogOfWarInPit();
 
+            int pitLevelBeforeOrb = Core.Services.GetService<PitWidthManager>()?.CurrentPitLevel ?? 0;
+
             QueueNextPitLevel();
 
             // Regenerate the queued pit level immediately
@@ -85,6 +87,10 @@ namespace PitHero.AI
 
             Debug.Log($"[ActivateWizardOrb] BossDefeated set to {hero.BossDefeated} for new pit level {newPitLevel}");
             Debug.Log("[ActivateWizardOrb] Wizard orb activation complete - pit regenerated and hero repositioned");
+
+            Services.Analytics.AnalyticsService.LogOrbActivated(pitLevelBeforeOrb, newPitLevel, hero.LinkedHero?.Level ?? 0);
+            Services.Analytics.AnalyticsService.LogPartySnapshot("orb", hero.LinkedHero);
+
             return true; // Action complete
         }
 

--- a/PitHero/AI/AttackMonsterAction.cs
+++ b/PitHero/AI/AttackMonsterAction.cs
@@ -723,6 +723,9 @@ namespace PitHero.AI
                         (skill.Name, Color.White),
                         (targetName, GameConfig.ConsoleColorHeroName),
                         (skill.HPRestoreAmount.ToString(), Color.White));
+
+                    int healHpAfter = healTarget is Hero hpAfterHero ? hpAfterHero.CurrentHP : ((Mercenary)healTarget).CurrentHP;
+                    PitHero.Services.Analytics.AnalyticsService.LogHeal(casterName, skill.Id, targetName, skill.HPRestoreAmount, healHpAfter);
                 }
             }
 
@@ -770,6 +773,8 @@ namespace PitHero.AI
                         (consumable.Name, RarityUtils.GetRarityColor(consumable.Rarity)),
                         (targetName, GameConfig.ConsoleColorHeroName),
                         (healAmount.ToString(), Color.White));
+
+                    PitHero.Services.Analytics.AnalyticsService.LogHeal(userName, consumable.Name, targetName, healAmount, hpAfter);
 
                     var targetEntity = FindTargetEntity(target, targetsHero, heroComponent, validMercenaries);
                     SoundEffectManager sfx = Core.GetGlobalManager<SoundEffectManager>();
@@ -832,10 +837,12 @@ namespace PitHero.AI
             hero.EarnSynergyPointsWithAcceleration(enemy.SPYield);
             AwardMercenaryExperience(validMercenaries, enemy.ExperienceYield);
 
+            PitHero.Services.Analytics.AnalyticsService.LogMonsterDefeated(enemy);
+
             var gameState = Nez.Core.Services.GetService<PitHero.Services.GameStateService>();
             if (gameState != null)
             {
-                gameState.Funds += enemy.GoldYield;
+                gameState.AddFunds(enemy.GoldYield, "battle");
                 if (heroComponent != null && enemy.GoldYield > 0)
                     heroComponent.InnExhausted = false;
                 Debug.Log($"[AttackMonster] Earned {enemy.ExperienceYield} XP, {enemy.JPYield} JP, {enemy.SPYield} SP, {enemy.GoldYield} Gold");
@@ -979,6 +986,9 @@ namespace PitHero.AI
                         (evtSvcSkill.MonsterName(enemy.Name), GameConfig.ConsoleColorEnemyName),
                         (damage.ToString(), Color.White));
 
+                PitHero.Services.Analytics.AnalyticsService.LogAttack(hero.Name, "hero", skill.Id,
+                    enemy.Name, "monster", damage, hpBefore, enemy.CurrentHP, enemy.CurrentHP <= 0);
+
                 var enemyBouncyDigit = monsterEntity.GetComponent<BouncyDigitComponent>();
                 if (enemyBouncyDigit != null)
                 {
@@ -1028,8 +1038,12 @@ namespace PitHero.AI
 
             if (heroAttackResult.Hit)
             {
+                int heroTargetHpBefore = targetEnemy.CurrentHP;
                 bool enemyDied = targetEnemy.TakeDamage(heroAttackResult.Damage);
                 Debug.Log($"[AttackMonster] Hero deals {heroAttackResult.Damage} damage to {targetEnemy.Name}. Enemy HP: {targetEnemy.CurrentHP}/{targetEnemy.MaxHP}");
+
+                PitHero.Services.Analytics.AnalyticsService.LogAttack(hero.Name, "hero", "physical",
+                    targetEnemy.Name, "monster", heroAttackResult.Damage, heroTargetHpBefore, targetEnemy.CurrentHP, enemyDied);
 
                 var evtSvc = Core.Services.GetService<GameEventService>();
                 evtSvc?.EmitLocalized(UITextKey.ConsoleAttack,
@@ -1169,8 +1183,12 @@ namespace PitHero.AI
 
                 if (sResult.Hit)
                 {
+                    int sHpBefore = sEnemy.CurrentHP;
                     bool sEnemyDied = sEnemy.TakeDamage(sResult.Damage);
                     Debug.Log($"[AttackMonster] {mercenary.Name}'s {atkSkill.Name} dealt {sResult.Damage} to {sEnemy.Name}. HP: {sEnemy.CurrentHP}/{sEnemy.MaxHP}");
+
+                    PitHero.Services.Analytics.AnalyticsService.LogAttack(mercenary.Name, "merc", atkSkill.Id,
+                        sEnemy.Name, "monster", sResult.Damage, sHpBefore, sEnemy.CurrentHP, sEnemyDied);
 
                     var evtSvcAtkSkill = Core.Services.GetService<GameEventService>();
                     if (evtSvcAtkSkill != null)
@@ -1244,8 +1262,12 @@ namespace PitHero.AI
 
             if (mercAttackResult.Hit)
             {
+                int mercTargetHpBefore = targetEnemy.CurrentHP;
                 bool enemyDied = targetEnemy.TakeDamage(mercAttackResult.Damage);
                 Debug.Log($"[AttackMonster] {mercenary.Name} deals {mercAttackResult.Damage} damage to {targetEnemy.Name}. Enemy HP: {targetEnemy.CurrentHP}/{targetEnemy.MaxHP}");
+
+                PitHero.Services.Analytics.AnalyticsService.LogAttack(mercenary.Name, "merc", "physical",
+                    targetEnemy.Name, "monster", mercAttackResult.Damage, mercTargetHpBefore, targetEnemy.CurrentHP, enemyDied);
 
                 var evtSvcMerc = Core.Services.GetService<GameEventService>();
                 if (evtSvcMerc != null)
@@ -1347,8 +1369,12 @@ namespace PitHero.AI
                 soundEffectManager?.PlaySound(SoundEffectType.TakeDamage);
 
                 int actualDamage = enemyAttackResult.Damage * DEBUG_DAMAGE_MULT;
+                int heroHpBefore = hero.CurrentHP;
                 bool heroDied = hero.TakeDamage(actualDamage);
                 Debug.Log($"[AttackMonster] {enemy.Name} deals {enemyAttackResult.Damage} damage to {hero.Name}. Hero HP: {hero.CurrentHP}/{hero.MaxHP}");
+
+                PitHero.Services.Analytics.AnalyticsService.LogAttack(enemy.Name, "monster", "physical",
+                    hero.Name, "hero", actualDamage, heroHpBefore, hero.CurrentHP, heroDied);
 
                 var evtSvcHeroAtk = Core.Services.GetService<GameEventService>();
                 if (evtSvcHeroAtk != null)
@@ -1364,6 +1390,9 @@ namespace PitHero.AI
                 if (heroDied)
                 {
                     Debug.Log($"[AttackMonster] {hero.Name} died! Battle continues with mercenaries.");
+
+                    PitHero.Services.Analytics.AnalyticsService.LogCharacterKilled(hero, enemy);
+
                     var deathComponent = heroComponent.Entity.GetComponent<HeroDeathComponent>();
                     if (deathComponent == null)
                         deathComponent = heroComponent.Entity.AddComponent(new HeroDeathComponent());
@@ -1401,8 +1430,12 @@ namespace PitHero.AI
                 soundEffectManager?.PlaySound(SoundEffectType.TakeDamage);
 
                 int actualDamage = enemyAttackResult.Damage * DEBUG_DAMAGE_MULT;
+                int mercHpBefore = targetMercenary.CurrentHP;
                 bool mercDied = targetMercenary.TakeDamage(actualDamage);
                 Debug.Log($"[AttackMonster] {enemy.Name} deals {enemyAttackResult.Damage} damage to {targetMercenary.Name}. Mercenary HP: {targetMercenary.CurrentHP}/{targetMercenary.MaxHP}");
+
+                PitHero.Services.Analytics.AnalyticsService.LogAttack(enemy.Name, "monster", "physical",
+                    targetMercenary.Name, "merc", actualDamage, mercHpBefore, targetMercenary.CurrentHP, mercDied);
 
                 var evtSvcMercAtk = Core.Services.GetService<GameEventService>();
                 if (evtSvcMercAtk != null)
@@ -1418,6 +1451,9 @@ namespace PitHero.AI
                 if (mercDied)
                 {
                     Debug.Log($"[AttackMonster] {targetMercenary.Name} died! Starting fade out");
+
+                    PitHero.Services.Analytics.AnalyticsService.LogCharacterKilled(targetMercenary, enemy);
+
                     HandleMercenaryDeath(targetEntity, heroComponent, validMercenaries, enemy.Name);
                     validMercenaries.Remove(targetEntity);
                     yield return FadeOutAndDestroyMercenary(targetEntity);

--- a/PitHero/AI/JumpIntoPitAction.cs
+++ b/PitHero/AI/JumpIntoPitAction.cs
@@ -60,6 +60,14 @@ namespace PitHero.AI
                 var endTile = currentTile;
                 Debug.Log($"[JumpIntoPit] Hero tile position at end of execution: X={endTile.X}, Y={endTile.Y}");
                 Debug.Log("[JumpIntoPit] Jump completed successfully");
+
+                if (hero.LinkedHero != null)
+                {
+                    var analyticsPitLevel = Core.Services.GetService<PitWidthManager>()?.CurrentPitLevel ?? 0;
+                    Services.Analytics.AnalyticsService.LogPitJump(analyticsPitLevel, hero.LinkedHero);
+                    Services.Analytics.AnalyticsService.LogPartySnapshot("pit_jump", hero.LinkedHero);
+                }
+
                 return true; // Action complete
             }
 

--- a/PitHero/AI/OpenChestAction.cs
+++ b/PitHero/AI/OpenChestAction.cs
@@ -300,6 +300,9 @@ namespace PitHero.AI
             {
                 Debug.Log($"[OpenChest] Added {containedItem.Name} to hero's main bag. Bag contents:");
 
+                Services.Analytics.AnalyticsService.LogItemAcquired(containedItem,
+                    Core.Services.GetService<PitWidthManager>()?.CurrentPitLevel ?? 0, treasureComponent.Level);
+
                 Core.Services.GetService<GameEventService>()?.EmitLocalized(UITextKey.ConsoleItemFound,
                     (hero.LinkedHero.Name, GameConfig.ConsoleColorHeroName),
                     (containedItem.Name, RarityUtils.GetRarityColor(containedItem.Rarity)));

--- a/PitHero/AI/SleepInBedAction.cs
+++ b/PitHero/AI/SleepInBedAction.cs
@@ -258,6 +258,8 @@ namespace PitHero.AI
                     _hasPaidInnkeeper = true;
                     soundEffectManager.PlaySound(SoundEffectType.PayGold);
                     Debug.Log($"[SleepInBedAction] Paid {GameConfig.InnCostGold} gold to innkeeper. Remaining funds: {gameState.Funds}");
+
+                    Services.Analytics.AnalyticsService.LogInnSleep(GameConfig.InnCostGold, gameState.Funds);
                 }
                 else
                 {
@@ -272,6 +274,9 @@ namespace PitHero.AI
             else
             {
                 Debug.Log("[SleepInBedAction] Night sleep — innkeeper stay is free");
+
+                Services.Analytics.AnalyticsService.LogInnSleep(0,
+                    Core.Services.GetService<GameStateService>()?.Funds ?? 0);
             }
 
             // Step 4: Walk to bed (73, 3)

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -110,6 +110,14 @@ namespace PitHero.ECS.Scenes
         public override void Initialize()
         {
             base.Initialize();
+
+            // Log session start before any scene setup so it is the first analytics event
+            // (pit generation and mercenary spawns fire during initialization below).
+            // Funds are already restored by SaveLoadService.ApplyLoadedState at load time.
+            Services.Analytics.AnalyticsService.LogSessionStart(
+                SaveLoadService.PendingLoadData != null ? "load" : "new_game",
+                Core.Services.GetService<GameStateService>()?.Funds ?? 0);
+
             SetDesignResolution(GameConfig.VirtualWidth, GameConfig.VirtualHeight, SceneResolutionPolicy.BestFit);
             ClearColor = Color.Transparent;
 
@@ -875,7 +883,7 @@ namespace PitHero.ECS.Scenes
                     onYes: () =>
                     {
                         var gameState = Core.Services.GetService<Services.GameStateService>();
-                        if (gameState != null) gameState.Funds += gold;
+                        gameState?.AddFunds(gold, "sell_building");
                         pb.WorldEntity?.Destroy();
                         Core.Services.GetService<Services.BuildingService>()?.RemoveBuilding(pb);
                     });

--- a/PitHero/Game1.cs
+++ b/PitHero/Game1.cs
@@ -43,6 +43,11 @@ namespace PitHero
             soundEffectManager.Init(Content);
             RegisterGlobalManager(soundEffectManager);
 
+#if DEBUG
+            // Analytics for game balancing (issue #289) - debug builds only
+            RegisterGlobalManager(new Services.Analytics.AnalyticsManager());
+#endif
+
             // Disable pausing when focus is lost - essential for idle game behavior
             PauseOnFocusLost = false;
 
@@ -69,6 +74,9 @@ namespace PitHero
         {
             if (disposing)
             {
+                PitHero.Services.Analytics.AnalyticsService.LogSessionEnd();
+                PitHero.Services.Analytics.AnalyticsService.Shutdown();
+
                 var soundEffectManager = GetGlobalManager<SoundEffectManager>();
                 soundEffectManager?.Dispose();
             }

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -82,6 +82,12 @@ namespace PitHero
         public const int DaytimeMonsterAddCostGold = 500;  // Gold to manually add a Daytime monster (issue #283)
         public const int NocturnalMonsterAddCostGold = 700; // Gold to manually add a Nocturnal monster (issue #283)
 
+        // Analytics configuration (issue #289; debug builds only)
+        public const bool AnalyticsEnabled = true; // Master switch for analytics logging in debug builds
+        public const float AnalyticsFlushIntervalSeconds = 15f; // How often buffered analytics events are written to disk
+        public const int AnalyticsFlushThresholdChars = 65536; // Buffer size that forces an immediate analytics flush
+        public const string AnalyticsDirectoryName = "analytics"; // Subfolder under %LOCALAPPDATA%\PitHero for analytics logs
+
         // Inn configuration
         public const int InnkeeperTileX = 69; // Innkeeper stands at (69, 3)
         public const int InnkeeperTileY = 3;

--- a/PitHero/PitGenerator.cs
+++ b/PitHero/PitGenerator.cs
@@ -370,6 +370,8 @@ namespace PitHero
             Debug.Log($"[PitGenerator]   Min Obstacles: {minObstacles}");
             Debug.Log($"[PitGenerator]   Max Obstacles: {maxObstacles}, Actual: {obstacleCount}");
 
+            Services.Analytics.AnalyticsService.LogPitGenerated(level, isBossFloor, monsterCount, chestCount);
+
             InitializeCollisionTiles(validMinX, validMinY, validMaxX, validMaxY);
 
             var maxAttempts = 10;
@@ -789,6 +791,10 @@ namespace PitHero
                     Flags.SetFlagExclusive(ref collider.PhysicsLayer, GameConfig.PhysicsHeroWorldLayer);
 
                     Debug.Log($"[PitGenerator] Created treasure level {treasureComponent.Level} at tile ({tilePos.X},{tilePos.Y})");
+
+                    Services.Analytics.AnalyticsService.LogChestSpawned(currentPitLevel, tilePos.X, tilePos.Y,
+                        treasureComponent.Level, treasureComponent.ContainedItem,
+                        treasureComponent.ContainedSeedType?.ToString(), treasureComponent.ContainedSeedCount);
                 }
                 else if (tag == GameConfig.TAG_WIZARD_ORB)
                 {
@@ -833,6 +839,8 @@ namespace PitHero
 
                     var enemyComponent = entity.AddComponent(new EnemyComponent(enemy, isStationary: enemy.IsBoss));
                     Debug.Log($"[PitGenerator] Created {enemy.Name} enemy (Level {enemy.Level}, HP {enemy.CurrentHP}, IsBoss {enemy.IsBoss}) at tile ({tilePos.X},{tilePos.Y})");
+
+                    Services.Analytics.AnalyticsService.LogMonsterSpawned(pitLevel, tilePos.X, tilePos.Y, enemy);
 
                     // Add animation component using atlas sprite animations for all monster types
                     EnemyAnimationComponent enemyAnimation;

--- a/PitHero/RolePlayingFramework/Equipment/GearAutoEquipService.cs
+++ b/PitHero/RolePlayingFramework/Equipment/GearAutoEquipService.cs
@@ -144,6 +144,7 @@ namespace RolePlayingFramework.Equipment
                     {
                         bag.Remove(gear);
                         Debug.Log($"[GearAutoEquip] Equipped {gear.Name} to hero's Accessory1 slot");
+                        PitHero.Services.Analytics.AnalyticsService.LogGearEquipped(hero, EquipmentSlot.Accessory1, gear);
                         return true;
                     }
                 }
@@ -153,6 +154,7 @@ namespace RolePlayingFramework.Equipment
                     {
                         bag.Remove(gear);
                         Debug.Log($"[GearAutoEquip] Equipped {gear.Name} to hero's Accessory2 slot");
+                        PitHero.Services.Analytics.AnalyticsService.LogGearEquipped(hero, EquipmentSlot.Accessory2, gear);
                         return true;
                     }
                 }
@@ -167,6 +169,7 @@ namespace RolePlayingFramework.Equipment
                 {
                     bag.Remove(gear);
                     Debug.Log($"[GearAutoEquip] Equipped {gear.Name} to hero's {slot} slot (empty)");
+                    PitHero.Services.Analytics.AnalyticsService.LogGearEquipped(hero, slot, gear);
                     return true;
                 }
                 return false;
@@ -180,6 +183,7 @@ namespace RolePlayingFramework.Equipment
                     bag.TryAdd(currentGear);
                     displacedGear = currentGear;
                     Debug.Log($"[GearAutoEquip] Swapped {currentGear.Name} with {gear.Name} in hero's {slot} slot");
+                    PitHero.Services.Analytics.AnalyticsService.LogGearEquipped(hero, slot, gear);
                     return true;
                 }
             }
@@ -213,6 +217,7 @@ namespace RolePlayingFramework.Equipment
                     {
                         heroBag.Remove(gear);
                         Debug.Log($"[GearAutoEquip] Equipped {gear.Name} to {merc.Name}'s Accessory1 slot");
+                        PitHero.Services.Analytics.AnalyticsService.LogGearEquipped(merc, EquipmentSlot.Accessory1, gear);
                         return true;
                     }
                 }
@@ -222,6 +227,7 @@ namespace RolePlayingFramework.Equipment
                     {
                         heroBag.Remove(gear);
                         Debug.Log($"[GearAutoEquip] Equipped {gear.Name} to {merc.Name}'s Accessory2 slot");
+                        PitHero.Services.Analytics.AnalyticsService.LogGearEquipped(merc, EquipmentSlot.Accessory2, gear);
                         return true;
                     }
                 }
@@ -236,6 +242,7 @@ namespace RolePlayingFramework.Equipment
                 {
                     heroBag.Remove(gear);
                     Debug.Log($"[GearAutoEquip] Equipped {gear.Name} to {merc.Name}'s {slot} slot (empty)");
+                    PitHero.Services.Analytics.AnalyticsService.LogGearEquipped(merc, slot, gear);
                     return true;
                 }
                 return false;
@@ -249,6 +256,7 @@ namespace RolePlayingFramework.Equipment
                     heroBag.TryAdd(currentGear);
                     displacedGear = currentGear;
                     Debug.Log($"[GearAutoEquip] Swapped {currentGear.Name} with {gear.Name} in {merc.Name}'s {slot} slot");
+                    PitHero.Services.Analytics.AnalyticsService.LogGearEquipped(merc, slot, gear);
                     return true;
                 }
             }

--- a/PitHero/Services/Analytics/AnalyticsManager.cs
+++ b/PitHero/Services/Analytics/AnalyticsManager.cs
@@ -1,0 +1,21 @@
+#if DEBUG
+using Nez;
+
+namespace PitHero.Services.Analytics
+{
+    /// <summary>Global manager that initializes analytics and drives periodic buffer flushes. Debug builds only.</summary>
+    public class AnalyticsManager : GlobalManager
+    {
+        public AnalyticsManager()
+        {
+            AnalyticsService.Initialize();
+        }
+
+        /// <summary>Accumulates unscaled frame time into the analytics flush timer.</summary>
+        public override void Update()
+        {
+            AnalyticsService.TickFlush(Time.UnscaledDeltaTime);
+        }
+    }
+}
+#endif

--- a/PitHero/Services/Analytics/AnalyticsService.cs
+++ b/PitHero/Services/Analytics/AnalyticsService.cs
@@ -1,0 +1,668 @@
+using System;
+using System.Diagnostics;
+using RolePlayingFramework.Enemies;
+using RolePlayingFramework.Equipment;
+using RolePlayingFramework.Heroes;
+using RolePlayingFramework.Mercenaries;
+#if DEBUG
+using System.IO;
+using System.Text;
+using Nez;
+using PitHero.ECS.Components;
+#endif
+
+namespace PitHero.Services.Analytics
+{
+    /// <summary>
+    /// Static facade for game-balance analytics logging (issue #289). Every log method is
+    /// [Conditional("DEBUG")] so call sites (including argument evaluation) are removed entirely
+    /// from Release builds. Events are buffered as JSONL and flushed periodically by AnalyticsManager.
+    /// </summary>
+    public static class AnalyticsService
+    {
+#if DEBUG
+        private static bool _enabled;
+        private static bool _sessionStarted;
+        private static string _directory;
+        private static StreamWriter _writer;
+        private static readonly StringBuilder _buffer = new StringBuilder(GameConfig.AnalyticsFlushThresholdChars);
+        private static readonly JsonLineBuilder _json = new JsonLineBuilder(_buffer);
+        private static float _flushTimer;
+        private static long _sessionGoldGained;
+        private static int _monstersDefeated;
+        private static DateTime _sessionStartUtc;
+#endif
+
+        /// <summary>Runtime toggle for analytics logging. Always false (and set is ignored) in Release builds.</summary>
+        public static bool Enabled
+        {
+#if DEBUG
+            get => _enabled;
+            set => _enabled = value;
+#else
+            get => false;
+            set { }
+#endif
+        }
+
+        /// <summary>Initializes analytics using the default output directory (%LOCALAPPDATA%\PitHero\analytics).</summary>
+        [Conditional("DEBUG")]
+        public static void Initialize()
+        {
+#if DEBUG
+            var baseDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "PitHero");
+            Initialize(Path.Combine(baseDir, GameConfig.AnalyticsDirectoryName));
+#endif
+        }
+
+        /// <summary>Initializes analytics with an explicit output directory. Logging is enabled only if GameConfig.AnalyticsEnabled is true.</summary>
+        [Conditional("DEBUG")]
+        public static void Initialize(string directory)
+        {
+#if DEBUG
+            _directory = directory;
+            _enabled = GameConfig.AnalyticsEnabled;
+            _sessionStartUtc = DateTime.UtcNow;
+#endif
+        }
+
+        /// <summary>Flushes remaining events and closes the output file.</summary>
+        [Conditional("DEBUG")]
+        public static void Shutdown()
+        {
+#if DEBUG
+            Flush();
+            if (_writer != null)
+            {
+                _writer.Dispose();
+                _writer = null;
+            }
+            _enabled = false;
+            _sessionStarted = false;
+#endif
+        }
+
+        /// <summary>Accumulates elapsed time and flushes the buffer once the configured interval passes. Called every frame by AnalyticsManager.</summary>
+        [Conditional("DEBUG")]
+        public static void TickFlush(float deltaSeconds)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            _flushTimer += deltaSeconds;
+            if (_flushTimer >= GameConfig.AnalyticsFlushIntervalSeconds)
+            {
+                _flushTimer = 0f;
+                Flush();
+            }
+#endif
+        }
+
+        /// <summary>Writes all buffered events to disk immediately.</summary>
+        [Conditional("DEBUG")]
+        public static void Flush()
+        {
+#if DEBUG
+            if (_writer == null || _buffer.Length == 0)
+                return;
+            try
+            {
+                _writer.Write(_buffer);
+                _writer.Flush();
+            }
+            catch (IOException e)
+            {
+                Nez.Debug.Warn($"[Analytics] Flush failed, disabling analytics: {e.Message}");
+                _enabled = false;
+            }
+            _buffer.Clear();
+#endif
+        }
+
+        /// <summary>Logs the start of a play session (new game or save load). Rotates to a new output file if a session was already active.</summary>
+        [Conditional("DEBUG")]
+        public static void LogSessionStart(string mode, int gold)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (_sessionStarted && _writer != null)
+            {
+                Flush();
+                _writer.Dispose();
+                _writer = null;
+            }
+            _sessionStarted = true;
+            _sessionStartUtc = DateTime.UtcNow;
+            _sessionGoldGained = 0;
+            _monstersDefeated = 0;
+            if (!BeginEvent("session_start"))
+                return;
+            _json.Field("mode", mode);
+            _json.Field("gold", gold);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs end-of-session totals.</summary>
+        [Conditional("DEBUG")]
+        public static void LogSessionEnd()
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("session_end"))
+                return;
+            _json.Field("goldGainedTotal", _sessionGoldGained);
+            _json.Field("monstersDefeated", _monstersDefeated);
+            _json.Field("durationSec", (int)(DateTime.UtcNow - _sessionStartUtc).TotalSeconds);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs generation of a new pit level.</summary>
+        [Conditional("DEBUG")]
+        public static void LogPitGenerated(int pitLevel, bool isBossFloor, int monsterCount, int chestCount)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("pit_generated"))
+                return;
+            _json.Field("pitLevel", pitLevel);
+            _json.Field("isBossFloor", isBossFloor);
+            _json.Field("monsterCount", monsterCount);
+            _json.Field("chestCount", chestCount);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs a spawned treasure chest and its contents.</summary>
+        [Conditional("DEBUG")]
+        public static void LogChestSpawned(int pitLevel, int x, int y, int chestLevel, IItem item, string seedType, int seedCount)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("chest_spawned"))
+                return;
+            _json.Field("pitLevel", pitLevel);
+            _json.Field("x", x);
+            _json.Field("y", y);
+            _json.Field("chestLevel", chestLevel);
+            _json.Field("item", item?.Name);
+            _json.Field("kind", item != null ? item.Kind.ToString() : null);
+            _json.Field("rarity", item != null ? item.Rarity.ToString() : null);
+            if (seedType != null)
+            {
+                _json.Field("seedType", seedType);
+                _json.Field("seedCount", seedCount);
+            }
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs a spawned monster.</summary>
+        [Conditional("DEBUG")]
+        public static void LogMonsterSpawned(int pitLevel, int x, int y, IEnemy enemy)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("monster_spawned"))
+                return;
+            _json.Field("pitLevel", pitLevel);
+            _json.Field("x", x);
+            _json.Field("y", y);
+            _json.Field("name", enemy.Name);
+            _json.Field("enemyId", enemy.EnemyId.ToString());
+            _json.Field("level", enemy.Level);
+            _json.Field("maxHP", enemy.MaxHP);
+            _json.Field("isBoss", enemy.IsBoss);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs the hero activating the wizard orb to advance to the next pit level.</summary>
+        [Conditional("DEBUG")]
+        public static void LogOrbActivated(int fromPitLevel, int toPitLevel, int heroLevel)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("orb_activated"))
+                return;
+            _json.Field("fromPitLevel", fromPitLevel);
+            _json.Field("toPitLevel", toPitLevel);
+            _json.Field("heroLevel", heroLevel);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs the hero jumping into the pit.</summary>
+        [Conditional("DEBUG")]
+        public static void LogPitJump(int pitLevel, Hero hero)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("pit_jump"))
+                return;
+            _json.Field("pitLevel", pitLevel);
+            _json.Field("heroLevel", hero.Level);
+            _json.Field("heroHP", hero.CurrentHP);
+            _json.Field("heroMaxHP", hero.MaxHP);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs a full snapshot of the party (hero plus hired mercenaries) with stats, skills and gear.</summary>
+        [Conditional("DEBUG")]
+        public static void LogPartySnapshot(string reason, Hero hero)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("party_snapshot"))
+                return;
+            _json.Field("reason", reason);
+            _json.BeginArray("members");
+            if (hero != null)
+            {
+                _json.BeginArrayObject();
+                WriteHeroFields(hero);
+                _json.EndObject();
+            }
+            if (Core.Instance != null)
+            {
+                var mercManager = Core.Services.GetService<MercenaryManager>();
+                if (mercManager != null)
+                {
+                    var hired = mercManager.GetHiredMercenaries();
+                    for (int i = 0; i < hired.Count; i++)
+                    {
+                        var merc = hired[i].GetComponent<MercenaryComponent>()?.LinkedMercenary;
+                        if (merc == null)
+                            continue;
+                        _json.BeginArrayObject();
+                        WriteMercenaryFields(merc);
+                        _json.EndObject();
+                    }
+                }
+            }
+            _json.EndArray();
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs the party sleeping at the inn.</summary>
+        [Conditional("DEBUG")]
+        public static void LogInnSleep(int cost, int goldAfter)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("inn_sleep"))
+                return;
+            _json.Field("cost", cost);
+            _json.Field("goldAfter", goldAfter);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs a new mercenary arriving at the tavern, with stats and hire cost.</summary>
+        [Conditional("DEBUG")]
+        public static void LogMercArrived(Mercenary merc, int hireCost)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("merc_arrived"))
+                return;
+            var stats = merc.GetTotalStats();
+            _json.Field("name", merc.Name);
+            _json.Field("job", merc.Job.NameKey);
+            _json.Field("level", merc.Level);
+            _json.Field("str", stats.Strength);
+            _json.Field("agi", stats.Agility);
+            _json.Field("vit", stats.Vitality);
+            _json.Field("mag", stats.Magic);
+            _json.Field("maxHP", merc.MaxHP);
+            _json.Field("maxMP", merc.MaxMP);
+            _json.Field("hireCost", hireCost);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs a mercenary being removed (left tavern rotation, or dismissed from the party).</summary>
+        [Conditional("DEBUG")]
+        public static void LogMercLeft(string name, string reason)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("merc_left"))
+                return;
+            _json.Field("name", name);
+            _json.Field("reason", reason);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs an item actually collected from a chest.</summary>
+        [Conditional("DEBUG")]
+        public static void LogItemAcquired(IItem item, int pitLevel, int chestLevel)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("item_acquired"))
+                return;
+            _json.Field("item", item.Name);
+            _json.Field("kind", item.Kind.ToString());
+            _json.Field("rarity", item.Rarity.ToString());
+            _json.Field("pitLevel", pitLevel);
+            _json.Field("chestLevel", chestLevel);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs gear equipped on the hero along with the hero's resulting stats.</summary>
+        [Conditional("DEBUG")]
+        public static void LogGearEquipped(Hero hero, EquipmentSlot slot, IItem item)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("gear_equipped"))
+                return;
+            _json.Field("character", hero.Name);
+            _json.Field("charType", "hero");
+            _json.Field("slot", slot.ToString());
+            _json.Field("item", item.Name);
+            _json.Field("rarity", item.Rarity.ToString());
+            WriteResultingStats(hero.GetTotalStats(), hero.MaxHP, hero.MaxMP);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs gear equipped on a mercenary along with the mercenary's resulting stats.</summary>
+        [Conditional("DEBUG")]
+        public static void LogGearEquipped(Mercenary merc, EquipmentSlot slot, IItem item)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("gear_equipped"))
+                return;
+            _json.Field("character", merc.Name);
+            _json.Field("charType", "merc");
+            _json.Field("slot", slot.ToString());
+            _json.Field("item", item.Name);
+            _json.Field("rarity", item.Rarity.ToString());
+            WriteResultingStats(merc.GetTotalStats(), merc.MaxHP, merc.MaxMP);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs a gold gain, its source, the session running total and the player's current gold.</summary>
+        [Conditional("DEBUG")]
+        public static void LogGoldGained(int amount, string source, int currentGold)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            _sessionGoldGained += amount;
+            if (!BeginEvent("gold_gained"))
+                return;
+            _json.Field("amount", amount);
+            _json.Field("source", source);
+            _json.Field("sessionTotal", _sessionGoldGained);
+            _json.Field("currentGold", currentGold);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs a monster defeated by the party.</summary>
+        [Conditional("DEBUG")]
+        public static void LogMonsterDefeated(IEnemy enemy)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            _monstersDefeated++;
+            if (!BeginEvent("monster_defeated"))
+                return;
+            _json.Field("name", enemy.Name);
+            _json.Field("enemyId", enemy.EnemyId.ToString());
+            _json.Field("level", enemy.Level);
+            _json.Field("isBoss", enemy.IsBoss);
+            _json.Field("pitLevel", GetCurrentPitLevel());
+            _json.Field("xp", enemy.ExperienceYield);
+            _json.Field("jp", enemy.JPYield);
+            _json.Field("gold", enemy.GoldYield);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs a single attack or offensive skill use with target and damage.</summary>
+        [Conditional("DEBUG")]
+        public static void LogAttack(string actor, string actorType, string action, string target, string targetType, int damage, int hpBefore, int hpAfter, bool killed)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("attack"))
+                return;
+            _json.Field("actor", actor);
+            _json.Field("actorType", actorType);
+            _json.Field("action", action);
+            _json.Field("target", target);
+            _json.Field("targetType", targetType);
+            _json.Field("dmg", damage);
+            _json.Field("hpBefore", hpBefore);
+            _json.Field("hpAfter", hpAfter);
+            _json.Field("killed", killed);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs HP restored by a skill or item.</summary>
+        [Conditional("DEBUG")]
+        public static void LogHeal(string actor, string source, string target, int amount, int hpAfter)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("heal"))
+                return;
+            _json.Field("actor", actor);
+            _json.Field("source", source);
+            _json.Field("target", target);
+            _json.Field("amount", amount);
+            _json.Field("hpAfter", hpAfter);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs the hero being killed by a monster, with full hero details and killer stats.</summary>
+        [Conditional("DEBUG")]
+        public static void LogCharacterKilled(Hero victim, IEnemy killer)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("char_killed"))
+                return;
+            WriteHeroFields(victim);
+            WriteKillerObject(killer);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs a mercenary being killed by a monster, with full mercenary details and killer stats.</summary>
+        [Conditional("DEBUG")]
+        public static void LogCharacterKilled(Mercenary victim, IEnemy killer)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("char_killed"))
+                return;
+            WriteMercenaryFields(victim);
+            WriteKillerObject(killer);
+            EndEvent();
+#endif
+        }
+
+#if DEBUG
+        /// <summary>Opens a new event object with timestamp, in-game time and event type. Returns false if output is unavailable.</summary>
+        private static bool BeginEvent(string eventType)
+        {
+            if (!EnsureWriter())
+                return false;
+            _json.BeginEvent();
+            var now = DateTime.Now;
+            _json.TimestampField("t", now, TimeZoneInfo.Local.GetUtcOffset(now));
+            if (Core.Instance != null)
+            {
+                var timeService = Core.Services.GetService<InGameTimeService>();
+                if (timeService != null)
+                    _json.TimeField("gt", timeService.Hour, timeService.Minute);
+            }
+            _json.Field("e", eventType);
+            return true;
+        }
+
+        /// <summary>Closes the current event line and flushes early if the buffer is large.</summary>
+        private static void EndEvent()
+        {
+            _json.EndEvent();
+            if (_buffer.Length >= GameConfig.AnalyticsFlushThresholdChars)
+                Flush();
+        }
+
+        /// <summary>Opens the session output file if not already open. Returns false when the file cannot be opened.</summary>
+        private static bool EnsureWriter()
+        {
+            if (_writer != null)
+                return true;
+            if (_directory == null)
+                return false;
+            try
+            {
+                Directory.CreateDirectory(_directory);
+                var fileName = "session_" + DateTime.Now.ToString("yyyyMMdd_HHmmss") + ".jsonl";
+                _writer = new StreamWriter(Path.Combine(_directory, fileName), append: true);
+                return true;
+            }
+            catch (IOException e)
+            {
+                Nez.Debug.Warn($"[Analytics] Could not open output file, disabling analytics: {e.Message}");
+                _enabled = false;
+                return false;
+            }
+        }
+
+        /// <summary>Writes the current pit level fetched from the PitWidthManager service (0 when unavailable).</summary>
+        private static int GetCurrentPitLevel()
+        {
+            if (Core.Instance == null)
+                return 0;
+            var pitWidthManager = Core.Services.GetService<PitWidthManager>();
+            return pitWidthManager?.CurrentPitLevel ?? 0;
+        }
+
+        /// <summary>Writes name/job/level/stats/skills/gear fields for a hero into the current object.</summary>
+        private static void WriteHeroFields(Hero hero)
+        {
+            var stats = hero.GetTotalStats();
+            _json.Field("name", hero.Name);
+            _json.Field("type", "hero");
+            _json.Field("job", hero.Job.NameKey);
+            _json.Field("level", hero.Level);
+            _json.Field("str", stats.Strength);
+            _json.Field("agi", stats.Agility);
+            _json.Field("vit", stats.Vitality);
+            _json.Field("mag", stats.Magic);
+            _json.Field("maxHP", hero.MaxHP);
+            _json.Field("curHP", hero.CurrentHP);
+            _json.Field("maxMP", hero.MaxMP);
+            _json.BeginArray("skills");
+            foreach (var kv in hero.LearnedSkills)
+                _json.ArrayStringValue(kv.Key);
+            _json.EndArray();
+            _json.BeginObject("gear");
+            WriteGearSlot("weapon", hero.WeaponShield1);
+            WriteGearSlot("armor", hero.Armor);
+            WriteGearSlot("hat", hero.Hat);
+            WriteGearSlot("shield", hero.WeaponShield2);
+            WriteGearSlot("acc1", hero.Accessory1);
+            WriteGearSlot("acc2", hero.Accessory2);
+            _json.EndObject();
+        }
+
+        /// <summary>Writes name/job/level/stats/skills/gear fields for a mercenary into the current object.</summary>
+        private static void WriteMercenaryFields(Mercenary merc)
+        {
+            var stats = merc.GetTotalStats();
+            _json.Field("name", merc.Name);
+            _json.Field("type", "merc");
+            _json.Field("job", merc.Job.NameKey);
+            _json.Field("level", merc.Level);
+            _json.Field("str", stats.Strength);
+            _json.Field("agi", stats.Agility);
+            _json.Field("vit", stats.Vitality);
+            _json.Field("mag", stats.Magic);
+            _json.Field("maxHP", merc.MaxHP);
+            _json.Field("curHP", merc.CurrentHP);
+            _json.Field("maxMP", merc.MaxMP);
+            _json.BeginArray("skills");
+            foreach (var kv in merc.LearnedSkills)
+                _json.ArrayStringValue(kv.Key);
+            _json.EndArray();
+            _json.BeginObject("gear");
+            WriteGearSlot("weapon", merc.WeaponShield1);
+            WriteGearSlot("armor", merc.Armor);
+            WriteGearSlot("hat", merc.Hat);
+            WriteGearSlot("shield", merc.WeaponShield2);
+            WriteGearSlot("acc1", merc.Accessory1);
+            WriteGearSlot("acc2", merc.Accessory2);
+            _json.EndObject();
+        }
+
+        /// <summary>Writes a killer sub-object for char_killed events.</summary>
+        private static void WriteKillerObject(IEnemy killer)
+        {
+            _json.BeginObject("killer");
+            _json.Field("name", killer.Name);
+            _json.Field("enemyId", killer.EnemyId.ToString());
+            _json.Field("level", killer.Level);
+            _json.Field("str", killer.Stats.Strength);
+            _json.Field("agi", killer.Stats.Agility);
+            _json.Field("vit", killer.Stats.Vitality);
+            _json.Field("mag", killer.Stats.Magic);
+            _json.Field("maxHP", killer.MaxHP);
+            _json.EndObject();
+        }
+
+        /// <summary>Writes a gear slot field when the slot is occupied.</summary>
+        private static void WriteGearSlot(string slotName, IItem item)
+        {
+            if (item != null)
+                _json.Field(slotName, item.Name);
+        }
+
+        /// <summary>Writes the post-equip resulting stat fields.</summary>
+        private static void WriteResultingStats(RolePlayingFramework.Stats.StatBlock stats, int maxHP, int maxMP)
+        {
+            _json.Field("str", stats.Strength);
+            _json.Field("agi", stats.Agility);
+            _json.Field("vit", stats.Vitality);
+            _json.Field("mag", stats.Magic);
+            _json.Field("maxHP", maxHP);
+            _json.Field("maxMP", maxMP);
+        }
+#endif
+    }
+}

--- a/PitHero/Services/Analytics/JsonLineBuilder.cs
+++ b/PitHero/Services/Analytics/JsonLineBuilder.cs
@@ -1,0 +1,249 @@
+#if DEBUG
+using System;
+using System.Text;
+
+namespace PitHero.Services.Analytics
+{
+    /// <summary>AOT-safe JSONL writer that appends one JSON object per line to a shared StringBuilder. Debug builds only.</summary>
+    public sealed class JsonLineBuilder
+    {
+        private readonly StringBuilder _sb;
+        private readonly bool[] _firstElement = new bool[16];
+        private int _depth;
+
+        public JsonLineBuilder(StringBuilder sb)
+        {
+            _sb = sb;
+        }
+
+        /// <summary>Begins a new event object line.</summary>
+        public void BeginEvent()
+        {
+            _sb.Append('{');
+            _depth = 0;
+            _firstElement[0] = true;
+        }
+
+        /// <summary>Closes the current event object and terminates the line.</summary>
+        public void EndEvent()
+        {
+            _sb.Append('}');
+            _sb.Append('\n');
+        }
+
+        /// <summary>Writes a string field (null value is written as JSON null).</summary>
+        public void Field(string name, string value)
+        {
+            WriteName(name);
+            if (value == null)
+            {
+                _sb.Append("null");
+                return;
+            }
+            WriteStringValue(value);
+        }
+
+        /// <summary>Writes an int field.</summary>
+        public void Field(string name, int value)
+        {
+            WriteName(name);
+            _sb.Append(value);
+        }
+
+        /// <summary>Writes a long field.</summary>
+        public void Field(string name, long value)
+        {
+            WriteName(name);
+            _sb.Append(value);
+        }
+
+        /// <summary>Writes a float field using invariant culture.</summary>
+        public void Field(string name, float value)
+        {
+            WriteName(name);
+            _sb.Append(value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        /// <summary>Writes a bool field.</summary>
+        public void Field(string name, bool value)
+        {
+            WriteName(name);
+            _sb.Append(value ? "true" : "false");
+        }
+
+        /// <summary>Opens a nested object field.</summary>
+        public void BeginObject(string name)
+        {
+            WriteName(name);
+            _sb.Append('{');
+            Push();
+        }
+
+        /// <summary>Closes the current nested object.</summary>
+        public void EndObject()
+        {
+            _sb.Append('}');
+            _depth--;
+        }
+
+        /// <summary>Opens an array field.</summary>
+        public void BeginArray(string name)
+        {
+            WriteName(name);
+            _sb.Append('[');
+            Push();
+        }
+
+        /// <summary>Closes the current array.</summary>
+        public void EndArray()
+        {
+            _sb.Append(']');
+            _depth--;
+        }
+
+        /// <summary>Opens an anonymous object as an array element.</summary>
+        public void BeginArrayObject()
+        {
+            PrepareForValue();
+            _sb.Append('{');
+            Push();
+        }
+
+        /// <summary>Writes a string value as an array element.</summary>
+        public void ArrayStringValue(string value)
+        {
+            PrepareForValue();
+            WriteStringValue(value);
+        }
+
+        /// <summary>Writes an ISO-8601 timestamp field with millisecond precision and UTC offset (e.g. 2026-07-09T18:30:05.123-08:00).</summary>
+        public void TimestampField(string name, DateTime local, TimeSpan utcOffset)
+        {
+            WriteName(name);
+            _sb.Append('"');
+            AppendPadded(local.Year, 4);
+            _sb.Append('-');
+            AppendPadded(local.Month, 2);
+            _sb.Append('-');
+            AppendPadded(local.Day, 2);
+            _sb.Append('T');
+            AppendPadded(local.Hour, 2);
+            _sb.Append(':');
+            AppendPadded(local.Minute, 2);
+            _sb.Append(':');
+            AppendPadded(local.Second, 2);
+            _sb.Append('.');
+            AppendPadded(local.Millisecond, 3);
+            if (utcOffset < TimeSpan.Zero)
+            {
+                _sb.Append('-');
+                utcOffset = utcOffset.Negate();
+            }
+            else
+            {
+                _sb.Append('+');
+            }
+            AppendPadded(utcOffset.Hours, 2);
+            _sb.Append(':');
+            AppendPadded(utcOffset.Minutes, 2);
+            _sb.Append('"');
+        }
+
+        /// <summary>Writes an in-game clock field as "HH:MM".</summary>
+        public void TimeField(string name, int hour, int minute)
+        {
+            WriteName(name);
+            _sb.Append('"');
+            AppendPadded(hour, 2);
+            _sb.Append(':');
+            AppendPadded(minute, 2);
+            _sb.Append('"');
+        }
+
+        private void Push()
+        {
+            _depth++;
+            _firstElement[_depth] = true;
+        }
+
+        private void PrepareForValue()
+        {
+            if (_firstElement[_depth])
+                _firstElement[_depth] = false;
+            else
+                _sb.Append(',');
+        }
+
+        private void WriteName(string name)
+        {
+            PrepareForValue();
+            _sb.Append('"');
+            AppendEscaped(name);
+            _sb.Append('"');
+            _sb.Append(':');
+        }
+
+        private void WriteStringValue(string value)
+        {
+            _sb.Append('"');
+            AppendEscaped(value);
+            _sb.Append('"');
+        }
+
+        private void AppendEscaped(string value)
+        {
+            for (int i = 0; i < value.Length; i++)
+            {
+                char c = value[i];
+                switch (c)
+                {
+                    case '"':
+                        _sb.Append('\\').Append('"');
+                        break;
+                    case '\\':
+                        _sb.Append('\\').Append('\\');
+                        break;
+                    case '\n':
+                        _sb.Append('\\').Append('n');
+                        break;
+                    case '\r':
+                        _sb.Append('\\').Append('r');
+                        break;
+                    case '\t':
+                        _sb.Append('\\').Append('t');
+                        break;
+                    default:
+                        if (c < 0x20)
+                        {
+                            _sb.Append('\\').Append('u').Append('0').Append('0');
+                            AppendHexDigit((c >> 4) & 0xF);
+                            AppendHexDigit(c & 0xF);
+                        }
+                        else
+                        {
+                            _sb.Append(c);
+                        }
+                        break;
+                }
+            }
+        }
+
+        private void AppendHexDigit(int digit)
+        {
+            _sb.Append((char)(digit < 10 ? '0' + digit : 'a' + digit - 10));
+        }
+
+        private void AppendPadded(int value, int digits)
+        {
+            int divisor = 1;
+            for (int i = 1; i < digits; i++)
+                divisor *= 10;
+            while (divisor > 0)
+            {
+                _sb.Append((char)('0' + (value / divisor) % 10));
+                divisor /= 10;
+            }
+        }
+    }
+}
+#endif

--- a/PitHero/Services/GameStateService.cs
+++ b/PitHero/Services/GameStateService.cs
@@ -11,6 +11,13 @@ namespace PitHero.Services
         /// <summary>Gold currency that persists across all heroes.</summary>
         public int Funds { get; set; }
 
+        /// <summary>Adds gold to Funds and records the gain with its source for balance analytics.</summary>
+        public void AddFunds(int amount, string source)
+        {
+            Funds += amount;
+            Analytics.AnalyticsService.LogGoldGained(amount, source, Funds);
+        }
+
         /// <summary>Discovered stencils mapped by pattern ID to discovery source.</summary>
         public Dictionary<string, StencilDiscoverySource> DiscoveredStencils { get; } = new();
 

--- a/PitHero/Services/MercenaryManager.cs
+++ b/PitHero/Services/MercenaryManager.cs
@@ -191,6 +191,8 @@ namespace PitHero.Services
             var mercenary = new Mercenary(name, job, mercLevel, baseStats);
             mercenary.LearnAllJobSkills();
 
+            Analytics.AnalyticsService.LogMercArrived(mercenary, BalanceConfig.CalculateMercenaryHireCost(mercLevel));
+
             // Create entity at spawn position
             var spawnWorldPos = new Vector2(
                 SpawnPosition.X * GameConfig.TileSize + GameConfig.TileSize / 2,
@@ -516,13 +518,15 @@ namespace PitHero.Services
         }
 
         /// <summary>Removes a mercenary from the game</summary>
-        private void RemoveMercenary(Entity mercEntity)
+        private void RemoveMercenary(Entity mercEntity, string reason = "tavern_left")
         {
             var mercComponent = mercEntity.GetComponent<MercenaryComponent>();
             if (mercComponent != null)
             {
                 _occupiedTavernPositions.Remove(mercComponent.TavernPosition);
                 Debug.Log($"[MercenaryManager] Removed mercenary {mercComponent.LinkedMercenary.Name}");
+
+                Analytics.AnalyticsService.LogMercLeft(mercComponent.LinkedMercenary?.Name, reason);
             }
 
             _mercenaryEntities.Remove(mercEntity);
@@ -582,7 +586,7 @@ namespace PitHero.Services
             ReassignFollowTargetsAfterDismissal(mercEntity);
 
             // Remove and destroy
-            RemoveMercenary(mercEntity);
+            RemoveMercenary(mercEntity, "dismissed");
         }
 
         /// <summary>

--- a/PitHero/UI/HarvestedCropsModeOverlay.cs
+++ b/PitHero/UI/HarvestedCropsModeOverlay.cs
@@ -163,7 +163,7 @@ namespace PitHero.UI
                 onYes: () =>
                 {
                     var gameState = Core.Services.GetService<GameStateService>();
-                    if (gameState != null) gameState.Funds += totalGold;
+                    gameState?.AddFunds(totalGold, "sell_crops");
                     storage.ClearBuilding(buildingId);
                     _descWindow?.SetVisible(false);
                     LayoutButtonRow();
@@ -200,7 +200,7 @@ namespace PitHero.UI
                 onYes: () =>
                 {
                     var gameState = Core.Services.GetService<GameStateService>();
-                    if (gameState != null) gameState.Funds += totalGold;
+                    gameState?.AddFunds(totalGold, "sell_crops");
                     for (int b = 0; b < all.Count; b++)
                         if (all[b].Type == BuildingType.CropStorage)
                             storage.ClearBuilding(all[b].UniqueId);
@@ -400,7 +400,7 @@ namespace PitHero.UI
                 {
                     var storage = Core.Services.GetService<CropStorageInventoryService>();
                     var gameState = Core.Services.GetService<GameStateService>();
-                    if (gameState != null) gameState.Funds += gold;
+                    gameState?.AddFunds(gold, "sell_crops");
                     storage?.ClearSlot(buildingId, slotIndex);
                     _descWindow.SetVisible(false);
                     LayoutButtonRow();

--- a/PitHero/UI/InventoryGrid.cs
+++ b/PitHero/UI/InventoryGrid.cs
@@ -832,7 +832,7 @@ namespace PitHero.UI
                 vault?.AddItem(item);
 
                 var gameState = Core.Services?.GetService<PitHero.Services.GameStateService>();
-                if (gameState != null) gameState.Funds += gold;
+                gameState?.AddFunds(gold, "sell_item");
 
                 _heroComponent.Bag.SetSlotItem(bagIndex, null);
                 Debug.Log($"Sold {item.Name} x{qty} for {gold}G");
@@ -1368,7 +1368,10 @@ namespace PitHero.UI
             if (heroEquipment == null) return true;
             var d = slot.SlotData;
             if (d.SlotType != InventorySlotType.Equipment || !d.EquipmentSlot.HasValue) return true;
-            return heroEquipment.SetEquipmentSlot(d.EquipmentSlot.Value, d.Item);
+            var equipped = heroEquipment.SetEquipmentSlot(d.EquipmentSlot.Value, d.Item);
+            if (equipped && d.Item != null)
+                Services.Analytics.AnalyticsService.LogGearEquipped(heroEquipment, d.EquipmentSlot.Value, d.Item);
+            return equipped;
         }
 
         /// <summary>Updates mercenary equipment when a mercenary equipment slot changed.</summary>
@@ -1378,7 +1381,8 @@ namespace PitHero.UI
             if (d.SlotType != InventorySlotType.MercenaryEquipment || !d.EquipmentSlot.HasValue) return;
             var merc = d.MercenaryRef;
             if (merc == null) return;
-            merc.SetEquipmentSlot(d.EquipmentSlot.Value, d.Item);
+            if (merc.SetEquipmentSlot(d.EquipmentSlot.Value, d.Item) && d.Item != null)
+                Services.Analytics.AnalyticsService.LogGearEquipped(merc, d.EquipmentSlot.Value, d.Item);
         }
 
         /// <summary>finds the first empty bag slot (shortcut or inventory).</summary>

--- a/PitHero/UI/SecondChanceShopUI.cs
+++ b/PitHero/UI/SecondChanceShopUI.cs
@@ -817,13 +817,17 @@ namespace PitHero.UI
             if (destSlot.SlotData.SlotType == InventorySlotType.MercenaryEquipment && destSlot.SlotData.EquipmentSlot.HasValue)
             {
                 // Mercenary equip slots always receive exactly 1 item
-                destSlot.SlotData.MercenaryRef?.SetEquipmentSlot(destSlot.SlotData.EquipmentSlot.Value, item);
+                var equipMerc = destSlot.SlotData.MercenaryRef;
+                if (equipMerc != null && equipMerc.SetEquipmentSlot(destSlot.SlotData.EquipmentSlot.Value, item))
+                    Services.Analytics.AnalyticsService.LogGearEquipped(equipMerc, destSlot.SlotData.EquipmentSlot.Value, item);
                 vault.RemoveQuantity(vaultStack, 1);
             }
             else if (destSlot.SlotData.SlotType == InventorySlotType.Equipment && destSlot.SlotData.EquipmentSlot.HasValue)
             {
                 // Hero equip slots always receive exactly 1 item
-                heroComp.LinkedHero?.SetEquipmentSlot(destSlot.SlotData.EquipmentSlot.Value, item);
+                var equipHero = heroComp.LinkedHero;
+                if (equipHero != null && equipHero.SetEquipmentSlot(destSlot.SlotData.EquipmentSlot.Value, item))
+                    Services.Analytics.AnalyticsService.LogGearEquipped(equipHero, destSlot.SlotData.EquipmentSlot.Value, item);
                 vault.RemoveQuantity(vaultStack, 1);
             }
             else if (destSlot.SlotData.SlotType == InventorySlotType.Inventory && destSlot.SlotData.BagIndex.HasValue)
@@ -1051,7 +1055,7 @@ namespace PitHero.UI
             if (!placed)
             {
                 // Inventory full — refund gold
-                gameState.Funds += price;
+                gameState.AddFunds(price, "refund");
                 InventoryDragManager.CancelDrag();
                 _vaultCrystalGrid?.ShowAllCrystalSprites();
                 return;

--- a/PitHero/docs/AnalyticsSchema.md
+++ b/PitHero/docs/AnalyticsSchema.md
@@ -1,0 +1,102 @@
+# Analytics Schema (Game Balancing)
+
+Reference for the debug-only analytics layer added in issue #289. Read this before analyzing
+analytics logs for balance work — it defines the file format, every event type, and the
+interpretation caveats that are not obvious from the raw data.
+
+## Where the data lives
+
+- **Path:** `%LOCALAPPDATA%\PitHero\analytics\session_yyyyMMdd_HHmmss.jsonl`
+- **Format:** JSONL — one JSON object per line, one line per event.
+- **Rotation:** a new file per session. Returning to the title screen and starting/loading
+  another game rotates to a new file within the same process.
+- **Flush cadence:** events are buffered and written every 15 seconds
+  (`GameConfig.AnalyticsFlushIntervalSeconds`), on 64 KB buffer overflow, and on clean exit.
+  **After a crash, up to the last flush interval of events is missing** — treat abrupt file
+  ends as truncation, not as "nothing happened".
+
+## Availability
+
+- Compiled into **Debug builds only**. Every `AnalyticsService` log method is
+  `[Conditional("DEBUG")]`; Release builds contain no analytics code or call sites.
+- Master switch: `GameConfig.AnalyticsEnabled` (const bool). `false` disables logging even
+  in Debug builds.
+- Implementation: `PitHero/Services/Analytics/` (`AnalyticsService`, `AnalyticsManager`,
+  `JsonLineBuilder`).
+
+## Envelope (every line)
+
+| Field | Meaning |
+|---|---|
+| `t` | Wall-clock timestamp, ISO-8601 local time with UTC offset, ms precision. Lines are written in event order; `t` is monotonically non-decreasing within a file. |
+| `gt` | In-game clock as `"HH:MM"` (24-hour). 1 real second = 1 in-game minute. Restored from save on load, so it can jump between adjacent lines during load. |
+| `e` | Event type (see below). |
+
+`session_start` is guaranteed to be the **first event** of each file.
+
+## Event types
+
+### Session
+| `e` | Fields | Notes |
+|---|---|---|
+| `session_start` | `mode` (`"new_game"`/`"load"`), `gold` | `gold` is the player's funds at session start. |
+| `session_end` | `goldGainedTotal`, `monstersDefeated`, `durationSec` | Written on clean exit only — absent after a crash. |
+
+### Pit
+| `e` | Fields | Notes |
+|---|---|---|
+| `pit_generated` | `pitLevel`, `isBossFloor`, `monsterCount`, `chestCount` | Fires on every pit (re)generation, including the initial load-time generation. `isBossFloor` comes from `CaveBiomeConfig.IsBossFloor` — see caveat below. |
+| `chest_spawned` | `pitLevel`, `x`, `y`, `chestLevel` (1–5), `item`, `kind`, `rarity`, optional `seedType` + `seedCount` | Contents decided at spawn time. `item` is `null` for seed chests. |
+| `monster_spawned` | `pitLevel`, `x`, `y`, `name`, `enemyId`, `level`, `maxHP`, `isBoss` | `level` is the enemy's own level (often a per-type preset — see caveats). |
+| `orb_activated` | `fromPitLevel`, `toPitLevel`, `heroLevel` | Wizard orb → next pit level. Followed by a `party_snapshot` with `reason:"orb"`. |
+| `pit_jump` | `pitLevel`, `heroLevel`, `heroHP`, `heroMaxHP` | Hero jumped into the pit. Followed by a `party_snapshot` with `reason:"pit_jump"`. |
+| `party_snapshot` | `reason`, `members[]` | Each member: `name`, `type` (`"hero"`/`"merc"`), `job`, `level`, `str/agi/vit/mag` (total stats incl. gear/synergy), `maxHP`, `curHP`, `maxMP`, `skills[]` (skill ids), `gear{}` (slot→item name; keys `weapon`, `armor`, `hat`, `shield`, `acc1`, `acc2`; empty slots omitted). |
+
+### Town
+| `e` | Fields | Notes |
+|---|---|---|
+| `inn_sleep` | `cost`, `goldAfter` | `cost` is 0 for the free night-sleep branch. |
+| `merc_arrived` | `name`, `job`, `level`, `str/agi/vit/mag`, `maxHP`, `maxMP`, `hireCost` | New tavern mercenary. Also fires for the immediate first spawn at scene start (that is a genuinely new mercenary, not save noise). |
+| `merc_left` | `name`, `reason` | `reason`: `"tavern_left"` (rotation or tavern dismissal) or `"dismissed"` (hired party member dismissed). |
+
+### Gear / gold
+| `e` | Fields | Notes |
+|---|---|---|
+| `item_acquired` | `item`, `kind`, `rarity`, `pitLevel`, `chestLevel` | Item actually collected from a chest. Pair with `chest_spawned` (availability) — they answer different questions. |
+| `gear_equipped` | `character`, `charType`, `slot`, `item`, `rarity`, `str/agi/vit/mag`, `maxHP`, `maxMP` | Stats are the character's **resulting totals after** the equip. Save-restore re-equips are deliberately not logged. |
+| `gold_gained` | `amount`, `source`, `sessionTotal`, `currentGold` | `source`: `"battle"`, `"sell_item"`, `"sell_building"`, `"sell_crops"`, `"refund"`. `sessionTotal` resets each `session_start`. Spends are not logged; infer from `currentGold` deltas (e.g. `inn_sleep.goldAfter`). |
+
+### Battle
+| `e` | Fields | Notes |
+|---|---|---|
+| `attack` | `actor`, `actorType` (`"hero"`/`"merc"`/`"monster"`), `action`, `target`, `targetType`, `dmg`, `hpBefore`, `hpAfter`, `killed` | `action` is `"physical"` or a skill id (e.g. `knight.heavy_strike`). `hpBefore`/`hpAfter` are the **target's** HP; `hpBefore − dmg = hpAfter` (floored at 0). AoE skills emit one line per target hit. Misses are not logged. Monsters only have physical attacks. |
+| `heal` | `actor`, `source` (skill id or item name), `target`, `amount`, `hpAfter` | Battle heals (skills and consumables). |
+| `monster_defeated` | `name`, `enemyId`, `level`, `isBoss`, `pitLevel`, `xp`, `jp`, `gold` | One per kill regardless of killer; the matching `gold_gained` (`source:"battle"`) follows. |
+| `char_killed` | full victim snapshot (same shape as a `party_snapshot` member) + `killer{name, enemyId, level, str/agi/vit/mag, maxHP}` | Hero or mercenary killed by a monster. |
+
+## Interpretation caveats
+
+- **Names are text keys, not display names.** Monsters log localization keys
+  (`Monster_Skeleton`), jobs log `IJob.NameKey` (`Job_Knight_Name`). Item names are the
+  localized display names (English by default). Strip the prefixes for readability.
+- **Damage is post-mitigation.** `dmg` is the applied damage (includes the debug
+  `DEBUG_DAMAGE_MULT` multiplier in `AttackMonsterAction`, normally 1).
+- **Enemy `level` may not track `pitLevel`.** Enemy constructors use per-type preset levels
+  (`EnemyLevelConfig.GetPresetLevel`) outside the Cave biome — see issues #290/#291 for the
+  known post-cave flattening this exposes.
+- **Load-time replay:** on `mode:"load"`, the pit is regenerated, so the first
+  `pit_generated`/`chest_spawned`/`monster_spawned` burst right after `session_start`
+  reflects the restored pit, and one `merc_arrived` fires for the initial tavern spawn.
+- **Not instrumented:** gold spends (except via `goldAfter`/`currentGold`), out-of-battle
+  healing GOAP actions, missed attacks, the virtual game layer (`PitHero.VirtualGame` has no
+  combat simulation).
+
+## Typical analysis joins
+
+- **Difficulty curve:** `attack` lines grouped by `pitLevel` (from surrounding
+  `pit_generated`) — hero dmg vs monster `maxHP`, monster dmg vs party `maxHP`.
+- **Progression vs performance:** `party_snapshot` (stats/gear per pit entry) joined to
+  battle outcomes at the same pit level.
+- **Gear access:** `chest_spawned` vs `item_acquired` vs `gear_equipped` per pit level.
+- **Economy:** `gold_gained` by `source` over `t`, against `inn_sleep`/`merc_arrived`
+  costs.


### PR DESCRIPTION
Closes #289.

## What

A debug-build-only analytics layer that logs balance-relevant game events as timestamped JSONL for later AI-driven balance analysis.

- **`AnalyticsService`** (static facade): every log method is `[Conditional("DEBUG")]`, so call sites *and their argument evaluation* are removed entirely from Release builds. Master switch: `GameConfig.AnalyticsEnabled` (flip to `false` to disable even in Debug).
- **`JsonLineBuilder`**: hand-written, reflection-free JSON writer (AOT-safe per AGENTS.md; no Nson/LINQ).
- **`AnalyticsManager`** (`GlobalManager`, `#if DEBUG`): flushes the buffer every 15s, on 64 KB overflow, and on exit — max data loss on a crash is one flush interval.
- **Output**: `%LOCALAPPDATA%\PitHero\analytics\session_yyyyMMdd_HHmmss.jsonl`, one file per session (new game / load).

## Events (18 types)

Session start/end · pit generation · chest spawns with contents · monster spawns · wizard orb activation · pit jumps (both with full party snapshots: stats, job, skills, gear) · inn sleeps · mercenary arrivals (stats + hire cost) and departures · item pickups · gear equips with resulting character stats · gold gains with source + running total (via new `GameStateService.AddFunds(amount, source)`) · monster defeats · per-attack/skill/heal battle logs with HP before/after · character deaths with full victim snapshot and killer stats.

Save-restore paths (equip restore, funds restore) deliberately do **not** log. Job names are logged as raw `NameKey` identifiers for stability.

## Verification

- Debug and Release solution builds clean (Release proves the conditional-compilation split).
- 16 new MSTest tests (JSON escaping/structure, file lifecycle, session rotation, disabled/uninitialized safety) — all pass; full suite shows zero regressions vs. baseline.
- Validated against a live session log; `session_start` ordering was fixed so it is always the first event.

The first live session already surfaced two pre-existing balance findings, filed as #290 (post-cave boss-floor inconsistency) and #291 (flat post-cave scaling/loot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)