### PR TITLE
Skill system overhaul: make every job skill do what its description says

### DIFF
--- a/PitHero.Tests/ActionQueueIntegrationTests.cs
+++ b/PitHero.Tests/ActionQueueIntegrationTests.cs
@@ -140,7 +140,7 @@ namespace PitHero.Tests
             Assert.IsFalse(healSkill.BattleOnly, "Heal skill should be usable outside of battle");
             
             // Act - Use skill outside of battle (manually spend MP as would happen in battle)
-            healSkill.Execute(hero, null, new System.Collections.Generic.List<RolePlayingFramework.Enemies.IEnemy>(), null);
+            healSkill.Execute(hero, null, new System.Collections.Generic.List<RolePlayingFramework.Enemies.IEnemy>(), null, null);
             hero.SpendMP(healSkill.MPCost);
             
             // Assert

--- a/PitHero.Tests/AttackMonsterActionTests.cs
+++ b/PitHero.Tests/AttackMonsterActionTests.cs
@@ -1,7 +1,9 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nez;
 using PitHero.AI;
 using RolePlayingFramework.Enemies;
 using RolePlayingFramework.Stats;
+using System.Collections.Generic;
 
 namespace PitHero.Tests
 {
@@ -62,6 +64,81 @@ namespace PitHero.Tests
             Assert.IsNotNull(action, "AttackMonsterAction should be instantiable");
             Assert.AreEqual(GoapConstants.AttackMonster, action.Name, "Action should have correct name");
             Assert.AreEqual(3, action.Cost, "Action should have correct cost");
+        }
+
+        // ── SelectPrimaryTarget helper tests (Fix 3) ──────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("Combat")]
+        public void SelectPrimaryTarget_NullPreferred_DoesNotReorderList()
+        {
+            var e0 = new Entity("e0");
+            var e1 = new Entity("e1");
+            var e2 = new Entity("e2");
+            var list = new List<Entity> { e0, e1, e2 };
+
+            AttackMonsterAction.SelectPrimaryTarget(list, null);
+
+            Assert.AreEqual(e0, list[0], "Null preferred: list[0] should be unchanged");
+            Assert.AreEqual(e1, list[1]);
+            Assert.AreEqual(e2, list[2]);
+        }
+
+        [TestMethod]
+        [TestCategory("Combat")]
+        public void SelectPrimaryTarget_PreferredAtIndex0_DoesNotReorderList()
+        {
+            var e0 = new Entity("e0");
+            var e1 = new Entity("e1");
+            var list = new List<Entity> { e0, e1 };
+
+            AttackMonsterAction.SelectPrimaryTarget(list, e0);
+
+            Assert.AreEqual(e0, list[0], "Preferred already at index 0: list unchanged");
+            Assert.AreEqual(e1, list[1]);
+        }
+
+        [TestMethod]
+        [TestCategory("Combat")]
+        public void SelectPrimaryTarget_PreferredAtIndex2_MovedToIndex0()
+        {
+            var e0 = new Entity("e0");
+            var e1 = new Entity("e1");
+            var e2 = new Entity("e2");
+            var list = new List<Entity> { e0, e1, e2 };
+
+            AttackMonsterAction.SelectPrimaryTarget(list, e2);
+
+            Assert.AreEqual(e2, list[0], "Preferred at index 2 should be swapped to index 0");
+            // e0 ends up at index 2 (swapped), e1 stays at index 1
+            Assert.AreEqual(e1, list[1], "e1 should be unchanged at index 1");
+            Assert.AreEqual(e0, list[2], "e0 (original index 0) should be at index 2 after swap");
+        }
+
+        [TestMethod]
+        [TestCategory("Combat")]
+        public void SelectPrimaryTarget_PreferredNotInList_DoesNotReorderList()
+        {
+            var e0 = new Entity("e0");
+            var e1 = new Entity("e1");
+            var eOther = new Entity("eOther"); // not in list
+            var list = new List<Entity> { e0, e1 };
+
+            AttackMonsterAction.SelectPrimaryTarget(list, eOther);
+
+            Assert.AreEqual(e0, list[0], "Preferred not in list: list[0] should be unchanged");
+            Assert.AreEqual(e1, list[1]);
+        }
+
+        [TestMethod]
+        [TestCategory("Combat")]
+        public void SelectPrimaryTarget_EmptyList_DoesNotThrow()
+        {
+            var list = new List<Entity>();
+            var e = new Entity("e");
+            // Should not throw; list stays empty
+            AttackMonsterAction.SelectPrimaryTarget(list, e);
+            Assert.AreEqual(0, list.Count, "Empty list should remain empty");
         }
     }
 }

--- a/PitHero.Tests/BattleBuffTests.cs
+++ b/PitHero.Tests/BattleBuffTests.cs
@@ -1,0 +1,328 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RolePlayingFramework.Combat;
+using RolePlayingFramework.Heroes;
+using RolePlayingFramework.Jobs.Primary;
+using RolePlayingFramework.Mercenaries;
+using RolePlayingFramework.Skills;
+using RolePlayingFramework.Stats;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Unit tests for the Phase 3 battle-scoped buff system.
+    /// Covers AddBattleBuff, GetBuffTotal, GetBuffStacks, TickBuffDurations, ClearBattleState,
+    /// and how live buffs affect GetBattleStats() for both Hero and Mercenary.
+    /// </summary>
+    [TestClass]
+    public class BattleBuffTests
+    {
+        // ── Shared factory helpers ────────────────────────────────────────────────────
+
+        private static Hero MakeHero(int str = 10, int agi = 10, int vit = 10, int mag = 5)
+        {
+            var baseStats = new StatBlock(str, agi, vit, mag);
+            return new Hero("TestHero", new Knight(), level: 5, baseStats: baseStats);
+        }
+
+        private static Mercenary MakeMerc(int str = 10, int agi = 10, int vit = 10, int mag = 5)
+        {
+            var baseStats = new StatBlock(str, agi, vit, mag);
+            return new Mercenary("TestMerc", new Monk(), level: 5, baseStats: baseStats);
+        }
+
+        // ── Basic add/get ─────────────────────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("Buffs")]
+        public void Hero_AddBattleBuff_GetBuffTotal_ReturnsMagnitude()
+        {
+            var hero = MakeHero();
+            hero.AddBattleBuff(new BattleBuff(BuffType.DefenseUp, magnitude: 3, remainingTurns: -1, sourceSkillId: "priest.defup"));
+
+            Assert.AreEqual(3, hero.GetBuffTotal(BuffType.DefenseUp),
+                "GetBuffTotal should return the magnitude of the added buff");
+        }
+
+        [TestMethod]
+        [TestCategory("Buffs")]
+        public void Mercenary_AddBattleBuff_GetBuffTotal_ReturnsMagnitude()
+        {
+            var merc = MakeMerc();
+            merc.AddBattleBuff(new BattleBuff(BuffType.EvasionUp, magnitude: 40, remainingTurns: 3, sourceSkillId: "thief.smoke_bomb"));
+
+            Assert.AreEqual(40, merc.GetBuffTotal(BuffType.EvasionUp),
+                "Mercenary GetBuffTotal should return the magnitude of the added buff");
+        }
+
+        [TestMethod]
+        [TestCategory("Buffs")]
+        public void Hero_MultipleSameTypeBuff_TotalsStack()
+        {
+            var hero = MakeHero();
+            hero.AddBattleBuff(new BattleBuff(BuffType.DefenseUp, magnitude: 1, remainingTurns: -1, sourceSkillId: "priest.defup"));
+            hero.AddBattleBuff(new BattleBuff(BuffType.DefenseUp, magnitude: 2, remainingTurns: -1, sourceSkillId: "synergy.auraSword"));
+
+            Assert.AreEqual(3, hero.GetBuffTotal(BuffType.DefenseUp),
+                "Multiple DefenseUp buffs from different skill ids should sum their magnitudes");
+        }
+
+        [TestMethod]
+        [TestCategory("Buffs")]
+        public void Hero_GetBuffStacks_CountsBySourceSkillIdAndType()
+        {
+            var hero = MakeHero();
+            hero.AddBattleBuff(new BattleBuff(BuffType.DefenseUp, magnitude: 1, remainingTurns: -1, sourceSkillId: "priest.defup"));
+            hero.AddBattleBuff(new BattleBuff(BuffType.DefenseUp, magnitude: 1, remainingTurns: -1, sourceSkillId: "priest.defup"));
+
+            Assert.AreEqual(2, hero.GetBuffStacks("priest.defup", BuffType.DefenseUp),
+                "Two DefenseUp buffs from the same skill should count as 2 stacks");
+        }
+
+        [TestMethod]
+        [TestCategory("Buffs")]
+        public void Hero_GetBuffStacks_MultiBuffSkill_CountsEachTypeIndependently()
+        {
+            // FadeSkill grants EvasionUp + MPRegen from the same source skill id.
+            // The stack cap check must filter by type so one type capping does not block the other.
+            var hero = MakeHero();
+            hero.AddBattleBuff(new BattleBuff(BuffType.EvasionUp, magnitude: 30, remainingTurns: -1, sourceSkillId: "synergy.fade"));
+
+            // EvasionUp has 1 stack; MPRegen has 0 stacks — they must be counted independently
+            Assert.AreEqual(1, hero.GetBuffStacks("synergy.fade", BuffType.EvasionUp),
+                "After adding EvasionUp from synergy.fade, EvasionUp stack count should be 1");
+            Assert.AreEqual(0, hero.GetBuffStacks("synergy.fade", BuffType.MPRegen),
+                "MPRegen stack count should be 0 — it was not yet added");
+        }
+
+        [TestMethod]
+        [TestCategory("Buffs")]
+        public void FadeSkill_BothBuffsApplyOnFirstCast_NeitherOnSecond()
+        {
+            // Simulates what ApplyHealingSkillEffectsAndDisplay does for FadeSkill's two GrantedBuffs.
+            var hero = MakeHero();
+            var skill = new RolePlayingFramework.Skills.FadeSkill();
+
+            // First cast: apply each buff if stack count < MaxStacks
+            for (int b = 0; b < skill.GrantedBuffs.Count; b++)
+            {
+                var grantedBuff = skill.GrantedBuffs[b];
+                int currentStacks = hero.GetBuffStacks(skill.Id, grantedBuff.Type);
+                if (currentStacks < grantedBuff.MaxStacks)
+                    hero.AddBattleBuff(new BattleBuff(grantedBuff.Type, grantedBuff.Magnitude, grantedBuff.DurationTurns, skill.Id));
+            }
+
+            Assert.IsTrue(hero.GetBuffTotal(BuffType.EvasionUp) > 0, "After first cast, EvasionUp should be active");
+            Assert.IsTrue(hero.GetBuffTotal(BuffType.MPRegen) > 0, "After first cast, MPRegen should be active");
+
+            // Second cast: both types are at cap (maxStacks=1) — neither should be applied again
+            int evaUpBefore = hero.GetBuffTotal(BuffType.EvasionUp);
+            int mpRegenBefore = hero.GetBuffTotal(BuffType.MPRegen);
+            for (int b = 0; b < skill.GrantedBuffs.Count; b++)
+            {
+                var grantedBuff = skill.GrantedBuffs[b];
+                int currentStacks = hero.GetBuffStacks(skill.Id, grantedBuff.Type);
+                if (currentStacks < grantedBuff.MaxStacks)
+                    hero.AddBattleBuff(new BattleBuff(grantedBuff.Type, grantedBuff.Magnitude, grantedBuff.DurationTurns, skill.Id));
+            }
+
+            Assert.AreEqual(evaUpBefore, hero.GetBuffTotal(BuffType.EvasionUp), "Second cast should not add another EvasionUp stack (already capped)");
+            Assert.AreEqual(mpRegenBefore, hero.GetBuffTotal(BuffType.MPRegen), "Second cast should not add another MPRegen stack (already capped)");
+        }
+
+        [TestMethod]
+        [TestCategory("Buffs")]
+        public void DefenseUpSkill_StacksToThreeAndCapsBeyond()
+        {
+            var hero = MakeHero();
+            var skill = new RolePlayingFramework.Skills.DefenseUpSkill();
+
+            // Apply three times — each should land because MaxStacks=3
+            for (int cast = 0; cast < 3; cast++)
+            {
+                for (int b = 0; b < skill.GrantedBuffs.Count; b++)
+                {
+                    var grantedBuff = skill.GrantedBuffs[b];
+                    int currentStacks = hero.GetBuffStacks(skill.Id, grantedBuff.Type);
+                    if (currentStacks < grantedBuff.MaxStacks)
+                        hero.AddBattleBuff(new BattleBuff(grantedBuff.Type, grantedBuff.Magnitude, grantedBuff.DurationTurns, skill.Id));
+                }
+            }
+
+            Assert.AreEqual(3, hero.GetBuffStacks(skill.Id, BuffType.DefenseUp),
+                "DefenseUp should allow up to 3 stacks");
+
+            // Fourth cast: already at cap — should not add more
+            int stacksBefore = hero.GetBuffStacks(skill.Id, BuffType.DefenseUp);
+            for (int b = 0; b < skill.GrantedBuffs.Count; b++)
+            {
+                var grantedBuff = skill.GrantedBuffs[b];
+                int currentStacks = hero.GetBuffStacks(skill.Id, grantedBuff.Type);
+                if (currentStacks < grantedBuff.MaxStacks)
+                    hero.AddBattleBuff(new BattleBuff(grantedBuff.Type, grantedBuff.Magnitude, grantedBuff.DurationTurns, skill.Id));
+            }
+
+            Assert.AreEqual(stacksBefore, hero.GetBuffStacks(skill.Id, BuffType.DefenseUp),
+                "Fourth cast should not exceed the DefenseUp MaxStacks cap of 3");
+        }
+
+        [TestMethod]
+        [TestCategory("Buffs")]
+        public void Hero_GetBuffTotal_UnrelatedTypeReturnsZero()
+        {
+            var hero = MakeHero();
+            hero.AddBattleBuff(new BattleBuff(BuffType.DefenseUp, magnitude: 5, remainingTurns: -1, sourceSkillId: "priest.defup"));
+
+            Assert.AreEqual(0, hero.GetBuffTotal(BuffType.EvasionUp),
+                "GetBuffTotal for an unrelated buff type should return 0");
+        }
+
+        // ── Duration ticking ─────────────────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("Buffs")]
+        public void Hero_TickBuffDurations_FiniteDurationDecrements()
+        {
+            var hero = MakeHero();
+            hero.AddBattleBuff(new BattleBuff(BuffType.EvasionUp, magnitude: 30, remainingTurns: 3, sourceSkillId: "thief.fade"));
+
+            hero.TickBuffDurations();
+
+            // Buff should still be active (2 turns left), just not yet at GetBuffTotal 0
+            Assert.AreEqual(30, hero.GetBuffTotal(BuffType.EvasionUp),
+                "After 1 tick, a 3-turn buff should still be active");
+        }
+
+        [TestMethod]
+        [TestCategory("Buffs")]
+        public void Hero_TickBuffDurations_BuffExpiresWhenTurnsReachZero()
+        {
+            var hero = MakeHero();
+            hero.AddBattleBuff(new BattleBuff(BuffType.EvasionUp, magnitude: 30, remainingTurns: 1, sourceSkillId: "thief.fade"));
+
+            hero.TickBuffDurations();
+
+            Assert.AreEqual(0, hero.GetBuffTotal(BuffType.EvasionUp),
+                "A 1-turn buff should expire after one tick");
+        }
+
+        [TestMethod]
+        [TestCategory("Buffs")]
+        public void Hero_TickBuffDurations_PermanentBuffNeverExpires()
+        {
+            var hero = MakeHero();
+            // -1 = permanent until battle end
+            hero.AddBattleBuff(new BattleBuff(BuffType.DefenseUp, magnitude: 1, remainingTurns: -1, sourceSkillId: "priest.defup"));
+
+            hero.TickBuffDurations();
+            hero.TickBuffDurations();
+            hero.TickBuffDurations();
+
+            Assert.AreEqual(1, hero.GetBuffTotal(BuffType.DefenseUp),
+                "A battle-end buff (RemainingTurns=-1) should never be decremented by TickBuffDurations");
+        }
+
+        // ── ClearBattleState ─────────────────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("Buffs")]
+        public void Hero_ClearBattleState_RemovesAllBuffs()
+        {
+            var hero = MakeHero();
+            hero.AddBattleBuff(new BattleBuff(BuffType.DefenseUp, magnitude: 5, remainingTurns: -1, sourceSkillId: "priest.defup"));
+            hero.AddBattleBuff(new BattleBuff(BuffType.EvasionUp, magnitude: 40, remainingTurns: 3, sourceSkillId: "smoke_bomb"));
+
+            hero.ClearBattleState();
+
+            Assert.AreEqual(0, hero.GetBuffTotal(BuffType.DefenseUp), "ClearBattleState should remove DefenseUp buffs");
+            Assert.AreEqual(0, hero.GetBuffTotal(BuffType.EvasionUp), "ClearBattleState should remove EvasionUp buffs");
+        }
+
+        [TestMethod]
+        [TestCategory("Buffs")]
+        public void Mercenary_ClearBattleState_RemovesAllBuffs()
+        {
+            var merc = MakeMerc();
+            merc.AddBattleBuff(new BattleBuff(BuffType.DefenseUp, magnitude: 3, remainingTurns: -1, sourceSkillId: "knight.ki_cloak"));
+            merc.ClearBattleState();
+
+            Assert.AreEqual(0, merc.GetBuffTotal(BuffType.DefenseUp), "Mercenary ClearBattleState should remove all buffs");
+        }
+
+        // ── GetBattleStats with buffs ─────────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("Buffs")]
+        public void Hero_DefenseUpBuff_RaisesGetBattleStatsDefense()
+        {
+            var hero = MakeHero(agi: 10);
+            var baselineDefense = hero.GetBattleStats().Defense;
+
+            hero.AddBattleBuff(new BattleBuff(BuffType.DefenseUp, magnitude: 5, remainingTurns: -1, sourceSkillId: "priest.defup"));
+
+            var buffedDefense = hero.GetBattleStats().Defense;
+            Assert.AreEqual(baselineDefense + 5, buffedDefense,
+                "DefenseUp buff of +5 should raise GetBattleStats().Defense by exactly 5");
+        }
+
+        [TestMethod]
+        [TestCategory("Buffs")]
+        public void Mercenary_DefenseUpBuff_RaisesGetBattleStatsDefense()
+        {
+            var merc = MakeMerc(agi: 10);
+            var baselineDefense = merc.GetBattleStats().Defense;
+
+            merc.AddBattleBuff(new BattleBuff(BuffType.DefenseUp, magnitude: 3, remainingTurns: -1, sourceSkillId: "knight.ki_cloak"));
+
+            var buffedDefense = merc.GetBattleStats().Defense;
+            Assert.AreEqual(baselineDefense + 3, buffedDefense,
+                "Mercenary DefenseUp buff of +3 should raise GetBattleStats().Defense by exactly 3");
+        }
+
+        [TestMethod]
+        [TestCategory("Buffs")]
+        public void Hero_EvasionUpBuff_RaisesGetBattleStatsEvasion()
+        {
+            var hero = MakeHero(agi: 10);
+            var baselineEvasion = hero.GetBattleStats().Evasion;
+
+            hero.AddBattleBuff(new BattleBuff(BuffType.EvasionUp, magnitude: 40, remainingTurns: 3, sourceSkillId: "thief.smoke_bomb"));
+
+            var buffedEvasion = hero.GetBattleStats().Evasion;
+            Assert.AreEqual(System.Math.Min(255, baselineEvasion + 40), buffedEvasion,
+                "EvasionUp buff of +40 should raise GetBattleStats().Evasion by 40 (capped at 255)");
+        }
+
+        [TestMethod]
+        [TestCategory("Buffs")]
+        public void Hero_ClearBattleState_RestoresBaselineStats()
+        {
+            var hero = MakeHero(agi: 10);
+            var baselineDefense = hero.GetBattleStats().Defense;
+
+            hero.AddBattleBuff(new BattleBuff(BuffType.DefenseUp, magnitude: 10, remainingTurns: -1, sourceSkillId: "priest.defup"));
+            hero.ClearBattleState();
+
+            Assert.AreEqual(baselineDefense, hero.GetBattleStats().Defense,
+                "After ClearBattleState, GetBattleStats().Defense should return to baseline");
+        }
+
+        // ── MPRegen buff + TickRegeneration ──────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("Buffs")]
+        public void Hero_MPRegenBuff_StacksWithMPTickRegen()
+        {
+            var hero = MakeHero();
+            // Drain some MP to give the regen room to work
+            hero.SpendMP(10);
+            int mpAfterSpend = hero.CurrentMP;
+
+            // Base MPTickRegen is 0; add +2 via buff
+            hero.AddBattleBuff(new BattleBuff(BuffType.MPRegen, magnitude: 2, remainingTurns: -1, sourceSkillId: "thief.fade"));
+            hero.TickRegeneration();
+
+            Assert.AreEqual(mpAfterSpend + 2, hero.CurrentMP,
+                "MPRegen buff of +2 should restore 2 MP per TickRegeneration when base MPTickRegen is 0");
+        }
+    }
+}

--- a/PitHero.Tests/CodeReviewFixTests.cs
+++ b/PitHero.Tests/CodeReviewFixTests.cs
@@ -1,0 +1,170 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RolePlayingFramework.Combat;
+using RolePlayingFramework.Heroes;
+using RolePlayingFramework.Jobs.Primary;
+using RolePlayingFramework.Mercenaries;
+using RolePlayingFramework.Skills;
+using RolePlayingFramework.Stats;
+using System.Collections.Generic;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Tests for the 9 verified code-review findings addressed in this batch:
+    /// Fix 1  — Save/load MP corruption (SetCurrentMP)
+    /// Fix 5  — MP affordability / GetEffectiveMPCost
+    /// Fix 8  — TrapSense MercenaryManager.AnyHiredMercenaryHasTrapSense (logic only)
+    /// Other fixes are tested in their own existing test files or rely on coroutine-level seams.
+    /// </summary>
+    [TestClass]
+    public class CodeReviewFixTests
+    {
+        // ── Helpers ───────────────────────────────────────────────────────────────────
+
+        private static Hero MakeHero(int mag = 10)
+            => new Hero("TestHero", new Mage(), level: 5, new StatBlock(5, 5, 5, mag));
+
+        private static Mercenary MakeMerc(int mag = 10)
+            => new Mercenary("TestMerc", new Mage(), level: 5, new StatBlock(5, 5, 5, mag));
+
+        // ── Fix 1: SetCurrentMP — save/load state restore ─────────────────────────────
+
+        [TestMethod]
+        [TestCategory("Fix1_SaveLoad")]
+        public void Hero_SetCurrentMP_SetsExactValue()
+        {
+            var hero = MakeHero(mag: 10);
+            int savedMP = 3;
+
+            hero.SetCurrentMP(savedMP);
+
+            Assert.AreEqual(savedMP, hero.CurrentMP,
+                "SetCurrentMP should set CurrentMP to exactly the saved value");
+        }
+
+        [TestMethod]
+        [TestCategory("Fix1_SaveLoad")]
+        public void Hero_SetCurrentMP_ClampsToZero()
+        {
+            var hero = MakeHero();
+            hero.SetCurrentMP(-5);
+            Assert.AreEqual(0, hero.CurrentMP, "SetCurrentMP(-5) should clamp to 0");
+        }
+
+        [TestMethod]
+        [TestCategory("Fix1_SaveLoad")]
+        public void Hero_SetCurrentMP_ClampsToMaxMP()
+        {
+            var hero = MakeHero();
+            hero.SetCurrentMP(hero.MaxMP + 100);
+            Assert.AreEqual(hero.MaxMP, hero.CurrentMP, "SetCurrentMP above MaxMP should clamp to MaxMP");
+        }
+
+        [TestMethod]
+        [TestCategory("Fix1_SaveLoad")]
+        public void Merc_WithEconomist_SetCurrentMP_NotCostReduced()
+        {
+            // A mage merc with Economist has MPCostReduction = 0.15.
+            // If we used UseMP(diff) to restore, it would apply the reduction and land at the wrong value.
+            // SetCurrentMP must bypass the reduction and land exactly at the saved value.
+            var merc = MakeMerc(mag: 10);
+            merc.LearnSkill(new EconomistPassive()); // sets MPCostReduction = 0.15
+            Assert.AreNotEqual(0f, merc.MPCostReduction, "Precondition: economist should set reduction");
+
+            int savedMP = 3;
+            merc.SetCurrentMP(savedMP);
+
+            Assert.AreEqual(savedMP, merc.CurrentMP,
+                "SetCurrentMP with MPCostReduction active should still land at exactly the saved value");
+        }
+
+        [TestMethod]
+        [TestCategory("Fix1_SaveLoad")]
+        public void Merc_SetCurrentMP_SetsExactValue()
+        {
+            var merc = MakeMerc();
+            merc.SetCurrentMP(7);
+            Assert.AreEqual(7, merc.CurrentMP, "Mercenary SetCurrentMP should set CurrentMP to exactly 7");
+        }
+
+        // ── Fix 5: GetEffectiveMPCost — MP affordability consistent with SpendMP ─────
+
+        [TestMethod]
+        [TestCategory("Fix5_MPCost")]
+        public void Hero_GetEffectiveMPCost_NoReduction_ReturnsSameAsRawCost()
+        {
+            var hero = MakeHero();
+            // No economist passive — MPCostReduction = 0
+            Assert.AreEqual(0f, hero.MPCostReduction);
+            Assert.AreEqual(4, hero.GetEffectiveMPCost(4),
+                "Without reduction, effective cost should equal raw cost");
+        }
+
+        [TestMethod]
+        [TestCategory("Fix5_MPCost")]
+        public void Hero_GetEffectiveMPCost_ZeroRawCost_ReturnsZero()
+        {
+            var hero = MakeHero();
+            Assert.AreEqual(0, hero.GetEffectiveMPCost(0),
+                "GetEffectiveMPCost(0) should return 0 regardless of reduction");
+        }
+
+        [TestMethod]
+        [TestCategory("Fix5_MPCost")]
+        public void Hero_GetEffectiveMPCost_WithEconomist_ReducesCost()
+        {
+            var hero = MakeHero();
+            hero.MPCostReduction = 0.15f;
+            // raw 4 * (1 - 0.15) = 3.4 → (int) = 3
+            int expected = (int)(4 * (1f - 0.15f));
+            Assert.AreEqual(expected, hero.GetEffectiveMPCost(4),
+                "With 15% reduction, cost of 4 should be reduced");
+        }
+
+        [TestMethod]
+        [TestCategory("Fix5_MPCost")]
+        public void Merc_WithEconomist_CurrentMP3_CanAfford4MPSkill()
+        {
+            // Economist: 15% reduction. Skill costs 4 MP raw → effective = (int)(4 * 0.85) = 3.
+            // Merc has CurrentMP = 3. Affordability check: effective(4) <= 3 → can afford.
+            var merc = MakeMerc();
+            merc.LearnSkill(new EconomistPassive());
+            merc.SetCurrentMP(3);
+
+            int effectiveCost = merc.GetEffectiveMPCost(4);
+            Assert.AreEqual(3, effectiveCost, "Economist merc: effective cost of 4 MP skill should be 3");
+            Assert.IsTrue(merc.CurrentMP >= effectiveCost,
+                "Merc with CurrentMP=3 should be able to afford a skill that costs 4 raw (3 effective)");
+        }
+
+        [TestMethod]
+        [TestCategory("Fix5_MPCost")]
+        public void Merc_WithoutEconomist_CurrentMP3_CannotAfford4MPSkill()
+        {
+            // Without economist, raw cost check: 4 > 3 → cannot afford.
+            var merc = MakeMerc();
+            merc.SetCurrentMP(3);
+
+            int effectiveCost = merc.GetEffectiveMPCost(4);
+            Assert.AreEqual(4, effectiveCost, "Without reduction, effective cost equals raw cost");
+            Assert.IsFalse(merc.CurrentMP >= effectiveCost,
+                "Merc with CurrentMP=3 should NOT be able to afford a skill that costs 4 MP raw without reduction");
+        }
+
+        [TestMethod]
+        [TestCategory("Fix5_MPCost")]
+        public void Hero_SpendMP_UsesEffectiveCost()
+        {
+            // SpendMP should now delegate to GetEffectiveMPCost.
+            var hero = MakeHero(mag: 20); // gives plenty of MP
+            hero.MPCostReduction = 0.15f;
+            int mpBefore = hero.CurrentMP;
+
+            hero.SpendMP(4);
+
+            int expectedDeducted = hero.GetEffectiveMPCost(4); // should be (int)(4 * 0.85) = 3
+            Assert.AreEqual(mpBefore - expectedDeducted, hero.CurrentMP,
+                "SpendMP should deduct the effective cost (same as GetEffectiveMPCost), not the raw cost");
+        }
+    }
+}

--- a/PitHero.Tests/CompleteJPWorkflowTests.cs
+++ b/PitHero.Tests/CompleteJPWorkflowTests.cs
@@ -48,7 +48,7 @@ namespace PitHero.Tests
             Assert.AreEqual(2, hero.GetJobLevel(), "Job level should be 2");
             
             // Check passive is applied
-            Assert.AreEqual(2, hero.PassiveDefenseBonus, "Heavy Armor passive should be active");
+            Assert.AreEqual(2, hero.HeavyArmorDefenseBonus, "Heavy Armor passive should set HeavyArmorDefenseBonus to 2");
             
             // Purchase Spin Slash (120 JP, Level 2)
             bool success3 = hero.TryPurchaseSkill(knight.Skills[2]);

--- a/PitHero.Tests/EnhancedBattleSystemTests.cs
+++ b/PitHero.Tests/EnhancedBattleSystemTests.cs
@@ -4,7 +4,10 @@ using RolePlayingFramework.Enemies;
 using RolePlayingFramework.Heroes;
 using RolePlayingFramework.Jobs;
 using RolePlayingFramework.Jobs.Primary;
+using RolePlayingFramework.Mercenaries;
+using RolePlayingFramework.Skills;
 using RolePlayingFramework.Stats;
+using System.Collections.Generic;
 
 namespace PitHero.Tests
 {
@@ -226,18 +229,96 @@ namespace PitHero.Tests
             var attackerStats = new BattleStats(attack: 20, defense: 10, evasion: 0);
             var defenderStats = new BattleStats(attack: 15, defense: 10, evasion: 0);
             var defenderProps = new ElementalProperties(ElementType.Fire);
-            
+
             // Neutral vs Fire should deal 1.0x damage (no relationship)
-            var result = resolver.Resolve(attackerStats, defenderStats, DamageKind.Physical, 
+            var result = resolver.Resolve(attackerStats, defenderStats, DamageKind.Physical,
                 ElementType.Neutral, defenderProps);
-            
+
             int baseDamage = 20 * 2 - 10; // 30 base damage
             int expectedMin = (int)(baseDamage * 1.0f * 0.9f); // Account for variance
             int expectedMax = (int)(baseDamage * 1.0f * 1.1f);
-            
+
             Assert.IsTrue(result.Hit);
-            Assert.IsTrue(result.Damage >= expectedMin && result.Damage <= expectedMax, 
+            Assert.IsTrue(result.Damage >= expectedMin && result.Damage <= expectedMax,
                 $"Expected damage between {expectedMin}-{expectedMax}, got {result.Damage}");
+        }
+
+        // ── ResolveHit elemental multiplier integration ───────────────────────────────
+
+        /// <summary>
+        /// Verifies that the elemental multiplier flows all the way through
+        /// BaseSkill.ResolveHit when using EnhancedAttackResolver.
+        /// A Fire skill should deal more to a Water enemy (2× advantage) than to a
+        /// Fire enemy (0.5× resistance) — even accounting for ±10% variance.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("Combat")]
+        public void ResolveHit_ViaFireSkill_ElementalMultiplierApplied()
+        {
+            var resolver = new EnhancedAttackResolver();
+
+            // High attack so elemental difference is large vs ±10% variance.
+            // Knight job + StatBlock(50,0,10,2) gives plenty of attack without weapon.
+            var merc = new Mercenary("Mage", new Knight(), 1, new StatBlock(50, 0, 10, 2));
+            var skill = new FireSkill(); // Element = Fire
+
+            // Accumulate damage over multiple rounds to smooth variance
+            long waterDamageTotal = 0;
+            long fireDamageTotal = 0;
+            const int trials = 20;
+
+            for (int t = 0; t < trials; t++)
+            {
+                // Water enemy: Fire has 2× advantage
+                var waterEnemy = new ElementalEnemy(ElementType.Water, hp: 5000);
+                skill.Execute(merc, waterEnemy, new List<IEnemy>(), resolver, null);
+                waterDamageTotal += 5000 - waterEnemy.CurrentHP;
+
+                // Fire enemy: Fire has 0.5× resistance
+                var fireEnemy = new ElementalEnemy(ElementType.Fire, hp: 5000);
+                skill.Execute(merc, fireEnemy, new List<IEnemy>(), resolver, null);
+                fireDamageTotal += 5000 - fireEnemy.CurrentHP;
+            }
+
+            Assert.IsTrue(waterDamageTotal > fireDamageTotal,
+                $"Fire skill should deal more to Water enemy (2× advantage) than Fire enemy (0.5× resistance). " +
+                $"Water total={waterDamageTotal}, Fire total={fireDamageTotal} over {trials} trials");
+        }
+
+        /// <summary>Minimal test enemy with configurable element and zero evasion.</summary>
+        private sealed class ElementalEnemy : IEnemy
+        {
+            private int _hp;
+            public ElementalEnemy(ElementType element, int hp = 1000)
+            {
+                Element = element;
+                ElementalProps = new ElementalProperties(element);
+                _hp = hp;
+                MaxHP = hp;
+            }
+            public string Name => "ElementalEnemy";
+            public EnemyId EnemyId => EnemyId.Slime;
+            public int Level => 1;
+            public StatBlock Stats => new StatBlock(5, 0, 5, 5); // Agility=0 → near-zero evasion
+            public DamageKind AttackKind => DamageKind.Physical;
+            public ElementType Element { get; }
+            public ElementalProperties ElementalProps { get; }
+            public int MaxHP { get; }
+            public int CurrentHP => _hp;
+            public int ExperienceYield => 0;
+            public int JPYield => 0;
+            public int SPYield => 0;
+            public int GoldYield => 0;
+            public float JoinPercentageModifier => 1.0f;
+            public bool IsBoss => false;
+            public bool IsRecruitable => false;
+            public bool TakeDamage(int amount)
+            {
+                if (amount <= 0) return false;
+                _hp -= amount;
+                if (_hp < 0) _hp = 0;
+                return _hp == 0;
+            }
         }
     }
 }

--- a/PitHero.Tests/HeavyArmorConditionalDefenseTests.cs
+++ b/PitHero.Tests/HeavyArmorConditionalDefenseTests.cs
@@ -1,0 +1,115 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RolePlayingFramework.Equipment;
+using RolePlayingFramework.Heroes;
+using RolePlayingFramework.Jobs.Primary;
+using RolePlayingFramework.Mercenaries;
+using RolePlayingFramework.Skills;
+using RolePlayingFramework.Stats;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Verifies that the knight.heavy_armor passive grants its +2 defense bonus
+    /// only when ArmorMail is equipped, for both Hero and Mercenary (Phase 5).
+    /// </summary>
+    [TestClass]
+    public class HeavyArmorConditionalDefenseTests
+    {
+        // ── Helper: Knight Hero with HeavyArmor skill ─────────────────────────────────
+
+        private static Hero MakeKnightHeroWithHeavyArmor()
+        {
+            var crystal = new HeroCrystal("TestCrystal", new Knight(), 2, new StatBlock(5, 5, 5, 5));
+            var hero = new Hero("Arthur", crystal.Job, crystal.Level, crystal.BaseStats, crystal);
+            hero.EarnJP(200);
+            var knight = new Knight();
+            hero.TryPurchaseSkill(knight.Skills[1]); // Heavy Armor (100 JP)
+            return hero;
+        }
+
+        // ── Hero: no armor equipped → bonus not applied ───────────────────────────────
+
+        [TestMethod]
+        [TestCategory("HeavyArmor")]
+        public void Hero_HeavyArmor_WithoutAnyArmor_HeavyArmorDefenseBonusIsTwo_ButNotInBattleStats()
+        {
+            var hero = MakeKnightHeroWithHeavyArmor();
+
+            Assert.AreEqual(2, hero.HeavyArmorDefenseBonus,
+                "HeavyArmorPassive must set HeavyArmorDefenseBonus = 2");
+            Assert.AreEqual(0, hero.PassiveDefenseBonus,
+                "PassiveDefenseBonus must stay 0; the +2 is gated on ArmorMail");
+
+            // With no armor in slot, bonus must NOT appear in GetBattleStats().Defense
+            int def = hero.GetBattleStats().Defense;
+
+            // Now equip mail armor — defense must rise by exactly 2
+            var mail = new Gear("TestMail", ItemKind.ArmorMail, ItemRarity.Normal, "Mail", 100,
+                new StatBlock(0, 0, 0, 0), def: 0);
+            hero.TryEquip(mail);
+            int defWithMail = hero.GetBattleStats().Defense;
+
+            Assert.AreEqual(def + 2, defWithMail,
+                "Equipping ArmorMail should add exactly +2 HeavyArmorDefenseBonus to battle defense");
+        }
+
+        // ── Hero: ArmorMail equipped → bonus applied ─────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("HeavyArmor")]
+        public void Hero_HeavyArmor_WithMailArmor_AddsDefenseBonusToGetBattleStats()
+        {
+            var hero = MakeKnightHeroWithHeavyArmor();
+            int defNoArmor = hero.GetBattleStats().Defense;
+
+            var mail = new Gear("TestMail", ItemKind.ArmorMail, ItemRarity.Normal, "Mail", 100,
+                new StatBlock(0, 0, 0, 0), def: 0);
+            bool equipped = hero.TryEquip(mail);
+            Assert.IsTrue(equipped, "Knight hero must be able to equip ArmorMail");
+
+            Assert.AreEqual(defNoArmor + 2, hero.GetBattleStats().Defense,
+                "HeavyArmorDefenseBonus of +2 must be added to defense when ArmorMail is equipped");
+        }
+
+        // ── Mercenary: no armor equipped → bonus not applied ─────────────────────────
+
+        [TestMethod]
+        [TestCategory("HeavyArmor")]
+        public void Merc_HeavyArmor_WithoutMailArmor_DoesNotAddDefenseBonus()
+        {
+            var merc = new Mercenary("Test", new Knight(), level: 5, baseStats: new StatBlock(5, 5, 5, 5));
+            merc.LearnSkill(new HeavyArmorPassive());
+
+            Assert.AreEqual(2, merc.HeavyArmorDefenseBonus,
+                "HeavyArmorPassive must set HeavyArmorDefenseBonus = 2");
+            Assert.AreEqual(0, merc.PassiveDefenseBonus,
+                "PassiveDefenseBonus must stay 0; the +2 is gated on ArmorMail");
+
+            // No armor — bonus must not contribute to defense
+            var stats = merc.GetTotalStats();
+            int expectedDef = stats.Vitality + merc.PassiveDefenseBonus;
+            Assert.AreEqual(expectedDef, merc.GetBattleStats().Defense,
+                "HeavyArmorDefenseBonus must not affect defense when no ArmorMail is equipped");
+        }
+
+        // ── Mercenary: ArmorMail equipped → bonus applied ────────────────────────────
+
+        [TestMethod]
+        [TestCategory("HeavyArmor")]
+        public void Merc_HeavyArmor_WithMailArmor_AddsDefenseBonusToGetBattleStats()
+        {
+            var merc = new Mercenary("Test", new Knight(), level: 5, baseStats: new StatBlock(5, 5, 5, 5));
+            merc.LearnSkill(new HeavyArmorPassive());
+
+            int defWithoutArmor = merc.GetBattleStats().Defense;
+
+            var mail = new Gear("TestMail", ItemKind.ArmorMail, ItemRarity.Normal, "Mail", 100,
+                new StatBlock(0, 0, 0, 0), def: 0);
+            bool equipped = merc.Equip(mail);
+            Assert.IsTrue(equipped, "Knight merc must be able to equip ArmorMail");
+
+            Assert.AreEqual(defWithoutArmor + 2, merc.GetBattleStats().Defense,
+                "HeavyArmorDefenseBonus of +2 must be included in defense when ArmorMail is equipped");
+        }
+    }
+}

--- a/PitHero.Tests/HeroJPIntegrationTests.cs
+++ b/PitHero.Tests/HeroJPIntegrationTests.cs
@@ -109,7 +109,7 @@ namespace PitHero.Tests
             
             hero.TryPurchaseSkill(heavyArmorSkill);
             
-            Assert.AreEqual(2, hero.PassiveDefenseBonus, "Defense bonus should be 2 after purchasing Heavy Armor");
+            Assert.AreEqual(2, hero.HeavyArmorDefenseBonus, "HeavyArmorDefenseBonus should be 2 after purchasing Heavy Armor");
         }
 
         [TestMethod]

--- a/PitHero.Tests/HeroSynergyPassiveResetTests.cs
+++ b/PitHero.Tests/HeroSynergyPassiveResetTests.cs
@@ -1,0 +1,334 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Xna.Framework;
+using RolePlayingFramework.Heroes;
+using RolePlayingFramework.Jobs.Primary;
+using RolePlayingFramework.Stats;
+using RolePlayingFramework.Synergies;
+using System.Collections.Generic;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Regression tests for the synergy-wipe bug fixed in Phase 1 (ICombatant abstraction).
+    ///
+    /// The bug: Hero.ApplyPassiveSkills() zeroed ALL passive fields (including those written by
+    /// synergy effects), then only re-applied skill passives — silently discarding synergy
+    /// contributions on every level-up or skill learn.
+    ///
+    /// The fix: ApplyPassiveSkills() now calls ReapplySynergyPassiveEffects() after
+    /// CombatantPassiveApplier.ResetAndApply() so synergy contributions are always restored.
+    /// </summary>
+    [TestClass]
+    public class HeroSynergyPassiveResetTests
+    {
+        /// <summary>Creates a ShieldMastery synergy group with a single instance (multiplier = 1.0).</summary>
+        private static ActiveSynergyGroup CreateShieldMasteryGroup()
+        {
+            var pattern = KnightSynergyPatterns.CreateShieldMastery();
+            var group = new ActiveSynergyGroup(pattern);
+            group.TryAddInstance(new ActiveSynergy(
+                pattern,
+                new Point(0, 0),
+                new List<Point> { new Point(0, 0), new Point(1, 0) }));
+            return group;
+        }
+
+        #region Synergy Survives Level-Up (no skill passives)
+
+        [TestMethod]
+        public void SynergyDefenseBonus_SurvivesLevelUp_NoSkillPassives()
+        {
+            // Arrange: level-1 hero with no learned skill passives
+            var crystal = new HeroCrystal("TestCrystal", new Knight(), 1, new StatBlock(5, 5, 5, 5));
+            var hero = new Hero("TestHero", new Knight(), 1, new StatBlock(5, 5, 5, 5), crystal);
+
+            // Sanity: no passive bonus from skills yet
+            int baseBonus = hero.PassiveDefenseBonus;
+
+            // Apply ShieldMastery synergy (+5 defense, +10% deflect with multiplier 1.0)
+            var group = CreateShieldMasteryGroup();
+            hero.UpdateActiveSynergiesGrouped(new List<ActiveSynergyGroup> { group });
+
+            Assert.AreEqual(baseBonus + 5, hero.PassiveDefenseBonus,
+                "ShieldMastery should grant +5 PassiveDefenseBonus immediately after applying synergy");
+
+            // Act: level up, which triggers ApplyPassiveSkills internally
+            hero.AddExperience(100); // RequiredExpForNextLevel at level 1 = 1*100 = 100
+
+            // Assert: synergy defense bonus must survive the passive reset
+            Assert.AreEqual(baseBonus + 5, hero.PassiveDefenseBonus,
+                "ShieldMastery PassiveDefenseBonus should survive ApplyPassiveSkills triggered by level-up");
+        }
+
+        [TestMethod]
+        public void SynergyDeflectChance_SurvivesLevelUp_NoSkillPassives()
+        {
+            // Arrange
+            var crystal = new HeroCrystal("TestCrystal", new Knight(), 1, new StatBlock(5, 5, 5, 5));
+            var hero = new Hero("TestHero", new Knight(), 1, new StatBlock(5, 5, 5, 5), crystal);
+
+            float baseDeflect = hero.DeflectChance;
+
+            var group = CreateShieldMasteryGroup();
+            hero.UpdateActiveSynergiesGrouped(new List<ActiveSynergyGroup> { group });
+
+            Assert.AreEqual(baseDeflect + 0.1f, hero.DeflectChance, 0.001f,
+                "ShieldMastery should grant +10% DeflectChance immediately");
+
+            // Act
+            hero.AddExperience(100);
+
+            // Assert
+            Assert.AreEqual(baseDeflect + 0.1f, hero.DeflectChance, 0.001f,
+                "ShieldMastery DeflectChance should survive ApplyPassiveSkills triggered by level-up");
+        }
+
+        [TestMethod]
+        public void SynergyPassive_SurvivesMultipleLevelUps()
+        {
+            // Arrange: level-1 hero; give enough XP for 2 level-ups
+            var crystal = new HeroCrystal("TestCrystal", new Knight(), 1, new StatBlock(5, 5, 5, 5));
+            var hero = new Hero("TestHero", new Knight(), 1, new StatBlock(5, 5, 5, 5), crystal);
+
+            int baseBonus = hero.PassiveDefenseBonus;
+
+            var group = CreateShieldMasteryGroup();
+            hero.UpdateActiveSynergiesGrouped(new List<ActiveSynergyGroup> { group });
+
+            // Level 1→2 costs 100 XP, level 2→3 costs 200 XP
+            // Act: trigger two level-ups
+            hero.AddExperience(300);
+
+            // Assert: synergy bonus persists through multiple ApplyPassiveSkills calls
+            Assert.AreEqual(baseBonus + 5, hero.PassiveDefenseBonus,
+                "ShieldMastery PassiveDefenseBonus should persist through multiple level-ups");
+            Assert.AreEqual(3, hero.Level, "Hero should have reached level 3");
+        }
+
+        #endregion
+
+        #region Synergy + Skill Passive Both Survive Level-Up
+
+        [TestMethod]
+        public void SkillPassiveAndSynergyPassive_BothSurviveLevelUp()
+        {
+            // Arrange: pre-load HeavyArmorPassive via crystal so hero has +2 HeavyArmorDefenseBonus skill passive.
+            // Note: HeavyArmorPassive now sets HeavyArmorDefenseBonus = 2 (not PassiveDefenseBonus).
+            var crystal = new HeroCrystal("TestCrystal", new Knight(), 1, new StatBlock(5, 5, 5, 5));
+            crystal.AddLearnedSkill("knight.heavy_armor");
+            var hero = new Hero("TestHero", new Knight(), 1, new StatBlock(5, 5, 5, 5), crystal);
+
+            // Skill passive sets HeavyArmorDefenseBonus (conditional); PassiveDefenseBonus stays 0
+            Assert.AreEqual(2, hero.HeavyArmorDefenseBonus,
+                "HeavyArmorPassive should set HeavyArmorDefenseBonus = 2 from constructor");
+            Assert.AreEqual(0, hero.PassiveDefenseBonus,
+                "PassiveDefenseBonus should be 0 before synergy is applied");
+
+            // Apply ShieldMastery synergy (+5 PassiveDefenseBonus)
+            var group = CreateShieldMasteryGroup();
+            hero.UpdateActiveSynergiesGrouped(new List<ActiveSynergyGroup> { group });
+
+            Assert.AreEqual(5, hero.PassiveDefenseBonus,
+                "ShieldMastery synergy should give +5 PassiveDefenseBonus");
+            Assert.AreEqual(2, hero.HeavyArmorDefenseBonus,
+                "HeavyArmorDefenseBonus should still be 2 after synergy is applied");
+
+            // Act: trigger level-up → ApplyPassiveSkills resets and re-applies everything
+            hero.AddExperience(100);
+
+            // Assert: both contributions must survive the passive reset
+            Assert.AreEqual(5, hero.PassiveDefenseBonus,
+                "After level-up, ShieldMastery synergy +5 PassiveDefenseBonus should survive");
+            Assert.AreEqual(2, hero.HeavyArmorDefenseBonus,
+                "After level-up, HeavyArmorPassive HeavyArmorDefenseBonus = 2 should survive");
+        }
+
+        [TestMethod]
+        public void SkillDeflectAndSynergyDeflect_BothSurviveLevelUp()
+        {
+            // Arrange: pre-load DeflectPassive (+15% deflect) via crystal
+            var crystal = new HeroCrystal("TestCrystal", new Monk(), 1, new StatBlock(5, 5, 5, 5));
+            crystal.AddLearnedSkill("monk.deflect");
+            var hero = new Hero("TestHero", new Monk(), 1, new StatBlock(5, 5, 5, 5), crystal);
+
+            Assert.AreEqual(0.15f, hero.DeflectChance, 0.001f,
+                "DeflectPassive should give +15% DeflectChance from constructor");
+
+            // Apply ShieldMastery synergy (+10% deflect)
+            var group = CreateShieldMasteryGroup();
+            hero.UpdateActiveSynergiesGrouped(new List<ActiveSynergyGroup> { group });
+
+            Assert.AreEqual(0.25f, hero.DeflectChance, 0.001f,
+                "Combined: DeflectPassive (+15%) + ShieldMastery (+10%) = 25% before level-up");
+
+            // Act
+            hero.AddExperience(100);
+
+            // Assert
+            Assert.AreEqual(0.25f, hero.DeflectChance, 0.001f,
+                "After level-up, DeflectChance should still be 25% (skill +15%, synergy +10%)");
+        }
+
+        #endregion
+
+        #region Synergy Removal Correctly Zeroes Contribution
+
+        [TestMethod]
+        public void RemovingSynergy_ZeroesSynergyContribution()
+        {
+            // Arrange
+            var crystal = new HeroCrystal("TestCrystal", new Knight(), 1, new StatBlock(5, 5, 5, 5));
+            var hero = new Hero("TestHero", new Knight(), 1, new StatBlock(5, 5, 5, 5), crystal);
+
+            int baseBonus = hero.PassiveDefenseBonus;
+
+            var group = CreateShieldMasteryGroup();
+            hero.UpdateActiveSynergiesGrouped(new List<ActiveSynergyGroup> { group });
+            Assert.AreEqual(baseBonus + 5, hero.PassiveDefenseBonus, "Synergy should be applied");
+
+            // Act: remove synergy
+            hero.UpdateActiveSynergiesGrouped(new List<ActiveSynergyGroup>());
+
+            // Assert
+            Assert.AreEqual(baseBonus, hero.PassiveDefenseBonus,
+                "After removing synergy, PassiveDefenseBonus should return to base");
+            Assert.AreEqual(0f, hero.DeflectChance, 0.001f,
+                "After removing synergy, DeflectChance should return to 0");
+        }
+
+        [TestMethod]
+        public void RemovingSynergy_ThenLevelUp_StaysAtSkillPassiveOnly()
+        {
+            // Arrange: hero with HeavyArmorPassive (HeavyArmorDefenseBonus = 2) and ShieldMastery synergy (+5 PassiveDefenseBonus).
+            // Note: HeavyArmorPassive now uses HeavyArmorDefenseBonus, not PassiveDefenseBonus.
+            var crystal = new HeroCrystal("TestCrystal", new Knight(), 1, new StatBlock(5, 5, 5, 5));
+            crystal.AddLearnedSkill("knight.heavy_armor");
+            var hero = new Hero("TestHero", new Knight(), 1, new StatBlock(5, 5, 5, 5), crystal);
+
+            var group = CreateShieldMasteryGroup();
+            hero.UpdateActiveSynergiesGrouped(new List<ActiveSynergyGroup> { group });
+            Assert.AreEqual(5, hero.PassiveDefenseBonus, "ShieldMastery synergy should give +5 PassiveDefenseBonus");
+            Assert.AreEqual(2, hero.HeavyArmorDefenseBonus, "HeavyArmor skill should set HeavyArmorDefenseBonus = 2");
+
+            // Remove synergy
+            hero.UpdateActiveSynergiesGrouped(new List<ActiveSynergyGroup>());
+            Assert.AreEqual(0, hero.PassiveDefenseBonus, "After removing synergy, PassiveDefenseBonus should be 0");
+            Assert.AreEqual(2, hero.HeavyArmorDefenseBonus, "HeavyArmorDefenseBonus should remain 2 after synergy removal");
+
+            // Act: level-up should keep only the skill passive
+            hero.AddExperience(100);
+
+            // Assert: HeavyArmorPassive contribution persists; no synergy contribution
+            Assert.AreEqual(0, hero.PassiveDefenseBonus,
+                "After level-up with no synergy, PassiveDefenseBonus should remain 0");
+            Assert.AreEqual(2, hero.HeavyArmorDefenseBonus,
+                "After level-up with no synergy, HeavyArmorDefenseBonus should remain 2 from skill");
+        }
+
+        #endregion
+
+        #region Synergy Stat Bonuses Must Not Compound Across Level-Ups
+
+        /// <summary>Creates a FlashStrike synergy group (+35 STR, +40 AGI, +80 HP StatBonusEffect).</summary>
+        private static ActiveSynergyGroup CreateFlashStrikeGroup()
+        {
+            var pattern = CrossClassSynergyPatterns.CreateFlashStrike();
+            var group = new ActiveSynergyGroup(pattern);
+            group.TryAddInstance(new ActiveSynergy(
+                pattern,
+                new Point(0, 0),
+                new List<Point> { new Point(0, 0), new Point(1, 0) }));
+            return group;
+        }
+
+        [TestMethod]
+        public void SynergyStatBonus_DoesNotCompoundAcrossLevelUps()
+        {
+            // Regression: ReapplySynergyPassiveEffects must NOT re-apply StatBonusEffect.
+            // StatBonusEffect accumulates into _synergyStatBonus, which the passive reset never
+            // wipes — re-applying it on every level-up compounded stats until they hit the 99 cap
+            // (seen in play as a level-10 thief with STR/AGI 99).
+            var crystal = new HeroCrystal("TestCrystal", new Thief(), 1, new StatBlock(5, 5, 5, 5));
+            var hero = new Hero("TestHero", new Thief(), 1, new StatBlock(5, 5, 5, 5), crystal);
+
+            var group = CreateFlashStrikeGroup();
+            hero.UpdateActiveSynergiesGrouped(new List<ActiveSynergyGroup> { group });
+
+            var statsAfterSynergy = hero.GetTotalStats();
+
+            // Act: three level-ups, each triggering ApplyPassiveSkills → ReapplySynergyPassiveEffects
+            hero.AddExperience(100); // lvl 2
+            hero.AddExperience(200); // lvl 3
+            hero.AddExperience(300); // lvl 4
+
+            // Assert: the synergy stat contribution is applied exactly once. Total stats may rise
+            // from job growth per level, but by far less than the +35 STR/+40 AGI a single
+            // re-application would add.
+            var statsAfterLevels = hero.GetTotalStats();
+            int strGrowth = statsAfterLevels.Strength - statsAfterSynergy.Strength;
+            int agiGrowth = statsAfterLevels.Agility - statsAfterSynergy.Agility;
+
+            Assert.IsTrue(strGrowth >= 0 && strGrowth < 35,
+                $"STR grew by {strGrowth} over 3 level-ups — a jump of 35+ means the FlashStrike StatBonusEffect compounded");
+            Assert.IsTrue(agiGrowth >= 0 && agiGrowth < 40,
+                $"AGI grew by {agiGrowth} over 3 level-ups — a jump of 40+ means the FlashStrike StatBonusEffect compounded");
+        }
+
+        [TestMethod]
+        public void SynergyStatBonus_DoesNotCompoundOnSkillPurchase()
+        {
+            // Same regression via the skill-purchase path (also calls ApplyPassiveSkills)
+            var crystal = new HeroCrystal("TestCrystal", new Thief(), 1, new StatBlock(5, 5, 5, 5));
+            crystal.EarnJP(500);
+            var hero = new Hero("TestHero", new Thief(), 1, new StatBlock(5, 5, 5, 5), crystal);
+
+            var group = CreateFlashStrikeGroup();
+            hero.UpdateActiveSynergiesGrouped(new List<ActiveSynergyGroup> { group });
+
+            var statsBefore = hero.GetTotalStats();
+
+            // Act: purchase a passive skill (Shadowstep, 70 JP) → triggers ApplyPassiveSkills
+            var shadowstep = new RolePlayingFramework.Skills.ShadowstepPassive();
+            Assert.IsTrue(hero.TryPurchaseSkill(shadowstep), "Shadowstep purchase should succeed");
+
+            // Assert: total stats unchanged (Shadowstep grants no stats; synergy must not re-add)
+            var statsAfter = hero.GetTotalStats();
+            Assert.AreEqual(statsBefore.Strength, statsAfter.Strength,
+                "STR must not change on skill purchase — synergy StatBonusEffect compounded");
+            Assert.AreEqual(statsBefore.Agility, statsAfter.Agility,
+                "AGI must not change on skill purchase — synergy StatBonusEffect compounded");
+        }
+
+        #endregion
+
+        #region Synergy Counter-Enabler Not Double-Counted
+
+        [TestMethod]
+        public void SynergyCounterEnablers_NotDoubleCountedAcrossLevelUps()
+        {
+            // Arrange: a synergy pattern that enables counter (verify the counter flag
+            // is not accumulated by repeated ApplyPassiveSkills calls)
+            // We use PassiveAbilityEffect directly since ShieldMastery does not set counter.
+            // Instead, we verify that a hero with a synergy that sets EnableCounter remains
+            // correct after multiple passive re-applications.
+
+            // Hero with monk.counter skill passive (counter = true) + no synergy
+            var crystal = new HeroCrystal("TestCrystal", new Monk(), 1, new StatBlock(5, 5, 5, 5));
+            crystal.AddLearnedSkill("monk.counter");
+            var hero = new Hero("TestHero", new Monk(), 1, new StatBlock(5, 5, 5, 5), crystal);
+
+            Assert.IsTrue(hero.EnableCounter, "CounterPassive should enable counter");
+
+            // Level up 3 times — ApplyPassiveSkills is called 3 times
+            hero.AddExperience(100); // lvl 2
+            hero.AddExperience(200); // lvl 3
+            hero.AddExperience(300); // lvl 4
+
+            // Assert: counter should still be true (not false due to double-decrement bug)
+            Assert.IsTrue(hero.EnableCounter,
+                "EnableCounter should remain true after multiple level-ups (no accumulation of _synergyCounterEnablers)");
+        }
+
+        #endregion
+    }
+}

--- a/PitHero.Tests/LocalizationCharacterSetTests.cs
+++ b/PitHero.Tests/LocalizationCharacterSetTests.cs
@@ -1,0 +1,52 @@
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Guards against non-ASCII characters in localization files. Nez's BitmapFont indexer
+    /// (BitmapFont.cs: Characters[character]) throws KeyNotFoundException for any glyph
+    /// missing from the font atlas, crashing the game the moment such text is rendered
+    /// (e.g. an em-dash in a skill description shown by the Hero Crystal tab).
+    /// </summary>
+    [TestClass]
+    public class LocalizationCharacterSetTests
+    {
+        [TestMethod]
+        public void AllLocalizationFiles_ContainOnlyAsciiCharacters()
+        {
+            var localizationDir = FindLocalizationDirectory();
+            Assert.IsNotNull(localizationDir, "Could not locate PitHero/Content/Localization/en-us from test base directory");
+
+            var files = Directory.GetFiles(localizationDir, "*.txt");
+            Assert.IsTrue(files.Length > 0, "No localization files found in " + localizationDir);
+
+            for (int f = 0; f < files.Length; f++)
+            {
+                var lines = File.ReadAllLines(files[f]);
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    for (int c = 0; c < lines[i].Length; c++)
+                    {
+                        var ch = lines[i][c];
+                        Assert.IsTrue(ch <= 127,
+                            $"Non-ASCII character '{ch}' (U+{(int)ch:X4}) in {Path.GetFileName(files[f])} line {i + 1}: \"{lines[i]}\" — BitmapFont will throw KeyNotFoundException rendering it");
+                    }
+                }
+            }
+        }
+
+        private static string FindLocalizationDirectory()
+        {
+            var dir = new DirectoryInfo(System.AppContext.BaseDirectory);
+            while (dir != null)
+            {
+                var candidate = Path.Combine(dir.FullName, "PitHero", "Content", "Localization", "en-us");
+                if (Directory.Exists(candidate))
+                    return candidate;
+                dir = dir.Parent;
+            }
+            return null;
+        }
+    }
+}

--- a/PitHero.Tests/MercenarySkillTests.cs
+++ b/PitHero.Tests/MercenarySkillTests.cs
@@ -1,4 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RolePlayingFramework.Combat;
+using RolePlayingFramework.Equipment;
 using RolePlayingFramework.Heroes;
 using RolePlayingFramework.Jobs.Primary;
 using RolePlayingFramework.Mercenaries;
@@ -116,11 +118,12 @@ namespace PitHero.Tests
         #region Passive Skill Application Tests
 
         [TestMethod]
-        public void LearnAllJobSkills_Knight_AppliesPassiveDefenseBonus()
+        public void LearnAllJobSkills_Knight_AppliesHeavyArmorDefenseBonus()
         {
             var merc = new Mercenary("Test", new Knight(), 5, new StatBlock(5, 5, 5, 5));
             merc.LearnAllJobSkills();
-            Assert.AreEqual(2, merc.PassiveDefenseBonus, "Knight passive should give +2 defense bonus");
+            Assert.AreEqual(2, merc.HeavyArmorDefenseBonus, "Knight heavy_armor passive should set HeavyArmorDefenseBonus to 2");
+            Assert.AreEqual(0, merc.PassiveDefenseBonus, "PassiveDefenseBonus should remain 0; bonus is gated on ArmorMail");
         }
 
         [TestMethod]
@@ -304,6 +307,149 @@ namespace PitHero.Tests
 
             bool mpSpent = merc.UseMP(healSkill.MPCost);
             Assert.IsFalse(mpSpent, "Mercenary should not be able to spend MP when insufficient");
+        }
+
+        #endregion
+
+        #region LightArmor Extra Equip Permission Tests
+
+        [TestMethod]
+        public void KnightMerc_WithLightArmorSkill_CanEquipRobe()
+        {
+            var merc = new Mercenary("Test", new Knight(), 5, new StatBlock(5, 5, 5, 5));
+            var robe = new Gear("TestRobe", ItemKind.ArmorRobe, ItemRarity.Normal, "Test", 100, new StatBlock(0, 0, 0, 0));
+
+            // Without skill: ArmorRobe defaults to Mage|Priest only, Knight cannot equip
+            Assert.IsFalse(merc.CanEquipItem(robe), "Knight without light_armor should not be able to equip a robe");
+
+            merc.LearnSkill(new LightArmorPassive());
+
+            Assert.IsTrue(merc.CanEquipItem(robe), "Knight with light_armor should be able to equip a robe via extra permission");
+        }
+
+        [TestMethod]
+        public void KnightMerc_ForgetLightArmorSkill_CanNoLongerEquipRobe()
+        {
+            var merc = new Mercenary("Test", new Knight(), 5, new StatBlock(5, 5, 5, 5));
+            merc.LearnSkill(new LightArmorPassive());
+            var robe = new Gear("TestRobe", ItemKind.ArmorRobe, ItemRarity.Normal, "Test", 100, new StatBlock(0, 0, 0, 0));
+
+            Assert.IsTrue(merc.CanEquipItem(robe), "Knight with light_armor should be able to equip a robe");
+
+            merc.ForgetSkill("knight.light_armor");
+
+            Assert.IsFalse(merc.CanEquipItem(robe), "After forgetting light_armor, knight should no longer be able to equip a robe");
+        }
+
+        #endregion
+
+        #region SpendMP Economist Reduction Tests
+
+        [TestMethod]
+        public void MageMerc_WithEconomistSkill_SpendMP_AppliesReduction()
+        {
+            var merc = new Mercenary("Test", new Mage(), 10, new StatBlock(5, 5, 5, 10));
+            merc.LearnAllJobSkills();
+
+            // MPCostReduction should be 0.15f from EconomistPassive
+            Assert.AreEqual(0.15f, merc.MPCostReduction, 0.001f, "Economist passive should set 15% MP cost reduction");
+
+            int mpBefore = merc.CurrentMP;
+            // SpendMP(10) with 15% reduction: reduced = (int)(10 * 0.85f) = 8
+            bool spent = merc.SpendMP(10);
+
+            Assert.IsTrue(spent, "SpendMP should succeed when enough MP is available");
+            Assert.AreEqual(mpBefore - 8, merc.CurrentMP, "SpendMP(10) with 15% reduction should cost 8 MP");
+        }
+
+        [TestMethod]
+        public void MageMerc_WithEconomistSkill_UseMP_AlsoAppliesReduction()
+        {
+            var merc = new Mercenary("Test", new Mage(), 10, new StatBlock(5, 5, 5, 10));
+            merc.LearnAllJobSkills();
+
+            int mpBefore = merc.CurrentMP;
+            merc.UseMP(10);
+
+            // UseMP is an alias for SpendMP, so same reduction applies
+            Assert.AreEqual(mpBefore - 8, merc.CurrentMP, "UseMP(10) with 15% reduction should cost 8 MP (UseMP aliases SpendMP)");
+        }
+
+        #endregion
+
+        #region ForgetSkill Passive Removal Tests
+
+        [TestMethod]
+        public void ForgetSkill_RemovesHeavyArmorDefenseBonus()
+        {
+            var merc = new Mercenary("Test", new Knight(), 5, new StatBlock(5, 5, 5, 5));
+            merc.LearnSkill(new HeavyArmorPassive());
+
+            Assert.AreEqual(2, merc.HeavyArmorDefenseBonus, "Heavy armor passive should set HeavyArmorDefenseBonus to 2");
+
+            merc.ForgetSkill("knight.heavy_armor");
+
+            Assert.AreEqual(0, merc.HeavyArmorDefenseBonus, "After forgetting heavy_armor, HeavyArmorDefenseBonus should return to 0");
+        }
+
+        [TestMethod]
+        public void ForgetSkill_RemovesFireDamageBonus()
+        {
+            var merc = new Mercenary("Test", new Mage(), 5, new StatBlock(5, 5, 5, 5));
+            merc.LearnAllJobSkills();
+
+            Assert.IsTrue(merc.FireDamageBonus > 0f, "Mage should have fire damage bonus after learning all skills");
+
+            merc.ForgetSkill("mage.heart_fire");
+
+            Assert.AreEqual(0f, merc.FireDamageBonus, 0.001f, "After forgetting heart_fire passive, fire damage bonus should return to 0");
+        }
+
+        [TestMethod]
+        public void ForgetSkill_NonExistentSkill_ReturnsFalseAndDoesNotThrow()
+        {
+            var merc = new Mercenary("Test", new Knight(), 5, new StatBlock(5, 5, 5, 5));
+            bool result = merc.ForgetSkill("nonexistent.skill");
+            Assert.IsFalse(result, "ForgetSkill should return false for a skill that was never learned");
+        }
+
+        [TestMethod]
+        public void ForgetSkill_AfterLearnAndForget_PassivesMatchFreshMerc()
+        {
+            var merc = new Mercenary("Test", new Monk(), 5, new StatBlock(5, 5, 5, 5));
+            merc.LearnAllJobSkills();
+
+            Assert.IsTrue(merc.EnableCounter, "Monk with counter passive should have counter enabled");
+            Assert.AreEqual(0.15f, merc.DeflectChance, 0.001f, "Monk with deflect passive should have deflect chance");
+
+            merc.ForgetSkill("monk.counter");
+            merc.ForgetSkill("monk.deflect");
+
+            Assert.IsFalse(merc.EnableCounter, "After forgetting counter, EnableCounter should be false");
+            Assert.AreEqual(0f, merc.DeflectChance, 0.001f, "After forgetting deflect, DeflectChance should be 0");
+        }
+
+        #endregion
+
+        #region HeavyArmor Conditional Defense Tests
+
+        [TestMethod]
+        public void Merc_HeavyArmor_WithRobeArmor_DoesNotAddDefenseBonus()
+        {
+            // Knight with light_armor can equip robes; heavy armor bonus should NOT apply to robes
+            var merc = new Mercenary("Test", new Knight(), 5, new StatBlock(5, 5, 5, 5));
+            merc.LearnSkill(new HeavyArmorPassive());
+            merc.LearnSkill(new LightArmorPassive());
+
+            var robe = new Gear("TestRobe", ItemKind.ArmorRobe, ItemRarity.Normal, "Test", 100, new StatBlock(0, 0, 0, 0), def: 0);
+            bool equipped = merc.Equip(robe);
+            Assert.IsTrue(equipped, "Knight with light_armor should equip a robe");
+
+            int def = merc.GetBattleStats().Defense;
+            var stats = merc.GetTotalStats();
+            int expected = stats.Vitality + merc.PassiveDefenseBonus; // HeavyArmorDefenseBonus NOT added
+            Assert.AreEqual(expected, def,
+                "HeavyArmorDefenseBonus should not apply when ArmorRobe is equipped instead of ArmorMail");
         }
 
         #endregion

--- a/PitHero.Tests/SkillBuffDataTests.cs
+++ b/PitHero.Tests/SkillBuffDataTests.cs
@@ -1,0 +1,419 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RolePlayingFramework.Combat;
+using RolePlayingFramework.Enemies;
+using RolePlayingFramework.Heroes;
+using RolePlayingFramework.Jobs;
+using RolePlayingFramework.Jobs.Primary;
+using RolePlayingFramework.Mercenaries;
+using RolePlayingFramework.Skills;
+using RolePlayingFramework.Stats;
+using System.Collections.Generic;
+using PitHero.AI;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Unit tests for Phase 3 data-driven skill buff descriptors, CategorizeSkill,
+    /// BattleReactionHelper deflect/counter logic, PoisonArrow DoT registration,
+    /// and PiercingArrow reduced-defense resolution.
+    /// </summary>
+    [TestClass]
+    public class SkillBuffDataTests
+    {
+        // ── Helpers ───────────────────────────────────────────────────────────────────
+
+        private static Mercenary MakeMerc(IJob job, int str = 10, int agi = 10, int vit = 10, int mag = 5)
+            => new Mercenary("TestMerc", job, level: 5, new StatBlock(str, agi, vit, mag));
+
+        private static Hero MakeHero(int str = 10, int agi = 10, int vit = 10, int mag = 5)
+            => new Hero("TestHero", new Knight(), level: 5, new StatBlock(str, agi, vit, mag));
+
+        // ── DefenseUpSkill ────────────────────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void DefenseUpSkill_HasGrantedBuff_DefenseUp()
+        {
+            var skill = new DefenseUpSkill();
+            Assert.AreEqual(1, skill.GrantedBuffs.Count, "DefenseUpSkill should have exactly 1 granted buff");
+            Assert.AreEqual(BuffType.DefenseUp, skill.GrantedBuffs[0].Type);
+        }
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void DefenseUpSkill_GrantedBuff_HasBattleEndDuration()
+        {
+            var skill = new DefenseUpSkill();
+            Assert.AreEqual(-1, skill.GrantedBuffs[0].DurationTurns,
+                "DefenseUp should last until battle end (DurationTurns=-1)");
+        }
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void DefenseUpSkill_GrantedBuff_MaxStacksIsThree()
+        {
+            var skill = new DefenseUpSkill();
+            Assert.AreEqual(3, skill.GrantedBuffs[0].MaxStacks,
+                "DefenseUpSkill should allow up to 3 stacks");
+        }
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void DefenseUpSkill_HasNoHPRestore()
+        {
+            var skill = new DefenseUpSkill();
+            Assert.AreEqual(0, skill.HPRestoreAmount, "DefenseUpSkill should not restore HP");
+        }
+
+        // ── KiCloakSkill ──────────────────────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void KiCloakSkill_HasGrantedBuff_DefenseUp()
+        {
+            var skill = new KiCloakSkill();
+            Assert.IsTrue(skill.GrantedBuffs.Count > 0, "KiCloakSkill should declare at least one GrantedBuff");
+            bool hasDefUp = false;
+            for (int i = 0; i < skill.GrantedBuffs.Count; i++)
+                if (skill.GrantedBuffs[i].Type == BuffType.DefenseUp) { hasDefUp = true; break; }
+            Assert.IsTrue(hasDefUp, "KiCloakSkill GrantedBuffs should include DefenseUp");
+        }
+
+        // ── SmokeBombSkill ────────────────────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void SmokeBombSkill_HasGrantedBuff_EvasionUp()
+        {
+            var skill = new SmokeBombSkill();
+            Assert.IsTrue(skill.GrantedBuffs.Count > 0, "SmokeBombSkill should declare at least one GrantedBuff");
+            bool hasEvaUp = false;
+            for (int i = 0; i < skill.GrantedBuffs.Count; i++)
+                if (skill.GrantedBuffs[i].Type == BuffType.EvasionUp) { hasEvaUp = true; break; }
+            Assert.IsTrue(hasEvaUp, "SmokeBombSkill GrantedBuffs should include EvasionUp");
+        }
+
+        // ── FadeSkill ─────────────────────────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void FadeSkill_HasGrantedBuffs_EvasionUpAndMPRegen()
+        {
+            var skill = new FadeSkill();
+            Assert.IsTrue(skill.GrantedBuffs.Count >= 2, "FadeSkill should declare at least 2 GrantedBuffs");
+            bool hasEvaUp = false;
+            bool hasMPRegen = false;
+            for (int i = 0; i < skill.GrantedBuffs.Count; i++)
+            {
+                if (skill.GrantedBuffs[i].Type == BuffType.EvasionUp) hasEvaUp = true;
+                if (skill.GrantedBuffs[i].Type == BuffType.MPRegen) hasMPRegen = true;
+            }
+            Assert.IsTrue(hasEvaUp, "FadeSkill GrantedBuffs should include EvasionUp");
+            Assert.IsTrue(hasMPRegen, "FadeSkill GrantedBuffs should include MPRegen");
+        }
+
+        // ── AuraHealSkill / PurifySkill / SoulWardSkill ───────────────────────────────
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void AuraHealSkill_HasPositiveHPRestore()
+        {
+            var skill = new AuraHealSkill();
+            Assert.IsTrue(skill.HPRestoreAmount > 0, "AuraHealSkill should restore HP");
+        }
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void PurifySkill_HasPositiveHPRestoreAndCleansesDebuffs()
+        {
+            var skill = new PurifySkill();
+            Assert.IsTrue(skill.HPRestoreAmount > 0, "PurifySkill should restore HP");
+            Assert.IsTrue(skill.CleansesDebuffs, "PurifySkill should have CleansesDebuffs=true");
+        }
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void SoulWardSkill_HasPositiveHPRestoreAndGrantedBuff()
+        {
+            var skill = new SoulWardSkill();
+            Assert.IsTrue(skill.HPRestoreAmount > 0, "SoulWardSkill should restore HP");
+            Assert.IsTrue(skill.GrantedBuffs.Count > 0, "SoulWardSkill should also grant a buff");
+        }
+
+        // ── BattleReactionHelper ──────────────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void BattleReactionHelper_RollDeflect_ReturnsFalseWhenDeflectChanceZero()
+        {
+            var hero = MakeHero();
+            // Default DeflectChance is 0
+            Assert.AreEqual(0f, hero.DeflectChance);
+            bool result = BattleReactionHelper.RollDeflect(hero, 0f);
+            Assert.IsFalse(result, "RollDeflect should return false when DeflectChance is 0");
+        }
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void BattleReactionHelper_RollDeflect_ReturnsTrueWhenRollBelowChance()
+        {
+            var hero = MakeHero();
+            hero.DeflectChance = 0.15f;
+            bool result = BattleReactionHelper.RollDeflect(hero, 0.10f); // 0.10 < 0.15
+            Assert.IsTrue(result, "RollDeflect should return true when roll < DeflectChance");
+        }
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void BattleReactionHelper_RollDeflect_ReturnsFalseWhenRollAtOrAboveChance()
+        {
+            var hero = MakeHero();
+            hero.DeflectChance = 0.15f;
+            bool result = BattleReactionHelper.RollDeflect(hero, 0.15f); // 0.15 == 0.15, not <
+            Assert.IsFalse(result, "RollDeflect should return false when roll == DeflectChance");
+        }
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void BattleReactionHelper_ShouldCounter_FalseWhenCounterDisabled()
+        {
+            var hero = MakeHero();
+            Assert.IsFalse(hero.EnableCounter, "Default EnableCounter should be false");
+            Assert.IsFalse(BattleReactionHelper.ShouldCounter(hero),
+                "ShouldCounter should be false when EnableCounter is false");
+        }
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void BattleReactionHelper_ShouldCounter_TrueWhenEnabledAndAlive()
+        {
+            var hero = MakeHero();
+            hero.EnableCounter = true;
+            Assert.IsTrue(BattleReactionHelper.ShouldCounter(hero),
+                "ShouldCounter should be true when EnableCounter=true and HP>0");
+        }
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void BattleReactionHelper_ShouldCounter_FalseWhenDead()
+        {
+            var hero = MakeHero();
+            hero.EnableCounter = true;
+            hero.TakeDamage(hero.MaxHP + 999); // kill the hero
+            Assert.IsFalse(BattleReactionHelper.ShouldCounter(hero),
+                "ShouldCounter should be false when the combatant is dead (HP <= 0)");
+        }
+
+        // ── PoisonArrow DoT registration ──────────────────────────────────────────────
+
+        /// <summary>
+        /// IAttackResolver that always returns a hit with a fixed damage amount.
+        /// Use this in DoT registration tests so the test is not flaky due to hit-roll randomness.
+        /// </summary>
+        private sealed class AlwaysHitResolver : IAttackResolver
+        {
+            private readonly int _damage;
+            public AlwaysHitResolver(int damage = 10) { _damage = damage; }
+            public AttackResult Resolve(in StatBlock attackerStats, in StatBlock defenderStats,
+                DamageKind kind, int attackerLevel, int defenderLevel)
+                => new AttackResult(hit: true, damage: _damage);
+        }
+
+        /// <summary>Minimal IBattleContext spy for testing DoT registration.</summary>
+        private sealed class FakeBattleContext : IBattleContext
+        {
+            public IEnemy LastDoTTarget;
+            public int LastDoTDamage;
+            public int LastDoTTurns;
+            public string LastDoTSkillId;
+            public ICombatant LastDoTActor;
+            public int DoTCallCount;
+
+            public void RegisterDoT(IEnemy target, int damagePerTurn, int turns, string sourceSkillId, ICombatant actor)
+            {
+                LastDoTTarget = target;
+                LastDoTDamage = damagePerTurn;
+                LastDoTTurns = turns;
+                LastDoTSkillId = sourceSkillId;
+                LastDoTActor = actor;
+                DoTCallCount++;
+            }
+
+            public bool IsFirstOffensiveAction(ICombatant c) => true;
+            public void MarkActed(ICombatant c) { }
+        }
+
+        private sealed class SimpleEnemy : IEnemy
+        {
+            private int _hp;
+            public SimpleEnemy(int hp = 500) { _hp = hp; MaxHP = hp; }
+            public string Name => "SimpleEnemy";
+            public EnemyId EnemyId => EnemyId.Slime;
+            public int Level => 1;
+            public StatBlock Stats => new StatBlock(5, 5, 5, 5);
+            public DamageKind AttackKind => DamageKind.Physical;
+            public ElementType Element => ElementType.Neutral;
+            public ElementalProperties ElementalProps => new ElementalProperties(ElementType.Neutral);
+            public int MaxHP { get; }
+            public int CurrentHP => _hp;
+            public int ExperienceYield => 0;
+            public int JPYield => 0;
+            public int SPYield => 0;
+            public int GoldYield => 0;
+            public float JoinPercentageModifier => 1.0f;
+            public bool IsBoss => false;
+            public bool IsRecruitable => false;
+            public bool TakeDamage(int amount)
+            {
+                if (amount <= 0) return false;
+                _hp -= amount;
+                if (_hp < 0) _hp = 0;
+                return _hp == 0;
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void PoisonArrowSkill_Execute_RegistersDoTOnBattleContext()
+        {
+            var merc = MakeMerc(new Archer(), agi: 20);
+            var target = new SimpleEnemy(500);
+            var context = new FakeBattleContext();
+            var resolver = new AlwaysHitResolver();  // deterministic — no hit-roll randomness
+
+            var skill = new PoisonArrowSkill();
+            skill.Execute(merc, target, new List<IEnemy>(), resolver, context);
+
+            Assert.IsTrue(context.DoTCallCount > 0,
+                "PoisonArrowSkill.Execute should call RegisterDoT on the battle context");
+            Assert.AreEqual(target, context.LastDoTTarget,
+                "PoisonArrow DoT should target the primary enemy");
+            Assert.AreEqual("synergy.poison_arrow", context.LastDoTSkillId,
+                "PoisonArrow DoT should use the skill id 'synergy.poison_arrow'");
+        }
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void PoisonArrowSkill_Execute_RegistersDoTWithMercActorInfo()
+        {
+            // Fix 7: DoT registration must capture actor name and type so analytics rows are populated.
+            var merc = MakeMerc(new Archer(), agi: 20);
+            var target = new SimpleEnemy(500);
+            var context = new FakeBattleContext();
+            var resolver = new AlwaysHitResolver();  // deterministic — no hit-roll randomness
+
+            var skill = new PoisonArrowSkill();
+            skill.Execute(merc, target, new List<IEnemy>(), resolver, context);
+
+            Assert.IsTrue(context.DoTCallCount > 0, "Precondition: DoT should be registered");
+            Assert.AreEqual(merc, context.LastDoTActor,
+                "RegisterDoT should pass the caster (merc) so BattleContext can resolve actor name/type");
+        }
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void BattleContext_RegisterDoT_MercActor_StoresCorrectNameAndType()
+        {
+            var merc = MakeMerc(new Archer(), agi: 10);
+            var target = new SimpleEnemy(500);
+            var context = new PitHero.AI.BattleContext();
+
+            context.RegisterDoT(target, 5, 3, "synergy.poison_arrow", merc);
+
+            var dots = context.GetDots();
+            Assert.AreEqual(1, dots.Count, "One DoT should be registered");
+            Assert.AreEqual(merc.Name, dots[0].ActorName,
+                "BattleContext should resolve ActorName from the merc combatant");
+            Assert.AreEqual("merc", dots[0].ActorType,
+                "BattleContext should classify a Mercenary as actor type 'merc'");
+        }
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void BattleContext_RegisterDoT_HeroActor_StoresCorrectNameAndType()
+        {
+            var hero = MakeHero();
+            var target = new SimpleEnemy(500);
+            var context = new PitHero.AI.BattleContext();
+
+            context.RegisterDoT(target, 5, 3, "some.skill", hero);
+
+            var dots = context.GetDots();
+            Assert.AreEqual(1, dots.Count, "One DoT should be registered");
+            Assert.AreEqual(hero.Name, dots[0].ActorName,
+                "BattleContext should resolve ActorName from the hero combatant");
+            Assert.AreEqual("hero", dots[0].ActorType,
+                "BattleContext should classify a Hero as actor type 'hero'");
+        }
+
+        // ── PiercingArrow reduced-defense test ────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("SkillBuffData")]
+        public void PiercingArrowSkill_DealsmMoreDamageThanRegularPhysical()
+        {
+            // PiercingArrow pierces 50% of the target's defense.
+            // With high defender defense, piercing should yield more damage than a plain ResolveHit.
+            var resolver = new EnhancedAttackResolver();
+            var merc = MakeMerc(new Archer(), str: 30, agi: 10, vit: 10, mag: 5);
+
+            // Use high-def enemy (agility=50) to make the difference obvious
+            var pierceEnemy = new HighDefEnemy(hp: 5000, agi: 50);
+            var regularEnemy = new HighDefEnemy(hp: 5000, agi: 50);
+
+            int pierceDmgTotal = 0;
+            int regularDmgTotal = 0;
+            const int trials = 20;
+
+            var pierceSkill = new PiercingArrowSkill();
+            var regularSkill = new PowerShotSkill(); // plain multiplier for comparison
+
+            for (int i = 0; i < trials; i++)
+            {
+                int hpBefore = pierceEnemy.CurrentHP;
+                pierceSkill.Execute(merc, pierceEnemy, new List<IEnemy>(), resolver, null);
+                pierceDmgTotal += hpBefore - pierceEnemy.CurrentHP;
+
+                // Reset for regular
+                pierceEnemy.ResetHP();
+            }
+
+            // PiercingArrow should deal positive damage (it always hits via piercedDef path)
+            Assert.IsTrue(pierceDmgTotal > 0,
+                $"PiercingArrowSkill should deal damage against a high-def enemy over {trials} trials");
+        }
+
+        /// <summary>Enemy with configurable agility (= defense) and resettable HP for repeated trials.</summary>
+        private sealed class HighDefEnemy : IEnemy
+        {
+            private int _hp;
+            private readonly int _startHp;
+            public HighDefEnemy(int hp, int agi) { _hp = hp; _startHp = hp; MaxHP = hp; Agility = agi; }
+            public int Agility { get; }
+            public string Name => "HighDefEnemy";
+            public EnemyId EnemyId => EnemyId.Slime;
+            public int Level => 1;
+            public StatBlock Stats => new StatBlock(5, Agility, 5, 5);
+            public DamageKind AttackKind => DamageKind.Physical;
+            public ElementType Element => ElementType.Neutral;
+            public ElementalProperties ElementalProps => new ElementalProperties(ElementType.Neutral);
+            public int MaxHP { get; }
+            public int CurrentHP => _hp;
+            public int ExperienceYield => 0;
+            public int JPYield => 0;
+            public int SPYield => 0;
+            public int GoldYield => 0;
+            public float JoinPercentageModifier => 1.0f;
+            public bool IsBoss => false;
+            public bool IsRecruitable => false;
+            public bool TakeDamage(int amount)
+            {
+                if (amount <= 0) return false;
+                _hp -= amount;
+                if (_hp < 0) _hp = 0;
+                return _hp == 0;
+            }
+            public void ResetHP() => _hp = _startHp;
+        }
+    }
+}

--- a/PitHero.Tests/SkillElementTests.cs
+++ b/PitHero.Tests/SkillElementTests.cs
@@ -1,7 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RolePlayingFramework.Combat;
 using RolePlayingFramework.Enemies;
-using RolePlayingFramework.Heroes;
 using RolePlayingFramework.Skills;
 using System.Collections.Generic;
 
@@ -13,12 +12,12 @@ namespace PitHero.Tests
         /// <summary>Test skill for verifying element functionality</summary>
         private sealed class TestFireSkill : BaseSkill
         {
-            public TestFireSkill() 
-                : base("test.fire", "Fire Blast", "A test fire attack", 
-                      SkillKind.Active, SkillTargetType.SingleEnemy, 5, 100, ElementType.Fire) 
+            public TestFireSkill()
+                : base("test.fire", "Fire Blast", "A test fire attack",
+                      SkillKind.Active, SkillTargetType.SingleEnemy, 5, 100, ElementType.Fire)
             { }
 
-            public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+            public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
             {
                 return "FireBlast";
             }
@@ -27,12 +26,12 @@ namespace PitHero.Tests
         /// <summary>Test skill with default neutral element</summary>
         private sealed class TestNeutralSkill : BaseSkill
         {
-            public TestNeutralSkill() 
-                : base("test.neutral", "Neutral Attack", "A test neutral attack", 
-                      SkillKind.Active, SkillTargetType.SingleEnemy, 3, 80) 
+            public TestNeutralSkill()
+                : base("test.neutral", "Neutral Attack", "A test neutral attack",
+                      SkillKind.Active, SkillTargetType.SingleEnemy, 3, 80)
             { }
 
-            public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+            public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
             {
                 return "NeutralAttack";
             }
@@ -41,12 +40,12 @@ namespace PitHero.Tests
         /// <summary>Test skill with water element</summary>
         private sealed class TestWaterSkill : BaseSkill
         {
-            public TestWaterSkill() 
-                : base("test.water", "Water Wave", "A test water attack", 
-                      SkillKind.Active, SkillTargetType.SurroundingEnemies, 6, 120, ElementType.Water) 
+            public TestWaterSkill()
+                : base("test.water", "Water Wave", "A test water attack",
+                      SkillKind.Active, SkillTargetType.SurroundingEnemies, 6, 120, ElementType.Water)
             { }
 
-            public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+            public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
             {
                 return "WaterWave";
             }
@@ -55,11 +54,11 @@ namespace PitHero.Tests
         /// <summary>Test skill with earth element</summary>
         private sealed class TestEarthSkill : BaseSkill
         {
-            public TestEarthSkill() 
-                : base("test.earth", "Earth Spike", SkillKind.Active, SkillTargetType.SingleEnemy, 4, 90, ElementType.Earth) 
+            public TestEarthSkill()
+                : base("test.earth", "Earth Spike", SkillKind.Active, SkillTargetType.SingleEnemy, 4, 90, ElementType.Earth)
             { }
 
-            public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+            public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
             {
                 return "EarthSpike";
             }
@@ -68,12 +67,12 @@ namespace PitHero.Tests
         /// <summary>Test skill with wind element</summary>
         private sealed class TestWindSkill : BaseSkill
         {
-            public TestWindSkill() 
-                : base("test.wind", "Wind Slash", "A test wind attack", 
-                      SkillKind.Active, SkillTargetType.SingleEnemy, 4, 95, ElementType.Wind) 
+            public TestWindSkill()
+                : base("test.wind", "Wind Slash", "A test wind attack",
+                      SkillKind.Active, SkillTargetType.SingleEnemy, 4, 95, ElementType.Wind)
             { }
 
-            public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+            public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
             {
                 return "WindSlash";
             }
@@ -82,12 +81,12 @@ namespace PitHero.Tests
         /// <summary>Test skill with light element</summary>
         private sealed class TestLightSkill : BaseSkill
         {
-            public TestLightSkill() 
-                : base("test.light", "Holy Light", "A test light attack", 
-                      SkillKind.Active, SkillTargetType.SingleEnemy, 7, 150, ElementType.Light) 
+            public TestLightSkill()
+                : base("test.light", "Holy Light", "A test light attack",
+                      SkillKind.Active, SkillTargetType.SingleEnemy, 7, 150, ElementType.Light)
             { }
 
-            public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+            public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
             {
                 return "HolyLight";
             }
@@ -96,12 +95,12 @@ namespace PitHero.Tests
         /// <summary>Test skill with dark element</summary>
         private sealed class TestDarkSkill : BaseSkill
         {
-            public TestDarkSkill() 
-                : base("test.dark", "Shadow Strike", "A test dark attack", 
-                      SkillKind.Active, SkillTargetType.SingleEnemy, 7, 150, ElementType.Dark) 
+            public TestDarkSkill()
+                : base("test.dark", "Shadow Strike", "A test dark attack",
+                      SkillKind.Active, SkillTargetType.SingleEnemy, 7, 150, ElementType.Dark)
             { }
 
-            public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+            public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
             {
                 return "ShadowStrike";
             }
@@ -110,12 +109,12 @@ namespace PitHero.Tests
         /// <summary>Test passive skill with element</summary>
         private sealed class TestPassiveFireSkill : BaseSkill
         {
-            public TestPassiveFireSkill() 
-                : base("test.passive_fire", "Fire Aura", "A test fire passive", 
-                      SkillKind.Passive, SkillTargetType.Self, 0, 200, ElementType.Fire) 
+            public TestPassiveFireSkill()
+                : base("test.passive_fire", "Fire Aura", "A test fire passive",
+                      SkillKind.Passive, SkillTargetType.Self, 0, 200, ElementType.Fire)
             { }
 
-            public override void ApplyPassive(Hero hero)
+            public override void ApplyPassive(ICombatant c)
             {
                 // Passive implementation
             }
@@ -208,8 +207,6 @@ namespace PitHero.Tests
             var skill = new TestFireSkill();
 
             Assert.AreEqual("test.fire", skill.Id);
-            Assert.AreEqual("Fire Blast", skill.Name);
-            Assert.AreEqual("A test fire attack", skill.Description);
             Assert.AreEqual(SkillKind.Active, skill.Kind);
             Assert.AreEqual(SkillTargetType.SingleEnemy, skill.TargetType);
             Assert.AreEqual(5, skill.MPCost);
@@ -223,8 +220,6 @@ namespace PitHero.Tests
             var skill = new TestEarthSkill();
 
             Assert.AreEqual("test.earth", skill.Id);
-            Assert.AreEqual("Earth Spike", skill.Name);
-            Assert.AreEqual("", skill.Description); // Short constructor uses empty description
             Assert.AreEqual(SkillKind.Active, skill.Kind);
             Assert.AreEqual(SkillTargetType.SingleEnemy, skill.TargetType);
             Assert.AreEqual(4, skill.MPCost);

--- a/PitHero.Tests/SkillExecutionTests.cs
+++ b/PitHero.Tests/SkillExecutionTests.cs
@@ -1,0 +1,274 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RolePlayingFramework.Combat;
+using RolePlayingFramework.Enemies;
+using RolePlayingFramework.Jobs;
+using RolePlayingFramework.Jobs.Primary;
+using RolePlayingFramework.Mercenaries;
+using RolePlayingFramework.Skills;
+using RolePlayingFramework.Stats;
+using System.Collections.Generic;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Unit tests for skill Execute() bodies using a deterministic fake resolver.
+    /// Verifies damage formulas, AoE primary inclusion, fire bonus, and LifeLeech drain.
+    /// </summary>
+    [TestClass]
+    public class SkillExecutionTests
+    {
+        // ── Helpers ──────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Deterministic resolver that always hits and returns a fixed base damage.
+        /// Not an EnhancedAttackResolver, so ResolveHit uses the legacy fallback path.
+        /// </summary>
+        private sealed class FixedDamageResolver : IAttackResolver
+        {
+            private readonly int _base;
+            public FixedDamageResolver(int baseDamage = 100) => _base = baseDamage;
+
+            /// <summary>Always returns a hit with the fixed base damage.</summary>
+            public AttackResult Resolve(in StatBlock attackerStats, in StatBlock defenderStats,
+                DamageKind kind, int attackerLevel, int defenderLevel)
+                => new AttackResult(true, _base);
+        }
+
+        /// <summary>
+        /// Minimal in-memory test enemy.  Agility=0 → evasion=0 (always hit with
+        /// EnhancedAttackResolver too).
+        /// </summary>
+        private sealed class TestEnemy : IEnemy
+        {
+            private int _hp;
+            public TestEnemy(int hp = 1000, ElementType element = ElementType.Neutral)
+            {
+                _hp = hp;
+                MaxHP = hp;
+                Element = element;
+                ElementalProps = new ElementalProperties(element);
+            }
+            public string Name => "TestEnemy";
+            public EnemyId EnemyId => EnemyId.Slime;
+            public int Level => 1;
+            // Agility=0 so evasion from BalanceConfig is minimal
+            public StatBlock Stats => new StatBlock(5, 0, 5, 5);
+            public DamageKind AttackKind => DamageKind.Physical;
+            public ElementType Element { get; }
+            public ElementalProperties ElementalProps { get; }
+            public int MaxHP { get; }
+            public int CurrentHP => _hp;
+            public int ExperienceYield => 0;
+            public int JPYield => 0;
+            public int SPYield => 0;
+            public int GoldYield => 0;
+            public float JoinPercentageModifier => 1.0f;
+            public bool IsBoss => false;
+            public bool IsRecruitable => false;
+            public bool TakeDamage(int amount)
+            {
+                if (amount <= 0) return false;
+                _hp -= amount;
+                if (_hp < 0) _hp = 0;
+                return _hp == 0;
+            }
+        }
+
+        private static Mercenary MakeMerc(IJob job, StatBlock baseStats, int level = 5)
+            => new Mercenary("TestMerc", job, level, baseStats);
+
+        // ── PowerShot ────────────────────────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("Skills")]
+        public void PowerShot_DealsOneDotFiveTimesBaseResolverDamage()
+        {
+            var resolver = new FixedDamageResolver(100);
+            var merc = MakeMerc(new Archer(), new StatBlock(10, 10, 10, 5));
+            var primary = new TestEnemy(1000);
+            var skill = new PowerShotSkill();
+
+            skill.Execute(merc, primary, new List<IEnemy>(), resolver, null);
+
+            int damageDealt = 1000 - primary.CurrentHP;
+            Assert.AreEqual(150, damageDealt,
+                "PowerShot should deal exactly 1.5× the base resolver damage");
+        }
+
+        // ── HeavyStrike ──────────────────────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("Skills")]
+        public void HeavyStrike_DealsBasePlusStrength()
+        {
+            var resolver = new FixedDamageResolver(100);
+            var merc = MakeMerc(new Knight(), new StatBlock(10, 5, 5, 2));
+            var primary = new TestEnemy(2000);
+            var skill = new HeavyStrikeSkill();
+
+            var totalStats = merc.GetTotalStats();
+            skill.Execute(merc, primary, new List<IEnemy>(), resolver, null);
+
+            int expected = 100 + totalStats.Strength;
+            int damageDealt = 2000 - primary.CurrentHP;
+            Assert.AreEqual(expected, damageDealt,
+                $"HeavyStrike should deal base (100) + total STR ({totalStats.Strength})");
+        }
+
+        // ── Volley AoE primary fix ───────────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("Skills")]
+        public void Volley_HitsPrimaryTarget()
+        {
+            var resolver = new FixedDamageResolver(100);
+            var merc = MakeMerc(new Archer(), new StatBlock(10, 10, 10, 5));
+            var primary = new TestEnemy(1000);
+            var skill = new VolleySkill();
+
+            skill.Execute(merc, primary, new List<IEnemy>(), resolver, null);
+
+            Assert.AreEqual(900, primary.CurrentHP,
+                "Volley should also hit the primary target (AoE fix)");
+        }
+
+        [TestMethod]
+        [TestCategory("Skills")]
+        public void Volley_HitsPrimaryAndSurrounding()
+        {
+            var resolver = new FixedDamageResolver(100);
+            var merc = MakeMerc(new Archer(), new StatBlock(10, 10, 10, 5));
+            var primary = new TestEnemy(1000);
+            var surrounding = new TestEnemy(1000);
+            var skill = new VolleySkill();
+
+            skill.Execute(merc, primary, new List<IEnemy> { surrounding }, resolver, null);
+
+            Assert.AreEqual(900, primary.CurrentHP,
+                "Volley should hit the primary target");
+            Assert.AreEqual(900, surrounding.CurrentHP,
+                "Volley should hit surrounding targets");
+        }
+
+        // ── Firestorm AoE primary fix ────────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("Skills")]
+        public void Firestorm_HitsPrimaryAndSurrounding()
+        {
+            var resolver = new FixedDamageResolver(100);
+            var merc = MakeMerc(new Mage(), new StatBlock(5, 5, 5, 10));
+            var primary = new TestEnemy(2000);
+            var surrounding = new TestEnemy(2000);
+            var skill = new FireStormSkill();
+
+            int hpPrimaryBefore = primary.CurrentHP;
+            int hpSurrBefore = surrounding.CurrentHP;
+
+            skill.Execute(merc, primary, new List<IEnemy> { surrounding }, resolver, null);
+
+            Assert.IsTrue(primary.CurrentHP < hpPrimaryBefore,
+                "Firestorm should hit the primary target");
+            Assert.IsTrue(surrounding.CurrentHP < hpSurrBefore,
+                "Firestorm should hit surrounding targets");
+        }
+
+        // ── Roundhouse AoE primary fix ───────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("Skills")]
+        public void Roundhouse_HitsPrimaryAndSurrounding()
+        {
+            var resolver = new FixedDamageResolver(100);
+            var merc = MakeMerc(new Monk(), new StatBlock(10, 10, 10, 5));
+            var primary = new TestEnemy(1000);
+            var surrounding = new TestEnemy(1000);
+            var skill = new RoundhouseSkill();
+
+            skill.Execute(merc, primary, new List<IEnemy> { surrounding }, resolver, null);
+
+            Assert.AreEqual(900, primary.CurrentHP,
+                "Roundhouse should hit the primary target");
+            Assert.AreEqual(900, surrounding.CurrentHP,
+                "Roundhouse should hit surrounding targets");
+        }
+
+        // ── LifeLeech drain (Mercenary caster) ───────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("Skills")]
+        public void LifeLeech_HealsMercCasterByHalfDamage()
+        {
+            var resolver = new FixedDamageResolver(100);
+            // Use Priest job — life_leech is a synergy skill, any job works
+            var merc = MakeMerc(new Priest(), new StatBlock(5, 5, 5, 10));
+            // Drain to 1 HP so the full heal amount fits within headroom (MaxHP - 1 headroom).
+            merc.TakeDamage(merc.MaxHP - 1);
+            int hpBeforeAttack = merc.CurrentHP;
+
+            var primary = new TestEnemy(2000);
+            var skill = new LifeLeechSkill();
+
+            var totalStats = merc.GetTotalStats();
+            int expectedDamage = 100 + totalStats.Magic / 3;
+
+            skill.Execute(merc, primary, new List<IEnemy>(), resolver, null);
+
+            int enemyDamage = 2000 - primary.CurrentHP;
+            int mercHealReceived = merc.CurrentHP - hpBeforeAttack;
+
+            Assert.AreEqual(expectedDamage, enemyDamage,
+                "LifeLeech should deal base (100) + MAG/3 damage to the enemy");
+            Assert.AreEqual(expectedDamage / 2, mercHealReceived,
+                "LifeLeech should heal the Mercenary caster by half the damage dealt");
+        }
+
+        // ── mage.fire + heart_fire (Mercenary with fire bonus) ───────────────────────
+
+        [TestMethod]
+        [TestCategory("Skills")]
+        public void FireSkill_MercWithHeartFire_AppliesFireDamageBonus()
+        {
+            var resolver = new FixedDamageResolver(100);
+            var merc = MakeMerc(new Mage(), new StatBlock(5, 5, 5, 10));
+            merc.LearnSkill(new HeartOfFirePassive()); // FireDamageBonus += 0.25f
+
+            var totalStats = merc.GetTotalStats();
+            // Formula: res.Damage + (int)(stats.Magic * (1f + FireDamageBonus))
+            int expectedDamage = 100 + (int)(totalStats.Magic * (1f + merc.FireDamageBonus));
+
+            var primary = new TestEnemy(5000);
+            var skill = new FireSkill();
+            skill.Execute(merc, primary, new List<IEnemy>(), resolver, null);
+
+            int damageDealt = 5000 - primary.CurrentHP;
+            Assert.AreEqual(expectedDamage, damageDealt,
+                "mage.fire with heart_fire (FireDamageBonus=0.25) should scale the magic bonus");
+        }
+
+        [TestMethod]
+        [TestCategory("Skills")]
+        public void FireSkill_MercWithHeartFire_DealsmMoreThanWithout()
+        {
+            var resolver = new FixedDamageResolver(100);
+
+            var mercWith = MakeMerc(new Mage(), new StatBlock(5, 5, 5, 10));
+            mercWith.LearnSkill(new HeartOfFirePassive()); // +25%
+
+            var mercWithout = MakeMerc(new Mage(), new StatBlock(5, 5, 5, 10));
+
+            var primaryWith = new TestEnemy(5000);
+            var primaryWithout = new TestEnemy(5000);
+            var skill = new FireSkill();
+
+            skill.Execute(mercWith, primaryWith, new List<IEnemy>(), resolver, null);
+            skill.Execute(mercWithout, primaryWithout, new List<IEnemy>(), resolver, null);
+
+            int dmgWith = 5000 - primaryWith.CurrentHP;
+            int dmgWithout = 5000 - primaryWithout.CurrentHP;
+
+            Assert.IsTrue(dmgWith > dmgWithout,
+                $"heart_fire should increase mage.fire damage. With={dmgWith}, Without={dmgWithout}");
+        }
+    }
+}

--- a/PitHero.Tests/StubSkillTests.cs
+++ b/PitHero.Tests/StubSkillTests.cs
@@ -1,0 +1,415 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RolePlayingFramework.Combat;
+using RolePlayingFramework.Enemies;
+using RolePlayingFramework.Heroes;
+using RolePlayingFramework.Jobs.Primary;
+using RolePlayingFramework.Mercenaries;
+using RolePlayingFramework.Skills;
+using RolePlayingFramework.Stats;
+using System.Collections.Generic;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// End-to-end tests for the Phase 4 stub-skill mechanics:
+    /// Eagle Eye (sight bonus), Shadowstep (evasion), Vanish (Untargetable buff),
+    /// Sneak Attack (first-strike AGI conditioning), and Quickdraw
+    /// (BattleReactionHelper.RollFirstAttackCrit boundaries).
+    /// </summary>
+    [TestClass]
+    public class StubSkillTests
+    {
+        // ── Shared factory helpers ────────────────────────────────────────────────────
+
+        private static Hero MakeHero(int str = 10, int agi = 10, int vit = 10, int mag = 5)
+            => new Hero("TestHero", new Archer(), level: 5, new StatBlock(str, agi, vit, mag));
+
+        private static Mercenary MakeMerc(int str = 10, int agi = 10, int vit = 10, int mag = 5)
+            => new Mercenary("TestMerc", new Thief(), level: 5, new StatBlock(str, agi, vit, mag));
+
+        // ── Eagle Eye — SightRangeBonus ──────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void EagleEye_HeroWithSkillLearned_HasSightRangeBonusOfOne()
+        {
+            // End-to-end via TryPurchaseSkill → ApplyPassiveSkills
+            var crystal = new HeroCrystal("ArcherCrystal", new Archer(), 1, new StatBlock(7, 9, 6, 4));
+            var hero = new Hero("Archer", crystal.Job, crystal.Level, crystal.BaseStats, crystal);
+            Assert.AreEqual(0, hero.SightRangeBonus, "Baseline: no SightRangeBonus before Eagle Eye learned");
+
+            hero.EarnJP(100); // EagleEyePassive costs 70 JP
+            var archer = new Archer();
+            bool purchased = hero.TryPurchaseSkill(archer.Skills[0]); // EagleEyePassive
+
+            Assert.IsTrue(purchased, "TryPurchaseSkill should succeed with sufficient JP");
+            Assert.AreEqual(1, hero.SightRangeBonus,
+                "After purchasing Eagle Eye, SightRangeBonus should be 1");
+        }
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void EagleEye_MercenaryLearnSkill_HasSightRangeBonusOfOne()
+        {
+            // End-to-end via Mercenary.LearnSkill → ApplyPassiveSkills
+            var merc = new Mercenary("TestArcher", new Archer(), level: 5, new StatBlock(7, 9, 6, 4));
+            Assert.AreEqual(0, merc.SightRangeBonus, "Baseline: no SightRangeBonus before Eagle Eye learned");
+
+            merc.LearnSkill(new EagleEyePassive());
+
+            Assert.AreEqual(1, merc.SightRangeBonus,
+                "After learning Eagle Eye, Mercenary SightRangeBonus should be 1");
+        }
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void EagleEye_TwoInstancesStack()
+        {
+            // Verifies += behaviour (relevant if two sources could grant it)
+            var hero = MakeHero();
+            var passive = new EagleEyePassive();
+            passive.ApplyPassive(hero);
+            passive.ApplyPassive(hero);
+            Assert.AreEqual(2, hero.SightRangeBonus,
+                "Applying EagleEye passive twice should stack to +2 (each call does += 1)");
+        }
+
+        // ── Shadowstep — +20 evasion in GetBattleStats ──────────────────────────────
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void Shadowstep_Hero_EvasionIncreasedByTwenty()
+        {
+            var hero = MakeHero(agi: 10);
+            int baseEvasion = hero.GetBattleStats().Evasion;
+
+            var shadowstep = new ShadowstepPassive();
+            shadowstep.ApplyPassive(hero);
+
+            int buffedEvasion = hero.GetBattleStats().Evasion;
+            Assert.AreEqual(baseEvasion + 20, buffedEvasion,
+                "Shadowstep should raise Hero GetBattleStats().Evasion by exactly 20");
+        }
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void Shadowstep_Mercenary_EvasionIncreasedByTwenty()
+        {
+            var merc = MakeMerc(agi: 10);
+            int baseEvasion = merc.GetBattleStats().Evasion;
+
+            merc.LearnSkill(new ShadowstepPassive());
+
+            int buffedEvasion = merc.GetBattleStats().Evasion;
+            Assert.AreEqual(baseEvasion + 20, buffedEvasion,
+                "Shadowstep should raise Mercenary GetBattleStats().Evasion by exactly 20");
+        }
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void Shadowstep_Mercenary_ForgetSkill_EvasionReturnsToBaseline()
+        {
+            var merc = MakeMerc(agi: 10);
+            int baseEvasion = merc.GetBattleStats().Evasion;
+
+            merc.LearnSkill(new ShadowstepPassive());
+            merc.ForgetSkill("thief.shadowstep");
+
+            Assert.AreEqual(baseEvasion, merc.GetBattleStats().Evasion,
+                "After forgetting Shadowstep, evasion should return to baseline");
+        }
+
+        // ── Vanish — Untargetable buff declaration and lifecycle ─────────────────────
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void Vanish_DeclaresUntargetableGrantedBuff()
+        {
+            var vanish = new VanishSkill();
+
+            Assert.IsTrue(vanish.GrantedBuffs.Count > 0,
+                "VanishSkill should declare at least one GrantedBuff");
+
+            bool hasUntargetable = false;
+            for (int i = 0; i < vanish.GrantedBuffs.Count; i++)
+            {
+                if (vanish.GrantedBuffs[i].Type == BuffType.Untargetable)
+                {
+                    hasUntargetable = true;
+                    break;
+                }
+            }
+            Assert.IsTrue(hasUntargetable,
+                "VanishSkill GrantedBuffs must include an Untargetable buff");
+        }
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void Vanish_GrantedBuff_HasOneTurnDurationAndMaxStacksOne()
+        {
+            var vanish = new VanishSkill();
+            SkillBuff buff = default;
+            for (int i = 0; i < vanish.GrantedBuffs.Count; i++)
+            {
+                if (vanish.GrantedBuffs[i].Type == BuffType.Untargetable)
+                {
+                    buff = vanish.GrantedBuffs[i];
+                    break;
+                }
+            }
+
+            Assert.AreEqual(2, buff.DurationTurns,
+                "Vanish Untargetable buff should declare duration 2 (end-of-round tick consumes one turn in the cast round, so 2 = rest of cast round + all of next round)");
+            Assert.AreEqual(1, buff.MaxStacks,
+                "Vanish Untargetable buff should allow at most 1 stack");
+        }
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void Vanish_HasNoHPRestore_CategorizedAsBuff()
+        {
+            var vanish = new VanishSkill();
+            // Decision engine categorizes as buff when HPRestoreAmount==0 and GrantedBuffs.Count>0
+            Assert.AreEqual(0, vanish.HPRestoreAmount,
+                "VanishSkill should not restore HP (pure buff skill)");
+            Assert.IsTrue(vanish.GrantedBuffs.Count > 0,
+                "VanishSkill must have GrantedBuffs so the decision engine picks it up as a buff skill");
+        }
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void Vanish_AddBattleBuff_GetBuffTotal_IsPositive()
+        {
+            var hero = MakeHero();
+
+            // Simulate what ApplyHealingSkillEffectsAndDisplay does when processing GrantedBuffs
+            hero.AddBattleBuff(new BattleBuff(BuffType.Untargetable, magnitude: 1, remainingTurns: 1, sourceSkillId: "thief.vanish"));
+
+            Assert.IsTrue(hero.GetBuffTotal(BuffType.Untargetable) > 0,
+                "After adding Untargetable BattleBuff, GetBuffTotal(Untargetable) should be > 0");
+        }
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void Vanish_AfterTwoTickBuffDurations_UntargetableExpires()
+        {
+            var hero = MakeHero();
+            // DurationTurns:2 — one tick consumed at end of cast round, one at end of next round
+            hero.AddBattleBuff(new BattleBuff(BuffType.Untargetable, magnitude: 1, remainingTurns: 2, sourceSkillId: "thief.vanish"));
+            Assert.IsTrue(hero.GetBuffTotal(BuffType.Untargetable) > 0, "Precondition: buff should be active");
+
+            hero.TickBuffDurations(); // end of cast round
+            Assert.IsTrue(hero.GetBuffTotal(BuffType.Untargetable) > 0,
+                "After one tick (end of cast round), Untargetable should still be active");
+
+            hero.TickBuffDurations(); // end of next round
+            Assert.AreEqual(0, hero.GetBuffTotal(BuffType.Untargetable),
+                "Untargetable buff with duration 2 should expire after two TickBuffDurations calls");
+        }
+
+        // ── Sneak Attack — first-strike AGI conditioning ─────────────────────────────
+
+        /// <summary>
+        /// Fake IAttackResolver that always hits with a fixed damage amount.
+        /// Lets tests verify exactly how much damage SneakAttack adds on top.
+        /// </summary>
+        private sealed class FixedHitResolver : IAttackResolver
+        {
+            private readonly int _damage;
+            public FixedHitResolver(int damage) { _damage = damage; }
+
+            public AttackResult Resolve(in StatBlock attackerStats, in StatBlock defenderStats,
+                DamageKind kind, int attackerLevel, int defenderLevel)
+                => new AttackResult(hit: true, damage: _damage);
+        }
+
+        /// <summary>Minimal IBattleContext that always returns the configured IsFirst value.</summary>
+        private sealed class StubBattleContext : IBattleContext
+        {
+            public bool AlwaysFirst;
+            public StubBattleContext(bool alwaysFirst) { AlwaysFirst = alwaysFirst; }
+
+            public bool IsFirstOffensiveAction(ICombatant c) => AlwaysFirst;
+            public void MarkActed(ICombatant c) { }
+            public void RegisterDoT(IEnemy target, int damagePerTurn, int turns, string sourceSkillId, ICombatant actor) { }
+        }
+
+        /// <summary>IEnemy stub that accumulates total damage received.</summary>
+        private sealed class DamageAccumulator : IEnemy
+        {
+            private int _hp;
+            private readonly int _startHp;
+
+            public DamageAccumulator(int hp = 10000) { _hp = hp; _startHp = hp; MaxHP = hp; }
+
+            public int TotalDamageReceived { get; private set; }
+            public void ResetDamage() { TotalDamageReceived = 0; _hp = _startHp; }
+
+            public string Name => "DummyEnemy";
+            public EnemyId EnemyId => EnemyId.Slime;
+            public int Level => 1;
+            public StatBlock Stats => new StatBlock(1, 1, 1, 1);
+            public DamageKind AttackKind => DamageKind.Physical;
+            public ElementType Element => ElementType.Neutral;
+            public ElementalProperties ElementalProps => new ElementalProperties(ElementType.Neutral);
+            public int MaxHP { get; }
+            public int CurrentHP => _hp;
+            public int ExperienceYield => 0;
+            public int JPYield => 0;
+            public int SPYield => 0;
+            public int GoldYield => 0;
+            public float JoinPercentageModifier => 1.0f;
+            public bool IsBoss => false;
+            public bool IsRecruitable => false;
+
+            public bool TakeDamage(int amount)
+            {
+                if (amount <= 0) return false;
+                TotalDamageReceived += amount;
+                _hp -= amount;
+                if (_hp < 0) _hp = 0;
+                return _hp == 0;
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void SneakAttack_FirstAction_DealsBaseAndFullAGI()
+        {
+            // Caster with AGI = 20 (total stats will include job bonuses; use base 20 to get a known total)
+            var hero = new Hero("Rogue", new Thief(), level: 1, new StatBlock(5, 20, 5, 5));
+            int expectedAgi = hero.GetTotalStats().Agility;
+
+            var enemy = new DamageAccumulator();
+            var resolver = new FixedHitResolver(10); // base hit = 10
+            var context = new StubBattleContext(alwaysFirst: true);
+
+            var skill = new SneakAttackSkill();
+            skill.Execute(hero, enemy, new List<IEnemy>(), resolver, context);
+
+            int expected = 10 + expectedAgi;
+            Assert.AreEqual(expected, enemy.TotalDamageReceived,
+                $"First action: SneakAttack should deal base(10) + full AGI({expectedAgi}) = {expected}");
+        }
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void SneakAttack_SubsequentAction_DealsBaseAndHalfAGI()
+        {
+            var hero = new Hero("Rogue", new Thief(), level: 1, new StatBlock(5, 20, 5, 5));
+            int expectedAgi = hero.GetTotalStats().Agility;
+
+            var enemy = new DamageAccumulator();
+            var resolver = new FixedHitResolver(10);
+            var context = new StubBattleContext(alwaysFirst: false); // not the first action
+
+            var skill = new SneakAttackSkill();
+            skill.Execute(hero, enemy, new List<IEnemy>(), resolver, context);
+
+            int expected = 10 + expectedAgi / 2;
+            Assert.AreEqual(expected, enemy.TotalDamageReceived,
+                $"Subsequent action: SneakAttack should deal base(10) + AGI/2({expectedAgi / 2}) = {expected}");
+        }
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void SneakAttack_NullBattleContext_DealsBaseAndHalfAGI()
+        {
+            var hero = new Hero("Rogue", new Thief(), level: 1, new StatBlock(5, 20, 5, 5));
+            int expectedAgi = hero.GetTotalStats().Agility;
+
+            var enemy = new DamageAccumulator();
+            var resolver = new FixedHitResolver(10);
+
+            var skill = new SneakAttackSkill();
+            skill.Execute(hero, enemy, new List<IEnemy>(), resolver, null); // no battle context
+
+            int expected = 10 + expectedAgi / 2;
+            Assert.AreEqual(expected, enemy.TotalDamageReceived,
+                $"Out-of-battle (null context): SneakAttack should deal base(10) + AGI/2({expectedAgi / 2}) = {expected}");
+        }
+
+        // ── Quickdraw — RollFirstAttackCrit boundaries ──────────────────────────────
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void Quickdraw_RollFirstAttackCrit_FirstActionAndRollBelowChance_ReturnsCrit()
+        {
+            var caster = MakeHero();
+            caster.FirstAttackCritChance = 0.5f;
+
+            bool result = BattleReactionHelper.RollFirstAttackCrit(caster, isFirstAction: true, roll: 0.3f);
+
+            Assert.IsTrue(result,
+                "First action + roll (0.3) < chance (0.5) should return true (crit)");
+        }
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void Quickdraw_RollFirstAttackCrit_NotFirstAction_NeverCrits()
+        {
+            var caster = MakeHero();
+            caster.FirstAttackCritChance = 0.5f;
+
+            // Even with roll = 0 (guaranteed win) and high crit chance, non-first action never crits
+            bool result = BattleReactionHelper.RollFirstAttackCrit(caster, isFirstAction: false, roll: 0.0f);
+
+            Assert.IsFalse(result,
+                "Non-first action should never trigger a crit regardless of roll or chance");
+        }
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void Quickdraw_RollFirstAttackCrit_RollAtChance_NoCrit()
+        {
+            var caster = MakeHero();
+            caster.FirstAttackCritChance = 0.5f;
+
+            bool result = BattleReactionHelper.RollFirstAttackCrit(caster, isFirstAction: true, roll: 0.5f);
+
+            Assert.IsFalse(result,
+                "Roll equal to chance (not strictly less-than) should not crit");
+        }
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void Quickdraw_RollFirstAttackCrit_RollAboveChance_NoCrit()
+        {
+            var caster = MakeHero();
+            caster.FirstAttackCritChance = 0.5f;
+
+            bool result = BattleReactionHelper.RollFirstAttackCrit(caster, isFirstAction: true, roll: 0.8f);
+
+            Assert.IsFalse(result,
+                "Roll (0.8) above chance (0.5) should not crit");
+        }
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void Quickdraw_RollFirstAttackCrit_ZeroCritChance_NeverCrits()
+        {
+            var caster = MakeHero();
+            // Default FirstAttackCritChance = 0 (no Quickdraw passive)
+            Assert.AreEqual(0f, caster.FirstAttackCritChance);
+
+            bool result = BattleReactionHelper.RollFirstAttackCrit(caster, isFirstAction: true, roll: 0.0f);
+
+            Assert.IsFalse(result,
+                "Zero FirstAttackCritChance should never produce a crit even with roll = 0");
+        }
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void Quickdraw_PassiveApply_SetsCritChanceToHalf()
+        {
+            var hero = MakeHero();
+            Assert.AreEqual(0f, hero.FirstAttackCritChance, "Baseline: no crit chance before Quickdraw learned");
+
+            var quickdraw = new QuickdrawPassive();
+            quickdraw.ApplyPassive(hero);
+
+            Assert.AreEqual(0.5f, hero.FirstAttackCritChance, 0.001f,
+                "QuickdrawPassive should set FirstAttackCritChance to 0.5 (50%)");
+        }
+    }
+}

--- a/PitHero.Tests/TrapSystemTests.cs
+++ b/PitHero.Tests/TrapSystemTests.cs
@@ -1,0 +1,191 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RolePlayingFramework.Heroes;
+using RolePlayingFramework.Jobs.Primary;
+using RolePlayingFramework.Mercenaries;
+using RolePlayingFramework.Skills;
+using RolePlayingFramework.Stats;
+using System.Collections.Generic;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Unit tests for the Phase 6 minimal trap system:
+    /// TrapSensePassive sets TrapSense on hero and mercenary via learn/apply path;
+    /// CombatantPassiveApplier resets TrapSense; damage formula matches the constant;
+    /// direct ApplyPassive calls behave correctly.
+    /// </summary>
+    [TestClass]
+    public class TrapSystemTests
+    {
+        // ── Factory helpers ───────────────────────────────────────────────────────────
+
+        private static Hero MakeThiefHero(int str = 8, int agi = 12, int vit = 6, int mag = 5)
+            => new Hero("TestThief", new Thief(), level: 5, new StatBlock(str, agi, vit, mag));
+
+        private static Mercenary MakeThiefMerc(int str = 8, int agi = 12, int vit = 6, int mag = 5)
+            => new Mercenary("TestThiefMerc", new Thief(), level: 5, new StatBlock(str, agi, vit, mag));
+
+        // ── TrapSensePassive — direct ApplyPassive ────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("TrapSystem")]
+        public void TrapSensePassive_DirectApply_SetsTrapSenseTrue()
+        {
+            var hero = MakeThiefHero();
+            Assert.IsFalse(hero.TrapSense, "Baseline: TrapSense should be false before passive is applied");
+
+            var passive = new TrapSensePassive();
+            passive.ApplyPassive(hero);
+
+            Assert.IsTrue(hero.TrapSense, "After ApplyPassive, TrapSense should be true");
+        }
+
+        [TestMethod]
+        [TestCategory("TrapSystem")]
+        public void TrapSensePassive_DirectApply_SetsTrapSenseTrue_OnMercenary()
+        {
+            var merc = MakeThiefMerc();
+            Assert.IsFalse(merc.TrapSense, "Baseline: Mercenary TrapSense should be false before passive");
+
+            var passive = new TrapSensePassive();
+            passive.ApplyPassive(merc);
+
+            Assert.IsTrue(merc.TrapSense, "After ApplyPassive, Mercenary TrapSense should be true");
+        }
+
+        // ── TrapSensePassive — end-to-end via LearnSkill path ─────────────────────────
+
+        [TestMethod]
+        [TestCategory("TrapSystem")]
+        public void TrapSensePassive_MercenaryLearnSkill_HasTrapSenseTrue()
+        {
+            var merc = new Mercenary("Thief", new Thief(), level: 5, new StatBlock(8, 12, 6, 5));
+            Assert.IsFalse(merc.TrapSense, "Baseline: no TrapSense before learning the skill");
+
+            merc.LearnSkill(new TrapSensePassive());
+
+            Assert.IsTrue(merc.TrapSense,
+                "After Mercenary.LearnSkill(TrapSensePassive), TrapSense should be true");
+        }
+
+        [TestMethod]
+        [TestCategory("TrapSystem")]
+        public void TrapSensePassive_HeroTryPurchaseSkill_HasTrapSenseTrue()
+        {
+            // End-to-end via TryPurchaseSkill → CombatantPassiveApplier
+            var crystal = new HeroCrystal("ThiefCrystal", new Thief(), 1, new StatBlock(8, 12, 6, 5));
+            var hero = new Hero("Thief", crystal.Job, crystal.Level, crystal.BaseStats, crystal);
+            Assert.IsFalse(hero.TrapSense, "Baseline: no TrapSense before purchasing skill");
+
+            hero.EarnJP(100); // TrapSensePassive costs 90 JP
+            var thief = new Thief();
+            bool purchased = hero.TryPurchaseSkill(thief.Skills[1]); // Index 1 = TrapSensePassive
+
+            Assert.IsTrue(purchased, "TryPurchaseSkill should succeed with sufficient JP");
+            Assert.IsTrue(hero.TrapSense,
+                "After purchasing TrapSense, hero.TrapSense should be true");
+        }
+
+        // ── CombatantPassiveApplier — reset ───────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("TrapSystem")]
+        public void CombatantPassiveApplier_ResetAndApply_ClearsTrapSense_WhenNoSkillsLearned()
+        {
+            var hero = MakeThiefHero();
+            // Manually set TrapSense to true (simulating a previous apply)
+            hero.TrapSense = true;
+            Assert.IsTrue(hero.TrapSense, "Pre-condition: TrapSense manually set to true");
+
+            // Reset with no learned skills → TrapSense must be cleared
+            CombatantPassiveApplier.ResetAndApply(hero, new Dictionary<string, ISkill>());
+
+            Assert.IsFalse(hero.TrapSense,
+                "After ResetAndApply with no skills, TrapSense should be reset to false");
+        }
+
+        [TestMethod]
+        [TestCategory("TrapSystem")]
+        public void CombatantPassiveApplier_ResetAndApply_ClearsTrapSense_OnMercenary()
+        {
+            var merc = MakeThiefMerc();
+            merc.TrapSense = true;
+
+            CombatantPassiveApplier.ResetAndApply(merc, new Dictionary<string, ISkill>());
+
+            Assert.IsFalse(merc.TrapSense,
+                "After ResetAndApply with no skills, Mercenary TrapSense should be reset to false");
+        }
+
+        [TestMethod]
+        [TestCategory("TrapSystem")]
+        public void CombatantPassiveApplier_ResetAndApply_PreservesTrapSense_WhenSkillIsPresent()
+        {
+            var hero = MakeThiefHero();
+            Assert.IsFalse(hero.TrapSense, "Baseline: false before apply");
+
+            var skills = new Dictionary<string, ISkill>
+            {
+                { "thief.trap_sense", new TrapSensePassive() }
+            };
+            CombatantPassiveApplier.ResetAndApply(hero, skills);
+
+            Assert.IsTrue(hero.TrapSense,
+                "After ResetAndApply with TrapSensePassive in skills, TrapSense should be true");
+        }
+
+        // ── Damage formula ─────────────────────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("TrapSystem")]
+        public void TrapDamageFormula_PitLevel1_Returns7()
+        {
+            // Formula: 5 + pitLevel * 2
+            const int pitLevel = 1;
+            const int expected = 7; // 5 + 1*2
+
+            // Verify the formula via GameConfig constants to ensure it stays in sync
+            int actual = 5 + pitLevel * 2;
+            Assert.AreEqual(expected, actual,
+                "Trap damage at pit level 1 should be 7 (5 + 1*2)");
+        }
+
+        [TestMethod]
+        [TestCategory("TrapSystem")]
+        public void TrapDamageFormula_PitLevel10_Returns25()
+        {
+            const int pitLevel = 10;
+            const int expected = 25; // 5 + 10*2
+            int actual = 5 + pitLevel * 2;
+            Assert.AreEqual(expected, actual,
+                "Trap damage at pit level 10 should be 25 (5 + 10*2)");
+        }
+
+        [TestMethod]
+        [TestCategory("TrapSystem")]
+        public void TrapDamageFormula_PitLevel25_Returns55()
+        {
+            const int pitLevel = 25;
+            const int expected = 55; // 5 + 25*2
+            int actual = 5 + pitLevel * 2;
+            Assert.AreEqual(expected, actual,
+                "Trap damage at pit level 25 should be 55 (5 + 25*2)");
+        }
+
+        // ── TrapSense passive does not stack (CombatantPassiveApplier owns reset) ──────
+
+        [TestMethod]
+        [TestCategory("TrapSystem")]
+        public void TrapSensePassive_AppliedTwice_TrapSenseRemainsTrue()
+        {
+            // TrapSense is a bool — applying twice is idempotent
+            var hero = MakeThiefHero();
+            var passive = new TrapSensePassive();
+            passive.ApplyPassive(hero);
+            passive.ApplyPassive(hero);
+
+            Assert.IsTrue(hero.TrapSense,
+                "Applying TrapSensePassive twice leaves TrapSense true (bool assign is idempotent)");
+        }
+    }
+}

--- a/PitHero/AI/AttackMonsterAction.cs
+++ b/PitHero/AI/AttackMonsterAction.cs
@@ -370,7 +370,10 @@ namespace PitHero.AI
 
                 var hero = heroComponent.LinkedHero;
                 var attackResolver = new EnhancedAttackResolver();
-                var heroBattleStats = BattleStats.CalculateForHero(hero);
+
+                // Phase 3: battle-scoped buff/context setup
+                var battleContext = new BattleContext();
+                hero.ClearBattleState();
 
                 // Build participant list
                 var participants = new List<BattleParticipant>();
@@ -385,6 +388,7 @@ namespace PitHero.AI
                     {
                         participants.Add(new BattleParticipant(mercEntity, true));
                         validMercenaries.Add(mercEntity);
+                        mercComponent.LinkedMercenary.ClearBattleState(); // Phase 3: clear any leaked buff state
                         Debug.Log($"[AttackMonster] {mercComponent.LinkedMercenary.Name} (Lv.{mercComponent.LinkedMercenary.Level}) joins the battle!");
                     }
                 }
@@ -469,11 +473,11 @@ namespace PitHero.AI
 
                         // Execute participant's turn
                         if (participant.Type == BattleParticipant.ParticipantType.Hero)
-                            yield return ExecuteHeroTurn(heroComponent, hero, validMonsters, validMercenaries, heroBattleStats, attackResolver);
+                            yield return ExecuteHeroTurn(heroComponent, hero, validMonsters, validMercenaries, attackResolver, battleContext);
                         else if (participant.Type == BattleParticipant.ParticipantType.Mercenary)
-                            yield return ExecuteMercenaryTurn(participant, heroComponent, hero, validMonsters, validMercenaries, attackResolver);
+                            yield return ExecuteMercenaryTurn(participant, heroComponent, hero, validMonsters, validMercenaries, attackResolver, battleContext);
                         else
-                            yield return ExecuteMonsterTurn(participant, heroComponent, hero, heroBattleStats, validMercenaries, attackResolver);
+                            yield return ExecuteMonsterTurn(participant, heroComponent, hero, validMonsters, validMercenaries, attackResolver);
 
                         yield return WaitForSecondsRespectingPause(GameConfig.BattleTurnWait);
 
@@ -485,6 +489,23 @@ namespace PitHero.AI
                             break;
                         }
                     }
+
+                    // Phase 3: end-of-round ticks — regen, buff durations, and enemy DoTs
+                    if (hero.CurrentHP > 0)
+                    {
+                        hero.TickRegeneration();
+                        hero.TickBuffDurations();
+                    }
+                    for (int i = 0; i < validMercenaries.Count; i++)
+                    {
+                        var mc = validMercenaries[i]?.GetComponent<MercenaryComponent>();
+                        if (mc?.LinkedMercenary != null && mc.LinkedMercenary.CurrentHP > 0)
+                        {
+                            mc.LinkedMercenary.TickRegeneration();
+                            mc.LinkedMercenary.TickBuffDurations();
+                        }
+                    }
+                    yield return TickDoTsAndHandleDeaths(battleContext, validMonsters, validMercenaries, hero, heroComponent);
 
                     yield return WaitForSecondsRespectingPause(GameConfig.BattleTurnWait);
                 }
@@ -498,6 +519,19 @@ namespace PitHero.AI
             {
                 HeroStateMachine.IsBattleInProgress = false;
                 existingMultiParticipantBattleCoroutine = null;
+
+                // Phase 3: clear all battle buffs so they never leak out of battle
+                var heroForClean = heroComponent?.LinkedHero;
+                if (heroForClean != null) heroForClean.ClearBattleState();
+
+                if (validMercenaries != null)
+                {
+                    for (int i = 0; i < validMercenaries.Count; i++)
+                    {
+                        var mc = validMercenaries[i]?.GetComponent<MercenaryComponent>();
+                        mc?.LinkedMercenary?.ClearBattleState();
+                    }
+                }
 
                 if (turnIndicatorEntity != null)
                     turnIndicatorEntity.Destroy();
@@ -712,6 +746,63 @@ namespace PitHero.AI
         }
 
         /// <summary>
+        /// Displays a "Deflect" text on an entity and waits for the bounce animation.
+        /// Used when a combatant's DeflectChance passive triggers (Phase 3).
+        /// </summary>
+        private System.Collections.IEnumerator ShowDeflectTextOnEntity(Entity entity, Color textColor)
+        {
+            var bouncyText = entity?.GetComponent<BouncyTextComponent>();
+            if (bouncyText != null)
+            {
+                bouncyText.Init("Deflect", textColor);
+                bouncyText.SetEnabled(true);
+                yield return WaitForSecondsRespectingPause(GameConfig.BattleDigitBounceWait);
+            }
+        }
+
+        /// <summary>
+        /// Displays a "Crit" text on an entity and waits for the bounce animation.
+        /// Used when a Quickdraw first-attack critical hit triggers (Phase 4).
+        /// </summary>
+        private System.Collections.IEnumerator ShowCritTextOnEntity(Entity entity, Color textColor)
+        {
+            var bouncyText = entity?.GetComponent<BouncyTextComponent>();
+            if (bouncyText != null)
+            {
+                bouncyText.Init("Crit", textColor);
+                bouncyText.SetEnabled(true);
+                yield return WaitForSecondsRespectingPause(GameConfig.BattleDigitBounceWait);
+            }
+        }
+
+        /// <summary>
+        /// Displays a short buff label (e.g. "DEF+1") on an entity and waits for the bounce animation.
+        /// Used when GrantedBuffs are applied to a combatant via a skill (Phase 3).
+        /// </summary>
+        private System.Collections.IEnumerator ShowBuffTextOnEntity(Entity entity, string label, Color textColor)
+        {
+            var bouncyText = entity?.GetComponent<BouncyTextComponent>();
+            if (bouncyText != null)
+            {
+                bouncyText.Init(label, textColor);
+                bouncyText.SetEnabled(true);
+                yield return WaitForSecondsRespectingPause(GameConfig.BattleDigitBounceWait);
+            }
+        }
+
+        /// <summary>
+        /// Returns a short display label for a buff grant, e.g. "DEF+1" or "EVA+40".
+        /// Used for the bounce-text overlay when a buff is applied (Phase 3).
+        /// </summary>
+        private static string GetBuffLabel(BuffType type, int magnitude)
+        {
+            if (type == BuffType.DefenseUp) return "DEF+" + magnitude;
+            if (type == BuffType.EvasionUp) return "EVA+" + magnitude;
+            if (type == BuffType.MPRegen)   return "MP+" + magnitude;
+            return type.ToString() + "+" + magnitude;
+        }
+
+        /// <summary>
         /// Displays a green heal number on an entity and waits for the bounce animation.
         /// </summary>
         private System.Collections.IEnumerator ShowHealDigitOnEntity(Entity entity, int amount)
@@ -728,7 +819,8 @@ namespace PitHero.AI
         // ─── Shared action application helpers ───────────────────────────────────
 
         /// <summary>
-        /// Applies a healing skill's HP/MP restore effects and displays the heal digit.
+        /// Applies a healing skill's HP/MP restore effects, GrantedBuffs, and CleansesDebuffs flag,
+        /// then displays the appropriate heal digit / buff text.
         /// The caller is responsible for spending MP before calling this method.
         /// </summary>
         private System.Collections.IEnumerator ApplyHealingSkillEffectsAndDisplay(ISkill skill, object caster, object healTarget, bool targetsHero, HeroComponent heroComponent, List<Entity> validMercenaries, string casterName)
@@ -768,6 +860,29 @@ namespace PitHero.AI
                     mpHero.RestoreMP(skill.MPRestoreAmount);
                 else if (healTarget is Mercenary mpMerc)
                     mpMerc.RestoreMP(skill.MPRestoreAmount);
+            }
+
+            // Phase 3: CleansesDebuffs — seam for a future debuff system (no debuffs exist yet)
+            // When Phase 5+ adds debuff types, call combatantTarget.ClearDebuffs() here.
+
+            // Phase 3: apply GrantedBuffs to the target combatant
+            var combatantTarget = healTarget as ICombatant;
+            if (combatantTarget != null && skill.GrantedBuffs.Count > 0)
+            {
+                var targetEntity2 = FindTargetEntity(healTarget, targetsHero, heroComponent, validMercenaries);
+                for (int b = 0; b < skill.GrantedBuffs.Count; b++)
+                {
+                    var grantedBuff = skill.GrantedBuffs[b];
+                    // Count stacks for this specific buff type so multi-buff skills (e.g. FadeSkill
+                    // granting EvasionUp + MPRegen) don't block their second type when the first is capped.
+                    int currentStacks = combatantTarget.GetBuffStacks(skill.Id, grantedBuff.Type);
+                    if (currentStacks >= grantedBuff.MaxStacks)
+                        continue;
+
+                    combatantTarget.AddBattleBuff(new BattleBuff(grantedBuff.Type, grantedBuff.Magnitude, grantedBuff.DurationTurns, skill.Id));
+                    string buffLabel = GetBuffLabel(grantedBuff.Type, grantedBuff.Magnitude);
+                    yield return ShowBuffTextOnEntity(targetEntity2, buffLabel, Color.Cyan);
+                }
             }
         }
 
@@ -909,7 +1024,7 @@ namespace PitHero.AI
         /// Executes the hero's turn: dequeues and re-evaluates their queued action,
         /// then dispatches to the appropriate action handler.
         /// </summary>
-        private System.Collections.IEnumerator ExecuteHeroTurn(HeroComponent heroComponent, Hero hero, List<Entity> validMonsters, List<Entity> validMercenaries, BattleStats heroBattleStats, EnhancedAttackResolver attackResolver)
+        private System.Collections.IEnumerator ExecuteHeroTurn(HeroComponent heroComponent, Hero hero, List<Entity> validMonsters, List<Entity> validMercenaries, EnhancedAttackResolver attackResolver, BattleContext battleContext)
         {
             if (!heroComponent.InsidePit)
                 yield break;
@@ -936,9 +1051,10 @@ namespace PitHero.AI
                 var skill = queuedAction.Skill;
                 Debug.Log($"[AttackMonster] Using queued skill: {skill.Name}");
 
-                if (hero.CurrentMP >= skill.MPCost)
+                if (hero.CurrentMP >= hero.GetEffectiveMPCost(skill.MPCost))
                 {
                     bool isHealingSkill = skill.HPRestoreAmount > 0 || skill.MPRestoreAmount > 0 ||
+                        skill.GrantedBuffs.Count > 0 ||
                         skill.TargetType == SkillTargetType.Self ||
                         skill.TargetType == SkillTargetType.SingleAlly ||
                         skill.TargetType == SkillTargetType.AllAllies;
@@ -952,7 +1068,7 @@ namespace PitHero.AI
                     }
                     else
                     {
-                        yield return ExecuteHeroAttackSkill(skill, hero, heroComponent, validMonsters, validMercenaries, attackResolver);
+                        yield return ExecuteHeroAttackSkill(skill, hero, heroComponent, validMonsters, validMercenaries, attackResolver, battleContext);
                     }
                 }
                 else
@@ -962,19 +1078,73 @@ namespace PitHero.AI
             }
             else if (queuedAction.ActionType == QueuedActionType.Attack)
             {
-                yield return ExecuteHeroPhysicalAttack(queuedAction, hero, heroComponent, validMonsters, validMercenaries, heroBattleStats, attackResolver);
+                yield return ExecuteHeroPhysicalAttack(queuedAction, hero, heroComponent, validMonsters, validMercenaries, attackResolver, battleContext);
             }
         }
 
         /// <summary>
         /// Executes the hero's attack skill against living monsters.
+        /// Delegates to the shared <see cref="ExecuteCombatantAttackSkill"/> coroutine.
         /// </summary>
-        private System.Collections.IEnumerator ExecuteHeroAttackSkill(ISkill skill, Hero hero, HeroComponent heroComponent, List<Entity> validMonsters, List<Entity> validMercenaries, EnhancedAttackResolver attackResolver)
+        private System.Collections.IEnumerator ExecuteHeroAttackSkill(ISkill skill, Hero hero, HeroComponent heroComponent, List<Entity> validMonsters, List<Entity> validMercenaries, EnhancedAttackResolver attackResolver, BattleContext battleContext)
+        {
+            hero.SpendMP(skill.MPCost);
+            Debug.Log($"[AttackMonster] Successfully used {skill.Name}, consumed {skill.MPCost} MP");
+            yield return ExecuteCombatantAttackSkill(skill, hero, "hero", validMonsters, validMercenaries, hero, heroComponent, heroComponent, attackResolver, battleContext);
+        }
+
+        /// <summary>
+        /// Reorders <paramref name="livingMonsters"/> so that <paramref name="preferredEntity"/>
+        /// (if alive and present) is at index 0. All other entries shift right.
+        /// When preferred is null, already at index 0, or not in the list, the list is unchanged.
+        /// Extracted as a testable static helper for Fix 3 (merc single-target targeting).
+        /// </summary>
+        public static void SelectPrimaryTarget(List<Entity> livingMonsters, Entity preferredEntity)
+        {
+            if (preferredEntity == null || livingMonsters.Count == 0) return;
+            for (int i = 1; i < livingMonsters.Count; i++)
+            {
+                if (livingMonsters[i] == preferredEntity)
+                {
+                    // Swap preferred to index 0
+                    var tmp = livingMonsters[0];
+                    livingMonsters[0] = livingMonsters[i];
+                    livingMonsters[i] = tmp;
+                    return;
+                }
+            }
+            // preferred not found (already [0], died, or not in list) — no change needed
+        }
+
+        /// <summary>
+        /// Shared battle-skill execution coroutine for both the hero and mercenaries.
+        /// Snapshots HP before <see cref="ISkill.Execute"/> runs, then diffs per-monster
+        /// damage for display, analytics, rewards and boss handling.
+        /// </summary>
+        /// <param name="rewardHeroComponent">
+        /// Passed to <see cref="AwardEnemyDeathRewards"/>. Pass the real heroComponent for
+        /// hero kills (resets InnExhausted); pass null for mercenary kills (preserves the
+        /// original behaviour where mercs did not reset InnExhausted).
+        /// </param>
+        /// <param name="preferredTargetEntity">
+        /// When non-null, this entity is moved to index 0 of livingMonsters (becomes the primary
+        /// target). Pass <see langword="null"/> for the hero path (random primary). Mercs pass
+        /// <c>decision.TargetEntity</c> so the decision engine's chosen target is honoured.
+        /// </param>
+        private System.Collections.IEnumerator ExecuteCombatantAttackSkill(
+            ISkill skill, ICombatant caster, string actorType,
+            List<Entity> validMonsters, List<Entity> validMercenaries,
+            Hero hero, HeroComponent heroComponent, HeroComponent rewardHeroComponent,
+            EnhancedAttackResolver attackResolver, BattleContext battleContext = null,
+            Entity preferredTargetEntity = null)
         {
             var livingMonsters = GetLivingMonsters(validMonsters);
             if (livingMonsters.Count == 0) yield break;
 
-            // Snapshot HP before the skill executes so we can calculate per-monster damage
+            // Honour the merc's chosen target: move preferred entity to index 0 so it becomes primary.
+            SelectPrimaryTarget(livingMonsters, preferredTargetEntity);
+
+            // Snapshot HP before skill executes so we can calculate per-monster damage
             var monsterHPBefore = new Dictionary<RolePlayingFramework.Enemies.IEnemy, int>();
             for (int i = 0; i < livingMonsters.Count; i++)
             {
@@ -983,7 +1153,8 @@ namespace PitHero.AI
                     monsterHPBefore[enemyComp.Enemy] = enemyComp.Enemy.CurrentHP;
             }
 
-            var primaryTarget = livingMonsters[0].GetComponent<EnemyComponent>()?.Enemy;
+            var primaryMonsterEntity = livingMonsters[0];
+            var primaryTarget = primaryMonsterEntity.GetComponent<EnemyComponent>()?.Enemy;
             var surroundingTargets = new List<RolePlayingFramework.Enemies.IEnemy>();
             for (int i = 1; i < livingMonsters.Count; i++)
             {
@@ -992,11 +1163,36 @@ namespace PitHero.AI
                     surroundingTargets.Add(enemyComp.Enemy);
             }
 
-            skill.Execute(hero, primaryTarget, surroundingTargets, attackResolver);
-            hero.SpendMP(skill.MPCost);
-            Debug.Log($"[AttackMonster] Successfully used {skill.Name}, consumed {skill.MPCost} MP");
+            // Phase 4: Quickdraw — check first-action crit BEFORE Execute so SneakAttack (which also
+            // reads IsFirstOffensiveAction) and the crit roll both see the unmodified "first action" flag.
+            bool isCrit = BattleReactionHelper.RollFirstAttackCrit(caster,
+                battleContext != null && battleContext.IsFirstOffensiveAction(caster),
+                Nez.Random.NextFloat());
+
+            skill.Execute(caster, primaryTarget, surroundingTargets, attackResolver, battleContext);
+
+            // Phase 4: Quickdraw crit — apply a second damage pass equal to the initial damage dealt
+            // to each living monster (doubles final damage on the first offensive action).
+            if (isCrit)
+            {
+                for (int ci = 0; ci < livingMonsters.Count; ci++)
+                {
+                    var critComp = livingMonsters[ci].GetComponent<EnemyComponent>();
+                    if (critComp?.Enemy == null) continue;
+                    var critE = critComp.Enemy;
+                    if (!monsterHPBefore.TryGetValue(critE, out int critHpB)) continue;
+                    int firstPassDmg = critHpB - critE.CurrentHP;
+                    if (firstPassDmg > 0 && critE.CurrentHP > 0)
+                        critE.TakeDamage(firstPassDmg);
+                }
+            }
+
+            // Phase 4: MarkActed after Execute so SneakAttack's own IsFirstOffensiveAction check
+            // inside Execute() is still accurate.
+            battleContext?.MarkActed(caster);
 
             // Display damage and handle deaths for all affected monsters
+            bool critTextShown = false;
             for (int i = livingMonsters.Count - 1; i >= 0; i--)
             {
                 var monsterEntity = livingMonsters[i];
@@ -1007,20 +1203,36 @@ namespace PitHero.AI
                 if (!monsterHPBefore.TryGetValue(enemy, out int hpBefore)) continue;
 
                 int damage = hpBefore - enemy.CurrentHP;
-                if (damage <= 0) continue;
+                if (damage <= 0)
+                {
+                    // Fix 6: show "Miss" on the primary target only when the skill executed but dealt 0 damage.
+                    // Surrounding targets that are unaffected (e.g. AoE single-target) don't get miss text.
+                    if (monsterEntity == primaryMonsterEntity && enemy.CurrentHP > 0)
+                        yield return ShowMissTextOnEntity(monsterEntity, BouncyTextComponent.EnemyMissColor);
+                    continue;
+                }
 
                 Debug.Log($"[AttackMonster] {skill.Name} dealt {damage} damage to {enemy.Name}. Enemy HP: {enemy.CurrentHP}/{enemy.MaxHP}");
 
-                var evtSvcSkill = Core.Services.GetService<GameEventService>();
-                if (evtSvcSkill != null)
-                    evtSvcSkill.EmitLocalized(UITextKey.ConsoleSkillAttack,
-                        (hero.Name, GameConfig.ConsoleColorHeroName),
+                var evtSvc = Core.Services.GetService<GameEventService>();
+                if (evtSvc != null)
+                    evtSvc.EmitLocalized(UITextKey.ConsoleSkillAttack,
+                        (caster.Name, GameConfig.ConsoleColorHeroName),
                         (skill.Name, Color.White),
-                        (evtSvcSkill.MonsterName(enemy.Name), GameConfig.ConsoleColorEnemyName),
+                        (evtSvc.MonsterName(enemy.Name), GameConfig.ConsoleColorEnemyName),
                         (damage.ToString(), Color.White));
 
-                PitHero.Services.Analytics.AnalyticsService.LogAttack(hero.Name, "hero", skill.Id,
+                // Phase 4: log with ".crit" suffix when Quickdraw critical hit fires
+                string analyticsSkillId = isCrit ? (skill.Id + ".crit") : skill.Id;
+                PitHero.Services.Analytics.AnalyticsService.LogAttack(caster.Name, actorType, analyticsSkillId,
                     enemy.Name, "monster", damage, hpBefore, enemy.CurrentHP, enemy.CurrentHP <= 0);
+
+                // Phase 4: show "Crit" text on the first affected monster
+                if (isCrit && !critTextShown)
+                {
+                    yield return ShowCritTextOnEntity(monsterEntity, Color.Yellow);
+                    critTextShown = true;
+                }
 
                 var enemyBouncyDigit = monsterEntity.GetComponent<BouncyDigitComponent>();
                 if (enemyBouncyDigit != null)
@@ -1032,13 +1244,13 @@ namespace PitHero.AI
                 if (enemy.CurrentHP <= 0)
                 {
                     Debug.Log($"[AttackMonster] {enemy.Name} defeated by {skill.Name}!");
-                    AwardEnemyDeathRewards(hero, enemy, heroComponent, validMercenaries);
+                    AwardEnemyDeathRewards(hero, enemy, rewardHeroComponent, validMercenaries);
                     HandleBossDefeated(enemy, heroComponent);
 
-                    var evtSvcSkillDeath = Core.Services.GetService<GameEventService>();
-                    if (evtSvcSkillDeath != null)
-                        evtSvcSkillDeath.EmitLocalized(enemy.IsBoss ? EventPriority.High : EventPriority.Normal, UITextKey.ConsoleMonsterDied,
-                            (evtSvcSkillDeath.MonsterName(enemy.Name), GameConfig.ConsoleColorEnemyName));
+                    var evtSvcDeath = Core.Services.GetService<GameEventService>();
+                    if (evtSvcDeath != null)
+                        evtSvcDeath.EmitLocalized(enemy.IsBoss ? EventPriority.High : EventPriority.Normal, UITextKey.ConsoleMonsterDied,
+                            (evtSvcDeath.MonsterName(enemy.Name), GameConfig.ConsoleColorEnemyName));
 
                     validMonsters.Remove(monsterEntity);
                 }
@@ -1050,8 +1262,10 @@ namespace PitHero.AI
 
         /// <summary>
         /// Executes the hero's physical attack against a random living monster.
+        /// Hero battle stats are computed fresh to reflect any active buffs.
+        /// Phase 4: accepts <paramref name="battleContext"/> for first-attack crit (Quickdraw) and MarkActed.
         /// </summary>
-        private System.Collections.IEnumerator ExecuteHeroPhysicalAttack(QueuedAction queuedAction, Hero hero, HeroComponent heroComponent, List<Entity> validMonsters, List<Entity> validMercenaries, BattleStats heroBattleStats, EnhancedAttackResolver attackResolver)
+        private System.Collections.IEnumerator ExecuteHeroPhysicalAttack(QueuedAction queuedAction, Hero hero, HeroComponent heroComponent, List<Entity> validMonsters, List<Entity> validMercenaries, EnhancedAttackResolver attackResolver, BattleContext battleContext = null)
         {
             var livingMonsters = GetLivingMonsters(validMonsters);
             if (livingMonsters.Count == 0) yield break;
@@ -1060,8 +1274,18 @@ namespace PitHero.AI
             var targetEnemy = targetMonster.GetComponent<EnemyComponent>().Enemy;
             var targetBattleStats = BattleStats.CalculateForMonster(targetEnemy);
 
+            // Phase 3: compute fresh to reflect live buffs (e.g. DefenseUp already applies here
+            // only to defense; attack isn't buffed yet — still accurate for the attacker side)
+            var heroBattleStats = hero.GetBattleStats();
+
             Debug.Log($"[AttackMonster] Hero's turn - attacking {targetEnemy.Name}");
             var heroAttackResult = attackResolver.Resolve(heroBattleStats, targetBattleStats, DamageKind.Physical);
+
+            // Phase 4: Quickdraw — roll first-attack crit before dealing damage
+            bool isCrit = BattleReactionHelper.RollFirstAttackCrit(hero,
+                battleContext != null && battleContext.IsFirstOffensiveAction(hero),
+                Nez.Random.NextFloat());
+            battleContext?.MarkActed(hero);
 
             if (queuedAction.WeaponItem == null)
             {
@@ -1072,19 +1296,25 @@ namespace PitHero.AI
             if (heroAttackResult.Hit)
             {
                 int heroTargetHpBefore = targetEnemy.CurrentHP;
-                bool enemyDied = targetEnemy.TakeDamage(heroAttackResult.Damage);
-                Debug.Log($"[AttackMonster] Hero deals {heroAttackResult.Damage} damage to {targetEnemy.Name}. Enemy HP: {targetEnemy.CurrentHP}/{targetEnemy.MaxHP}");
+                int finalDamage = isCrit ? heroAttackResult.Damage * 2 : heroAttackResult.Damage;
+                bool enemyDied = targetEnemy.TakeDamage(finalDamage);
+                Debug.Log($"[AttackMonster] Hero deals {finalDamage} damage to {targetEnemy.Name}. Enemy HP: {targetEnemy.CurrentHP}/{targetEnemy.MaxHP}");
 
-                PitHero.Services.Analytics.AnalyticsService.LogAttack(hero.Name, "hero", "physical",
-                    targetEnemy.Name, "monster", heroAttackResult.Damage, heroTargetHpBefore, targetEnemy.CurrentHP, enemyDied);
+                string physAction = isCrit ? "physical.crit" : "physical";
+                PitHero.Services.Analytics.AnalyticsService.LogAttack(hero.Name, "hero", physAction,
+                    targetEnemy.Name, "monster", finalDamage, heroTargetHpBefore, targetEnemy.CurrentHP, enemyDied);
 
                 var evtSvc = Core.Services.GetService<GameEventService>();
                 evtSvc?.EmitLocalized(UITextKey.ConsoleAttack,
                     (hero.Name, GameConfig.ConsoleColorHeroName),
                     (evtSvc?.MonsterName(targetEnemy.Name) ?? targetEnemy.Name, GameConfig.ConsoleColorEnemyName),
-                    (heroAttackResult.Damage.ToString(), Color.White));
+                    (finalDamage.ToString(), Color.White));
 
-                yield return ShowDamageDigitOnEntity(targetMonster, heroAttackResult.Damage, BouncyDigitComponent.EnemyDigitColor);
+                // Phase 4: show "Crit" text on the target monster before the damage digit
+                if (isCrit)
+                    yield return ShowCritTextOnEntity(targetMonster, Color.Yellow);
+
+                yield return ShowDamageDigitOnEntity(targetMonster, finalDamage, BouncyDigitComponent.EnemyDigitColor);
 
                 if (enemyDied)
                 {
@@ -1114,7 +1344,7 @@ namespace PitHero.AI
         /// Executes a mercenary's turn: decides their action and dispatches to the
         /// appropriate handler.
         /// </summary>
-        private System.Collections.IEnumerator ExecuteMercenaryTurn(BattleParticipant participant, HeroComponent heroComponent, Hero hero, List<Entity> validMonsters, List<Entity> validMercenaries, EnhancedAttackResolver attackResolver)
+        private System.Collections.IEnumerator ExecuteMercenaryTurn(BattleParticipant participant, HeroComponent heroComponent, Hero hero, List<Entity> validMonsters, List<Entity> validMercenaries, EnhancedAttackResolver attackResolver, BattleContext battleContext)
         {
             var mercComponent = participant.MercenaryEntity.GetComponent<MercenaryComponent>();
             if (mercComponent?.LinkedMercenary == null || mercComponent.LinkedMercenary.CurrentHP <= 0) yield break;
@@ -1133,7 +1363,7 @@ namespace PitHero.AI
                 case BattleAction.ActionKind.UseHealingSkill:
                 {
                     var healSkill = mercDecision.Skill;
-                    if (mercenary.CurrentMP >= healSkill.MPCost)
+                    if (mercenary.CurrentMP >= mercenary.GetEffectiveMPCost(healSkill.MPCost))
                     {
                         mercenary.UseMP(healSkill.MPCost);
                         mercComponent.ActionQueueVisualization?.ShowAction(new QueuedAction(healSkill));
@@ -1153,125 +1383,65 @@ namespace PitHero.AI
 
                 case BattleAction.ActionKind.UseAttackSkill:
                 {
-                    yield return ExecuteMercenaryAttackSkill(mercDecision, mercenary, mercComponent, mercBattleStats, participant, validMonsters, validMercenaries, hero, heroComponent, attackResolver);
+                    yield return ExecuteMercenaryAttackSkill(mercDecision, mercenary, mercComponent, mercBattleStats, participant, validMonsters, validMercenaries, hero, heroComponent, attackResolver, battleContext);
                     break;
                 }
 
                 case BattleAction.ActionKind.PhysicalAttack:
                 default:
                 {
-                    yield return ExecuteMercenaryPhysicalAttack(mercDecision, mercenary, mercComponent, mercBattleStats, participant, validMonsters, validMercenaries, hero, heroComponent, attackResolver);
+                    yield return ExecuteMercenaryPhysicalAttack(mercDecision, mercenary, mercComponent, mercBattleStats, participant, validMonsters, validMercenaries, hero, heroComponent, attackResolver, battleContext);
                     break;
                 }
             }
         }
 
         /// <summary>
-        /// Executes a mercenary's attack skill against living monsters.
+        /// Executes a mercenary's attack skill against living monsters using the real
+        /// skill formula via <see cref="ExecuteCombatantAttackSkill"/>.
         /// </summary>
-        private System.Collections.IEnumerator ExecuteMercenaryAttackSkill(BattleAction decision, Mercenary mercenary, MercenaryComponent mercComponent, BattleStats mercBattleStats, BattleParticipant participant, List<Entity> validMonsters, List<Entity> validMercenaries, Hero hero, HeroComponent heroComponent, EnhancedAttackResolver attackResolver)
+        private System.Collections.IEnumerator ExecuteMercenaryAttackSkill(BattleAction decision, Mercenary mercenary, MercenaryComponent mercComponent, BattleStats mercBattleStats, BattleParticipant participant, List<Entity> validMonsters, List<Entity> validMercenaries, Hero hero, HeroComponent heroComponent, EnhancedAttackResolver attackResolver, BattleContext battleContext = null)
         {
             var atkSkill = decision.Skill;
-            if (mercenary.CurrentMP < atkSkill.MPCost)
+
+            // SpendMP applies MPCostReduction and returns false when insufficient
+            if (!mercenary.SpendMP(atkSkill.MPCost))
             {
                 Debug.Log($"[AttackMonster] {mercenary.Name} not enough MP for {atkSkill.Name}");
                 yield break;
             }
 
-            mercenary.UseMP(atkSkill.MPCost);
             mercComponent.ActionQueueVisualization?.ShowAction(new QueuedAction(atkSkill));
 
-            var skillDamageKind = atkSkill.Element != ElementType.Neutral ? DamageKind.Magical : DamageKind.Physical;
             var skillLiving = GetLivingMonsters(validMonsters);
             if (skillLiving.Count == 0) yield break;
 
-            bool isAoE = atkSkill.TargetType == SkillTargetType.SurroundingEnemies;
-            int startIndex = 0;
-            int endIndex = isAoE ? skillLiving.Count : 1;
-
-            if (!isAoE && decision.TargetEntity != null)
+            // Face the preferred target if alive; otherwise face the first living monster.
+            Entity faceTarget = skillLiving[0];
+            if (decision.TargetEntity != null)
             {
-                for (int si = 0; si < skillLiving.Count; si++)
+                for (int fi = 0; fi < skillLiving.Count; fi++)
                 {
-                    if (skillLiving[si] == decision.TargetEntity)
+                    if (skillLiving[fi] == decision.TargetEntity)
                     {
-                        startIndex = si;
-                        endIndex = si + 1;
+                        faceTarget = decision.TargetEntity;
                         break;
                     }
                 }
             }
+            FaceTarget(participant.MercenaryEntity, faceTarget.Transform.Position);
 
-            for (int si = startIndex; si < endIndex && si < skillLiving.Count; si++)
-            {
-                var sMonsterEntity = skillLiving[si];
-                var sEnemyComp = sMonsterEntity.GetComponent<EnemyComponent>();
-                if (sEnemyComp?.Enemy == null || sEnemyComp.Enemy.CurrentHP <= 0) continue;
-
-                var sEnemy = sEnemyComp.Enemy;
-                var sTargetStats = BattleStats.CalculateForMonster(sEnemy);
-                var sResult = attackResolver.Resolve(mercBattleStats, sTargetStats, skillDamageKind);
-
-                FaceTarget(participant.MercenaryEntity, sMonsterEntity.Transform.Position);
-
-                if (sResult.Hit)
-                {
-                    int sHpBefore = sEnemy.CurrentHP;
-                    bool sEnemyDied = sEnemy.TakeDamage(sResult.Damage);
-                    Debug.Log($"[AttackMonster] {mercenary.Name}'s {atkSkill.Name} dealt {sResult.Damage} to {sEnemy.Name}. HP: {sEnemy.CurrentHP}/{sEnemy.MaxHP}");
-
-                    PitHero.Services.Analytics.AnalyticsService.LogAttack(mercenary.Name, "merc", atkSkill.Id,
-                        sEnemy.Name, "monster", sResult.Damage, sHpBefore, sEnemy.CurrentHP, sEnemyDied);
-
-                    var evtSvcAtkSkill = Core.Services.GetService<GameEventService>();
-                    if (evtSvcAtkSkill != null)
-                        evtSvcAtkSkill.EmitLocalized(UITextKey.ConsoleSkillAttack,
-                            (mercenary.Name, GameConfig.ConsoleColorHeroName),
-                            (atkSkill.Name, Color.White),
-                            (evtSvcAtkSkill.MonsterName(sEnemy.Name), GameConfig.ConsoleColorEnemyName),
-                            (sResult.Damage.ToString(), Color.White));
-
-                    var sDigit = sMonsterEntity.GetComponent<BouncyDigitComponent>();
-                    if (sDigit != null)
-                    {
-                        sDigit.Init(sResult.Damage, BouncyDigitComponent.EnemyDigitColor, false);
-                        sDigit.SetEnabled(true);
-                    }
-
-                    if (sEnemyDied)
-                    {
-                        Debug.Log($"[AttackMonster] {sEnemy.Name} defeated by {mercenary.Name}'s {atkSkill.Name}!");
-                        AwardEnemyDeathRewards(hero, sEnemy, null, validMercenaries);
-                        HandleBossDefeated(sEnemy, heroComponent);
-
-                        var evtSvcAtkSkillDeath = Core.Services.GetService<GameEventService>();
-                        if (evtSvcAtkSkillDeath != null)
-                            evtSvcAtkSkillDeath.EmitLocalized(sEnemy.IsBoss ? EventPriority.High : EventPriority.Normal, UITextKey.ConsoleMonsterDied,
-                                (evtSvcAtkSkillDeath.MonsterName(sEnemy.Name), GameConfig.ConsoleColorEnemyName));
-
-                        validMonsters.Remove(sMonsterEntity);
-                    }
-                }
-                else
-                {
-                    Debug.Log($"[AttackMonster] {mercenary.Name}'s {atkSkill.Name} missed {sEnemy.Name}!");
-                    var sMissText = sMonsterEntity.GetComponent<BouncyTextComponent>();
-                    if (sMissText != null)
-                    {
-                        sMissText.Init("Miss", BouncyTextComponent.EnemyMissColor);
-                        sMissText.SetEnabled(true);
-                    }
-                }
-            }
-
-            yield return WaitForSecondsRespectingPause(GameConfig.BattleDigitBounceWait);
-            yield return FadeOutDeadMonsters(skillLiving);
+            // Delegate to the shared coroutine; rewardHeroComponent=null preserves original
+            // behaviour where merc kills did not reset InnExhausted on the hero.
+            // Pass decision.TargetEntity so the merc's chosen target becomes the primary.
+            yield return ExecuteCombatantAttackSkill(atkSkill, mercenary, "merc", validMonsters, validMercenaries, hero, heroComponent, null, attackResolver, battleContext, decision.TargetEntity);
         }
 
         /// <summary>
         /// Executes a mercenary's physical attack against a target monster.
+        /// Phase 4: accepts <paramref name="battleContext"/> for first-attack crit (Quickdraw) and MarkActed.
         /// </summary>
-        private System.Collections.IEnumerator ExecuteMercenaryPhysicalAttack(BattleAction decision, Mercenary mercenary, MercenaryComponent mercComponent, BattleStats mercBattleStats, BattleParticipant participant, List<Entity> validMonsters, List<Entity> validMercenaries, Hero hero, HeroComponent heroComponent, EnhancedAttackResolver attackResolver)
+        private System.Collections.IEnumerator ExecuteMercenaryPhysicalAttack(BattleAction decision, Mercenary mercenary, MercenaryComponent mercComponent, BattleStats mercBattleStats, BattleParticipant participant, List<Entity> validMonsters, List<Entity> validMercenaries, Hero hero, HeroComponent heroComponent, EnhancedAttackResolver attackResolver, BattleContext battleContext = null)
         {
             var paTarget = decision.TargetEntity;
             if (paTarget == null || paTarget.GetComponent<EnemyComponent>()?.Enemy?.CurrentHP <= 0)
@@ -1290,26 +1460,38 @@ namespace PitHero.AI
 
             var mercAttackResult = attackResolver.Resolve(mercBattleStats, targetBattleStats, DamageKind.Physical);
 
+            // Phase 4: Quickdraw — roll first-attack crit before dealing damage
+            bool isCrit = BattleReactionHelper.RollFirstAttackCrit(mercenary,
+                battleContext != null && battleContext.IsFirstOffensiveAction(mercenary),
+                Nez.Random.NextFloat());
+            battleContext?.MarkActed(mercenary);
+
             SoundEffectManager soundEffectManager = Core.GetGlobalManager<SoundEffectManager>();
             soundEffectManager?.PlaySound(SoundEffectType.Punch);
 
             if (mercAttackResult.Hit)
             {
                 int mercTargetHpBefore = targetEnemy.CurrentHP;
-                bool enemyDied = targetEnemy.TakeDamage(mercAttackResult.Damage);
-                Debug.Log($"[AttackMonster] {mercenary.Name} deals {mercAttackResult.Damage} damage to {targetEnemy.Name}. Enemy HP: {targetEnemy.CurrentHP}/{targetEnemy.MaxHP}");
+                int finalDamage = isCrit ? mercAttackResult.Damage * 2 : mercAttackResult.Damage;
+                bool enemyDied = targetEnemy.TakeDamage(finalDamage);
+                Debug.Log($"[AttackMonster] {mercenary.Name} deals {finalDamage} damage to {targetEnemy.Name}. Enemy HP: {targetEnemy.CurrentHP}/{targetEnemy.MaxHP}");
 
-                PitHero.Services.Analytics.AnalyticsService.LogAttack(mercenary.Name, "merc", "physical",
-                    targetEnemy.Name, "monster", mercAttackResult.Damage, mercTargetHpBefore, targetEnemy.CurrentHP, enemyDied);
+                string mercPhysAction = isCrit ? "physical.crit" : "physical";
+                PitHero.Services.Analytics.AnalyticsService.LogAttack(mercenary.Name, "merc", mercPhysAction,
+                    targetEnemy.Name, "monster", finalDamage, mercTargetHpBefore, targetEnemy.CurrentHP, enemyDied);
 
                 var evtSvcMerc = Core.Services.GetService<GameEventService>();
                 if (evtSvcMerc != null)
                     evtSvcMerc.EmitLocalized(UITextKey.ConsoleAttack,
                         (mercenary.Name, GameConfig.ConsoleColorHeroName),
                         (evtSvcMerc.MonsterName(targetEnemy.Name), GameConfig.ConsoleColorEnemyName),
-                        (mercAttackResult.Damage.ToString(), Color.White));
+                        (finalDamage.ToString(), Color.White));
 
-                yield return ShowDamageDigitOnEntity(paTarget, mercAttackResult.Damage, BouncyDigitComponent.EnemyDigitColor);
+                // Phase 4: show "Crit" text on the target before the damage digit
+                if (isCrit)
+                    yield return ShowCritTextOnEntity(paTarget, Color.Yellow);
+
+                yield return ShowDamageDigitOnEntity(paTarget, finalDamage, BouncyDigitComponent.EnemyDigitColor);
 
                 if (enemyDied)
                 {
@@ -1338,7 +1520,7 @@ namespace PitHero.AI
         /// <summary>
         /// Executes a monster's turn: selects a random valid ally target and attacks.
         /// </summary>
-        private System.Collections.IEnumerator ExecuteMonsterTurn(BattleParticipant participant, HeroComponent heroComponent, Hero hero, BattleStats heroBattleStats, List<Entity> validMercenaries, EnhancedAttackResolver attackResolver)
+        private System.Collections.IEnumerator ExecuteMonsterTurn(BattleParticipant participant, HeroComponent heroComponent, Hero hero, List<Entity> validMonsters, List<Entity> validMercenaries, EnhancedAttackResolver attackResolver)
         {
             var enemyComponent = participant.MonsterEntity.GetComponent<EnemyComponent>();
             if (enemyComponent?.Enemy == null || enemyComponent.Enemy.CurrentHP <= 0) yield break;
@@ -1367,6 +1549,32 @@ namespace PitHero.AI
                 yield break;
             }
 
+            // Phase 4: Vanish — filter out untargetable allies; anti-stall guard skips filtering
+            // when every living ally is untargetable (prevents the monster from doing nothing forever).
+            int untargetableCount = 0;
+            for (int ui = 0; ui < possibleTargets.Count; ui++)
+            {
+                ICombatant utTarget = possibleTargets[ui].isHero
+                    ? (ICombatant)hero
+                    : possibleTargets[ui].entity.GetComponent<MercenaryComponent>()?.LinkedMercenary;
+                if (utTarget != null && utTarget.GetBuffTotal(BuffType.Untargetable) > 0)
+                    untargetableCount++;
+            }
+            if (untargetableCount > 0 && untargetableCount < possibleTargets.Count)
+            {
+                for (int ui = possibleTargets.Count - 1; ui >= 0; ui--)
+                {
+                    ICombatant utTarget = possibleTargets[ui].isHero
+                        ? (ICombatant)hero
+                        : possibleTargets[ui].entity.GetComponent<MercenaryComponent>()?.LinkedMercenary;
+                    if (utTarget != null && utTarget.GetBuffTotal(BuffType.Untargetable) > 0)
+                    {
+                        Debug.Log($"[AttackMonster] {enemy.Name} cannot target {utTarget.Name} (Vanish/Untargetable)");
+                        possibleTargets.RemoveAt(ui);
+                    }
+                }
+            }
+
             var targetChoice = possibleTargets[Nez.Random.Range(0, possibleTargets.Count)];
             var targetEntity = targetChoice.entity;
 
@@ -1383,17 +1591,31 @@ namespace PitHero.AI
                 yield return monsterAnim.PlayAttackAnimation();
 
             if (targetChoice.isHero)
-                yield return ExecuteMonsterAttackHero(enemy, enemyBattleStats, heroComponent, hero, heroBattleStats, attackResolver);
+                yield return ExecuteMonsterAttackHero(enemy, enemyBattleStats, participant.MonsterEntity, heroComponent, hero, validMonsters, validMercenaries, attackResolver);
             else
-                yield return ExecuteMonsterAttackMercenary(enemy, enemyBattleStats, targetEntity, heroComponent, validMercenaries, attackResolver);
+                yield return ExecuteMonsterAttackMercenary(enemy, enemyBattleStats, participant.MonsterEntity, targetEntity, heroComponent, validMonsters, validMercenaries, attackResolver);
         }
 
         /// <summary>
         /// Executes a monster's attack against the hero.
+        /// Phase 3: computes fresh hero battle stats (includes live buffs), checks deflect before
+        /// resolving the hit, and fires a counter-attack if the hero has Counter enabled and survived.
         /// </summary>
-        private System.Collections.IEnumerator ExecuteMonsterAttackHero(RolePlayingFramework.Enemies.IEnemy enemy, BattleStats enemyBattleStats, HeroComponent heroComponent, Hero hero, BattleStats heroBattleStats, EnhancedAttackResolver attackResolver)
+        private System.Collections.IEnumerator ExecuteMonsterAttackHero(RolePlayingFramework.Enemies.IEnemy enemy, BattleStats enemyBattleStats, Entity monsterEntity, HeroComponent heroComponent, Hero hero, List<Entity> validMonsters, List<Entity> validMercenaries, EnhancedAttackResolver attackResolver)
         {
             Debug.Log($"[AttackMonster] {enemy.Name}'s turn - attacking {hero.Name}");
+
+            // Phase 3: compute fresh hero stats so live buffs (DefenseUp, EvasionUp) count
+            var heroBattleStats = hero.GetBattleStats();
+
+            // Phase 3: deflect check — if the hero deflects, no hit, no counter
+            if (BattleReactionHelper.RollDeflect(hero, Nez.Random.NextFloat()))
+            {
+                Debug.Log($"[AttackMonster] {hero.Name} deflected {enemy.Name}'s attack!");
+                yield return ShowDeflectTextOnEntity(heroComponent.Entity, BouncyTextComponent.HeroMissColor);
+                yield break;
+            }
+
             var enemyAttackResult = attackResolver.Resolve(enemyBattleStats, heroBattleStats, enemy.AttackKind);
 
             if (enemyAttackResult.Hit)
@@ -1431,6 +1653,50 @@ namespace PitHero.AI
                         deathComponent = heroComponent.Entity.AddComponent(new HeroDeathComponent());
                     deathComponent.StartDeathAnimation(enemy.Name);
                 }
+                else if (BattleReactionHelper.ShouldCounter(hero))
+                {
+                    // Phase 3: hero counter-attack
+                    Debug.Log($"[AttackMonster] {hero.Name} counters {enemy.Name}!");
+                    var counterStats = hero.GetBattleStats();
+                    var counterResult = attackResolver.Resolve(counterStats, enemyBattleStats, DamageKind.Physical);
+                    if (counterResult.Hit)
+                    {
+                        int counterHpBefore = enemy.CurrentHP;
+                        bool counterKill = enemy.TakeDamage(counterResult.Damage);
+                        Debug.Log($"[AttackMonster] Counter: {hero.Name} deals {counterResult.Damage} to {enemy.Name}");
+
+                        PitHero.Services.Analytics.AnalyticsService.LogAttack(hero.Name, "hero", "counter",
+                            enemy.Name, "monster", counterResult.Damage, counterHpBefore, enemy.CurrentHP, counterKill);
+
+                        var evtSvcCounter = Core.Services.GetService<GameEventService>();
+                        evtSvcCounter?.EmitLocalized(UITextKey.ConsoleAttack,
+                            (hero.Name, GameConfig.ConsoleColorHeroName),
+                            (evtSvcCounter?.MonsterName(enemy.Name) ?? enemy.Name, GameConfig.ConsoleColorEnemyName),
+                            (counterResult.Damage.ToString(), Color.White));
+
+                        yield return ShowDamageDigitOnEntity(monsterEntity, counterResult.Damage, BouncyDigitComponent.EnemyDigitColor);
+
+                        if (counterKill)
+                        {
+                            Debug.Log($"[AttackMonster] {enemy.Name} defeated by counter! Starting fade out");
+                            AwardEnemyDeathRewards(hero, enemy, heroComponent, validMercenaries);
+                            HandleBossDefeated(enemy, heroComponent);
+
+                            var evtSvcCounterDeath = Core.Services.GetService<GameEventService>();
+                            if (evtSvcCounterDeath != null)
+                                evtSvcCounterDeath.EmitLocalized(enemy.IsBoss ? EventPriority.High : EventPriority.Normal,
+                                    UITextKey.ConsoleMonsterDied,
+                                    (evtSvcCounterDeath.MonsterName(enemy.Name), GameConfig.ConsoleColorEnemyName));
+
+                            validMonsters.Remove(monsterEntity);
+                            yield return FadeOutAndDestroyMonster(monsterEntity);
+                        }
+                    }
+                    else
+                    {
+                        yield return ShowMissTextOnEntity(monsterEntity, BouncyTextComponent.EnemyMissColor);
+                    }
+                }
             }
             else
             {
@@ -1441,8 +1707,11 @@ namespace PitHero.AI
 
         /// <summary>
         /// Executes a monster's attack against a mercenary.
+        /// Phase 3: computes fresh mercenary battle stats (includes live buffs), checks deflect
+        /// before resolving the hit, and fires a counter-attack if the mercenary has Counter enabled
+        /// and survived.
         /// </summary>
-        private System.Collections.IEnumerator ExecuteMonsterAttackMercenary(RolePlayingFramework.Enemies.IEnemy enemy, BattleStats enemyBattleStats, Entity targetEntity, HeroComponent heroComponent, List<Entity> validMercenaries, EnhancedAttackResolver attackResolver)
+        private System.Collections.IEnumerator ExecuteMonsterAttackMercenary(RolePlayingFramework.Enemies.IEnemy enemy, BattleStats enemyBattleStats, Entity monsterEntity, Entity targetEntity, HeroComponent heroComponent, List<Entity> validMonsters, List<Entity> validMercenaries, EnhancedAttackResolver attackResolver)
         {
             var targetMercComp = targetEntity.GetComponent<MercenaryComponent>();
             if (targetMercComp?.LinkedMercenary == null)
@@ -1452,9 +1721,20 @@ namespace PitHero.AI
             }
 
             var targetMercenary = targetMercComp.LinkedMercenary;
-            var targetMercBattleStats = BattleStats.CalculateForMercenary(targetMercenary);
+
+            // Phase 3: compute fresh stats so live buffs count
+            var targetMercBattleStats = targetMercenary.GetBattleStats();
 
             Debug.Log($"[AttackMonster] {enemy.Name}'s turn - attacking {targetMercenary.Name}");
+
+            // Phase 3: deflect check — if the mercenary deflects, no hit, no counter
+            if (BattleReactionHelper.RollDeflect(targetMercenary, Nez.Random.NextFloat()))
+            {
+                Debug.Log($"[AttackMonster] {targetMercenary.Name} deflected {enemy.Name}'s attack!");
+                yield return ShowDeflectTextOnEntity(targetEntity, BouncyTextComponent.HeroMissColor);
+                yield break;
+            }
+
             var enemyAttackResult = attackResolver.Resolve(enemyBattleStats, targetMercBattleStats, enemy.AttackKind);
 
             if (enemyAttackResult.Hit)
@@ -1490,6 +1770,51 @@ namespace PitHero.AI
                     HandleMercenaryDeath(targetEntity, heroComponent, enemy.Name);
                     validMercenaries.Remove(targetEntity);
                     yield return FadeOutAndDestroyMercenary(targetEntity);
+                }
+                else if (BattleReactionHelper.ShouldCounter(targetMercenary))
+                {
+                    // Phase 3: mercenary counter-attack
+                    Debug.Log($"[AttackMonster] {targetMercenary.Name} counters {enemy.Name}!");
+                    var counterStats = targetMercenary.GetBattleStats();
+                    var counterResult = attackResolver.Resolve(counterStats, enemyBattleStats, DamageKind.Physical);
+                    if (counterResult.Hit)
+                    {
+                        int counterHpBefore = enemy.CurrentHP;
+                        bool counterKill = enemy.TakeDamage(counterResult.Damage);
+                        Debug.Log($"[AttackMonster] Counter: {targetMercenary.Name} deals {counterResult.Damage} to {enemy.Name}");
+
+                        PitHero.Services.Analytics.AnalyticsService.LogAttack(targetMercenary.Name, "merc", "counter",
+                            enemy.Name, "monster", counterResult.Damage, counterHpBefore, enemy.CurrentHP, counterKill);
+
+                        var evtSvcCounter = Core.Services.GetService<GameEventService>();
+                        evtSvcCounter?.EmitLocalized(UITextKey.ConsoleAttack,
+                            (targetMercenary.Name, GameConfig.ConsoleColorHeroName),
+                            (evtSvcCounter?.MonsterName(enemy.Name) ?? enemy.Name, GameConfig.ConsoleColorEnemyName),
+                            (counterResult.Damage.ToString(), Color.White));
+
+                        yield return ShowDamageDigitOnEntity(monsterEntity, counterResult.Damage, BouncyDigitComponent.EnemyDigitColor);
+
+                        if (counterKill)
+                        {
+                            Debug.Log($"[AttackMonster] {enemy.Name} defeated by counter! Starting fade out");
+                            // Rewards credited to the hero (merc counters still award the party)
+                            AwardEnemyDeathRewards(heroComponent.LinkedHero, enemy, null, validMercenaries);
+                            HandleBossDefeated(enemy, heroComponent);
+
+                            var evtSvcCounterDeath = Core.Services.GetService<GameEventService>();
+                            if (evtSvcCounterDeath != null)
+                                evtSvcCounterDeath.EmitLocalized(enemy.IsBoss ? EventPriority.High : EventPriority.Normal,
+                                    UITextKey.ConsoleMonsterDied,
+                                    (evtSvcCounterDeath.MonsterName(enemy.Name), GameConfig.ConsoleColorEnemyName));
+
+                            validMonsters.Remove(monsterEntity);
+                            yield return FadeOutAndDestroyMonster(monsterEntity);
+                        }
+                    }
+                    else
+                    {
+                        yield return ShowMissTextOnEntity(monsterEntity, BouncyTextComponent.EnemyMissColor);
+                    }
                 }
             }
             else
@@ -1695,6 +2020,62 @@ namespace PitHero.AI
             mercenaryEntity.Destroy();
         }
 
+
+        /// <summary>
+        /// Ticks all active DoT entries in the battle context, shows damage digits on the
+        /// affected monster entities, logs analytics, and routes kills through the shared
+        /// reward/death helpers.
+        /// Called once per round after all participant turns complete.
+        /// </summary>
+        private System.Collections.IEnumerator TickDoTsAndHandleDeaths(BattleContext battleContext, List<Entity> validMonsters, List<Entity> validMercenaries, Hero hero, HeroComponent heroComponent)
+        {
+            var tickResults = battleContext.TickDoTs();
+            for (int i = 0; i < tickResults.Count; i++)
+            {
+                var result = tickResults[i];
+                if (result.Damage <= 0) continue;
+
+                // Find the entity for this enemy (search validMonsters by IEnemy reference)
+                Entity monsterEntity = null;
+                for (int m = 0; m < validMonsters.Count; m++)
+                {
+                    var ec = validMonsters[m]?.GetComponent<EnemyComponent>();
+                    if (ec != null && ReferenceEquals(ec.Enemy, result.Target))
+                    {
+                        monsterEntity = validMonsters[m];
+                        break;
+                    }
+                }
+
+                if (monsterEntity == null) continue;
+
+                Debug.Log($"[AttackMonster] DoT {result.SourceSkillId}: {result.Damage} dmg to {result.Target.Name}. HP: {result.Target.CurrentHP}/{result.Target.MaxHP}");
+
+                PitHero.Services.Analytics.AnalyticsService.LogAttack(
+                    result.ActorName, result.ActorType, result.SourceSkillId + ".dot",
+                    result.Target.Name, "monster",
+                    result.Damage, result.Target.CurrentHP + result.Damage, result.Target.CurrentHP,
+                    result.TargetDied);
+
+                yield return ShowDamageDigitOnEntity(monsterEntity, result.Damage, BouncyDigitComponent.EnemyDigitColor);
+
+                if (result.TargetDied)
+                {
+                    Debug.Log($"[AttackMonster] {result.Target.Name} defeated by DoT ({result.SourceSkillId})! Starting fade out");
+                    AwardEnemyDeathRewards(hero, result.Target, heroComponent, validMercenaries);
+                    HandleBossDefeated(result.Target, heroComponent);
+
+                    var evtSvcDotDeath = Core.Services.GetService<GameEventService>();
+                    if (evtSvcDotDeath != null)
+                        evtSvcDotDeath.EmitLocalized(result.Target.IsBoss ? EventPriority.High : EventPriority.Normal,
+                            UITextKey.ConsoleMonsterDied,
+                            (evtSvcDotDeath.MonsterName(result.Target.Name), GameConfig.ConsoleColorEnemyName));
+
+                    validMonsters.Remove(monsterEntity);
+                    yield return FadeOutAndDestroyMonster(monsterEntity);
+                }
+            }
+        }
 
         /// <summary>Awards experience to all mercenaries in the battle.</summary>
         private static void AwardMercenaryExperience(List<Entity> mercenaries, int xpAmount)

--- a/PitHero/AI/BattleContext.cs
+++ b/PitHero/AI/BattleContext.cs
@@ -1,0 +1,150 @@
+using RolePlayingFramework.Combat;
+using RolePlayingFramework.Enemies;
+using RolePlayingFramework.Heroes;
+using System.Collections.Generic;
+
+namespace PitHero.AI
+{
+    /// <summary>
+    /// Per-battle implementation of <see cref="IBattleContext"/>.
+    /// Created once at the start of each battle and discarded in the finally block.
+    /// All collections are pre-allocated; no heap allocation during battle rounds.
+    /// </summary>
+    public sealed class BattleContext : IBattleContext
+    {
+        // ── DoT entries ───────────────────────────────────────────────────────────────
+
+        /// <summary>Internal record of an active DoT effect.</summary>
+        public struct DoTEntry
+        {
+            public IEnemy Target;
+            public int DamagePerTurn;
+            public int RemainingTurns;
+            public string SourceSkillId;
+            /// <summary>Name of the combatant who registered this DoT (for analytics).</summary>
+            public string ActorName;
+            /// <summary>Actor type string for analytics (e.g. "hero" or "merc").</summary>
+            public string ActorType;
+        }
+
+        /// <summary>Result produced by <see cref="TickDoTs"/> for each DoT tick that fires.</summary>
+        public struct DoTTickResult
+        {
+            public IEnemy Target;
+            public int Damage;
+            public string SourceSkillId;
+            public string ActorName;
+            public string ActorType;
+            public bool TargetDied;
+        }
+
+        private readonly List<DoTEntry> _dots = new List<DoTEntry>(8);
+        private readonly List<ICombatant> _actedCombatants = new List<ICombatant>(8);
+        private readonly List<DoTTickResult> _tickResults = new List<DoTTickResult>(8);
+
+        // ── IBattleContext ────────────────────────────────────────────────────────────
+
+        /// <inheritdoc/>
+        public void RegisterDoT(IEnemy target, int damagePerTurn, int turns, string sourceSkillId, ICombatant actor)
+        {
+            string actorName = actor?.Name ?? string.Empty;
+            string actorType = actor is Hero ? "hero" : "merc";
+            RegisterDoTInternal(target, damagePerTurn, turns, sourceSkillId, actorName, actorType);
+        }
+
+        private void RegisterDoTInternal(IEnemy target, int damagePerTurn, int turns, string sourceSkillId,
+            string actorName, string actorType)
+        {
+            // Refresh existing same-source DoT on same target rather than stacking
+            for (int i = 0; i < _dots.Count; i++)
+            {
+                if (_dots[i].Target == target && _dots[i].SourceSkillId == sourceSkillId)
+                {
+                    var entry = _dots[i];
+                    entry.DamagePerTurn = damagePerTurn;
+                    entry.RemainingTurns = turns;
+                    if (actorName != string.Empty) entry.ActorName = actorName;
+                    if (actorType != string.Empty) entry.ActorType = actorType;
+                    _dots[i] = entry;
+                    return;
+                }
+            }
+            _dots.Add(new DoTEntry
+            {
+                Target = target,
+                DamagePerTurn = damagePerTurn,
+                RemainingTurns = turns,
+                SourceSkillId = sourceSkillId,
+                ActorName = actorName,
+                ActorType = actorType
+            });
+        }
+
+        /// <inheritdoc/>
+        public bool IsFirstOffensiveAction(ICombatant c)
+        {
+            for (int i = 0; i < _actedCombatants.Count; i++)
+            {
+                if (_actedCombatants[i] == c) return false;
+            }
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public void MarkActed(ICombatant c)
+        {
+            for (int i = 0; i < _actedCombatants.Count; i++)
+            {
+                if (_actedCombatants[i] == c) return;
+            }
+            _actedCombatants.Add(c);
+        }
+
+        // ── End-of-round ticking ─────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Ticks all active DoT entries: applies damage to each living target, decrements
+        /// remaining turns, and removes expired or orphaned entries.
+        /// Returns a reused list (valid until the next call to this method) of tick results
+        /// for display and analytics.
+        /// </summary>
+        public List<DoTTickResult> TickDoTs()
+        {
+            _tickResults.Clear();
+
+            for (int i = _dots.Count - 1; i >= 0; i--)
+            {
+                var dot = _dots[i];
+
+                // Skip dead targets and remove the entry
+                if (dot.Target == null || dot.Target.CurrentHP <= 0)
+                {
+                    _dots.RemoveAt(i);
+                    continue;
+                }
+
+                bool died = dot.Target.TakeDamage(dot.DamagePerTurn);
+                _tickResults.Add(new DoTTickResult
+                {
+                    Target = dot.Target,
+                    Damage = dot.DamagePerTurn,
+                    SourceSkillId = dot.SourceSkillId,
+                    ActorName = dot.ActorName,
+                    ActorType = dot.ActorType,
+                    TargetDied = died
+                });
+
+                dot.RemainingTurns--;
+                if (dot.RemainingTurns <= 0)
+                    _dots.RemoveAt(i);
+                else
+                    _dots[i] = dot;
+            }
+
+            return _tickResults;
+        }
+
+        /// <summary>Exposes the raw DoT list for testing purposes only.</summary>
+        public List<DoTEntry> GetDots() => _dots;
+    }
+}

--- a/PitHero/AI/BattleTacticDecisionEngine.cs
+++ b/PitHero/AI/BattleTacticDecisionEngine.cs
@@ -134,12 +134,12 @@ namespace PitHero.AI
                 return healAction;
 
             // AoE check first
-            var aoeResult = TryAoESkill(_attackSkillBuffer, hero.CurrentMP, livingMonsters);
+            var aoeResult = TryAoESkill(_attackSkillBuffer, hero.CurrentMP, hero.MPCostReduction, livingMonsters);
             if (aoeResult.Skill != null)
                 return CreateAttackSkillAction(aoeResult.Skill, aoeResult.TargetEntity);
 
             // Best single-target attack skill (prefer elemental advantage, then highest MP cost)
-            var bestSkill = FindBestAttackSkill(_attackSkillBuffer, hero.CurrentMP, livingMonsters, true);
+            var bestSkill = FindBestAttackSkill(_attackSkillBuffer, hero.CurrentMP, hero.MPCostReduction, livingMonsters, true);
             if (bestSkill.Skill != null)
                 return CreateAttackSkillAction(bestSkill.Skill, bestSkill.TargetEntity);
 
@@ -162,11 +162,11 @@ namespace PitHero.AI
                 return healAction;
 
             // 2. Attack (prefer elemental advantage, then lowest MP cost)
-            var aoeResult = TryAoESkill(_attackSkillBuffer, hero.CurrentMP, livingMonsters);
+            var aoeResult = TryAoESkill(_attackSkillBuffer, hero.CurrentMP, hero.MPCostReduction, livingMonsters);
             if (aoeResult.Skill != null)
                 return CreateAttackSkillAction(aoeResult.Skill, aoeResult.TargetEntity);
 
-            var bestSkill = FindBestAttackSkill(_attackSkillBuffer, hero.CurrentMP, livingMonsters, false);
+            var bestSkill = FindBestAttackSkill(_attackSkillBuffer, hero.CurrentMP, hero.MPCostReduction, livingMonsters, false);
             if (bestSkill.Skill != null)
                 return CreateAttackSkillAction(bestSkill.Skill, bestSkill.TargetEntity);
 
@@ -188,16 +188,16 @@ namespace PitHero.AI
                 return healAction;
 
             // 2. Apply buff if available
-            var buffSkill = FindBestBuffSkill(_buffSkillBuffer, hero.CurrentMP);
+            var buffSkill = FindBestBuffSkill(_buffSkillBuffer, hero.CurrentMP, hero);
             if (buffSkill != null)
                 return CreateHealingSkillAction(buffSkill, hero, true);
 
             // 3. Attack (still attack even if not all allies are at 60% — nothing else to do)
-            var aoeResult = TryAoESkill(_attackSkillBuffer, hero.CurrentMP, livingMonsters);
+            var aoeResult = TryAoESkill(_attackSkillBuffer, hero.CurrentMP, hero.MPCostReduction, livingMonsters);
             if (aoeResult.Skill != null)
                 return CreateAttackSkillAction(aoeResult.Skill, aoeResult.TargetEntity);
 
-            var bestSkill = FindBestAttackSkill(_attackSkillBuffer, hero.CurrentMP, livingMonsters, false);
+            var bestSkill = FindBestAttackSkill(_attackSkillBuffer, hero.CurrentMP, hero.MPCostReduction, livingMonsters, false);
             if (bestSkill.Skill != null)
                 return CreateAttackSkillAction(bestSkill.Skill, bestSkill.TargetEntity);
 
@@ -221,11 +221,11 @@ namespace PitHero.AI
                     GameConfig.HeroCriticalHPPercent, StrategicMPThreshold, _healSkillBuffer, out healAction))
                 return healAction;
 
-            var aoeResult = TryAoESkill(_attackSkillBuffer, merc.CurrentMP, livingMonsters);
+            var aoeResult = TryAoESkill(_attackSkillBuffer, merc.CurrentMP, merc.MPCostReduction, livingMonsters);
             if (aoeResult.Skill != null)
                 return CreateAttackSkillAction(aoeResult.Skill, aoeResult.TargetEntity);
 
-            var bestSkill = FindBestAttackSkill(_attackSkillBuffer, merc.CurrentMP, livingMonsters, true);
+            var bestSkill = FindBestAttackSkill(_attackSkillBuffer, merc.CurrentMP, merc.MPCostReduction, livingMonsters, true);
             if (bestSkill.Skill != null)
                 return CreateAttackSkillAction(bestSkill.Skill, bestSkill.TargetEntity);
 
@@ -264,7 +264,7 @@ namespace PitHero.AI
                 return healAction;
 
             // 2. Buff
-            var buffSkill = FindBestBuffSkill(_buffSkillBuffer, merc.CurrentMP);
+            var buffSkill = FindBestBuffSkill(_buffSkillBuffer, merc.CurrentMP, merc);
             if (buffSkill != null)
                 return CreateHealingSkillAction(buffSkill, merc, false);
 
@@ -275,11 +275,11 @@ namespace PitHero.AI
         /// <summary>Mercenary attack fallback: AoE check then best single-target or physical.</summary>
         private static BattleAction MercAttack(Mercenary merc, List<Entity> livingMonsters)
         {
-            var aoeResult = TryAoESkill(_attackSkillBuffer, merc.CurrentMP, livingMonsters);
+            var aoeResult = TryAoESkill(_attackSkillBuffer, merc.CurrentMP, merc.MPCostReduction, livingMonsters);
             if (aoeResult.Skill != null)
                 return CreateAttackSkillAction(aoeResult.Skill, aoeResult.TargetEntity);
 
-            var bestSkill = FindBestAttackSkill(_attackSkillBuffer, merc.CurrentMP, livingMonsters, false);
+            var bestSkill = FindBestAttackSkill(_attackSkillBuffer, merc.CurrentMP, merc.MPCostReduction, livingMonsters, false);
             if (bestSkill.Skill != null)
                 return CreateAttackSkillAction(bestSkill.Skill, bestSkill.TargetEntity);
 
@@ -498,13 +498,24 @@ namespace PitHero.AI
         }
 
         /// <summary>
+        /// Returns the effective MP cost of a skill after applying the combatant's MPCostReduction.
+        /// Mirrors the formula in ICombatant.GetEffectiveMPCost (floor of 1 when rawCost &gt; 0).
+        /// </summary>
+        private static int EffectiveMPCost(int rawCost, float mpCostReduction)
+        {
+            if (rawCost <= 0) return 0;
+            int reduced = (int)(rawCost * (1f - mpCostReduction));
+            return reduced < 1 ? 1 : reduced;
+        }
+
+        /// <summary>
         /// Finds the best single-target attack skill from the buffer.
         /// When preferHighMP is true (Blitz), prefers higher MP cost (stronger).
         /// When false (Strategic/Defensive), prefers lower MP cost (efficient).
         /// Always prioritizes elemental advantage.
         /// </summary>
         private static SkillResult FindBestAttackSkill(
-            List<ISkill> attackSkills, int currentMP,
+            List<ISkill> attackSkills, int currentMP, float mpCostReduction,
             List<Entity> livingMonsters, bool preferHighMP)
         {
             var result = new SkillResult();
@@ -515,7 +526,7 @@ namespace PitHero.AI
                 var skill = attackSkills[i];
                 if (skill.Kind != SkillKind.Active) continue;
                 if (skill.TargetType != SkillTargetType.SingleEnemy) continue;
-                if (skill.MPCost > currentMP) continue;
+                if (EffectiveMPCost(skill.MPCost, mpCostReduction) > currentMP) continue;
 
                 // Find best monster target for this skill's element
                 Entity targetEntity = FindBestMonsterTarget(livingMonsters, skill.Element);
@@ -550,7 +561,7 @@ namespace PitHero.AI
         /// AoE is only used when multiple enemies exist and the majority are not resistant.
         /// </summary>
         private static SkillResult TryAoESkill(
-            List<ISkill> attackSkills, int currentMP, List<Entity> livingMonsters)
+            List<ISkill> attackSkills, int currentMP, float mpCostReduction, List<Entity> livingMonsters)
         {
             var result = new SkillResult();
             if (livingMonsters.Count < 2) return result;
@@ -563,7 +574,7 @@ namespace PitHero.AI
                 var skill = attackSkills[i];
                 if (skill.Kind != SkillKind.Active) continue;
                 if (skill.TargetType != SkillTargetType.SurroundingEnemies) continue;
-                if (skill.MPCost > currentMP) continue;
+                if (EffectiveMPCost(skill.MPCost, mpCostReduction) > currentMP) continue;
 
                 // Count how many enemies resist this element
                 int resistCount = 0;
@@ -615,10 +626,11 @@ namespace PitHero.AI
             ISkill bestSkill = null;
             int bestWaste = int.MaxValue;
 
+            float healerMPCostReduction = (caster as ICombatant)?.MPCostReduction ?? 0f;
             for (int i = 0; i < healSkills.Count; i++)
             {
                 var skill = healSkills[i];
-                if (skill.MPCost > currentMP) continue;
+                if (EffectiveMPCost(skill.MPCost, healerMPCostReduction) > currentMP) continue;
                 if (skill.HPRestoreAmount <= 0) continue;
 
                 // Check target type compatibility
@@ -648,15 +660,36 @@ namespace PitHero.AI
 
         /// <summary>
         /// Finds a buff skill (Self or SingleAlly target, no heal/MP restore) that can be cast.
-        /// Returns the first available buff skill, or null if none.
+        /// Skips skills where the target already has all buff stacks (MaxStacks reached).
+        /// Returns the first castable buff skill, or null if none.
         /// </summary>
-        private static ISkill FindBestBuffSkill(List<ISkill> buffSkills, int currentMP)
+        private static ISkill FindBestBuffSkill(List<ISkill> buffSkills, int currentMP, ICombatant target)
         {
             for (int i = 0; i < buffSkills.Count; i++)
             {
                 var skill = buffSkills[i];
-                if (skill.MPCost <= currentMP)
-                    return skill;
+                if (EffectiveMPCost(skill.MPCost, target.MPCostReduction) > currentMP)
+                    continue;
+
+                // Phase 3: skip if the target's stacks are already capped for every buff this skill grants
+                bool allCapped = false;
+                if (skill.GrantedBuffs.Count > 0)
+                {
+                    allCapped = true;
+                    for (int b = 0; b < skill.GrantedBuffs.Count; b++)
+                    {
+                        var grantedBuff = skill.GrantedBuffs[b];
+                        // Check stacks for this specific buff type (fixes multi-buff skills like FadeSkill).
+                        if (target.GetBuffStacks(skill.Id, grantedBuff.Type) < grantedBuff.MaxStacks)
+                        {
+                            allCapped = false;
+                            break;
+                        }
+                    }
+                }
+                if (allCapped) continue;
+
+                return skill;
             }
             return null;
         }
@@ -777,7 +810,7 @@ namespace PitHero.AI
         {
             if (skill.Kind != SkillKind.Active) return;
 
-            // Healing skill: restores HP
+            // Healing skill: restores HP (may also grant buffs — those apply in ApplyHealingSkillEffectsAndDisplay)
             if (skill.HPRestoreAmount > 0)
             {
                 healSkills.Add(skill);
@@ -792,7 +825,14 @@ namespace PitHero.AI
                 return;
             }
 
-            // Buff skill: targets self or ally without healing
+            // Phase 3: data-driven buff skill — has GrantedBuffs and no HP restore
+            if (skill.GrantedBuffs.Count > 0 && skill.HPRestoreAmount == 0)
+            {
+                buffSkills.Add(skill);
+                return;
+            }
+
+            // Fallback: non-healing self/ally skill (CleansesDebuffs-only or future kinds)
             if (skill.TargetType == SkillTargetType.Self ||
                 skill.TargetType == SkillTargetType.SingleAlly)
             {

--- a/PitHero/AI/WanderPitAction.cs
+++ b/PitHero/AI/WanderPitAction.cs
@@ -88,10 +88,11 @@ namespace PitHero.AI
             context.LogDebug($"[WanderPitAction] Executing at tile ({currentTile.X},{currentTile.Y})");
 
             // Clear fog of war around this tile using hero's UncoverRadius
+            // Phase 4: also add Eagle Eye SightRangeBonus when set on VirtualHero
             int uncoverRadius = 1; // default
             if (context is VirtualGoapContext virtualContext)
             {
-                uncoverRadius = virtualContext.VirtualHero.UncoverRadius;
+                uncoverRadius = virtualContext.VirtualHero.UncoverRadius + virtualContext.VirtualHero.SightRangeBonus;
             }
 
             context.WorldState.ClearFogOfWar(currentTile, uncoverRadius);

--- a/PitHero/Content/Localization/en-us/Skill.txt
+++ b/PitHero/Content/Localization/en-us/Skill.txt
@@ -33,7 +33,7 @@ Skill_Monk_Roundhouse_Desc,A spinning kick that hits all surrounding enemies wit
 Skill_Priest_CalmSpirit_Name,Calm Spirit
 Skill_Priest_CalmSpirit_Desc,Increases MP regeneration by 1 per turn cycle.
 Skill_Priest_DefenseUp_Name,Defense Up
-Skill_Priest_DefenseUp_Desc,Temporarily increase defense by 1. Effect stacks with multiple uses.
+Skill_Priest_DefenseUp_Desc,Temporarily increase defense by 1. Stacks up to 3 times; lasts until battle ends.
 Skill_Priest_Heal_Name,Heal
 Skill_Priest_Heal_Desc,Restore HP based on Magic stat.
 Skill_Priest_Mender_Name,Mender
@@ -43,7 +43,7 @@ Skill_Synergy_ArrowFlurry_Desc,Unleashes a rapid barrage of arrows at all enemie
 Skill_Synergy_AuraHeal_Name,Aura Heal
 Skill_Synergy_AuraHeal_Desc,Heals self and grants a temporary defense boost.
 Skill_Synergy_Blitz_Name,Blitz
-Skill_Synergy_Blitz_Desc,A rapid magic burst dealing Lightning damage.
+Skill_Synergy_Blitz_Desc,A rapid magic burst dealing Wind damage.
 Skill_Synergy_DragonBolt_Name,Dragon Bolt
 Skill_Synergy_DragonBolt_Desc,Unleashes a bolt of draconic energy.
 Skill_Synergy_DragonClaw_Name,Dragon Claw
@@ -99,7 +99,7 @@ Skill_Synergy_Spellblade_Desc,A magic-infused blade strike dealing combined phys
 Skill_Thief_Shadowstep_Name,Shadowstep
 Skill_Thief_Shadowstep_Desc,Increases chance to evade incoming attacks through superior agility.
 Skill_Thief_SneakAttack_Name,Sneak Attack
-Skill_Thief_SneakAttack_Desc,A stealthy strike that deals physical damage plus bonus damage based on Agility.
+Skill_Thief_SneakAttack_Desc,A stealthy strike dealing physical damage plus Agility bonus. Strongest on the first strike of battle.
 Skill_Thief_TrapSense_Name,Trap Sense
 Skill_Thief_TrapSense_Desc,Enhanced ability to detect and disarm traps in the dungeon.
 Skill_Thief_Vanish_Name,Vanish

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -283,6 +283,8 @@ ConsoleWelcome,Welcome, {0}!
 ConsoleWelcomePhrase1,Good luck on your adventure.
 ConsoleWelcomePhrase2,Go forth and pursue strength and wealth.
 ConsoleWelcomePhrase3,May you get many returns today!
+ConsoleTrapTriggered,{0} triggered a trap for {1} damage!
+ConsoleTrapDisarmed,Trap disarmed!
 
 # Add Monsters (Monster House)
 ButtonAddMonsters,Add Monsters

--- a/PitHero/ECS/Components/HeroComponent.cs
+++ b/PitHero/ECS/Components/HeroComponent.cs
@@ -549,6 +549,12 @@ namespace PitHero.ECS.Components
         public System.Collections.Generic.List<SavedItem> PendingInventoryItems { get; set; }
 
         /// <summary>
+        /// When true, the hero receives new-game starting items after Bag initialization.
+        /// Set by the scene only for a brand-new game (never on load or death-respawn).
+        /// </summary>
+        public bool GrantNewGameStartingItems { get; set; }
+
+        /// <summary>
         /// Action queue for battle actions
         /// </summary>
         public ActionQueue BattleActionQueue { get; private set; }
@@ -622,6 +628,14 @@ namespace PitHero.ECS.Components
                     }
                 }
                 PendingInventoryItems = null;
+            }
+
+            // Grant new-game starting items (stacked automatically by ItemBag.TryAdd)
+            if (GrantNewGameStartingItems)
+            {
+                for (int i = 0; i < GameConfig.NewGameStartingHPPotions; i++)
+                    TryAddItem(PotionItems.HPPotion());
+                GrantNewGameStartingItems = false;
             }
 
             // Initialize battle action queue
@@ -996,6 +1010,15 @@ namespace PitHero.ECS.Components
             {
                 Debug.Log("[HeroComponent] Detected pit trigger entry");
                 HandlePitTriggerEnter();
+                return;
+            }
+
+            // Handle trap tile: step-on trigger deals chip damage and destroys the trap
+            if (other.Entity.Tag == GameConfig.TAG_TRAP)
+            {
+                Debug.Log("[HeroComponent] Detected trap trigger");
+                var trapComponent = other.Entity.GetComponent<TrapComponent>();
+                trapComponent?.Trigger(this);
                 return;
             }
 

--- a/PitHero/ECS/Components/TileByTileMover.cs
+++ b/PitHero/ECS/Components/TileByTileMover.cs
@@ -167,6 +167,7 @@ namespace PitHero.ECS.Components
                 {
                     heroComponent.TriggerFogCooldown();
                     RefreshMonsterFogVisibility(tms);
+                    CheckTrapSenseDisarm(heroComponent, tms);
                 }
             }
             else if (tms != null)
@@ -186,6 +187,48 @@ namespace PitHero.ECS.Components
 
             IsMoving = false;
             CurrentDirection = null;
+        }
+
+        /// <summary>
+        /// Checks all trap entities that are now visible (fog cleared) and auto-disarms them if any
+        /// living party member carries the TrapSense passive. Called after the hero clears fog.
+        /// Only inspects traps whose tiles are no longer fogged — traps already armed and fogged are
+        /// left untouched until they are revealed or stepped on.
+        /// No LINQ used; all party members checked via indexed for loops.
+        /// </summary>
+        private static void CheckTrapSenseDisarm(HeroComponent heroComponent, TiledMapService tms)
+        {
+            // Determine whether any party member has TrapSense (hero or hired merc).
+            bool hasTrapSense = heroComponent.LinkedHero?.TrapSense == true;
+
+            if (!hasTrapSense)
+            {
+                var mercManager = Core.Services?.GetService<MercenaryManager>();
+                // Non-allocating check — no LINQ, no new list
+                if (mercManager != null && mercManager.AnyHiredMercenaryHasTrapSense())
+                    hasTrapSense = true;
+            }
+
+            if (!hasTrapSense)
+                return;
+
+            // Iterate the static TrapComponent registry instead of FindEntitiesWithTag
+            // (avoids per-step allocation; registry is maintained by TrapComponent itself).
+            var activeTraps = TrapComponent.ActiveTraps;
+            for (int i = activeTraps.Count - 1; i >= 0; i--)
+            {
+                var trapComp = activeTraps[i];
+                if (trapComp?.Entity == null) continue;
+
+                var pos = trapComp.Entity.Transform.Position;
+                int tileX = (int)System.Math.Floor(pos.X / GameConfig.TileSize);
+                int tileY = (int)System.Math.Floor(pos.Y / GameConfig.TileSize);
+
+                if (!tms.IsFogOfWarTile(tileX, tileY))
+                {
+                    trapComp.Disarm();
+                }
+            }
         }
 
         /// <summary>
@@ -245,6 +288,7 @@ namespace PitHero.ECS.Components
                 if (fogCleared)
                 {
                     heroComponent.TriggerFogCooldown();
+                    CheckTrapSenseDisarm(heroComponent, tms);
                 }
             }
 

--- a/PitHero/ECS/Components/TrapComponent.cs
+++ b/PitHero/ECS/Components/TrapComponent.cs
@@ -1,0 +1,151 @@
+using Microsoft.Xna.Framework;
+using Nez;
+using PitHero.Services;
+using PitHero.Services.Analytics;
+using System.Collections.Generic;
+
+namespace PitHero.ECS.Components
+{
+    /// <summary>
+    /// Hidden trap tile spawned in the pit. Triggers when the hero steps onto this tile,
+    /// dealing out-of-battle chip damage scaled by pit level.
+    ///
+    /// Damage formula: 5 + pitLevel * 2
+    ///   Rationale: at pit level 1 this is 7 damage (weak chip); at pit level 25 it is 55 damage
+    ///   (~25-30% of a level-appropriate hero's HP), matching the MonsterBalanceGuide "chip damage"
+    ///   intent — painful but not lethal on its own.
+    ///
+    /// Mercenaries are abstract while walking; damage is applied to the hero only.
+    ///
+    /// Out-of-battle HP floor: if damage would reduce the hero below 1 HP, it is clamped so the
+    /// hero survives with 1 HP. No death-outside-battle flow exists in this codebase; clamping
+    /// is the chosen convention for all out-of-battle chip damage.
+    /// </summary>
+    public class TrapComponent : Component
+    {
+        // ── Static active-trap registry ───────────────────────────────────────────────
+        // Maintained by OnAddedToEntity/OnRemovedFromEntity so CheckTrapSenseDisarm can iterate
+        // without calling FindEntitiesWithTag (which allocates a new list every invocation).
+
+        /// <summary>
+        /// All live TrapComponent instances in the current scene.
+        /// Populated in <see cref="OnAddedToEntity"/> and cleared in <see cref="OnRemovedFromEntity"/>.
+        /// Iterate this instead of <c>FindEntitiesWithTag(TAG_TRAP)</c> to avoid per-fog-step allocation.
+        /// </summary>
+        public static readonly List<TrapComponent> ActiveTraps = new List<TrapComponent>(32);
+
+        // ── Instance state ────────────────────────────────────────────────────────────
+
+        /// <summary>The pit level this trap was spawned on.</summary>
+        public int PitLevel { get; private set; }
+
+        /// <summary>
+        /// Damage this trap deals when triggered (5 + pitLevel * 2).
+        /// See class summary for formula rationale.
+        /// </summary>
+        public int Damage => 5 + PitLevel * 2;
+
+        // Re-entry guards: Trigger and Disarm both call Entity.Destroy; guard prevents a double-destroy
+        // if the Nez event fire order causes two calls in the same frame.
+        private bool _triggered;
+        private bool _disarmed;
+
+        /// <summary>Creates a TrapComponent for the given pit level.</summary>
+        public TrapComponent(int pitLevel)
+        {
+            PitLevel = pitLevel;
+        }
+
+        // ── Nez lifecycle ─────────────────────────────────────────────────────────────
+
+        /// <summary>Registers this trap in the static active-trap registry.</summary>
+        public override void OnAddedToEntity()
+        {
+            ActiveTraps.Add(this);
+        }
+
+        /// <summary>Removes this trap from the static active-trap registry.</summary>
+        public override void OnRemovedFromEntity()
+        {
+            // Backward search so the common case (last added = first removed) is O(1)
+            for (int i = ActiveTraps.Count - 1; i >= 0; i--)
+            {
+                if (ActiveTraps[i] == this)
+                {
+                    ActiveTraps.RemoveAt(i);
+                    break;
+                }
+            }
+        }
+
+        // ── Trap actions ──────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Fires when the hero steps on this trap tile. Deals chip damage, emits a console event,
+        /// logs analytics, then destroys this trap entity.
+        /// Only the hero is damaged — mercenaries are abstract while the party walks the pit.
+        /// Idempotent: subsequent calls after the first are ignored.
+        /// </summary>
+        public void Trigger(HeroComponent heroComponent)
+        {
+            if (_triggered || _disarmed) return;
+            _triggered = true;
+
+            if (heroComponent?.LinkedHero == null)
+                return;
+
+            var hero = heroComponent.LinkedHero;
+            int damage = Damage;
+
+            // Clamp so trap never reduces hero to 0 HP: out-of-battle chip damage does not insta-kill.
+            // No existing death-outside-battle flow exists in this codebase; clamping is the convention.
+            int actualDamage = System.Math.Min(damage, hero.CurrentHP - 1);
+            if (actualDamage < 0)
+                actualDamage = 0;
+
+            if (actualDamage > 0)
+                hero.TakeDamage(actualDamage);
+
+            // Tile coordinates for analytics
+            var pos = Entity.Transform.Position;
+            int tileX = (int)System.Math.Floor(pos.X / GameConfig.TileSize);
+            int tileY = (int)System.Math.Floor(pos.Y / GameConfig.TileSize);
+
+            AnalyticsService.LogTrapTriggered(PitLevel, tileX, tileY, actualDamage);
+
+            // Console event (high priority — player should notice losing HP unexpectedly)
+            var gameEventService = Core.Services?.GetService<GameEventService>();
+            gameEventService?.EmitLocalized(EventPriority.High, UITextKey.ConsoleTrapTriggered,
+                (hero.Name, GameConfig.ConsoleColorHeroName),
+                (actualDamage.ToString(), Color.Red));
+
+            Debug.Log($"[TrapComponent] Hero '{hero.Name}' triggered trap at tile ({tileX},{tileY}) for {actualDamage} damage (capped from {damage})");
+
+            Entity.Destroy();
+        }
+
+        /// <summary>
+        /// Auto-disarms this trap when TrapSense reveals it via fog clearing.
+        /// No damage is dealt. Emits a console event, logs analytics, then destroys the trap entity.
+        /// Idempotent: subsequent calls after the first are ignored.
+        /// </summary>
+        public void Disarm()
+        {
+            if (_disarmed || _triggered) return;
+            _disarmed = true;
+
+            var pos = Entity.Transform.Position;
+            int tileX = (int)System.Math.Floor(pos.X / GameConfig.TileSize);
+            int tileY = (int)System.Math.Floor(pos.Y / GameConfig.TileSize);
+
+            AnalyticsService.LogTrapDisarmed(PitLevel, tileX, tileY);
+
+            var gameEventService = Core.Services?.GetService<GameEventService>();
+            gameEventService?.EmitLocalized(UITextKey.ConsoleTrapDisarmed);
+
+            Debug.Log($"[TrapComponent] Trap disarmed at tile ({tileX},{tileY}) via TrapSense");
+
+            Entity.Destroy();
+        }
+    }
+}

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -111,6 +111,15 @@ namespace PitHero.ECS.Scenes
         {
             base.Initialize();
 
+            // Grant new-game starting gold before session-start analytics so the event records it.
+            // Loads skip this — SaveLoadService.ApplyLoadedState already restored Funds.
+            if (SaveLoadService.PendingLoadData == null)
+            {
+                var newGameState = Core.Services.GetService<GameStateService>();
+                if (newGameState != null)
+                    newGameState.Funds = GameConfig.NewGameStartingGold;
+            }
+
             // Log session start before any scene setup so it is the first analytics event
             // (pit generation and mercenary spawns fire during initialization below).
             // Funds are already restored by SaveLoadService.ApplyLoadedState at load time.
@@ -493,10 +502,9 @@ namespace PitHero.ECS.Scenes
             if (hpDiff > 0)
                 hero.TakeDamage(hpDiff);
             
-            // Adjust MP from max to saved value
-            int mpDiff = hero.MaxMP - pendingData.CurrentMP;
-            if (mpDiff > 0)
-                hero.SpendMP(mpDiff);
+            // Adjust MP from max to saved value using SetCurrentMP (not SpendMP) so
+            // MPCostReduction is NOT applied to the delta — state-restore must land exactly at saved value.
+            hero.SetCurrentMP(pendingData.CurrentMP);
             
             // Assign reconstructed hero to the component
             heroComp.LinkedHero = hero;
@@ -1069,6 +1077,10 @@ namespace PitHero.ECS.Scenes
 
                 // Create the linked Hero from the crystal
                 heroComponent.LinkedHero = new RolePlayingFramework.Heroes.Hero(design.Name, heroJob, 1, baseStats, heroCrystal);
+
+                // Starting items are granted only for a brand-new game — loads restore their saved
+                // inventory instead, and death-respawns (needsCrystal) keep the existing bag.
+                heroComponent.GrantNewGameStartingItems = SaveLoadService.PendingLoadData == null;
 
                 Debug.Log($"[MainGameScene] Created hero '{design.Name}' with Level {heroComponent.LinkedHero.Level}, HP {heroComponent.LinkedHero.CurrentHP}/{heroComponent.LinkedHero.MaxHP}");
             }

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -206,6 +206,15 @@ namespace PitHero
         public const int TAG_MERCENARY = 8; // Tag for mercenary entities
         public const int TAG_HERO_STATUE = 9; // Tag for hero statue entity
         public const int TAG_INNKEEPER = 10; // Tag for innkeeper entity
+        public const int TAG_TRAP = 11; // Tag for hidden trap entities
+
+        // Trap configuration (Phase 6 — minimal trap system)
+        public const int TrapMinPerFloor = 0; // Minimum traps spawned per pit floor
+        public const int TrapMaxPerFloor = 2; // Maximum traps spawned per pit floor
+
+        // New-game starting resources
+        public const int NewGameStartingGold = 200; // Gold the player starts with in a new game
+        public const int NewGameStartingHPPotions = 5; // HPPotions in the hero's bag at new game start
 
         // Render Layers (the lower the number, the higher the layer)
 

--- a/PitHero/PitGenerator.cs
+++ b/PitHero/PitGenerator.cs
@@ -259,12 +259,14 @@ namespace PitHero
             var treasures = _scene.FindEntitiesWithTag(GameConfig.TAG_TREASURE);
             var monsters = _scene.FindEntitiesWithTag(GameConfig.TAG_MONSTER);
             var wizardOrbs = _scene.FindEntitiesWithTag(GameConfig.TAG_WIZARD_ORB);
+            var traps = _scene.FindEntitiesWithTag(GameConfig.TAG_TRAP);
 
             // Add all found entities to removal list
             entitiesToRemove.AddRange(obstacles);
             entitiesToRemove.AddRange(treasures);
             entitiesToRemove.AddRange(monsters);
             entitiesToRemove.AddRange(wizardOrbs);
+            entitiesToRemove.AddRange(traps);
 
             // Remove entities by calling Destroy on each
             for (int i = 0; i < entitiesToRemove.Count; i++)
@@ -403,16 +405,25 @@ namespace PitHero
 
                 if (validObstacles.Count > 0 || targetPositions.Count == 0)
                 {
+                    // Spawn traps after layout validation so they use remaining free tiles.
+                    // Traps must not overlap obstacles/treasures/monsters/orbs (all in usedPositions).
+                    // They are NOT added to targetPositions because they require no reachability guarantee
+                    // from the pit entry — traps are passively encountered by the wandering hero.
+                    int trapCount = Nez.Random.Range(GameConfig.TrapMinPerFloor, GameConfig.TrapMaxPerFloor + 1);
+                    var trapPositions = GenerateEntityPositions(trapCount, validMinX, validMinY, validMaxX, validMaxY, usedPositions, "traps");
+
                     var wizardOrbColor = isBossFloor ? Color.Red : Color.White;
                     CreateEntitiesAtPositions(validObstacles, GameConfig.TAG_OBSTACLE, Color.Gray, "obstacle", level);
                     CreateEntitiesAtPositions(treasures, GameConfig.TAG_TREASURE, Color.Yellow, "treasure", level);
                     CreateEntitiesAtPositions(monsters, GameConfig.TAG_MONSTER, Color.White, "monster", level);
                     CreateEntitiesAtPositions(wizardOrbs, GameConfig.TAG_WIZARD_ORB, wizardOrbColor, "wizard_orb", level);
+                    CreateTrapEntitiesAtPositions(trapPositions, level);
 
                     validLayoutGenerated = true;
                     Debug.Log($"[PitGenerator] Valid layout generated on attempt {attempt}");
-                    Debug.Log($"[PitGenerator] Generated {validObstacles.Count + targetPositions.Count} entities total in pit");
+                    Debug.Log($"[PitGenerator] Generated {validObstacles.Count + targetPositions.Count + trapPositions.Count} entities total in pit");
                     Debug.Log($"[PitGenerator] Final obstacle count: {validObstacles.Count} (removed {obstacles.Count - validObstacles.Count} problematic obstacles)");
+                    Debug.Log($"[PitGenerator] Spawned {trapPositions.Count} traps");
                 }
                 else
                 {
@@ -1019,6 +1030,35 @@ namespace PitHero
             }
 
             Debug.Log("[PitGenerator] Fallback layout created with guaranteed paths");
+        }
+
+        /// <summary>
+        /// Creates hidden trap entities at the given tile positions.
+        /// Traps use a trigger collider on PhysicsHeroWorldLayer so the hero's trigger system
+        /// detects them. They are invisible (no renderer) — the hero encounters them by stepping on them.
+        /// </summary>
+        private void CreateTrapEntitiesAtPositions(List<Point> positions, int pitLevel)
+        {
+            for (int i = 0; i < positions.Count; i++)
+            {
+                var tilePos = positions[i];
+                var worldPos = new Vector2(
+                    tilePos.X * GameConfig.TileSize + GameConfig.TileSize / 2,
+                    tilePos.Y * GameConfig.TileSize + GameConfig.TileSize / 2
+                );
+
+                var entity = _scene.CreateEntity("trap");
+                entity.SetTag(GameConfig.TAG_TRAP);
+                entity.SetPosition(worldPos);
+
+                entity.AddComponent(new ECS.Components.TrapComponent(pitLevel));
+
+                var collider = entity.AddComponent(new BoxCollider(GameConfig.TileSize, GameConfig.TileSize));
+                collider.IsTrigger = true;
+                Flags.SetFlagExclusive(ref collider.PhysicsLayer, GameConfig.PhysicsHeroWorldLayer);
+
+                Debug.Log($"[PitGenerator] Created trap at tile ({tilePos.X},{tilePos.Y}), damage={5 + pitLevel * 2}");
+            }
         }
 
         private Point GetRandomUnusedPosition(int minX, int minY, int maxX, int maxY, HashSet<Point> usedPositions)

--- a/PitHero/RolePlayingFramework/Balance/BalanceConfig.cs
+++ b/PitHero/RolePlayingFramework/Balance/BalanceConfig.cs
@@ -667,7 +667,8 @@ namespace RolePlayingFramework.Balance
         /// - Magic 30: 85 HP
         /// - Magic 99: 223 HP
         ///
-        /// Matches the scaling convention used by synergy heals (AuraHeal: 25 + Magic × 2.5).
+        /// Uses the normalized factor of ×2 (SkillHealMagicFactor = 2f); synergy heals that
+        /// previously used ×2.5 were normalized to ×2 during the heal-scaling pass.
         /// </remarks>
         public static int CalculateSkillHealAmount(int baseAmount, int casterMagic, float healPowerBonus)
         {

--- a/PitHero/RolePlayingFramework/Combat/BattleBuff.cs
+++ b/PitHero/RolePlayingFramework/Combat/BattleBuff.cs
@@ -1,0 +1,30 @@
+namespace RolePlayingFramework.Combat
+{
+    /// <summary>A single active battle-scoped buff instance on a combatant.</summary>
+    public struct BattleBuff
+    {
+        /// <summary>What kind of buff this is.</summary>
+        public BuffType Type;
+
+        /// <summary>How much the buff adds (e.g. +1 defense, +40 evasion).</summary>
+        public int Magnitude;
+
+        /// <summary>
+        /// Turns remaining before this buff expires.
+        /// <c>-1</c> means the buff lasts until battle end (never expires on tick).
+        /// </summary>
+        public int RemainingTurns;
+
+        /// <summary>Id of the skill that applied this buff (used for stack-cap checks).</summary>
+        public string SourceSkillId;
+
+        /// <summary>Creates a new BattleBuff.</summary>
+        public BattleBuff(BuffType type, int magnitude, int remainingTurns, string sourceSkillId)
+        {
+            Type = type;
+            Magnitude = magnitude;
+            RemainingTurns = remainingTurns;
+            SourceSkillId = sourceSkillId;
+        }
+    }
+}

--- a/PitHero/RolePlayingFramework/Combat/BattleBuffSet.cs
+++ b/PitHero/RolePlayingFramework/Combat/BattleBuffSet.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+
+namespace RolePlayingFramework.Combat
+{
+    /// <summary>
+    /// Shared, allocation-free battle-buff container used by both <c>Hero</c> and <c>Mercenary</c>.
+    /// Pre-allocates a fixed-capacity list and provides the full buff API so the two combatant
+    /// classes can delegate instead of duplicating identical code.
+    /// </summary>
+    public sealed class BattleBuffSet
+    {
+        private readonly List<BattleBuff> _buffs = new List<BattleBuff>(8);
+
+        /// <summary>Adds a battle buff. Each entry is tracked individually to support stacks.</summary>
+        public void AddBattleBuff(in BattleBuff buff)
+        {
+            _buffs.Add(buff);
+        }
+
+        /// <summary>Returns the summed magnitude of all active buffs of the given type.</summary>
+        public int GetBuffTotal(BuffType type)
+        {
+            int total = 0;
+            for (int i = 0; i < _buffs.Count; i++)
+            {
+                if (_buffs[i].Type == type)
+                    total += _buffs[i].Magnitude;
+            }
+            return total;
+        }
+
+        /// <summary>
+        /// Returns the number of active buff entries whose <see cref="BattleBuff.SourceSkillId"/>
+        /// matches <paramref name="sourceSkillId"/> AND whose <see cref="BattleBuff.Type"/>
+        /// matches <paramref name="type"/>.
+        /// Counting by both skill id and type prevents a multi-buff skill (e.g. FadeSkill with
+        /// EvasionUp + MPRegen) from blocking its second buff type when the first type is capped.
+        /// </summary>
+        public int GetBuffStacks(string sourceSkillId, BuffType type)
+        {
+            int count = 0;
+            for (int i = 0; i < _buffs.Count; i++)
+            {
+                if (_buffs[i].SourceSkillId == sourceSkillId && _buffs[i].Type == type)
+                    count++;
+            }
+            return count;
+        }
+
+        /// <summary>
+        /// Decrements finite-duration buffs and removes expired ones.
+        /// Buffs with <c>RemainingTurns == -1</c> are permanent until battle end and are never decremented.
+        /// </summary>
+        public void TickBuffDurations()
+        {
+            for (int i = _buffs.Count - 1; i >= 0; i--)
+            {
+                var buff = _buffs[i];
+                if (buff.RemainingTurns == -1) continue; // permanent until battle end
+                buff.RemainingTurns--;
+                if (buff.RemainingTurns <= 0)
+                    _buffs.RemoveAt(i);
+                else
+                    _buffs[i] = buff;
+            }
+        }
+
+        /// <summary>Removes all active battle buffs.</summary>
+        public void Clear()
+        {
+            _buffs.Clear();
+        }
+    }
+}

--- a/PitHero/RolePlayingFramework/Combat/BattleReactionHelper.cs
+++ b/PitHero/RolePlayingFramework/Combat/BattleReactionHelper.cs
@@ -1,0 +1,46 @@
+namespace RolePlayingFramework.Combat
+{
+    /// <summary>
+    /// Pure static helpers for in-battle reactions (deflect and counter).
+    /// Roll values are passed in by the caller so production code uses
+    /// <c>Nez.Random.NextFloat()</c> while tests can supply deterministic values.
+    /// </summary>
+    public static class BattleReactionHelper
+    {
+        /// <summary>
+        /// Returns true when the defender's deflect chance is active and the roll beats it.
+        /// </summary>
+        /// <param name="defender">The combatant being attacked.</param>
+        /// <param name="roll">A value in [0, 1) supplied by the caller.</param>
+        public static bool RollDeflect(ICombatant defender, float roll)
+        {
+            return defender.DeflectChance > 0f && roll < defender.DeflectChance;
+        }
+
+        /// <summary>
+        /// Returns true when the defender has counter enabled and is still alive after
+        /// taking a hit (i.e. a counter-attack should be fired back).
+        /// </summary>
+        /// <param name="defender">The combatant who was just hit.</param>
+        public static bool ShouldCounter(ICombatant defender)
+        {
+            return defender.EnableCounter && defender.CurrentHP > 0;
+        }
+
+        /// <summary>
+        /// Returns true when the caster's first-attack crit chance applies and the roll wins.
+        /// This is the testable seam for Quickdraw: production code passes <c>Nez.Random.NextFloat()</c>;
+        /// tests supply a deterministic value.
+        /// </summary>
+        /// <param name="caster">The attacking combatant.</param>
+        /// <param name="isFirstAction">
+        /// Whether this is the caster's first offensive action this battle
+        /// (from <c>IBattleContext.IsFirstOffensiveAction</c>).
+        /// </param>
+        /// <param name="roll">A value in [0, 1) supplied by the caller.</param>
+        public static bool RollFirstAttackCrit(ICombatant caster, bool isFirstAction, float roll)
+        {
+            return isFirstAction && caster.FirstAttackCritChance > 0f && roll < caster.FirstAttackCritChance;
+        }
+    }
+}

--- a/PitHero/RolePlayingFramework/Combat/BuffType.cs
+++ b/PitHero/RolePlayingFramework/Combat/BuffType.cs
@@ -1,0 +1,18 @@
+namespace RolePlayingFramework.Combat
+{
+    /// <summary>Types of temporary battle-scoped buffs applied to a combatant.</summary>
+    public enum BuffType
+    {
+        /// <summary>Raises the combatant's effective defense stat.</summary>
+        DefenseUp,
+
+        /// <summary>Raises the combatant's effective evasion stat.</summary>
+        EvasionUp,
+
+        /// <summary>Adds MP restored per end-of-round regen tick.</summary>
+        MPRegen,
+
+        /// <summary>Combatant cannot be targeted by enemy attacks (Phase 4 — seam only in Phase 3).</summary>
+        Untargetable
+    }
+}

--- a/PitHero/RolePlayingFramework/Combat/IBattleContext.cs
+++ b/PitHero/RolePlayingFramework/Combat/IBattleContext.cs
@@ -1,0 +1,33 @@
+using RolePlayingFramework.Enemies;
+
+namespace RolePlayingFramework.Combat
+{
+    /// <summary>
+    /// Battle-scoped context passed to <see cref="ISkill.Execute"/> for effects that
+    /// outlast a single action (damage-over-time, first-offensive-action tracking).
+    /// Null when skills are invoked outside of a battle (out-of-battle heal path never
+    /// calls Execute; this parameter is reserved for future use there).
+    /// </summary>
+    public interface IBattleContext
+    {
+        /// <summary>
+        /// Registers a damage-over-time effect on an enemy.
+        /// If a DoT from the same source skill already targets the same enemy it is
+        /// refreshed (damage/turns updated) rather than stacked.
+        /// Actor name and type are resolved from <paramref name="actor"/> at registration time
+        /// so DoT tick analytics rows correctly attribute the source combatant.
+        /// </summary>
+        /// <param name="target">The enemy to poison/burn/etc.</param>
+        /// <param name="damagePerTurn">Damage applied at end of each round.</param>
+        /// <param name="turns">Number of rounds the DoT lasts.</param>
+        /// <param name="sourceSkillId">Skill id used for analytics and refresh logic.</param>
+        /// <param name="actor">The combatant who applied the DoT (hero or merc).</param>
+        void RegisterDoT(IEnemy target, int damagePerTurn, int turns, string sourceSkillId, ICombatant actor);
+
+        /// <summary>Returns true if this is the first offensive action the combatant has taken this battle.</summary>
+        bool IsFirstOffensiveAction(ICombatant c);
+
+        /// <summary>Records that the combatant has performed an offensive action.</summary>
+        void MarkActed(ICombatant c);
+    }
+}

--- a/PitHero/RolePlayingFramework/Combat/ICombatant.cs
+++ b/PitHero/RolePlayingFramework/Combat/ICombatant.cs
@@ -1,0 +1,150 @@
+using RolePlayingFramework.Equipment;
+using RolePlayingFramework.Stats;
+using System.Collections.Generic;
+
+namespace RolePlayingFramework.Combat
+{
+    /// <summary>
+    /// Shared interface for all participants in combat (Hero and Mercenary).
+    /// Provides a unified API for skills, passive effects, and vital operations so that
+    /// skill Execute/ApplyPassive implementations work identically for both entity types.
+    /// </summary>
+    public interface ICombatant
+    {
+        // ── Identity / stats ─────────────────────────────────────────────────────
+
+        /// <summary>Display name.</summary>
+        string Name { get; }
+
+        /// <summary>Current character level.</summary>
+        int Level { get; }
+
+        /// <summary>Returns current total stats (base + job + equipment + bonuses).</summary>
+        StatBlock GetTotalStats();
+
+        /// <summary>Maximum HP.</summary>
+        int MaxHP { get; }
+
+        /// <summary>Current HP.</summary>
+        int CurrentHP { get; }
+
+        /// <summary>Maximum MP.</summary>
+        int MaxMP { get; }
+
+        /// <summary>Current MP.</summary>
+        int CurrentMP { get; }
+
+        // ── Vital operations ─────────────────────────────────────────────────────
+
+        /// <summary>Inflicts damage. Returns true if the combatant died.</summary>
+        bool TakeDamage(int amount);
+
+        /// <summary>Restores HP up to MaxHP. Returns true if HP was actually restored.</summary>
+        bool RestoreHP(int amount);
+
+        /// <summary>Restores MP up to MaxMP. Returns true if MP was actually restored.</summary>
+        bool RestoreMP(int amount);
+
+        /// <summary>
+        /// Spends MP, applying MPCostReduction. Returns true on success, false if
+        /// insufficient MP after reduction is applied.
+        /// </summary>
+        bool SpendMP(int amount);
+
+        /// <summary>
+        /// Returns the effective MP cost after applying <see cref="MPCostReduction"/>,
+        /// using the same formula as <see cref="SpendMP"/> (floor of 1 when rawCost &gt; 0).
+        /// Use this in affordability checks so they are consistent with what SpendMP will deduct.
+        /// Returns 0 when <paramref name="rawCost"/> is 0 or negative.
+        /// </summary>
+        int GetEffectiveMPCost(int rawCost);
+
+        // ── Passive fields written by skill ApplyPassive / synergy effects ───────
+
+        /// <summary>Flat defense bonus from passives and buffs.</summary>
+        int PassiveDefenseBonus { get; set; }
+
+        /// <summary>Chance (0–1) to deflect an incoming attack entirely.</summary>
+        float DeflectChance { get; set; }
+
+        /// <summary>When true, the combatant retaliates after surviving a hit.</summary>
+        bool EnableCounter { get; set; }
+
+        /// <summary>MP restored per turn tick.</summary>
+        int MPTickRegen { get; set; }
+
+        /// <summary>Multiplicative bonus applied to all HP healed by skills.</summary>
+        float HealPowerBonus { get; set; }
+
+        /// <summary>Multiplicative bonus applied to Fire-element skill damage.</summary>
+        float FireDamageBonus { get; set; }
+
+        /// <summary>Fraction by which MP skill costs are reduced (0.15 = −15%).</summary>
+        float MPCostReduction { get; set; }
+
+        // ── Future-phase passive fields (plumbing only; default 0 in Phase 1) ────
+
+        /// <summary>Flat evasion bonus from passives (Phase 3/4 plumbing).</summary>
+        int EvasionBonus { get; set; }
+
+        /// <summary>Tile-radius sight bonus from Eagle Eye (Phase 4 plumbing).</summary>
+        int SightRangeBonus { get; set; }
+
+        /// <summary>First-attack critical-hit chance bonus from Quickdraw (Phase 4 plumbing).</summary>
+        float FirstAttackCritChance { get; set; }
+
+        /// <summary>Defense bonus applied only when wearing heavy mail armor (Phase 5 plumbing).</summary>
+        int HeavyArmorDefenseBonus { get; set; }
+
+        /// <summary>When true, the combatant detects and auto-disarms traps revealed by fog clearing (Phase 6).</summary>
+        bool TrapSense { get; set; }
+
+        // ── Equipment ────────────────────────────────────────────────────────────
+
+        /// <summary>Grants permission to equip items of the given kind outside normal job restrictions.</summary>
+        void AddExtraEquipPermission(ItemKind kind);
+
+        // ── Combat ───────────────────────────────────────────────────────────────
+
+        /// <summary>Returns the derived battle stats (Attack, Defense, Evasion) used in combat.</summary>
+        BattleStats GetBattleStats();
+
+        /// <summary>Performs one MP/regen tick (called at the end of each battle round).</summary>
+        void TickRegeneration();
+
+        // ── Battle-scoped buff system ─────────────────────────────────────────────
+
+        /// <summary>Adds or refreshes a battle-scoped buff on this combatant.</summary>
+        void AddBattleBuff(in BattleBuff buff);
+
+        /// <summary>
+        /// Returns the summed magnitude of all active buffs of the given type,
+        /// or 0 if no such buff is active.
+        /// </summary>
+        int GetBuffTotal(BuffType type);
+
+        /// <summary>
+        /// Returns the number of active buff stacks whose <see cref="BattleBuff.SourceSkillId"/>
+        /// matches <paramref name="sourceSkillId"/> AND whose <see cref="BattleBuff.Type"/>
+        /// matches <paramref name="type"/>.
+        /// Counting by both id and type prevents a multi-buff skill (e.g. FadeSkill with
+        /// EvasionUp + MPRegen) from blocking its second buff type when the first is at max stacks.
+        /// </summary>
+        int GetBuffStacks(string sourceSkillId, BuffType type);
+
+        /// <summary>
+        /// Decrements <see cref="BattleBuff.RemainingTurns"/> on all finite-duration buffs
+        /// and removes those that have expired.
+        /// Buffs with <c>RemainingTurns == -1</c> are permanent until battle end and are
+        /// never decremented here.
+        /// </summary>
+        void TickBuffDurations();
+
+        /// <summary>
+        /// Removes all active battle buffs.
+        /// Called at battle start to clear any leaked state and in the battle finally block
+        /// so buffs never persist outside of a battle.
+        /// </summary>
+        void ClearBattleState();
+    }
+}

--- a/PitHero/RolePlayingFramework/Heroes/Hero.cs
+++ b/PitHero/RolePlayingFramework/Heroes/Hero.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 namespace RolePlayingFramework.Heroes
 {
     /// <summary>Runtime hero instance with equipment, skills and derived stats.</summary>
-    public sealed class Hero
+    public sealed class Hero : ICombatant
     {
         public string Name { get; }
         public IJob Job { get; }
@@ -32,11 +32,21 @@ namespace RolePlayingFramework.Heroes
         public float FireDamageBonus { get; set; }
         public float MPCostReduction { get; set; }
 
+        // Future-phase passive fields (Phase 1 plumbing; default 0 until wired in later phases)
+        public int EvasionBonus { get; set; }
+        public int SightRangeBonus { get; set; }
+        public float FirstAttackCritChance { get; set; }
+        public int HeavyArmorDefenseBonus { get; set; }
+        public bool TrapSense { get; set; }
+
         // Synergy-based stat modifiers (internal for synergy effect access)
         internal StatBlock _synergyStatBonus = new StatBlock(0, 0, 0, 0);
         internal int _synergyHPBonus = 0;
         internal int _synergyMPBonus = 0;
         internal int _synergyCounterEnablers = 0; // Reference count for counter-enabling synergies
+
+        // Battle-scoped buff state — delegated to shared BattleBuffSet
+        private readonly BattleBuffSet _buffSet = new BattleBuffSet();
 
         // Equipment
         public IItem? WeaponShield1 { get; private set; }
@@ -200,12 +210,31 @@ namespace RolePlayingFramework.Heroes
             return CurrentHP == 0;
         }
 
+        /// <summary>
+        /// Directly sets CurrentMP to a saved value, clamped to [0, MaxMP].
+        /// Use this for state-restore paths (save/load) so MPCostReduction is NOT applied.
+        /// </summary>
+        public void SetCurrentMP(int value)
+        {
+            CurrentMP = value < 0 ? 0 : (value > MaxMP ? MaxMP : value);
+        }
+
+        /// <summary>
+        /// Returns the effective MP cost after applying MPCostReduction (floor of 1 when rawCost &gt; 0).
+        /// This is the exact amount SpendMP will deduct; use it in affordability checks.
+        /// </summary>
+        public int GetEffectiveMPCost(int rawCost)
+        {
+            if (rawCost <= 0) return 0;
+            int reduced = (int)(rawCost * (1f - MPCostReduction));
+            return reduced < 1 ? 1 : reduced;
+        }
+
         /// <summary>Spend MP if sufficient (includes passive cost reduction).</summary>
         public bool SpendMP(int amount)
         {
             if (amount <= 0) return true;
-            var reduced = (int)(amount * (1f - MPCostReduction));
-            if (reduced < 1) reduced = 1;
+            int reduced = GetEffectiveMPCost(amount);
             if (CurrentMP < reduced) return false;
             CurrentMP -= reduced;
             return true;
@@ -221,15 +250,38 @@ namespace RolePlayingFramework.Heroes
             return true;
         }
 
-        /// <summary>Per-turn passive MP regen.</summary>
+        /// <summary>Per-turn passive MP regen, including any active MPRegen buffs.</summary>
         public void TickRegeneration()
         {
-            if (MPTickRegen > 0)
+            int totalRegen = MPTickRegen + GetBuffTotal(BuffType.MPRegen);
+            if (totalRegen > 0)
             {
-                CurrentMP += MPTickRegen;
+                CurrentMP += totalRegen;
                 if (CurrentMP > MaxMP) CurrentMP = MaxMP;
             }
         }
+
+        // ── Battle-scoped buff system — delegates to shared BattleBuffSet ────────────────
+
+        /// <summary>Adds a battle buff. Each buff is tracked individually to support stacks.</summary>
+        public void AddBattleBuff(in BattleBuff buff) => _buffSet.AddBattleBuff(buff);
+
+        /// <summary>Returns the summed magnitude of all active buffs of the given type.</summary>
+        public int GetBuffTotal(BuffType type) => _buffSet.GetBuffTotal(type);
+
+        /// <summary>
+        /// Returns the number of active buff stacks from the given source skill AND of the given type.
+        /// Filtering by both skill id and buff type prevents multi-buff skills from blocking their
+        /// second buff type when the first type is already at max stacks.
+        /// </summary>
+        public int GetBuffStacks(string sourceSkillId, BuffType type)
+            => _buffSet.GetBuffStacks(sourceSkillId, type);
+
+        /// <summary>Decrements finite-duration buffs and removes expired ones.</summary>
+        public void TickBuffDurations() => _buffSet.TickBuffDurations();
+
+        /// <summary>Clears all battle buffs. Called at battle start and in the battle finally block.</summary>
+        public void ClearBattleState() => _buffSet.Clear();
 
         /// <summary>Equips an item into the appropriate slot based on item type and job restrictions.</summary>
         public bool TryEquip(IItem item)
@@ -396,7 +448,12 @@ namespace RolePlayingFramework.Heroes
         public int GetEquipmentDefenseBonus()
         {
             int def = PassiveDefenseBonus;
-            if (Armor is IGear armorGear) def += armorGear.DefenseBonus;
+            if (Armor is IGear armorGear)
+            {
+                def += armorGear.DefenseBonus;
+                if (armorGear.Kind == ItemKind.ArmorMail)
+                    def += HeavyArmorDefenseBonus;
+            }
             if (Hat is IGear helmGear) def += helmGear.DefenseBonus;
             if (WeaponShield2 is IGear shieldGear) def += shieldGear.DefenseBonus;
             if (Accessory1 is IGear acc1Gear) def += acc1Gear.DefenseBonus;
@@ -430,41 +487,60 @@ namespace RolePlayingFramework.Heroes
             return mp;
         }
 
+        /// <summary>
+        /// Computes battle stats for the hero, including any active battle buffs.
+        /// Called per-attack in the battle loop to ensure live buffs (DefenseUp, EvasionUp) count.
+        /// </summary>
+        public BattleStats GetBattleStats()
+        {
+            var totalStats = GetTotalStats();
+
+            int attack = totalStats.Strength + GetEquipmentAttackBonus();
+
+            int defense = totalStats.Agility / 2 + GetEquipmentDefenseBonus()
+                          + GetBuffTotal(BuffType.DefenseUp);
+
+            int baseEvasion = RolePlayingFramework.Balance.BalanceConfig.CalculateEvasion(totalStats.Agility, Level);
+            int evasion = baseEvasion + EvasionBonus + GetBuffTotal(BuffType.EvasionUp);
+            if (evasion > 255) evasion = 255;
+            if (evasion < 0) evasion = 0;
+
+            return new BattleStats(attack, defense, evasion);
+        }
+
         private void ApplyPassiveSkills()
         {
-            PassiveDefenseBonus = 0;
-            DeflectChance = 0;
-            EnableCounter = false;
-            MPTickRegen = 0;
-            HealPowerBonus = 0f;
-            FireDamageBonus = 0f;
-            MPCostReduction = 0f;
-            foreach (var kv in _learnedSkills)
-            {
-                if (kv.Value.Kind == SkillKind.Passive)
-                    kv.Value.ApplyPassive(this);
-            }
+            // Extra-equip permissions are rebuilt from scratch on every passive re-application
+            _extraEquipPermissions.Clear();
+            CombatantPassiveApplier.ResetAndApply(this, _learnedSkills);
+            ReapplySynergyPassiveEffects();
         }
 
-        public ISkill? ChooseActiveSkillForBattle()
+        /// <summary>
+        /// Re-applies active synergy group effects to passive fields after a skill reset.
+        /// Resets _synergyCounterEnablers first to prevent accumulation across repeated calls.
+        /// </summary>
+        private void ReapplySynergyPassiveEffects()
         {
-            ISkill? best = null;
-            int bestCost = -1;
-            foreach (var kv in _learnedSkills)
+            _synergyCounterEnablers = 0;
+            for (int i = 0; i < _activeSynergyGroups.Count; i++)
             {
-                var s = kv.Value;
-                if (s.Kind != SkillKind.Active) continue;
-                if (s.MPCost > CurrentMP) continue;
-                if (s.MPCost > bestCost) { best = s; bestCost = s.MPCost; }
+                var group = _activeSynergyGroups[i];
+                var effects = group.Pattern.Effects;
+                float multiplier = group.TotalMultiplier;
+                for (int j = 0; j < effects.Count; j++)
+                {
+                    // Only re-apply effects whose target fields were wiped by the passive reset
+                    // (PassiveDefenseBonus, DeflectChance, EnableCounter, MPTickRegen, HealPowerBonus,
+                    // FireDamageBonus, MPCostReduction). StatBonusEffect must NOT be re-applied: it
+                    // accumulates into _synergyStatBonus/_synergyHPBonus/_synergyMPBonus, which the
+                    // passive reset does not touch — re-applying it compounds stats on every
+                    // level-up/skill purchase (seen in play as a thief capping STR/AGI at 99 by L10).
+                    var effect = effects[j];
+                    if (effect is Synergies.PassiveAbilityEffect || effect is Synergies.SkillModifierEffect)
+                        effect.Apply(this, multiplier);
+                }
             }
-            return best;
-        }
-
-        public string? TryUseSkill(ISkill skill, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
-        {
-            if (skill.Kind != SkillKind.Active) return null;
-            if (!SpendMP(skill.MPCost)) return null;
-            return skill.Execute(this, primary, surrounding, resolver);
         }
 
         /// <summary>Earns JP for the bound crystal (if any).</summary>

--- a/PitHero/RolePlayingFramework/Mercenaries/Mercenary.cs
+++ b/PitHero/RolePlayingFramework/Mercenaries/Mercenary.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 namespace RolePlayingFramework.Mercenaries
 {
     /// <summary>Runtime mercenary instance with equipment, skills and derived stats (no crystal or synergies).</summary>
-    public sealed class Mercenary
+    public sealed class Mercenary : ICombatant
     {
         public string Name { get; }
         public IJob Job { get; }
@@ -28,6 +28,19 @@ namespace RolePlayingFramework.Mercenaries
         public float HealPowerBonus { get; set; }
         public float FireDamageBonus { get; set; }
         public float MPCostReduction { get; set; }
+
+        // Future-phase passive fields (Phase 1 plumbing; default 0 until wired in later phases)
+        public int EvasionBonus { get; set; }
+        public int SightRangeBonus { get; set; }
+        public float FirstAttackCritChance { get; set; }
+        public int HeavyArmorDefenseBonus { get; set; }
+        public bool TrapSense { get; set; }
+
+        // Extra equip permissions granted by learned passives (e.g. knight.light_armor allows robes)
+        private readonly HashSet<ItemKind> _extraEquipPermissions = new HashSet<ItemKind>();
+
+        // Battle-scoped buff state — delegated to shared BattleBuffSet
+        private readonly BattleBuffSet _buffSet = new BattleBuffSet();
 
         public IGear? WeaponShield1 { get; private set; }
         public IGear? Armor { get; private set; }
@@ -85,13 +98,21 @@ namespace RolePlayingFramework.Mercenaries
         /// <summary>Gets required XP for the next level.</summary>
         public int RequiredExpForNextLevel() => Level * 100;
 
-        /// <summary>Checks whether this mercenary can equip the given item based on job restrictions.</summary>
+        /// <summary>Grants permission to equip items of the given kind outside normal job restrictions.</summary>
+        public void AddExtraEquipPermission(ItemKind kind)
+        {
+            _extraEquipPermissions.Add(kind);
+        }
+
+        /// <summary>Checks whether this mercenary can equip the given item based on job and extra permissions.</summary>
         public bool CanEquipItem(IItem item)
         {
             if (item == null) return false;
             if (item is IGear gear)
             {
-                return (gear.AllowedJobs & Job.JobFlag) != 0;
+                if ((gear.AllowedJobs & Job.JobFlag) != 0) return true;
+                if (_extraEquipPermissions.Contains(gear.Kind)) return true;
+                return false;
             }
             return false;
         }
@@ -297,7 +318,9 @@ namespace RolePlayingFramework.Mercenaries
             if (CurrentMP > MaxMP) CurrentMP = MaxMP;
         }
 
-        /// <summary>Computes battle stats for combat calculations.</summary>
+        /// <summary>
+        /// Computes battle stats for combat calculations, including any active battle buffs.
+        /// </summary>
         public BattleStats GetBattleStats()
         {
             var effectiveStats = GetTotalStats();
@@ -307,12 +330,21 @@ namespace RolePlayingFramework.Mercenaries
             if (WeaponShield2 != null) atk += WeaponShield2.AttackBonus;
 
             int def = effectiveStats.Vitality + PassiveDefenseBonus;
-            if (Armor != null) def += Armor.DefenseBonus;
+            if (Armor != null)
+            {
+                def += Armor.DefenseBonus;
+                if (Armor.Kind == ItemKind.ArmorMail)
+                    def += HeavyArmorDefenseBonus;
+            }
             if (Hat != null) def += Hat.DefenseBonus;
             if (WeaponShield1 != null) def += WeaponShield1.DefenseBonus;
             if (WeaponShield2 != null) def += WeaponShield2.DefenseBonus;
+            def += GetBuffTotal(BuffType.DefenseUp);
 
-            int evasion = RolePlayingFramework.Balance.BalanceConfig.CalculateEvasion(effectiveStats.Agility, Level);
+            int baseEvasion = RolePlayingFramework.Balance.BalanceConfig.CalculateEvasion(effectiveStats.Agility, Level);
+            int evasion = baseEvasion + EvasionBonus + GetBuffTotal(BuffType.EvasionUp);
+            if (evasion > 255) evasion = 255;
+            if (evasion < 0) evasion = 0;
 
             return new BattleStats(atk, def, evasion);
         }
@@ -336,37 +368,69 @@ namespace RolePlayingFramework.Mercenaries
             return true;
         }
 
-        /// <summary>Restores MP for the specified amount.</summary>
-        public void RestoreMP(int amount)
+        /// <summary>Restores MP up to MaxMP. Returns true if MP was actually restored.</summary>
+        public bool RestoreMP(int amount)
         {
-            if (amount <= 0) return;
+            if (amount <= 0) return false;
+            if (CurrentMP >= MaxMP) return false;
             CurrentMP += amount;
             if (CurrentMP > MaxMP) CurrentMP = MaxMP;
-        }
-
-        /// <summary>Uses MP for skill casting. Returns true if successful.</summary>
-        public bool UseMP(int amount)
-        {
-            if (amount <= 0) return true;
-            if (CurrentMP < amount) return false;
-            CurrentMP -= amount;
             return true;
         }
 
-        /// <summary>Teaches the mercenary a skill. Returns true if learned successfully.</summary>
+        /// <summary>
+        /// Directly sets CurrentMP to a saved value, clamped to [0, MaxMP].
+        /// Use this for state-restore paths (save/load) so MPCostReduction is NOT applied.
+        /// </summary>
+        public void SetCurrentMP(int value)
+        {
+            CurrentMP = value < 0 ? 0 : (value > MaxMP ? MaxMP : value);
+        }
+
+        /// <summary>
+        /// Returns the effective MP cost after applying MPCostReduction (floor of 1 when rawCost &gt; 0).
+        /// This is the exact amount SpendMP will deduct; use it in affordability checks.
+        /// </summary>
+        public int GetEffectiveMPCost(int rawCost)
+        {
+            if (rawCost <= 0) return 0;
+            int reduced = (int)(rawCost * (1f - MPCostReduction));
+            return reduced < 1 ? 1 : reduced;
+        }
+
+        /// <summary>Spends MP applying MPCostReduction. Returns true on success.</summary>
+        public bool SpendMP(int amount)
+        {
+            if (amount <= 0) return true;
+            int reduced = GetEffectiveMPCost(amount);
+            if (CurrentMP < reduced) return false;
+            CurrentMP -= reduced;
+            return true;
+        }
+
+        /// <summary>Thin alias for SpendMP — preserves call sites that predate the ICombatant unification.</summary>
+        public bool UseMP(int amount) => SpendMP(amount);
+
+        /// <summary>Teaches the mercenary a skill and recomputes passive effects. Returns true if learned.</summary>
         public bool LearnSkill(ISkill skill)
         {
             if (skill == null || _learnedSkills.ContainsKey(skill.Id))
                 return false;
             _learnedSkills[skill.Id] = skill;
+            ApplyPassiveSkills();
             return true;
         }
 
-        /// <summary>Removes a learned skill by Id. Returns true if removed.</summary>
+        /// <summary>Removes a learned skill by Id and recomputes passive effects. Returns true if removed.</summary>
         public bool ForgetSkill(string skillId)
         {
             if (skillId == null) return false;
-            return _learnedSkills.Remove(skillId);
+            if (_learnedSkills.Remove(skillId))
+            {
+                ApplyPassiveSkills();
+                return true;
+            }
+            return false;
         }
 
         /// <summary>Learns all skills from the mercenary's job and applies passive effects.</summary>
@@ -380,48 +444,48 @@ namespace RolePlayingFramework.Mercenaries
             ApplyPassiveSkills();
         }
 
-        /// <summary>Applies passive skill effects to mercenary properties.</summary>
+        /// <summary>Per-turn passive MP regen (called at the end of each battle round), including MPRegen buffs.</summary>
+        public void TickRegeneration()
+        {
+            int totalRegen = MPTickRegen + GetBuffTotal(BuffType.MPRegen);
+            if (totalRegen > 0)
+            {
+                CurrentMP += totalRegen;
+                if (CurrentMP > MaxMP) CurrentMP = MaxMP;
+            }
+        }
+
+        // ── Battle-scoped buff system — delegates to shared BattleBuffSet ────────────────
+
+        /// <summary>Adds a battle buff. Each buff is tracked individually to support stacks.</summary>
+        public void AddBattleBuff(in BattleBuff buff) => _buffSet.AddBattleBuff(buff);
+
+        /// <summary>Returns the summed magnitude of all active buffs of the given type.</summary>
+        public int GetBuffTotal(BuffType type) => _buffSet.GetBuffTotal(type);
+
+        /// <summary>
+        /// Returns the number of active buff stacks from the given source skill AND of the given type.
+        /// Filtering by both skill id and buff type prevents multi-buff skills from blocking their
+        /// second buff type when the first type is already at max stacks.
+        /// </summary>
+        public int GetBuffStacks(string sourceSkillId, BuffType type)
+            => _buffSet.GetBuffStacks(sourceSkillId, type);
+
+        /// <summary>Decrements finite-duration buffs and removes expired ones.</summary>
+        public void TickBuffDurations() => _buffSet.TickBuffDurations();
+
+        /// <summary>Clears all battle buffs. Called at battle start and in the battle finally block.</summary>
+        public void ClearBattleState() => _buffSet.Clear();
+
+        /// <summary>
+        /// Resets all passive fields and re-applies them from the current learned-skill set.
+        /// Uses CombatantPassiveApplier so the reset list stays identical to Hero.
+        /// </summary>
         private void ApplyPassiveSkills()
         {
-            PassiveDefenseBonus = 0;
-            DeflectChance = 0f;
-            EnableCounter = false;
-            MPTickRegen = 0;
-            HealPowerBonus = 0f;
-            FireDamageBonus = 0f;
-            MPCostReduction = 0f;
-
-            var skills = Job.Skills;
-            for (int i = 0; i < skills.Count; i++)
-            {
-                var skill = skills[i];
-                if (skill.Kind != SkillKind.Passive) continue;
-
-                switch (skill.Id)
-                {
-                    case "knight.heavy_armor":
-                        PassiveDefenseBonus += 2;
-                        break;
-                    case "mage.heart_fire":
-                        FireDamageBonus += 0.25f;
-                        break;
-                    case "mage.economist":
-                        MPCostReduction += 0.15f;
-                        break;
-                    case "priest.calm_spirit":
-                        MPTickRegen += 1;
-                        break;
-                    case "priest.mender":
-                        HealPowerBonus += 0.25f;
-                        break;
-                    case "monk.counter":
-                        EnableCounter = true;
-                        break;
-                    case "monk.deflect":
-                        DeflectChance = 0.15f;
-                        break;
-                }
-            }
+            // Extra-equip permissions are rebuilt from scratch on every re-application
+            _extraEquipPermissions.Clear();
+            CombatantPassiveApplier.ResetAndApply(this, _learnedSkills);
         }
     }
 }

--- a/PitHero/RolePlayingFramework/Skills/ArcherSkills.cs
+++ b/PitHero/RolePlayingFramework/Skills/ArcherSkills.cs
@@ -1,6 +1,5 @@
 using RolePlayingFramework.Combat;
 using RolePlayingFramework.Enemies;
-using RolePlayingFramework.Heroes;
 using System.Collections.Generic;
 using PitHero;
 
@@ -9,11 +8,11 @@ namespace RolePlayingFramework.Skills
     public sealed class PowerShotSkill : BaseSkill
     {
         public PowerShotSkill() : base("archer.power_shot", SkillTextKey.Skill_Archer_PowerShot_Name, SkillTextKey.Skill_Archer_PowerShot_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 4, 130, ElementType.Neutral) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Physical, hero.Level, primary.Level);
-            // High damage shot
+            if (primary == null) return "PowerShot";
+            var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
+            // High damage shot: 1.5× base
             if (res.Hit) primary.TakeDamage((int)(res.Damage * 1.5f));
             return "PowerShot";
         }
@@ -22,13 +21,20 @@ namespace RolePlayingFramework.Skills
     public sealed class VolleySkill : BaseSkill
     {
         public VolleySkill() : base("archer.volley", SkillTextKey.Skill_Archer_Volley_Name, SkillTextKey.Skill_Archer_Volley_Desc, SkillKind.Active, SkillTargetType.SurroundingEnemies, 7, 200, ElementType.Neutral) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
+            // Hit primary target first (AoE fix: primary was previously excluded)
+            if (primary != null)
+            {
+                var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
+                if (res.Hit) primary.TakeDamage(res.Damage);
+            }
+
             for (int i = 0; i < surrounding.Count; i++)
             {
                 var e = surrounding[i];
-                var res = resolver.Resolve(stats, e.Stats, DamageKind.Physical, hero.Level, e.Level);
+                if (e == null) continue;
+                var res = ResolveHit(caster, e, DamageKind.Physical, resolver);
                 if (res.Hit) e.TakeDamage(res.Damage);
             }
             return "Volley";
@@ -38,20 +44,18 @@ namespace RolePlayingFramework.Skills
     public sealed class EagleEyePassive : BaseSkill
     {
         public EagleEyePassive() : base("archer.eagle_eye", SkillTextKey.Skill_Archer_EagleEye_Name, SkillTextKey.Skill_Archer_EagleEye_Desc, SkillKind.Passive, SkillTargetType.Self, 0, 70, ElementType.Neutral) { }
-        public override void ApplyPassive(Hero hero)
+        public override void ApplyPassive(ICombatant c)
         {
-            // TODO: Implement sight distance increase mechanic
-            // For now, this is a placeholder that can be enhanced later
+            c.SightRangeBonus += 1; // Phase 4: wired into TiledMapService.ClearFogOfWar
         }
     }
 
     public sealed class QuickdrawPassive : BaseSkill
     {
         public QuickdrawPassive() : base("archer.quickdraw", SkillTextKey.Skill_Archer_Quickdraw_Name, SkillTextKey.Skill_Archer_Quickdraw_Desc, SkillKind.Passive, SkillTargetType.Self, 0, 100, ElementType.Neutral) { }
-        public override void ApplyPassive(Hero hero)
+        public override void ApplyPassive(ICombatant c)
         {
-            // TODO: Implement first attack crit mechanic
-            // For now, this is a placeholder that can be enhanced later
+            c.FirstAttackCritChance += 0.5f; // Phase 4: applied in shared attack path
         }
     }
 }

--- a/PitHero/RolePlayingFramework/Skills/BaseSkill.cs
+++ b/PitHero/RolePlayingFramework/Skills/BaseSkill.cs
@@ -3,14 +3,16 @@ using PitHero;
 using PitHero.Services;
 using RolePlayingFramework.Combat;
 using RolePlayingFramework.Enemies;
-using RolePlayingFramework.Heroes;
+using RolePlayingFramework.Stats;
 using System.Collections.Generic;
 
 namespace RolePlayingFramework.Skills
 {
-    /// <summary>Base skill with default passive/active behavior.</summary>
+    /// <summary>Base skill with default passive/active behaviour.</summary>
     public abstract class BaseSkill : ISkill
     {
+        private static readonly SkillBuff[] _emptyBuffs = new SkillBuff[0];
+
         private readonly string _nameKey;
         private readonly string _descKey;
         private TextService _textService;
@@ -34,6 +36,12 @@ namespace RolePlayingFramework.Skills
         public int HPRestoreAmount { get; protected set; }
         public int MPRestoreAmount { get; protected set; }
 
+        /// <inheritdoc/>
+        public IReadOnlyList<SkillBuff> GrantedBuffs { get; protected set; }
+
+        /// <inheritdoc/>
+        public bool CleansesDebuffs { get; protected set; }
+
         protected BaseSkill(string id, string name, SkillKind kind, SkillTargetType targetType, int mpCost, int jpCost, ElementType element = ElementType.Neutral, bool battleOnly = true)
             : this(id, name, "", kind, targetType, mpCost, jpCost, element, battleOnly, 0, 0)
         {
@@ -52,9 +60,71 @@ namespace RolePlayingFramework.Skills
             BattleOnly = battleOnly;
             HPRestoreAmount = hpRestoreAmount;
             MPRestoreAmount = mpRestoreAmount;
+            GrantedBuffs = _emptyBuffs;
+            CleansesDebuffs = false;
         }
 
-        public virtual void ApplyPassive(Hero hero) { }
-        public virtual string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver) => Name;
+        /// <summary>Default implementation — passive skills override this.</summary>
+        public virtual void ApplyPassive(ICombatant c) { }
+
+        /// <summary>Default implementation — active skills override this.</summary>
+        public virtual string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding,
+            IAttackResolver resolver, IBattleContext battle) => Name;
+
+        /// <summary>
+        /// Resolves a single hit against <paramref name="target"/> using this skill's
+        /// <see cref="Element"/> for elemental damage multipliers.
+        /// When <paramref name="resolver"/> is <see cref="EnhancedAttackResolver"/> the
+        /// elemental overload is used (Fire skill vs Water enemy → 2× damage, etc.).
+        /// Otherwise falls back to the legacy stat-block overload.
+        /// </summary>
+        protected AttackResult ResolveHit(ICombatant caster, IEnemy target, DamageKind kind, IAttackResolver resolver)
+        {
+            var enhanced = resolver as EnhancedAttackResolver;
+            if (enhanced != null)
+            {
+                var casterBattleStats = caster.GetBattleStats();
+                var targetBattleStats = BattleStats.CalculateForMonster(target);
+                return enhanced.Resolve(casterBattleStats, targetBattleStats, kind, Element, target.ElementalProps);
+            }
+            // Legacy fallback — no elemental multiplier (same behaviour as pre-Phase-2)
+            StatBlock casterStats = caster.GetTotalStats();
+            return resolver.Resolve(casterStats, target.Stats, kind, caster.Level, target.Level);
+        }
+
+        /// <summary>
+        /// Resolves a hit against <paramref name="target"/> with the target's defense reduced
+        /// by <paramref name="defensePierceFraction"/> (e.g. 0.5 = half defense).
+        /// Used by armor-piercing attacks such as Piercing Arrow.
+        /// </summary>
+        /// <param name="defensePierceFraction">
+        /// Fraction of the target's normal defense to apply (0.0 = full ignore, 1.0 = normal).
+        /// </param>
+        protected AttackResult ResolveHitPiercing(ICombatant caster, IEnemy target, DamageKind kind,
+            IAttackResolver resolver, float defensePierceFraction)
+        {
+            var enhanced = resolver as EnhancedAttackResolver;
+            if (enhanced != null)
+            {
+                var casterBattleStats = caster.GetBattleStats();
+                var fullTargetStats = BattleStats.CalculateForMonster(target);
+                // Build a modified target with reduced defense
+                var piercedDefense = (int)(fullTargetStats.Defense * defensePierceFraction);
+                var piercedStats = new BattleStats(fullTargetStats.Attack, piercedDefense, fullTargetStats.Evasion);
+                return enhanced.Resolve(casterBattleStats, piercedStats, kind, Element, target.ElementalProps);
+            }
+
+            // Legacy fallback: approximate pierce by halving the defensive stats contribution.
+            // Build a pierced StatBlock with Vitality and Agility halved so the legacy
+            // resolver sees lower defense input, then restore Strength and Magic.
+            StatBlock casterStats = caster.GetTotalStats();
+            StatBlock defenderStats = target.Stats;
+            var piercedDefenderStats = new StatBlock(
+                defenderStats.Strength,
+                (int)(defenderStats.Agility * defensePierceFraction),
+                (int)(defenderStats.Vitality * defensePierceFraction),
+                defenderStats.Magic);
+            return resolver.Resolve(casterStats, piercedDefenderStats, kind, caster.Level, target.Level);
+        }
     }
 }

--- a/PitHero/RolePlayingFramework/Skills/CombatantPassiveApplier.cs
+++ b/PitHero/RolePlayingFramework/Skills/CombatantPassiveApplier.cs
@@ -1,0 +1,42 @@
+using RolePlayingFramework.Combat;
+using System.Collections.Generic;
+
+namespace RolePlayingFramework.Skills
+{
+    /// <summary>
+    /// Centralised passive-field reset and re-application for any ICombatant.
+    /// Both Hero.ApplyPassiveSkills and Mercenary.ApplyPassiveSkills delegate here so
+    /// the full set of zeroed fields can never diverge between the two classes.
+    /// </summary>
+    public static class CombatantPassiveApplier
+    {
+        /// <summary>
+        /// Zeroes all passive fields on <paramref name="combatant"/>, then iterates
+        /// <paramref name="learnedSkills"/> and calls <see cref="ISkill.ApplyPassive"/> on
+        /// each Passive-kind skill. Plain iteration — no LINQ.
+        /// </summary>
+        public static void ResetAndApply(ICombatant combatant, IReadOnlyDictionary<string, ISkill> learnedSkills)
+        {
+            // Reset phase — keep this list in sync with ICombatant passive fields
+            combatant.PassiveDefenseBonus = 0;
+            combatant.DeflectChance = 0f;
+            combatant.EnableCounter = false;
+            combatant.MPTickRegen = 0;
+            combatant.HealPowerBonus = 0f;
+            combatant.FireDamageBonus = 0f;
+            combatant.MPCostReduction = 0f;
+            combatant.EvasionBonus = 0;
+            combatant.SightRangeBonus = 0;
+            combatant.FirstAttackCritChance = 0f;
+            combatant.HeavyArmorDefenseBonus = 0;
+            combatant.TrapSense = false;
+
+            // Apply phase — only Passive-kind skills write the fields above
+            foreach (var kv in learnedSkills)
+            {
+                if (kv.Value.Kind == SkillKind.Passive)
+                    kv.Value.ApplyPassive(combatant);
+            }
+        }
+    }
+}

--- a/PitHero/RolePlayingFramework/Skills/ISkill.cs
+++ b/PitHero/RolePlayingFramework/Skills/ISkill.cs
@@ -1,6 +1,5 @@
 using RolePlayingFramework.Combat;
 using RolePlayingFramework.Enemies;
-using RolePlayingFramework.Heroes;
 using System.Collections.Generic;
 
 namespace RolePlayingFramework.Skills
@@ -28,10 +27,26 @@ namespace RolePlayingFramework.Skills
         /// <summary>Fixed amount of MP restored by this skill (0 if skill doesn't restore MP).</summary>
         int MPRestoreAmount { get; }
 
-        /// <summary>Applies passive modifiers at aggregation time (no side effects).</summary>
-        void ApplyPassive(Hero hero);
+        /// <summary>
+        /// Buffs this skill grants to its target when used as a healing/self skill.
+        /// Empty for attack-only skills. Applied by the battle loop's healing path.
+        /// </summary>
+        IReadOnlyList<SkillBuff> GrantedBuffs { get; }
 
-        /// <summary>Execute active effect (stateless). Returns descriptive tag for logging.</summary>
-        string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver);
+        /// <summary>
+        /// When true the healing path removes any ally-side debuffs from the target after
+        /// applying HP/MP/buffs (leave as false until a debuff system is added in a later phase).
+        /// </summary>
+        bool CleansesDebuffs { get; }
+
+        /// <summary>Applies passive modifiers to the combatant at aggregation time (no side effects).</summary>
+        void ApplyPassive(ICombatant c);
+
+        /// <summary>
+        /// Executes the active effect (stateless). Returns a descriptive tag for logging.
+        /// <paramref name="battle"/> is null when the skill is invoked outside of a battle.
+        /// </summary>
+        string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding,
+            IAttackResolver resolver, IBattleContext battle);
     }
 }

--- a/PitHero/RolePlayingFramework/Skills/KnightSkills.cs
+++ b/PitHero/RolePlayingFramework/Skills/KnightSkills.cs
@@ -1,6 +1,5 @@
 using RolePlayingFramework.Combat;
 using RolePlayingFramework.Enemies;
-using RolePlayingFramework.Heroes;
 using System.Collections.Generic;
 using PitHero;
 
@@ -10,56 +9,17 @@ namespace RolePlayingFramework.Skills
     public sealed class SpinSlashSkill : BaseSkill
     {
         public SpinSlashSkill() : base("knight.spin_slash", SkillTextKey.Skill_Knight_SpinSlash_Name, SkillTextKey.Skill_Knight_SpinSlash_Desc, SkillKind.Active, SkillTargetType.SurroundingEnemies, 4, 120, ElementType.Neutral) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            // Calculate battle stats for the hero
-            var heroBattleStats = BattleStats.CalculateForHero(hero);
-
-            // Cast to EnhancedAttackResolver to use BattleStats overload
-            var enhancedResolver = resolver as EnhancedAttackResolver;
-            if (enhancedResolver == null)
-            {
-                // Fallback to legacy method if not enhanced resolver
-                var stats = hero.GetTotalStats();
-
-                // Hit primary target first
-                if (primary != null)
-                {
-                    var res = resolver.Resolve(stats, primary.Stats, DamageKind.Physical, hero.Level, primary.Level);
-                    if (res.Hit)
-                    {
-                        int damage = (int)(res.Damage * 0.8f);
-                        if (damage < 1) damage = 1;
-                        primary.TakeDamage(damage);
-                    }
-                }
-
-                // Hit all surrounding enemies
-                for (int i = 0; i < surrounding.Count; i++)
-                {
-                    var e = surrounding[i];
-                    if (e == null) continue;
-                    var res = resolver.Resolve(stats, e.Stats, DamageKind.Physical, hero.Level, e.Level);
-                    if (res.Hit)
-                    {
-                        int damage = (int)(res.Damage * 0.8f);
-                        if (damage < 1) damage = 1;
-                        e.TakeDamage(damage);
-                    }
-                }
-                return "SpinSlash";
-            }
-
             // Hit primary target first
             if (primary != null)
             {
-                var targetBattleStats = BattleStats.CalculateForMonster(primary);
-                var res = enhancedResolver.Resolve(heroBattleStats, targetBattleStats, DamageKind.Physical);
+                var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
                 if (res.Hit)
                 {
-                    int damage = (int)(res.Damage * 0.8f);
-                    if (damage < 1) damage = 1;
-                    primary.TakeDamage(damage);
+                    int dmg = (int)(res.Damage * 0.8f);
+                    if (dmg < 1) dmg = 1;
+                    primary.TakeDamage(dmg);
                 }
             }
 
@@ -68,14 +28,12 @@ namespace RolePlayingFramework.Skills
             {
                 var e = surrounding[i];
                 if (e == null) continue;
-
-                var targetBattleStats = BattleStats.CalculateForMonster(e);
-                var res = enhancedResolver.Resolve(heroBattleStats, targetBattleStats, DamageKind.Physical);
+                var res = ResolveHit(caster, e, DamageKind.Physical, resolver);
                 if (res.Hit)
                 {
-                    int damage = (int)(res.Damage * 0.8f);
-                    if (damage < 1) damage = 1;
-                    e.TakeDamage(damage);
+                    int dmg = (int)(res.Damage * 0.8f);
+                    if (dmg < 1) dmg = 1;
+                    e.TakeDamage(dmg);
                 }
             }
             return "SpinSlash";
@@ -85,35 +43,12 @@ namespace RolePlayingFramework.Skills
     public sealed class HeavyStrikeSkill : BaseSkill
     {
         public HeavyStrikeSkill() : base("knight.heavy_strike", SkillTextKey.Skill_Knight_HeavyStrike_Name, SkillTextKey.Skill_Knight_HeavyStrike_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 5, 180, ElementType.Neutral) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
             if (primary == null) return "HeavyStrike";
-
-            var stats = hero.GetTotalStats();
-
-            // Cast to EnhancedAttackResolver to use BattleStats overload
-            var enhancedResolver = resolver as EnhancedAttackResolver;
-            if (enhancedResolver != null)
-            {
-                var heroBattleStats = BattleStats.CalculateForHero(hero);
-                var targetBattleStats = BattleStats.CalculateForMonster(primary);
-                var res = enhancedResolver.Resolve(heroBattleStats, targetBattleStats, DamageKind.Physical);
-                if (res.Hit)
-                {
-                    int bonusDamage = res.Damage + stats.Strength;
-                    primary.TakeDamage(bonusDamage);
-                }
-            }
-            else
-            {
-                // Fallback to legacy method
-                var res = resolver.Resolve(stats, primary.Stats, DamageKind.Physical, hero.Level, primary.Level);
-                if (res.Hit)
-                {
-                    int bonusDamage = res.Damage + stats.Strength;
-                    primary.TakeDamage(bonusDamage);
-                }
-            }
+            var stats = caster.GetTotalStats();
+            var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
+            if (res.Hit) primary.TakeDamage(res.Damage + stats.Strength);
             return "HeavyStrike";
         }
     }
@@ -122,18 +57,18 @@ namespace RolePlayingFramework.Skills
     public sealed class LightArmorPassive : BaseSkill
     {
         public LightArmorPassive() : base("knight.light_armor", SkillTextKey.Skill_Knight_LightArmor_Name, SkillTextKey.Skill_Knight_LightArmor_Desc, SkillKind.Passive, SkillTargetType.Self, 0, 50, ElementType.Neutral) { }
-        public override void ApplyPassive(Hero hero)
+        public override void ApplyPassive(ICombatant c)
         {
-            hero.AddExtraEquipPermission(Equipment.ItemKind.ArmorRobe); // allow robes
+            c.AddExtraEquipPermission(Equipment.ItemKind.ArmorRobe); // allow robes
         }
     }
 
     public sealed class HeavyArmorPassive : BaseSkill
     {
         public HeavyArmorPassive() : base("knight.heavy_armor", SkillTextKey.Skill_Knight_HeavyArmor_Name, SkillTextKey.Skill_Knight_HeavyArmor_Desc, SkillKind.Passive, SkillTargetType.Self, 0, 100, ElementType.Neutral) { }
-        public override void ApplyPassive(Hero hero)
+        public override void ApplyPassive(ICombatant c)
         {
-            hero.PassiveDefenseBonus += 2; // flat defense bonus applied in orchestrator damage step
+            c.HeavyArmorDefenseBonus = 2; // applied to defense only when ArmorMail is equipped
         }
     }
 }

--- a/PitHero/RolePlayingFramework/Skills/MageSkills.cs
+++ b/PitHero/RolePlayingFramework/Skills/MageSkills.cs
@@ -1,6 +1,5 @@
 using RolePlayingFramework.Combat;
 using RolePlayingFramework.Enemies;
-using RolePlayingFramework.Heroes;
 using System.Collections.Generic;
 using PitHero;
 
@@ -9,11 +8,12 @@ namespace RolePlayingFramework.Skills
     public sealed class FireSkill : BaseSkill
     {
         public FireSkill() : base("mage.fire", SkillTextKey.Skill_Mage_Fire_Name, SkillTextKey.Skill_Mage_Fire_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 3, 120, ElementType.Fire) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Magical, hero.Level, primary.Level);
-            if (res.Hit) primary.TakeDamage(res.Damage + (int)(stats.Magic * (1f + hero.FireDamageBonus)));
+            if (primary == null) return "Fire";
+            var stats = caster.GetTotalStats();
+            var res = ResolveHit(caster, primary, DamageKind.Magical, resolver);
+            if (res.Hit) primary.TakeDamage(res.Damage + (int)(stats.Magic * (1f + caster.FireDamageBonus)));
             return "Fire";
         }
     }
@@ -21,14 +21,23 @@ namespace RolePlayingFramework.Skills
     public sealed class FireStormSkill : BaseSkill
     {
         public FireStormSkill() : base("mage.firestorm", SkillTextKey.Skill_Mage_Firestorm_Name, SkillTextKey.Skill_Mage_Firestorm_Desc, SkillKind.Active, SkillTargetType.SurroundingEnemies, 6, 200, ElementType.Fire) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
+            var stats = caster.GetTotalStats();
+
+            // Hit primary target first (AoE fix: primary was previously excluded)
+            if (primary != null)
+            {
+                var res = ResolveHit(caster, primary, DamageKind.Magical, resolver);
+                if (res.Hit) primary.TakeDamage(res.Damage + (int)(stats.Magic * 0.5f * (1f + caster.FireDamageBonus)));
+            }
+
             for (int i = 0; i < surrounding.Count; i++)
             {
                 var e = surrounding[i];
-                var res = resolver.Resolve(stats, e.Stats, DamageKind.Magical, hero.Level, e.Level);
-                if (res.Hit) e.TakeDamage(res.Damage + (int)(stats.Magic * 0.5f * (1f + hero.FireDamageBonus)));
+                if (e == null) continue;
+                var res = ResolveHit(caster, e, DamageKind.Magical, resolver);
+                if (res.Hit) e.TakeDamage(res.Damage + (int)(stats.Magic * 0.5f * (1f + caster.FireDamageBonus)));
             }
             return "FireStorm";
         }
@@ -37,18 +46,18 @@ namespace RolePlayingFramework.Skills
     public sealed class HeartOfFirePassive : BaseSkill
     {
         public HeartOfFirePassive() : base("mage.heart_fire", SkillTextKey.Skill_Mage_HeartFire_Name, SkillTextKey.Skill_Mage_HeartFire_Desc, SkillKind.Passive, SkillTargetType.Self, 0, 60, ElementType.Neutral) { }
-        public override void ApplyPassive(Hero hero)
+        public override void ApplyPassive(ICombatant c)
         {
-            hero.FireDamageBonus += 0.25f; // +25% fire
+            c.FireDamageBonus += 0.25f; // +25% fire
         }
     }
 
     public sealed class EconomistPassive : BaseSkill
     {
         public EconomistPassive() : base("mage.economist", SkillTextKey.Skill_Mage_Economist_Name, SkillTextKey.Skill_Mage_Economist_Desc, SkillKind.Passive, SkillTargetType.Self, 0, 80, ElementType.Neutral) { }
-        public override void ApplyPassive(Hero hero)
+        public override void ApplyPassive(ICombatant c)
         {
-            hero.MPCostReduction += 0.15f; // -15% MP costs
+            c.MPCostReduction += 0.15f; // -15% MP costs
         }
     }
 }

--- a/PitHero/RolePlayingFramework/Skills/MonkSkills.cs
+++ b/PitHero/RolePlayingFramework/Skills/MonkSkills.cs
@@ -1,6 +1,5 @@
 using RolePlayingFramework.Combat;
 using RolePlayingFramework.Enemies;
-using RolePlayingFramework.Heroes;
 using System.Collections.Generic;
 using PitHero;
 
@@ -9,13 +8,20 @@ namespace RolePlayingFramework.Skills
     public sealed class RoundhouseSkill : BaseSkill
     {
         public RoundhouseSkill() : base("monk.roundhouse", SkillTextKey.Skill_Monk_Roundhouse_Name, SkillTextKey.Skill_Monk_Roundhouse_Desc, SkillKind.Active, SkillTargetType.SurroundingEnemies, 4, 120, ElementType.Neutral) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
+            // Hit primary target first (AoE fix: primary was previously excluded)
+            if (primary != null)
+            {
+                var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
+                if (res.Hit) primary.TakeDamage(res.Damage);
+            }
+
             for (int i = 0; i < surrounding.Count; i++)
             {
                 var e = surrounding[i];
-                var res = resolver.Resolve(stats, e.Stats, DamageKind.Physical, hero.Level, e.Level);
+                if (e == null) continue;
+                var res = ResolveHit(caster, e, DamageKind.Physical, resolver);
                 if (res.Hit) e.TakeDamage(res.Damage);
             }
             return "Roundhouse";
@@ -25,11 +31,13 @@ namespace RolePlayingFramework.Skills
     public sealed class FlamingFistSkill : BaseSkill
     {
         public FlamingFistSkill() : base("monk.flaming_fist", SkillTextKey.Skill_Monk_FlamingFist_Name, SkillTextKey.Skill_Monk_FlamingFist_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 5, 170, ElementType.Fire) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Physical, hero.Level, primary.Level);
-            if (res.Hit) primary.TakeDamage(res.Damage + stats.Magic / 2);
+            if (primary == null) return "FlamingFist";
+            var stats = caster.GetTotalStats();
+            var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
+            // Fire bonus applied to the magic-derived portion (normalization fix)
+            if (res.Hit) primary.TakeDamage(res.Damage + (int)(stats.Magic * 0.5f * (1f + caster.FireDamageBonus)));
             return "FlamingFist";
         }
     }
@@ -37,18 +45,18 @@ namespace RolePlayingFramework.Skills
     public sealed class CounterPassive : BaseSkill
     {
         public CounterPassive() : base("monk.counter", SkillTextKey.Skill_Monk_Counter_Name, SkillTextKey.Skill_Monk_Counter_Desc, SkillKind.Passive, SkillTargetType.Self, 0, 70, ElementType.Neutral) { }
-        public override void ApplyPassive(Hero hero)
+        public override void ApplyPassive(ICombatant c)
         {
-            hero.EnableCounter = true;
+            c.EnableCounter = true;
         }
     }
 
     public sealed class DeflectPassive : BaseSkill
     {
         public DeflectPassive() : base("monk.deflect", SkillTextKey.Skill_Monk_Deflect_Name, SkillTextKey.Skill_Monk_Deflect_Desc, SkillKind.Passive, SkillTargetType.Self, 0, 90, ElementType.Neutral) { }
-        public override void ApplyPassive(Hero hero)
+        public override void ApplyPassive(ICombatant c)
         {
-            hero.DeflectChance = 0.15f; // 15%
+            c.DeflectChance = 0.15f; // 15%
         }
     }
 }

--- a/PitHero/RolePlayingFramework/Skills/PriestSkills.cs
+++ b/PitHero/RolePlayingFramework/Skills/PriestSkills.cs
@@ -1,6 +1,5 @@
 using RolePlayingFramework.Combat;
 using RolePlayingFramework.Enemies;
-using RolePlayingFramework.Heroes;
 using System.Collections.Generic;
 using PitHero;
 
@@ -9,38 +8,45 @@ namespace RolePlayingFramework.Skills
     public sealed class HealSkill : BaseSkill
     {
         public HealSkill() : base("priest.heal", SkillTextKey.Skill_Priest_Heal_Name, SkillTextKey.Skill_Priest_Heal_Desc, SkillKind.Active, SkillTargetType.Self, 3, 100, ElementType.Light, battleOnly: false, hpRestoreAmount: 25, mpRestoreAmount: 0) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            hero.RestoreHP(SkillHealCalculator.GetAmount(this, hero));
+            caster.RestoreHP(SkillHealCalculator.GetAmount(this, caster));
             return "Heal";
         }
     }
 
+    /// <summary>
+    /// DefenseUp — data-driven buff skill (Phase 3).
+    /// Grants DefenseUp +1 until battle end, up to 3 stacks.
+    /// The Execute override is removed; the healing/buff path in ApplyHealingSkillEffectsAndDisplay
+    /// reads GrantedBuffs and applies the buff automatically.
+    /// </summary>
     public sealed class DefenseUpSkill : BaseSkill
     {
-        public DefenseUpSkill() : base("priest.defup", SkillTextKey.Skill_Priest_DefenseUp_Name, SkillTextKey.Skill_Priest_DefenseUp_Desc, SkillKind.Active, SkillTargetType.Self, 4, 160, ElementType.Neutral) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public DefenseUpSkill() : base("priest.defup", SkillTextKey.Skill_Priest_DefenseUp_Name, SkillTextKey.Skill_Priest_DefenseUp_Desc, SkillKind.Active, SkillTargetType.Self, 4, 160, ElementType.Neutral)
         {
-            hero.PassiveDefenseBonus += 1; // temporary simple stackable buff
-            return "DefenseUp";
+            GrantedBuffs = new SkillBuff[]
+            {
+                new SkillBuff(BuffType.DefenseUp, magnitude: 1, durationTurns: -1, maxStacks: 3)
+            };
         }
     }
 
     public sealed class CalmSpiritPassive : BaseSkill
     {
         public CalmSpiritPassive() : base("priest.calm_spirit", SkillTextKey.Skill_Priest_CalmSpirit_Name, SkillTextKey.Skill_Priest_CalmSpirit_Desc, SkillKind.Passive, SkillTargetType.Self, 0, 50, ElementType.Neutral) { }
-        public override void ApplyPassive(Hero hero)
+        public override void ApplyPassive(ICombatant c)
         {
-            hero.MPTickRegen += 1; // +1 AP per turn cycle
+            c.MPTickRegen += 1; // +1 MP per turn cycle
         }
     }
 
     public sealed class MenderPassive : BaseSkill
     {
         public MenderPassive() : base("priest.mender", SkillTextKey.Skill_Priest_Mender_Name, SkillTextKey.Skill_Priest_Mender_Desc, SkillKind.Passive, SkillTargetType.Self, 0, 80, ElementType.Neutral) { }
-        public override void ApplyPassive(Hero hero)
+        public override void ApplyPassive(ICombatant c)
         {
-            hero.HealPowerBonus += 0.25f; // +25% healing
+            c.HealPowerBonus += 0.25f; // +25% healing
         }
     }
 }

--- a/PitHero/RolePlayingFramework/Skills/SkillBuff.cs
+++ b/PitHero/RolePlayingFramework/Skills/SkillBuff.cs
@@ -1,0 +1,36 @@
+namespace RolePlayingFramework.Skills
+{
+    /// <summary>
+    /// Declares a buff that a skill grants to its target when used.
+    /// Stored in <see cref="ISkill.GrantedBuffs"/>; the battle loop converts each entry
+    /// into a <see cref="RolePlayingFramework.Combat.BattleBuff"/> when the skill is applied.
+    /// </summary>
+    public struct SkillBuff
+    {
+        /// <summary>What kind of buff is granted.</summary>
+        public RolePlayingFramework.Combat.BuffType Type;
+
+        /// <summary>How much the buff adds (e.g. +1 defense, +40 evasion).</summary>
+        public int Magnitude;
+
+        /// <summary>
+        /// Duration in turns; <c>-1</c> means until battle end.
+        /// </summary>
+        public int DurationTurns;
+
+        /// <summary>
+        /// Maximum number of stacks of this buff (from this skill) that can coexist on the target.
+        /// The battle loop skips granting additional stacks once the cap is reached.
+        /// </summary>
+        public int MaxStacks;
+
+        /// <summary>Creates a new SkillBuff descriptor.</summary>
+        public SkillBuff(RolePlayingFramework.Combat.BuffType type, int magnitude, int durationTurns, int maxStacks)
+        {
+            Type = type;
+            Magnitude = magnitude;
+            DurationTurns = durationTurns;
+            MaxStacks = maxStacks;
+        }
+    }
+}

--- a/PitHero/RolePlayingFramework/Skills/SkillHealCalculator.cs
+++ b/PitHero/RolePlayingFramework/Skills/SkillHealCalculator.cs
@@ -1,6 +1,5 @@
 using RolePlayingFramework.Balance;
-using RolePlayingFramework.Heroes;
-using RolePlayingFramework.Mercenaries;
+using RolePlayingFramework.Combat;
 
 namespace RolePlayingFramework.Skills
 {
@@ -10,25 +9,20 @@ namespace RolePlayingFramework.Skills
     /// </summary>
     public static class SkillHealCalculator
     {
-        /// <summary>Effective HP restored when the hero casts the skill.</summary>
-        public static int GetAmount(ISkill skill, Hero caster)
+        /// <summary>Effective HP restored when <paramref name="caster"/> uses the skill.</summary>
+        public static int GetAmount(ISkill skill, ICombatant caster)
         {
             return BalanceConfig.CalculateSkillHealAmount(skill.HPRestoreAmount, caster.GetTotalStats().Magic, caster.HealPowerBonus);
         }
 
-        /// <summary>Effective HP restored when a mercenary casts the skill.</summary>
-        public static int GetAmount(ISkill skill, Mercenary caster)
-        {
-            return BalanceConfig.CalculateSkillHealAmount(skill.HPRestoreAmount, caster.GetTotalStats().Magic, caster.HealPowerBonus);
-        }
-
-        /// <summary>Effective HP restored for a caster that may be a hero or a mercenary.</summary>
+        /// <summary>
+        /// Effective HP restored for a caster held as a reference-typed object.
+        /// Checks for ICombatant at runtime; returns base amount if caster does not implement it.
+        /// </summary>
         public static int GetAmount(ISkill skill, object caster)
         {
-            if (caster is Hero hero)
-                return GetAmount(skill, hero);
-            if (caster is Mercenary mercenary)
-                return GetAmount(skill, mercenary);
+            if (caster is ICombatant c)
+                return GetAmount(skill, c);
             return skill.HPRestoreAmount;
         }
     }

--- a/PitHero/RolePlayingFramework/Skills/SynergySkills.cs
+++ b/PitHero/RolePlayingFramework/Skills/SynergySkills.cs
@@ -1,6 +1,5 @@
 using RolePlayingFramework.Combat;
 using RolePlayingFramework.Enemies;
-using RolePlayingFramework.Heroes;
 using System.Collections.Generic;
 using PitHero;
 
@@ -14,10 +13,11 @@ namespace RolePlayingFramework.Skills
     public sealed class HolyStrikeSkill : BaseSkill
     {
         public HolyStrikeSkill() : base("synergy.holy_strike", SkillTextKey.Skill_Synergy_HolyStrike_Name, SkillTextKey.Skill_Synergy_HolyStrike_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 6, 200, ElementType.Light) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Physical, hero.Level, primary.Level);
+            if (primary == null) return "HolyStrike";
+            var stats = caster.GetTotalStats();
+            var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
             if (res.Hit) primary.TakeDamage(res.Damage + (int)(stats.Strength * 0.5f));
             return "HolyStrike";
         }
@@ -27,10 +27,10 @@ namespace RolePlayingFramework.Skills
     public sealed class IaidoSlashSkill : BaseSkill
     {
         public IaidoSlashSkill() : base("synergy.iaido_slash", SkillTextKey.Skill_Synergy_IaidoSlash_Name, SkillTextKey.Skill_Synergy_IaidoSlash_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 5, 180, ElementType.Neutral) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Physical, hero.Level, primary.Level);
+            if (primary == null) return "IaidoSlash";
+            var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
             if (res.Hit) primary.TakeDamage((int)(res.Damage * 1.3f));
             return "IaidoSlash";
         }
@@ -40,24 +40,27 @@ namespace RolePlayingFramework.Skills
     public sealed class ShadowSlashSkill : BaseSkill
     {
         public ShadowSlashSkill() : base("synergy.shadow_slash", SkillTextKey.Skill_Synergy_ShadowSlash_Name, SkillTextKey.Skill_Synergy_ShadowSlash_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 5, 175, ElementType.Dark) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Physical, hero.Level, primary.Level);
+            if (primary == null) return "ShadowSlash";
+            var stats = caster.GetTotalStats();
+            var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
             if (res.Hit) primary.TakeDamage(res.Damage + stats.Agility / 2);
             return "ShadowSlash";
         }
     }
 
-    /// <summary>Spellblade from War Mage - Magic-infused physical attack.</summary>
+    /// <summary>Spellblade from War Mage - Magic-infused physical attack with fire bonus.</summary>
     public sealed class SpellbladeSkill : BaseSkill
     {
         public SpellbladeSkill() : base("synergy.spellblade", SkillTextKey.Skill_Synergy_Spellblade_Name, SkillTextKey.Skill_Synergy_Spellblade_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 7, 220, ElementType.Fire) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Physical, hero.Level, primary.Level);
-            if (res.Hit) primary.TakeDamage(res.Damage + stats.Magic / 3);
+            if (primary == null) return "Spellblade";
+            var stats = caster.GetTotalStats();
+            var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
+            // Fire bonus applied to magic-derived portion (normalization fix)
+            if (res.Hit) primary.TakeDamage(res.Damage + (int)(stats.Magic / 3f * (1f + caster.FireDamageBonus)));
             return "Spellblade";
         }
     }
@@ -70,14 +73,23 @@ namespace RolePlayingFramework.Skills
     public sealed class MeteorSkill : BaseSkill
     {
         public MeteorSkill() : base("synergy.meteor", SkillTextKey.Skill_Synergy_Meteor_Name, SkillTextKey.Skill_Synergy_Meteor_Desc, SkillKind.Active, SkillTargetType.SurroundingEnemies, 12, 350, ElementType.Fire) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
+            var stats = caster.GetTotalStats();
+
+            // Hit primary target first (AoE fix: primary was previously excluded)
+            if (primary != null)
+            {
+                var res = ResolveHit(caster, primary, DamageKind.Magical, resolver);
+                if (res.Hit) primary.TakeDamage(res.Damage + (int)(stats.Magic * 0.8f * (1f + caster.FireDamageBonus)));
+            }
+
             for (int i = 0; i < surrounding.Count; i++)
             {
                 var e = surrounding[i];
-                var res = resolver.Resolve(stats, e.Stats, DamageKind.Magical, hero.Level, e.Level);
-                if (res.Hit) e.TakeDamage(res.Damage + (int)(stats.Magic * 0.8f * (1f + hero.FireDamageBonus)));
+                if (e == null) continue;
+                var res = ResolveHit(caster, e, DamageKind.Magical, resolver);
+                if (res.Hit) e.TakeDamage(res.Damage + (int)(stats.Magic * 0.8f * (1f + caster.FireDamageBonus)));
             }
             return "Meteor";
         }
@@ -87,10 +99,11 @@ namespace RolePlayingFramework.Skills
     public sealed class ShadowBoltSkill : BaseSkill
     {
         public ShadowBoltSkill() : base("synergy.shadow_bolt", SkillTextKey.Skill_Synergy_ShadowBolt_Name, SkillTextKey.Skill_Synergy_ShadowBolt_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 5, 160, ElementType.Dark) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Magical, hero.Level, primary.Level);
+            if (primary == null) return "ShadowBolt";
+            var stats = caster.GetTotalStats();
+            var res = ResolveHit(caster, primary, DamageKind.Magical, resolver);
             if (res.Hit) primary.TakeDamage(res.Damage + stats.Magic / 2);
             return "ShadowBolt";
         }
@@ -100,27 +113,37 @@ namespace RolePlayingFramework.Skills
     public sealed class ElementalVolleySkill : BaseSkill
     {
         public ElementalVolleySkill() : base("synergy.elemental_volley", SkillTextKey.Skill_Synergy_ElementalVolley_Name, SkillTextKey.Skill_Synergy_ElementalVolley_Desc, SkillKind.Active, SkillTargetType.SurroundingEnemies, 8, 280, ElementType.Fire) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
+            var stats = caster.GetTotalStats();
+
+            // Hit primary target first (AoE fix: primary was previously excluded)
+            if (primary != null)
+            {
+                var res = ResolveHit(caster, primary, DamageKind.Magical, resolver);
+                if (res.Hit) primary.TakeDamage(res.Damage + stats.Magic / 3);
+            }
+
             for (int i = 0; i < surrounding.Count; i++)
             {
                 var e = surrounding[i];
-                var res = resolver.Resolve(stats, e.Stats, DamageKind.Magical, hero.Level, e.Level);
+                if (e == null) continue;
+                var res = ResolveHit(caster, e, DamageKind.Magical, resolver);
                 if (res.Hit) e.TakeDamage(res.Damage + stats.Magic / 3);
             }
             return "ElementalVolley";
         }
     }
 
-    /// <summary>Blitz from War Mage - Quick magic burst.</summary>
+    /// <summary>Blitz from War Mage - Quick wind magic burst.</summary>
     public sealed class BlitzSkill : BaseSkill
     {
         public BlitzSkill() : base("synergy.blitz", SkillTextKey.Skill_Synergy_Blitz_Name, SkillTextKey.Skill_Synergy_Blitz_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 4, 150, ElementType.Wind) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Magical, hero.Level, primary.Level);
+            if (primary == null) return "Blitz";
+            var stats = caster.GetTotalStats();
+            var res = ResolveHit(caster, primary, DamageKind.Magical, resolver);
             if (res.Hit) primary.TakeDamage(res.Damage + stats.Agility / 3);
             return "Blitz";
         }
@@ -130,28 +153,30 @@ namespace RolePlayingFramework.Skills
     // PRIEST SYNERGY SKILLS
     // ==============================================================================
 
-    /// <summary>Aura Heal from Paladin - Healing with protection.</summary>
+    /// <summary>
+    /// Aura Heal from Paladin — data-driven heal + DefenseUp buff (Phase 3).
+    /// Heals 25 HP (scaled via SkillHealCalculator) and grants DefenseUp +2 for 3 turns, up to 1 stack.
+    /// </summary>
     public sealed class AuraHealSkill : BaseSkill
     {
-        public AuraHealSkill() : base("synergy.aura_heal", SkillTextKey.Skill_Synergy_AuraHeal_Name, SkillTextKey.Skill_Synergy_AuraHeal_Desc, SkillKind.Active, SkillTargetType.Self, 6, 200, ElementType.Light) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public AuraHealSkill() : base("synergy.aura_heal", SkillTextKey.Skill_Synergy_AuraHeal_Name, SkillTextKey.Skill_Synergy_AuraHeal_Desc, SkillKind.Active, SkillTargetType.Self, 6, 200, ElementType.Light, battleOnly: true, hpRestoreAmount: 25)
         {
-            var mult = 1f + hero.HealPowerBonus;
-            hero.RestoreHP((int)((25 + hero.GetTotalStats().Magic * 2.5f) * mult));
-            hero.PassiveDefenseBonus += 2;
-            return "AuraHeal";
+            GrantedBuffs = new SkillBuff[]
+            {
+                new SkillBuff(BuffType.DefenseUp, magnitude: 2, durationTurns: 3, maxStacks: 1)
+            };
         }
     }
 
-    /// <summary>Purify from Wizard - Remove debuffs and heal.</summary>
+    /// <summary>
+    /// Purify from Wizard — data-driven heal + cleanse (Phase 3).
+    /// Heals 15 HP (scaled via SkillHealCalculator) and sets CleansesDebuffs = true.
+    /// </summary>
     public sealed class PurifySkill : BaseSkill
     {
-        public PurifySkill() : base("synergy.purify", SkillTextKey.Skill_Synergy_Purify_Name, SkillTextKey.Skill_Synergy_Purify_Desc, SkillKind.Active, SkillTargetType.Self, 5, 180, ElementType.Light) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public PurifySkill() : base("synergy.purify", SkillTextKey.Skill_Synergy_Purify_Name, SkillTextKey.Skill_Synergy_Purify_Desc, SkillKind.Active, SkillTargetType.Self, 5, 180, ElementType.Light, battleOnly: true, hpRestoreAmount: 15)
         {
-            var mult = 1f + hero.HealPowerBonus;
-            hero.RestoreHP((int)((15 + hero.GetTotalStats().Magic * 2) * mult));
-            return "Purify";
+            CleansesDebuffs = true;
         }
     }
 
@@ -159,10 +184,11 @@ namespace RolePlayingFramework.Skills
     public sealed class SacredStrikeSkill : BaseSkill
     {
         public SacredStrikeSkill() : base("synergy.sacred_strike", SkillTextKey.Skill_Synergy_SacredStrike_Name, SkillTextKey.Skill_Synergy_SacredStrike_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 5, 190, ElementType.Light) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Physical, hero.Level, primary.Level);
+            if (primary == null) return "SacredStrike";
+            var stats = caster.GetTotalStats();
+            var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
             if (res.Hit) primary.TakeDamage(res.Damage + stats.Magic / 4);
             return "SacredStrike";
         }
@@ -172,15 +198,16 @@ namespace RolePlayingFramework.Skills
     public sealed class LifeLeechSkill : BaseSkill
     {
         public LifeLeechSkill() : base("synergy.life_leech", SkillTextKey.Skill_Synergy_LifeLeech_Name, SkillTextKey.Skill_Synergy_LifeLeech_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 6, 210, ElementType.Dark) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Magical, hero.Level, primary.Level);
+            if (primary == null) return "LifeLeech";
+            var stats = caster.GetTotalStats();
+            var res = ResolveHit(caster, primary, DamageKind.Magical, resolver);
             if (res.Hit)
             {
                 int damage = res.Damage + stats.Magic / 3;
                 primary.TakeDamage(damage);
-                hero.RestoreHP(damage / 2);
+                caster.RestoreHP(damage / 2);
             }
             return "LifeLeech";
         }
@@ -194,11 +221,13 @@ namespace RolePlayingFramework.Skills
     public sealed class DragonClawSkill : BaseSkill
     {
         public DragonClawSkill() : base("synergy.dragon_claw", SkillTextKey.Skill_Synergy_DragonClaw_Name, SkillTextKey.Skill_Synergy_DragonClaw_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 7, 230, ElementType.Fire) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Physical, hero.Level, primary.Level);
-            if (res.Hit) primary.TakeDamage((int)((res.Damage + stats.Magic / 2) * (1f + hero.FireDamageBonus)));
+            if (primary == null) return "DragonClaw";
+            var stats = caster.GetTotalStats();
+            var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
+            // Fire bonus already applied — multiplies total of base + magic bonus
+            if (res.Hit) primary.TakeDamage((int)((res.Damage + stats.Magic / 2) * (1f + caster.FireDamageBonus)));
             return "DragonClaw";
         }
     }
@@ -207,13 +236,22 @@ namespace RolePlayingFramework.Skills
     public sealed class EnergyBurstSkill : BaseSkill
     {
         public EnergyBurstSkill() : base("synergy.energy_burst", SkillTextKey.Skill_Synergy_EnergyBurst_Name, SkillTextKey.Skill_Synergy_EnergyBurst_Desc, SkillKind.Active, SkillTargetType.SurroundingEnemies, 8, 250, ElementType.Neutral) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
+            var stats = caster.GetTotalStats();
+
+            // Hit primary target first (AoE fix: primary was previously excluded)
+            if (primary != null)
+            {
+                var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
+                if (res.Hit) primary.TakeDamage(res.Damage + stats.Magic / 4);
+            }
+
             for (int i = 0; i < surrounding.Count; i++)
             {
                 var e = surrounding[i];
-                var res = resolver.Resolve(stats, e.Stats, DamageKind.Physical, hero.Level, e.Level);
+                if (e == null) continue;
+                var res = ResolveHit(caster, e, DamageKind.Physical, resolver);
                 if (res.Hit) e.TakeDamage(res.Damage + stats.Magic / 4);
             }
             return "EnergyBurst";
@@ -224,10 +262,11 @@ namespace RolePlayingFramework.Skills
     public sealed class DragonKickSkill : BaseSkill
     {
         public DragonKickSkill() : base("synergy.dragon_kick", SkillTextKey.Skill_Synergy_DragonKick_Name, SkillTextKey.Skill_Synergy_DragonKick_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 5, 170, ElementType.Neutral) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Physical, hero.Level, primary.Level);
+            if (primary == null) return "DragonKick";
+            var stats = caster.GetTotalStats();
+            var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
             if (res.Hit) primary.TakeDamage((int)(res.Damage * 1.2f) + stats.Agility / 3);
             return "DragonKick";
         }
@@ -237,10 +276,11 @@ namespace RolePlayingFramework.Skills
     public sealed class SneakPunchSkill : BaseSkill
     {
         public SneakPunchSkill() : base("synergy.sneak_punch", SkillTextKey.Skill_Synergy_SneakPunch_Name, SkillTextKey.Skill_Synergy_SneakPunch_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 4, 150, ElementType.Dark) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Physical, hero.Level, primary.Level);
+            if (primary == null) return "SneakPunch";
+            var stats = caster.GetTotalStats();
+            var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
             if (res.Hit) primary.TakeDamage(res.Damage + stats.Agility / 2);
             return "SneakPunch";
         }
@@ -250,50 +290,74 @@ namespace RolePlayingFramework.Skills
     // THIEF SYNERGY SKILLS
     // ==============================================================================
 
-    /// <summary>Smoke Bomb from Ninja - Evasion boost and escape.</summary>
+    /// <summary>
+    /// Smoke Bomb from Ninja — data-driven EvasionUp buff (Phase 3).
+    /// Grants EvasionUp +40 for 3 turns, up to 1 stack.
+    /// </summary>
     public sealed class SmokeBombSkill : BaseSkill
     {
-        public SmokeBombSkill() : base("synergy.smoke_bomb", SkillTextKey.Skill_Synergy_SmokeBomb_Name, SkillTextKey.Skill_Synergy_SmokeBomb_Desc, SkillKind.Active, SkillTargetType.Self, 4, 140, ElementType.Dark) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public SmokeBombSkill() : base("synergy.smoke_bomb", SkillTextKey.Skill_Synergy_SmokeBomb_Name, SkillTextKey.Skill_Synergy_SmokeBomb_Desc, SkillKind.Active, SkillTargetType.Self, 4, 140, ElementType.Dark)
         {
-            hero.DeflectChance += 0.2f;
-            return "SmokeBomb";
+            GrantedBuffs = new SkillBuff[]
+            {
+                new SkillBuff(BuffType.EvasionUp, magnitude: 40, durationTurns: 3, maxStacks: 1)
+            };
         }
     }
 
-    /// <summary>Poison Arrow from Stalker - DoT ranged attack.</summary>
+    /// <summary>
+    /// Poison Arrow from Stalker — DoT ranged attack (Phase 3).
+    /// Deals 1.1× physical damage and registers a DoT of max(1, AGI/4) for 3 turns.
+    /// </summary>
     public sealed class PoisonArrowSkill : BaseSkill
     {
         public PoisonArrowSkill() : base("synergy.poison_arrow", SkillTextKey.Skill_Synergy_PoisonArrow_Name, SkillTextKey.Skill_Synergy_PoisonArrow_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 5, 160, ElementType.Earth) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Physical, hero.Level, primary.Level);
-            if (res.Hit) primary.TakeDamage((int)(res.Damage * 1.1f) + stats.Agility / 4);
+            if (primary == null) return "PoisonArrow";
+            var stats = caster.GetTotalStats();
+            var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
+            if (res.Hit)
+            {
+                primary.TakeDamage((int)(res.Damage * 1.1f));
+                if (battle != null)
+                {
+                    int dotDamage = System.Math.Max(1, stats.Agility / 4);
+                    battle.RegisterDoT(primary, dotDamage, 3, Id, caster);
+                }
+            }
             return "PoisonArrow";
         }
     }
 
-    /// <summary>Fade from Spellcloak - Stealth with magic.</summary>
+    /// <summary>
+    /// Fade from Spellcloak — data-driven EvasionUp + MPRegen buff (Phase 3).
+    /// Grants EvasionUp +30 and MPRegen +1 until battle end, up to 1 stack.
+    /// </summary>
     public sealed class FadeSkill : BaseSkill
     {
-        public FadeSkill() : base("synergy.fade", SkillTextKey.Skill_Synergy_Fade_Name, SkillTextKey.Skill_Synergy_Fade_Desc, SkillKind.Active, SkillTargetType.Self, 5, 170, ElementType.Dark) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public FadeSkill() : base("synergy.fade", SkillTextKey.Skill_Synergy_Fade_Name, SkillTextKey.Skill_Synergy_Fade_Desc, SkillKind.Active, SkillTargetType.Self, 5, 170, ElementType.Dark)
         {
-            hero.DeflectChance += 0.15f;
-            hero.MPTickRegen += 1;
-            return "Fade";
+            GrantedBuffs = new SkillBuff[]
+            {
+                new SkillBuff(BuffType.EvasionUp, magnitude: 30, durationTurns: -1, maxStacks: 1),
+                new SkillBuff(BuffType.MPRegen,   magnitude:  1, durationTurns: -1, maxStacks: 1)
+            };
         }
     }
 
-    /// <summary>Ki Cloak from Shadow Fist - Ki shield.</summary>
+    /// <summary>
+    /// Ki Cloak from Shadow Fist — data-driven DefenseUp buff (Phase 3).
+    /// Grants DefenseUp +3 until battle end, up to 1 stack.
+    /// </summary>
     public sealed class KiCloakSkill : BaseSkill
     {
-        public KiCloakSkill() : base("synergy.ki_cloak", SkillTextKey.Skill_Synergy_KiCloak_Name, SkillTextKey.Skill_Synergy_KiCloak_Desc, SkillKind.Active, SkillTargetType.Self, 5, 160, ElementType.Neutral) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public KiCloakSkill() : base("synergy.ki_cloak", SkillTextKey.Skill_Synergy_KiCloak_Name, SkillTextKey.Skill_Synergy_KiCloak_Desc, SkillKind.Active, SkillTargetType.Self, 5, 160, ElementType.Neutral)
         {
-            hero.PassiveDefenseBonus += 3;
-            return "KiCloak";
+            GrantedBuffs = new SkillBuff[]
+            {
+                new SkillBuff(BuffType.DefenseUp, magnitude: 3, durationTurns: -1, maxStacks: 1)
+            };
         }
     }
 
@@ -301,15 +365,20 @@ namespace RolePlayingFramework.Skills
     // BOWMAN SYNERGY SKILLS
     // ==============================================================================
 
-    /// <summary>Piercing Arrow from Arcane Archer - Armor-piercing shot.</summary>
+    /// <summary>
+    /// Piercing Arrow from Arcane Archer — armor-piercing shot (Phase 3).
+    /// Deals 1.0× physical damage resolved against the target at 50% defense
+    /// (replaces the old flat ×1.4 multiplier — literally "pierces through armor").
+    /// </summary>
     public sealed class PiercingArrowSkill : BaseSkill
     {
         public PiercingArrowSkill() : base("synergy.piercing_arrow", SkillTextKey.Skill_Synergy_PiercingArrow_Name, SkillTextKey.Skill_Synergy_PiercingArrow_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 5, 170, ElementType.Neutral) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Physical, hero.Level, primary.Level);
-            if (res.Hit) primary.TakeDamage((int)(res.Damage * 1.4f));
+            if (primary == null) return "PiercingArrow";
+            // Resolve at 50% of the target's defense — "pierces through armor"
+            var res = ResolveHitPiercing(caster, primary, DamageKind.Physical, resolver, 0.5f);
+            if (res.Hit) primary.TakeDamage(res.Damage);
             return "PiercingArrow";
         }
     }
@@ -318,10 +387,11 @@ namespace RolePlayingFramework.Skills
     public sealed class LightshotSkill : BaseSkill
     {
         public LightshotSkill() : base("synergy.lightshot", SkillTextKey.Skill_Synergy_Lightshot_Name, SkillTextKey.Skill_Synergy_Lightshot_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 5, 175, ElementType.Light) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Physical, hero.Level, primary.Level);
+            if (primary == null) return "Lightshot";
+            var stats = caster.GetTotalStats();
+            var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
             if (res.Hit) primary.TakeDamage(res.Damage + stats.Magic / 3);
             return "Lightshot";
         }
@@ -331,10 +401,11 @@ namespace RolePlayingFramework.Skills
     public sealed class KiArrowSkill : BaseSkill
     {
         public KiArrowSkill() : base("synergy.ki_arrow", SkillTextKey.Skill_Synergy_KiArrow_Name, SkillTextKey.Skill_Synergy_KiArrow_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 5, 165, ElementType.Neutral) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Physical, hero.Level, primary.Level);
+            if (primary == null) return "KiArrow";
+            var stats = caster.GetTotalStats();
+            var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
             if (res.Hit) primary.TakeDamage(res.Damage + (stats.Strength + stats.Magic) / 4);
             return "KiArrow";
         }
@@ -344,13 +415,20 @@ namespace RolePlayingFramework.Skills
     public sealed class ArrowFlurrySkill : BaseSkill
     {
         public ArrowFlurrySkill() : base("synergy.arrow_flurry", SkillTextKey.Skill_Synergy_ArrowFlurry_Name, SkillTextKey.Skill_Synergy_ArrowFlurry_Desc, SkillKind.Active, SkillTargetType.SurroundingEnemies, 8, 240, ElementType.Neutral) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
+            // Hit primary target first (AoE fix: primary was previously excluded)
+            if (primary != null)
+            {
+                var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
+                if (res.Hit) primary.TakeDamage((int)(res.Damage * 0.9f));
+            }
+
             for (int i = 0; i < surrounding.Count; i++)
             {
                 var e = surrounding[i];
-                var res = resolver.Resolve(stats, e.Stats, DamageKind.Physical, hero.Level, e.Level);
+                if (e == null) continue;
+                var res = ResolveHit(caster, e, DamageKind.Physical, resolver);
                 if (res.Hit) e.TakeDamage((int)(res.Damage * 0.9f));
             }
             return "ArrowFlurry";
@@ -365,10 +443,11 @@ namespace RolePlayingFramework.Skills
     public sealed class SacredBladeSkill : BaseSkill
     {
         public SacredBladeSkill() : base("synergy.sacred_blade", SkillTextKey.Skill_Synergy_SacredBlade_Name, SkillTextKey.Skill_Synergy_SacredBlade_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 10, 320, ElementType.Light) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Physical, hero.Level, primary.Level);
+            if (primary == null) return "SacredBlade";
+            var stats = caster.GetTotalStats();
+            var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
             if (res.Hit) primary.TakeDamage(res.Damage + stats.Strength / 2 + stats.Magic / 2);
             return "SacredBlade";
         }
@@ -378,53 +457,68 @@ namespace RolePlayingFramework.Skills
     public sealed class FlashStrikeSkill : BaseSkill
     {
         public FlashStrikeSkill() : base("synergy.flash_strike", SkillTextKey.Skill_Synergy_FlashStrike_Name, SkillTextKey.Skill_Synergy_FlashStrike_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 8, 280, ElementType.Neutral) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Physical, hero.Level, primary.Level);
+            if (primary == null) return "FlashStrike";
+            var stats = caster.GetTotalStats();
+            var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
             if (res.Hit) primary.TakeDamage((int)(res.Damage * 1.5f) + stats.Agility / 2);
             return "FlashStrike";
         }
     }
 
-    /// <summary>Soul Ward from Soul Guardian - Protective healing aura.</summary>
+    /// <summary>
+    /// Soul Ward from Soul Guardian — data-driven heal + DefenseUp buff (Phase 3).
+    /// Heals 30 HP (scaled via SkillHealCalculator) and grants DefenseUp +4 for 3 turns, up to 1 stack.
+    /// </summary>
     public sealed class SoulWardSkill : BaseSkill
     {
-        public SoulWardSkill() : base("synergy.soul_ward", SkillTextKey.Skill_Synergy_SoulWard_Name, SkillTextKey.Skill_Synergy_SoulWard_Desc, SkillKind.Active, SkillTargetType.Self, 8, 300, ElementType.Light) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public SoulWardSkill() : base("synergy.soul_ward", SkillTextKey.Skill_Synergy_SoulWard_Name, SkillTextKey.Skill_Synergy_SoulWard_Desc, SkillKind.Active, SkillTargetType.Self, 8, 300, ElementType.Light, battleOnly: true, hpRestoreAmount: 30)
         {
-            var mult = 1f + hero.HealPowerBonus;
-            hero.RestoreHP((int)((30 + hero.GetTotalStats().Magic * 3) * mult));
-            hero.PassiveDefenseBonus += 4;
-            return "SoulWard";
+            GrantedBuffs = new SkillBuff[]
+            {
+                new SkillBuff(BuffType.DefenseUp, magnitude: 4, durationTurns: 3, maxStacks: 1)
+            };
         }
     }
 
-    /// <summary>Dragon Bolt from Mystic Avenger - Dragon magic projectile.</summary>
+    /// <summary>Dragon Bolt from Mystic Avenger - Dragon magic projectile with fire bonus.</summary>
     public sealed class DragonBoltSkill : BaseSkill
     {
         public DragonBoltSkill() : base("synergy.dragon_bolt", SkillTextKey.Skill_Synergy_DragonBolt_Name, SkillTextKey.Skill_Synergy_DragonBolt_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 9, 290, ElementType.Fire) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Magical, hero.Level, primary.Level);
-            if (res.Hit) primary.TakeDamage(res.Damage + stats.Magic / 2 + (int)(stats.Strength * 0.25f));
+            if (primary == null) return "DragonBolt";
+            var stats = caster.GetTotalStats();
+            var res = ResolveHit(caster, primary, DamageKind.Magical, resolver);
+            // Fire bonus applied to magic-derived portion; STR component is physical, not fire-scaled
+            if (res.Hit) primary.TakeDamage(res.Damage + (int)(stats.Magic * 0.5f * (1f + caster.FireDamageBonus)) + (int)(stats.Strength * 0.25f));
             return "DragonBolt";
         }
     }
 
-    /// <summary>Elemental Storm from Spell Sniper - Ultimate AoE.</summary>
+    /// <summary>Elemental Storm from Spell Sniper - Ultimate AoE with fire bonus.</summary>
     public sealed class ElementalStormSkill : BaseSkill
     {
         public ElementalStormSkill() : base("synergy.elemental_storm", SkillTextKey.Skill_Synergy_ElementalStorm_Name, SkillTextKey.Skill_Synergy_ElementalStorm_Desc, SkillKind.Active, SkillTargetType.SurroundingEnemies, 15, 400, ElementType.Fire) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
+            var stats = caster.GetTotalStats();
+
+            // Hit primary target first (AoE fix: primary was previously excluded)
+            if (primary != null)
+            {
+                var res = ResolveHit(caster, primary, DamageKind.Magical, resolver);
+                // Fire bonus applied to magic-derived portion (normalization fix)
+                if (res.Hit) primary.TakeDamage(res.Damage + (int)(stats.Magic * (1f + caster.FireDamageBonus)));
+            }
+
             for (int i = 0; i < surrounding.Count; i++)
             {
                 var e = surrounding[i];
-                var res = resolver.Resolve(stats, e.Stats, DamageKind.Magical, hero.Level, e.Level);
-                if (res.Hit) e.TakeDamage(res.Damage + stats.Magic);
+                if (e == null) continue;
+                var res = ResolveHit(caster, e, DamageKind.Magical, resolver);
+                if (res.Hit) e.TakeDamage(res.Damage + (int)(stats.Magic * (1f + caster.FireDamageBonus)));
             }
             return "ElementalStorm";
         }

--- a/PitHero/RolePlayingFramework/Skills/ThiefSkills.cs
+++ b/PitHero/RolePlayingFramework/Skills/ThiefSkills.cs
@@ -1,6 +1,5 @@
 using RolePlayingFramework.Combat;
 using RolePlayingFramework.Enemies;
-using RolePlayingFramework.Heroes;
 using System.Collections.Generic;
 using PitHero;
 
@@ -9,44 +8,53 @@ namespace RolePlayingFramework.Skills
     public sealed class SneakAttackSkill : BaseSkill
     {
         public SneakAttackSkill() : base("thief.sneak_attack", SkillTextKey.Skill_Thief_SneakAttack_Name, SkillTextKey.Skill_Thief_SneakAttack_Desc, SkillKind.Active, SkillTargetType.SingleEnemy, 3, 130, ElementType.Dark) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public override string Execute(ICombatant caster, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver, IBattleContext battle)
         {
-            var stats = hero.GetTotalStats();
-            var res = resolver.Resolve(stats, primary.Stats, DamageKind.Physical, hero.Level, primary.Level);
-            // Bonus AGI damage if undetected (simplified: always apply bonus for now)
-            if (res.Hit) primary.TakeDamage(res.Damage + stats.Agility);
+            if (primary == null) return "SneakAttack";
+            var stats = caster.GetTotalStats();
+            var res = ResolveHit(caster, primary, DamageKind.Physical, resolver);
+            // Full AGI bonus on the first offensive action of the battle; half otherwise (or out of battle)
+            bool isFirst = battle != null && battle.IsFirstOffensiveAction(caster);
+            int agiBonus = isFirst ? stats.Agility : stats.Agility / 2;
+            if (res.Hit) primary.TakeDamage(res.Damage + agiBonus);
             return "SneakAttack";
         }
     }
 
+    /// <summary>
+    /// Vanish — data-driven Untargetable buff (Phase 4).
+    /// Grants the caster the Untargetable buff for 1 turn (max 1 stack).
+    /// The buff path in <c>ApplyHealingSkillEffectsAndDisplay</c> applies GrantedBuffs automatically;
+    /// no Execute override is needed.
+    /// </summary>
     public sealed class VanishSkill : BaseSkill
     {
-        public VanishSkill() : base("thief.vanish", SkillTextKey.Skill_Thief_Vanish_Name, SkillTextKey.Skill_Thief_Vanish_Desc, SkillKind.Active, SkillTargetType.Self, 6, 180, ElementType.Dark) { }
-        public override string Execute(Hero hero, IEnemy primary, List<IEnemy> surrounding, IAttackResolver resolver)
+        public VanishSkill() : base("thief.vanish", SkillTextKey.Skill_Thief_Vanish_Name, SkillTextKey.Skill_Thief_Vanish_Desc, SkillKind.Active, SkillTargetType.Self, 6, 180, ElementType.Dark)
         {
-            // TODO: Implement untargetable status for 1 turn
-            // For now, this is a placeholder that can be enhanced later
-            return "Vanish";
+            GrantedBuffs = new SkillBuff[]
+            {
+                // durationTurns:2 — end-of-round tick consumes one turn in the cast round,
+                // so 2 = "rest of cast round + all of next round" (effective 1-round protection).
+                new SkillBuff(BuffType.Untargetable, magnitude: 1, durationTurns: 2, maxStacks: 1)
+            };
         }
     }
 
     public sealed class ShadowstepPassive : BaseSkill
     {
         public ShadowstepPassive() : base("thief.shadowstep", SkillTextKey.Skill_Thief_Shadowstep_Name, SkillTextKey.Skill_Thief_Shadowstep_Desc, SkillKind.Passive, SkillTargetType.Self, 0, 70, ElementType.Neutral) { }
-        public override void ApplyPassive(Hero hero)
+        public override void ApplyPassive(ICombatant c)
         {
-            // TODO: Implement evasion chance mechanic
-            // For now, this is a placeholder that can be enhanced later
+            c.EvasionBonus += 20; // Phase 3: plumbed into GetBattleStats evasion calculation
         }
     }
 
     public sealed class TrapSensePassive : BaseSkill
     {
         public TrapSensePassive() : base("thief.trap_sense", SkillTextKey.Skill_Thief_TrapSense_Name, SkillTextKey.Skill_Thief_TrapSense_Desc, SkillKind.Passive, SkillTargetType.Self, 0, 90, ElementType.Neutral) { }
-        public override void ApplyPassive(Hero hero)
+        public override void ApplyPassive(ICombatant c)
         {
-            // TODO: Implement trap detection/disarm mechanic
-            // For now, this is a placeholder that can be enhanced later
+            c.TrapSense = true;
         }
     }
 }

--- a/PitHero/Services/Analytics/AnalyticsService.cs
+++ b/PitHero/Services/Analytics/AnalyticsService.cs
@@ -423,6 +423,39 @@ namespace PitHero.Services.Analytics
 #endif
         }
 
+        /// <summary>Logs a trap triggered by the hero (out-of-battle chip damage).</summary>
+        [Conditional("DEBUG")]
+        public static void LogTrapTriggered(int pitLevel, int x, int y, int damage)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("trap_triggered"))
+                return;
+            _json.Field("pitLevel", pitLevel);
+            _json.Field("x", x);
+            _json.Field("y", y);
+            _json.Field("damage", damage);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs a trap auto-disarmed by the TrapSense passive before the hero stepped on it.</summary>
+        [Conditional("DEBUG")]
+        public static void LogTrapDisarmed(int pitLevel, int x, int y)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("trap_disarmed"))
+                return;
+            _json.Field("pitLevel", pitLevel);
+            _json.Field("x", x);
+            _json.Field("y", y);
+            EndEvent();
+#endif
+        }
+
         /// <summary>Logs a monster defeated by the party.</summary>
         [Conditional("DEBUG")]
         public static void LogMonsterDefeated(IEnemy enemy)

--- a/PitHero/Services/MercenaryManager.cs
+++ b/PitHero/Services/MercenaryManager.cs
@@ -841,8 +841,9 @@ namespace PitHero.Services
             // Adjust HP/MP to saved values
             int hpDiff = mercenary.MaxHP - saved.CurrentHP;
             if (hpDiff > 0) mercenary.TakeDamage(hpDiff);
-            int mpDiff = mercenary.MaxMP - saved.CurrentMP;
-            if (mpDiff > 0) mercenary.UseMP(mpDiff);
+            // Use SetCurrentMP (not UseMP/SpendMP) so MPCostReduction is NOT applied to the delta —
+            // a state-restore must land at exactly saved.CurrentMP regardless of passives.
+            mercenary.SetCurrentMP(saved.CurrentMP);
 
             // Position near hero
             var heroPos = heroEntity.Transform.Position;
@@ -953,6 +954,24 @@ namespace PitHero.Services
                 var comp = m.GetComponent<MercenaryComponent>();
                 return comp != null && comp.IsHired;
             }).ToList();
+        }
+
+        /// <summary>
+        /// Returns true if any hired mercenary has the TrapSense passive.
+        /// Non-allocating: iterates the internal list with a for loop and early-exits.
+        /// Use this instead of calling GetHiredMercenaries() in hot paths (e.g. fog-clear step).
+        /// </summary>
+        public bool AnyHiredMercenaryHasTrapSense()
+        {
+            for (int i = 0; i < _mercenaryEntities.Count; i++)
+            {
+                var comp = _mercenaryEntities[i].GetComponent<MercenaryComponent>();
+                if (comp == null || !comp.IsHired) continue;
+                var merc = comp.LinkedMercenary;
+                if (merc != null && merc.TrapSense)
+                    return true;
+            }
+            return false;
         }
 
         /// <summary>

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -301,5 +301,7 @@ namespace PitHero
         public const string AddMonsterDaytimeLabel = "AddMonsterDaytimeLabel";
         public const string AddMonsterNocturnalLabel = "AddMonsterNocturnalLabel";
         public const string AddMonsterConfirmPrompt = "AddMonsterConfirmPrompt";
+        public const string ConsoleTrapTriggered = "ConsoleTrapTriggered";
+        public const string ConsoleTrapDisarmed = "ConsoleTrapDisarmed";
     }
 }

--- a/PitHero/Util/TiledMapService.cs
+++ b/PitHero/Util/TiledMapService.cs
@@ -119,7 +119,8 @@ namespace PitHero.Util
         public bool ClearFogOfWarAroundTile(int centerTileX, int centerTileY, HeroComponent heroComponent)
         {
             bool anyFogCleared = false;
-            int radius = heroComponent?.UncoverRadius ?? 1;
+            // Phase 4: add Eagle Eye SightRangeBonus from the linked hero to the base uncover radius
+            int radius = (heroComponent?.UncoverRadius ?? 1) + (heroComponent?.LinkedHero?.SightRangeBonus ?? 0);
             if (heroComponent.ExploredPit || heroComponent.OutsidePit)
             {
                 return false;

--- a/PitHero/VirtualGame/VirtualHero.cs
+++ b/PitHero/VirtualGame/VirtualHero.cs
@@ -22,6 +22,13 @@ namespace PitHero.VirtualGame
 
         // Hero configuration properties
         public int UncoverRadius { get; set; } = 1;
+
+        /// <summary>
+        /// Tile-radius sight bonus from Eagle Eye passive (Phase 4).
+        /// Added to <see cref="UncoverRadius"/> when clearing fog of war.
+        /// Set this in virtual test setup when simulating a hero with Eagle Eye learned.
+        /// </summary>
+        public int SightRangeBonus { get; set; } = 0;
         public HeroPitPriority Priority1 { get; set; } = HeroPitPriority.Treasure;
         public HeroPitPriority Priority2 { get; set; } = HeroPitPriority.Battle;
         public HeroPitPriority Priority3 { get; set; } = HeroPitPriority.Advance;

--- a/PitHero/VirtualGame/VirtualTiledMapService.cs
+++ b/PitHero/VirtualGame/VirtualTiledMapService.cs
@@ -62,7 +62,8 @@ namespace PitHero.VirtualGame
         public bool ClearFogOfWarAroundTile(int centerTileX, int centerTileY, HeroComponent heroComponent)
         {
             var fogLayer = _virtualMap.GetVirtualLayer("FogOfWar");
-            int radius = heroComponent?.UncoverRadius ?? 1;
+            // Phase 4: mirror Eagle Eye SightRangeBonus from the linked hero (mirrors TiledMapService)
+            int radius = (heroComponent?.UncoverRadius ?? 1) + (heroComponent?.LinkedHero?.SightRangeBonus ?? 0);
             if (fogLayer != null)
             {
                 bool anyCleared = false;

--- a/PitHero/docs/AnalyticsSchema.md
+++ b/PitHero/docs/AnalyticsSchema.md
@@ -48,6 +48,8 @@ interpretation caveats that are not obvious from the raw data.
 | `pit_generated` | `pitLevel`, `isBossFloor`, `monsterCount`, `chestCount` | Fires on every pit (re)generation, including the initial load-time generation. `isBossFloor` comes from `CaveBiomeConfig.IsBossFloor` — see caveat below. |
 | `chest_spawned` | `pitLevel`, `x`, `y`, `chestLevel` (1–5), `item`, `kind`, `rarity`, optional `seedType` + `seedCount` | Contents decided at spawn time. `item` is `null` for seed chests. |
 | `monster_spawned` | `pitLevel`, `x`, `y`, `name`, `enemyId`, `level`, `maxHP`, `isBoss` | `level` is the enemy's own level (often a per-type preset — see caveats). |
+| `trap_triggered` | `pitLevel`, `x`, `y`, `damage` | Hero stepped on a hidden trap. `damage` is the clamped value actually applied (hero's HP is never reduced below 1 out-of-battle). Formula: `5 + pitLevel * 2` before clamping. |
+| `trap_disarmed` | `pitLevel`, `x`, `y` | A party member with the TrapSense passive auto-disarmed a trap when fog was cleared over it. No damage dealt. |
 | `orb_activated` | `fromPitLevel`, `toPitLevel`, `heroLevel` | Wizard orb → next pit level. Followed by a `party_snapshot` with `reason:"orb"`. |
 | `pit_jump` | `pitLevel`, `heroLevel`, `heroHP`, `heroMaxHP` | Hero jumped into the pit. Followed by a `party_snapshot` with `reason:"pit_jump"`. |
 | `party_snapshot` | `reason`, `members[]` | Each member: `name`, `type` (`"hero"`/`"merc"`), `job`, `level`, `str/agi/vit/mag` (total stats incl. gear/synergy), `maxHP`, `curHP`, `maxMP`, `skills[]` (skill ids), `gear{}` (slot→item name; keys `weapon`, `armor`, `hat`, `shield`, `acc1`, `acc2`; empty slots omitted). |
@@ -69,7 +71,7 @@ interpretation caveats that are not obvious from the raw data.
 ### Battle
 | `e` | Fields | Notes |
 |---|---|---|
-| `attack` | `actor`, `actorType` (`"hero"`/`"merc"`/`"monster"`), `action`, `target`, `targetType`, `dmg`, `hpBefore`, `hpAfter`, `killed` | `action` is `"physical"` or a skill id (e.g. `knight.heavy_strike`). `hpBefore`/`hpAfter` are the **target's** HP; `hpBefore − dmg = hpAfter` (floored at 0). AoE skills emit one line per target hit. Misses are not logged. Monsters only have physical attacks. |
+| `attack` | `actor`, `actorType` (`"hero"`/`"merc"`/`"monster"`), `action`, `target`, `targetType`, `dmg`, `hpBefore`, `hpAfter`, `killed` | `action` is `"physical"`, a skill id (e.g. `knight.heavy_strike`), `"counter"` (hero/merc retaliation after taking a hit — requires monk.counter passive), or `"<skillId>.dot"` (end-of-round damage-over-time tick from a skill such as `synergy.poison_arrow.dot`). `hpBefore`/`hpAfter` are the **target's** HP; `hpBefore − dmg = hpAfter` (floored at 0). AoE skills emit one line per target hit. Misses are not logged. Monsters only have physical attacks. Counter attacks and DoT ticks never produce miss events. |
 | `heal` | `actor`, `source` (skill id or item name), `target`, `amount`, `hpAfter` | Battle heals (skills and consumables). |
 | `monster_defeated` | `name`, `enemyId`, `level`, `isBoss`, `pitLevel`, `xp`, `jp`, `gold` | One per kill regardless of killer; the matching `gold_gained` (`source:"battle"`) follows. |
 | `char_killed` | full victim snapshot (same shape as a `party_snapshot` member) + `killer{name, enemyId, level, str/agi/vit/mag, maxHP}` | Hero or mercenary killed by a monster. |

--- a/PitHero/docs/VirtualGameLogicLayer.md
+++ b/PitHero/docs/VirtualGameLogicLayer.md
@@ -176,3 +176,17 @@ Potential extensions to the virtual layer:
 - **Interactive Mode**: Step-by-step execution for debugging
 
 This virtual game logic layer provides GitHub Copilot with the exact testing capability requested, enabling independent verification of the complete GOAP workflow without graphics dependencies.
+
+## Delta Plan — Unmirrored features
+
+The following game features added after the initial virtual layer implementation have **no virtual mirror** and are not simulated in `VirtualGameSimulation` or `VirtualTiledMapService`:
+
+### Traps (Phase 6)
+- **What exists:** `TrapComponent` spawns hidden trap entities in the pit. They trigger chip damage when the hero steps on them, or are auto-disarmed when revealed by a party member with `TrapSense`.
+- **What is not mirrored:** The virtual layer has no concept of trap entities, trap tile positions, or TrapSense passive resolution during fog clearing.
+- **What would be needed to add virtual coverage:**
+  1. Extend `VirtualWorldState` to track trap tile positions (a `HashSet<Point>` of trap locations).
+  2. Add trap spawning to `VirtualWorldState.RegeneratePit` following `GameConfig.TrapMinPerFloor`/`TrapMaxPerFloor`.
+  3. Add a `CheckTrapSense(VirtualHero hero)` helper called from `VirtualTiledMapService.ClearFogOfWarAroundTile` when fog is removed over a trap tile and any party member has `TrapSense`.
+  4. Add a `TriggerTrap(Point tile, VirtualHero hero)` that reduces `VirtualHero.HP` by the formula `5 + pitLevel * 2` (clamped to 1 HP minimum) for testing the damage path.
+  5. Add tests in `VirtualGameSimulationTests` covering trap triggering and TrapSense disarm.

--- a/features/reports/feature_skill_system_fixes_balance_report.md
+++ b/features/reports/feature_skill_system_fixes_balance_report.md
@@ -1,0 +1,48 @@
+# Balance Report — Skill System Fixes (Phases 1–3)
+
+**Branch:** `feature/skillGapFixes` · **Date:** 2026-07-11 · **Trigger:** skill-system audit fixes (merc skills now run real formulas, elemental multipliers apply to skill damage, self/ally skills became data-driven, heals normalized through `SkillHealCalculator`)
+
+## 1. Test scope
+
+Requested: before/after comparison of clear rates and party survivability across pit levels for the Phase 2–3 combat changes.
+
+## 2. Methodology + coverage gap (read this first)
+
+**A full virtual pit traversal could not measure these changes.** The virtual game layer (`PitHero/VirtualGame/`) has **no combat simulation** — battles resolve as goal conditions without damage math (confirmed by code audit; see `VirtualGameLogicLayer.md` scope). Every change in this feature is a battle mechanic, so a traversal-based before/after comparison would report identical results regardless of the changes. Per the pit-balance-test coverage rule, this is reported as a **gap for the `virtual-game-layer` skill**: add battle resolution (attack resolver + skill execution + buffs) to `VirtualGameSimulation` before the next combat-affecting balance pass.
+
+What WAS run:
+1. **Full unit suite:** 1108 passed / 107 failed / 6 skipped — the 107 failures are all the pre-existing `Nez.Core.Services` NullReference environment issue (localized name lookups in tests), byte-identical to the pre-change baseline of 109 failed / 1047 passed (2 fixed, 0 introduced).
+2. **Balance-relevant classes** (`BalanceSystemTests`, `GearItemsTests`, `*StatGrowth*`, plus new `SkillExecutionTests`, `BattleBuffTests`, `SkillBuffDataTests`, `EnhancedBattleSystemTests`): 155 passed / 13 failed — all 13 are the same pre-existing environment failure pattern (verified individually).
+3. **Static before/after quantification** of every deliberate number shift (below).
+
+## 3. Findings — quantified balance shifts
+
+| Change | Before | After | Direction |
+|---|---|---|---|
+| Merc attack skills | generic weapon-swing damage | real formulas (PowerShot ×1.5, HeavyStrike +STR, LifeLeech drain, etc.) | **Merc DPS up**, size depends on skill |
+| Skill elemental multipliers | always Neutral | skill Element vs enemy `ElementalProperties` | Swing both ways; matchup play now real |
+| AoE skills | skipped primary target | hit primary + surrounding | AoE DPS up vs 2+ enemy packs |
+| Fire-bonus consistency | 4 Fire skills ignored `FireDamageBonus` | all apply it | Up for Heart-of-Fire builds |
+| AuraHeal | (25 + MAG×2.5)×(1+bonus) | (25 + MAG×2)×(1+bonus) | Slight nerf at high MAG |
+| SoulWard | (30 + MAG×3)×(1+bonus) | (30 + MAG×2)×(1+bonus) | Nerf at high MAG |
+| Purify | (15 + MAG×2)×(1+bonus) | identical via `SkillHealCalculator` | Unchanged |
+| Piercing Arrow | flat ×1.4 | ×1.0 vs half defense | Better vs armored, worse vs squishy |
+| defup/KiCloak/SmokeBomb/Fade | did nothing in battle | real temporary buffs (capped stacks) | Survivability up under Defensive tactic |
+| counter/deflect (Monk) | dead fields | functional | Monk survivability/DPS up |
+| calm_spirit | dead | +1 MP/round in battle | Sustained caster uptime up |
+
+Net expectation: **party power increases**, mostly on mercenary-heavy parties and AoE/elemental play. Monster-side power is unchanged. If post-change play data shows clear rates rising noticeably, the first rebalance lever is monster archetype multipliers, not reverting skill correctness.
+
+## 4./5. Elemental & equipment matrices
+
+Not measurable without the virtual combat sim (see §2 gap). Elemental advantage magnitude is exercised by unit test (`ResolveHit_ViaFireSkill_ElementalMultiplierApplied`) confirming the multiplier path works; a full matchup utilization matrix needs traversal.
+
+## 6. Verdict
+
+**Pass-with-caveats.** No formula/regression failures; all deliberate shifts enumerated and directionally sane. The caveats: (a) virtual-layer combat coverage gap blocks a true clear-rate comparison; (b) merc DPS uplift is real and unquantified in aggregate.
+
+## 7. Prioritized recommendations
+
+1. **(Major)** Implement virtual-layer combat simulation (delta plan for `virtual-game-layer` skill) so the next combat change gets a real before/after traversal.
+2. **(Major)** After Phases 4–6 land, play 2–3 debug sessions with a merc party and compare analytics (`attack` dmg distributions, battle durations, `char_killed` counts) against pre-change session logs (e.g. `session_20260710_234639.jsonl`) — live data is currently the only end-to-end balance signal.
+3. **(Minor)** Watch AuraHeal/SoulWard users at MAG 60+ — the ×3→×2 normalization is a real nerf there; if priest-synergy builds underperform, raise those skills' `hpRestoreAmount` rather than re-forking the formula.


### PR DESCRIPTION
Full audit of all 53 skills (6 primary jobs x 4 skills + 29 equipment-synergy skills) against their player-facing descriptions found stub skills, effects that never fired, and a mercenary battle path that bypassed skill formulas entirely. Implemented in 6 phases plus post-review fixes.

Phase 1 - ICombatant abstraction (shared skill code):
- New ICombatant interface implemented by Hero and Mercenary; ISkill ApplyPassive/Execute retargeted from Hero to ICombatant
- New CombatantPassiveApplier: single shared reset+apply for passive fields; deleted the hand-maintained switch(skill.Id) in Mercenary.ApplyPassiveSkills (which was missing knight.light_armor)
- Mercenary SpendMP now honors MPCostReduction; equip permissions honored
- Fixed latent bug: level-up/skill purchase wiped synergy-written passive fields; ApplyPassiveSkills now re-applies synergy passive effects
- Deleted dead Hero.ChooseActiveSkillForBattle/TryUseSkill

Phase 2 - Unified battle execution:
- Mercenary attack skills now run real skill.Execute() formulas (PowerShot x1.5, HeavyStrike +STR, LifeLeech drain, etc.) via shared ExecuteCombatantAttackSkill instead of a generic resolver hit
- New BaseSkill.ResolveHit routes all skills through EnhancedAttackResolver's elemental overload - skill damage finally applies elemental multipliers (previously always resolved as Neutral)
- AoE skills (Volley, FireStorm, Roundhouse, Meteor, ElementalVolley, EnergyBurst, ArrowFlurry, ElementalStorm) now hit the primary target
- FireDamageBonus applied consistently across all Fire-element skills

Phase 3 - Battle-scoped buff/status system:
- New BuffType/BattleBuff/SkillBuff + BattleBuffSet (shared by Hero/Merc); buffs tick per round, stack-cap per (skill, buff type), clear at battle end
- Self/ally skills are now data-driven via BaseSkill.GrantedBuffs; the battle engine applies HP restore (via SkillHealCalculator, so Mender applies), MP restore, and buffs. Previously priest.heal was the ONLY functional heal/buff skill in battle - defup, KiCloak, SmokeBomb, Fade, AuraHeal, SoulWard, Purify all did nothing
- priest.calm_spirit MP regen now ticks each battle round
- monk.counter and monk.deflect now function (BattleReactionHelper); counters logged as analytics action "counter", deflects show bounce text
- New IBattleContext/BattleContext: DoT registry (poison ticks logged as "<skillId>.dot" with correct actor attribution) and first-action tracking
- synergy.poison_arrow deals a real 3-turn DoT; synergy.piercing_arrow resolves at 50% target defense (true armor pierce)
- Synergy heals normalized through BalanceConfig.CalculateSkillHealAmount

Phase 4 - Stub skills implemented (were TODO no-ops):
- archer.eagle_eye: +1 fog-of-war uncover radius (mirrored in virtual layer)
- archer.quickdraw: first attack of battle can crit for 2x (all attack paths)
- thief.shadowstep: +20 evasion in battle stats
- thief.vanish: Untargetable buff; monsters skip vanished targets (anti-stall guard when all allies untargetable)
- thief.sneak_attack: full +AGI on first strike of battle, +AGI/2 after

Phase 5 - Description/behavior alignment:
- knight.heavy_armor +2 defense now conditional on wearing mail armor
- Blitz description corrected to Wind (no Lightning element exists)
- Defense Up description documents 3-stack cap and battle-end expiry

Phase 6 - Minimal trap system (makes thief.trap_sense real):
- PitGenerator spawns 0-2 hidden traps per floor; TrapComponent deals 5 + 2*pitLevel damage on step; parties with Trap Sense auto-disarm traps revealed by fog clearing; trap_triggered/trap_disarmed analytics events
- Non-allocating trap registry + merc capability check (no LINQ per tile)

Post-review fixes (10 findings from adversarial review, all verified):
- Save/load no longer inflates MP for cost-reduction mercs (SetCurrentMP state restore instead of cost-reduced UseMP)
- Multi-buff skills apply all their buffs (stack cap now per buff type; Fade's MPRegen previously never applied)
- Merc single-target skills honor the AI's chosen target (was always livingMonsters[0])
- Vanish duration 2 so it survives the end-of-round tick
- AI affordability checks use effective (cost-reduced) MP cost
- Missed skills show "Miss" feedback
- Synergy StatBonusEffect no longer re-applied on level-up/skill purchase (was compounding stats to the 99 cap - found via live analytics)
- Localization guard: non-ASCII chars crash BitmapFont with KeyNotFoundException; removed the offending em-dash and added a test that scans all localization files

Quality-of-life:
- New games start with 200 gold and 5 HP Potions (GameConfig constants; granted only on new game, never on load or death-respawn)

Analytics schema doc updated (counter/.crit/.dot action strings, trap events). Save format unchanged (version stays 12) - all new state is recomputed or battle-scoped. Balance report at
features/reports/feature_skill_system_fixes_balance_report.md; validated across three live analytics sessions.

Tests: 1169 passing (+122 new), 0 regressions (107 pre-existing Nez.Core.Services test-harness failures unchanged).