### PR TITLE
Overhaul virtual-simulation docs for future agent runs (#296 follow-up)

### DIFF
--- a/.claude/skills/pit-balance-test/references/virtual-game-runner.md
+++ b/.claude/skills/pit-balance-test/references/virtual-game-runner.md
@@ -33,8 +33,13 @@ Critical test classes for balance:
 
 ## Driving the Simulation
 
-The simulation is invoked from C# test code. Canonical pattern (real combat via the
-shared `BattleEngine`, issue #296):
+The simulation is invoked from C# test code. **Read the Quick Start + gotchas in
+`PitHero/docs/VirtualGameLogicLayer.md` first** — in particular the "fully-equipped party"
+requirements (hero needs a JP-loaded `HeroCrystal` + purchased skills; manually-built
+mercs need `LearnAllJobSkills()`; stock potions in `sim.Bag`) or results will show
+`healing=0` and understate survivability.
+
+Canonical single-level pattern (real combat via the shared `BattleEngine`, issue #296):
 
 ```csharp
 // Seeded constructor => deterministic combat rolls (turn order, evasion/variance,
@@ -43,19 +48,29 @@ var sim = new VirtualGameSimulation(rngSeed: 12345);
 
 // Hero level should track BalanceConfig.EstimatePlayerLevelForPitLevel(pitLevel);
 // stats scale with level automatically via GrowthCurveCalculator.
-sim.ConfigureHero(new Knight(), level: 8, new StatBlock(10, 8, 10, 4));
+sim.ConfigureHero(new Knight(), level: 8, new StatBlock(10, 8, 10, 4), crystal);
 sim.ConfigureMercenaries(mercList); // optional, up to 2 real Mercenary instances
 
-var metrics = sim.RunPitLevel(5);   // full traversal: explore, fight, boss gate, orb
-
-// metrics: BattleCount, TotalRounds, DamageDealt/Taken, HpLossPercent,
-//          HealingConsumed, PartyDeaths, Wiped, RngSeed, JobName
-VirtualRunMetrics.WriteCsvHeader(writer);
-metrics.WriteRow(writer);
+var metrics = sim.RunPitLevel(5);   // full traversal: explore, fight, loot, boss gate, orb
 ```
 
-See `PitHero.Tests/VirtualBalanceTraversalTests.cs` for a working sampled traversal
-(levels 1/5/10/15/20/25 including all Cave boss floors) and the same-seed
+Preferred for balance curves — a persistent full-game run (gold economy: auto-hire up to
+2 mercs + inn rest between levels, chest loot + auto-equip during levels):
+
+```csharp
+var sim = new VirtualGameSimulation(rngSeed: 12345);
+sim.ConfigureHero(new Knight(), level: 1, new StatBlock(10, 8, 10, 4), crystal);
+for (int i = 0; i < 5; i++) sim.Bag.TryAdd(PotionItems.HPPotion());
+List<VirtualRunMetrics> perLevel = sim.RunLevelRange(1, 25); // stops early on wipe
+
+VirtualRunMetrics.WriteCsvHeader(writer);
+for (int i = 0; i < perLevel.Count; i++) perLevel[i].WriteRow(writer);
+// Columns: pitLevel,battles,rounds,dmgDealt,dmgTaken,hpLossPct,healing,deaths,wiped,
+//          treasures,gearEquipped,goldEarned,wallet,innRested,mercsHired
+```
+
+See `PitHero.Tests/VirtualBalanceTraversalTests.cs` for working examples of all three
+configurations (solo / party / persistent run) and the same-seed ⇒ identical-CSV
 reproducibility contract. Run it with:
 `dotnet test PitHero.Tests/PitHero.Tests.csproj --filter "TestCategory=BalanceTraversal"`
 
@@ -65,9 +80,14 @@ If the virtual layer **doesn't support** a piece of functionality you need to te
 
 ## Repeatability
 
-- Use a **deterministic seed** for `Nez.Random` when running tests so runs are reproducible.
-- Capture seed + job + traversal range at the top of every balance report.
-- Re-run the same seed after rebalance changes to verify the fix.
+- Use the **seeded constructor** — `new VirtualGameSimulation(rngSeed)` — which seeds
+  `Nez.Random` for all combat and hire rolls. Pit layout/loot is separately deterministic
+  per level (local `Random(level)`). Same seed ⇒ byte-identical metrics CSV (pinned by test).
+- The seed is recorded in `VirtualRunMetrics.RngSeed` — capture seed + job + traversal
+  range at the top of every balance report.
+- Re-run the same seed after rebalance changes to verify the fix (before/after diff).
+- Test-suite baseline: **12 known pre-existing failures** in `dotnet test` — anything
+  above that is a regression introduced by the change under test.
 
 ## Performance Note
 

--- a/.claude/skills/virtual-game-layer/references/architecture.md
+++ b/.claude/skills/virtual-game-layer/references/architecture.md
@@ -7,11 +7,15 @@ Authoritative deep-dive: `PitHero/docs/VirtualGameLogicLayer.md`. Below is a qui
 ```
 PitHero/VirtualGame/
 ├── VirtualGameSimulation.cs   — headless harness, the main entry point
-├── VirtualHeroStateMachine.cs — virtual GOAP + FSM
+├── VirtualHeroStateMachine.cs — virtual GOAP + FSM (wander/monster/chest sweeps)
 ├── VirtualGoapContext.cs      — IGoapContext implementation for tests
 ├── VirtualHeroController.cs   — virtual hero control surface
 ├── VirtualPathfinder.cs       — virtual A* implementation
+├── VirtualBattle*.cs          — combat: runner/sink/party view/allies/metrics
 └── ...                        — additional virtual components added per feature
+
+PitHero/Combat/                — the SHARED headless BattleEngine + sink interfaces
+                                 (used by both live play and the virtual layer)
 ```
 
 ## State Mirroring
@@ -42,9 +46,15 @@ When adding a new virtual class:
 
 ## Determinism Rules
 
-- **Seeded RNG only.** `Nez.Random.SetSeed(seed)` at simulation start; never use `System.Random`.
+- **Two sanctioned RNG streams** (see the determinism model in `VirtualGameLogicLayer.md`):
+  combat/hire rolls use the global `Nez.Random`, seeded via `new VirtualGameSimulation(rngSeed)`;
+  pit layout + loot contents use a local `Random(level)` inside the generators
+  (deterministic per level). Don't introduce a third source of randomness.
 - **No wall-clock time.** `Time.DeltaTime` is fine because the virtual layer advances it manually in `VirtualGameSimulation.Tick()`.
-- **No coroutines** for headless tests — the virtual layer ticks synchronously. If an action uses coroutines for visual animation (e.g. jump arcs), gate them with a virtual-mode check or short-circuit them in the virtual context.
+- **Coroutines**: the shared `BattleEngine` is a coroutine drained synchronously by
+  `HeadlessCoroutineRunner.RunToCompletion` (the virtual sink returns null for every
+  display/timing hook). Follow that pattern for shared live/virtual logic; for
+  virtual-only code, tick synchronously and short-circuit visual-animation coroutines.
 
 ## Validating Changes
 

--- a/.claude/skills/virtual-game-layer/references/coverage-checklist.md
+++ b/.claude/skills/virtual-game-layer/references/coverage-checklist.md
@@ -2,46 +2,47 @@
 
 For each subsystem, verify the listed items. If any are missing **and the current feature exercises that subsystem**, implement them.
 
-## 1. Pit Generation
+**Baseline status (post issue #296 / PR #297):** all six core systems below are mirrored.
+The authoritative current-state reference is `PitHero/docs/VirtualGameLogicLayer.md` —
+read it first; this checklist is for verifying NEW features against that baseline.
 
-- [ ] `VirtualPitGenerator` (or equivalent) produces a layout matching `PitGenerator`
-- [ ] Tile grid size, fog-of-war placement, treasure positions all reproducible from a seed
-- [ ] Boss-floor flag propagates correctly (every 5 levels)
-- [ ] Biome boundary recognized at levels 25/50/75/100+
+## 1. Pit Generation — ✅ mirrored
 
-## 2. Monsters
+- [x] `VirtualPitGenerator` produces layouts with the live count formulas and `CaveBiomeConfig` pools
+- [x] Tile grid, fog-of-war, treasure positions reproducible (local `Random(level)` per level)
+- [x] Boss floors use the LIVE mapping (5=StoneGuardian, 10=EarthElemental, 15=AncientWyrm, 20=PitLord, 25=MoltenTitan)
+- [ ] New biome boundaries / generation rules added to live `PitGenerator` are mirrored
 
-- [ ] Virtual spawn pool mirrors the live spawn pool (sliding window of 10)
-- [ ] Boss vs non-boss flag set correctly
-- [ ] `VirtualEnemy` reproduces `IEnemy` stats from `BalanceConfig.MonsterArchetype`
-- [ ] Elemental properties (`ElementalProperties`) propagated
-- [ ] Encounter trigger (adjacency) translates to `AdjacentToMonster` GOAP flag in virtual context
+## 2. Monsters — ✅ mirrored
 
-## 3. Equipment
+- [x] Real `IEnemy` instances via `EnemyFactory.Create` with `CaveBiomeConfig.GetScaledEnemyLevelForPitLevel` (no `VirtualEnemy` stand-in exists or is needed)
+- [x] Stored in `VirtualWorldState`'s `Dictionary<Point, IEnemy>`; adjacency triggers battles during wander + a monster-sweep phase
+- [ ] New enemy types/archetypes spawn correctly in the virtual pool (usually automatic via `EnemyFactory` — verify the pool config)
 
-- [ ] Virtual chest drops produce the same `Gear` items as live (formula-driven)
-- [ ] Rarity distribution matches live (Cave: 1-10 → tier 1; 11+ weighted)
-- [ ] Stat bonuses applied to virtual hero on equip
-- [ ] Elemental properties propagated through `ElementalProperties`
+## 3. Equipment & Loot — ✅ mirrored
 
-## 4. Items (Consumables)
+- [x] Chest items are real `IItem`s using live treasure formulas + party-job loot weighting (`TreasureComponent.*Deterministic` overloads + `LootJobContext`)
+- [x] Auto-equip mirrors `OpenChestAction` (hero → mercs, hand-me-down cascade via `GearAutoEquipService`)
+- [ ] New gear kinds/rarity tiers reachable through the deterministic generation path (extend the `Get*ItemAtIndex` pools in `TreasureComponent` for BOTH live and deterministic paths)
 
-- [ ] Virtual hero inventory supports add/remove
-- [ ] Healing item use updates virtual HP/MP
-- [ ] `HealingItemExhausted` GOAP flag tracked correctly
+## 4. Items (Consumables) — ✅ mirrored
 
-## 5. Mercenaries
+- [x] `VirtualGameSimulation.Bag` (real `ItemBag`); battle consumable use through the decision engine; `HealingItemExhausted` tracked in `VirtualBattlePartyView`
+- [ ] New consumable effects work through `Consumable.Consume` headlessly (no `Core.Services` dependencies — see the `GetTextService` guard pattern)
 
-- [ ] `VirtualMercenaryStateMachine` parity with `MercenaryStateMachine`
-- [ ] All 5 mercenary actions executable on virtual layer
-- [ ] Pit-status sync (`_expectedTargetInPit`) drives replanning in virtual context too
+## 5. Mercenaries — ✅ mirrored (battle + economy; no per-tile state machine)
 
-## 6. Battle
+- [x] Real `Mercenary` objects fight in battles as `IBattleAlly`s; death prunes the roster; XP awarded
+- [x] Hiring mirrors `MercenaryManager` (level distribution, job pool, cost) via `VirtualMercenaryLevelRoller`; inn rest restores them
+- [x] Note: there is deliberately NO `VirtualMercenaryStateMachine` — mercs don't walk in the virtual layer; they are roster members present in every battle
+- [ ] New mercenary battle behaviors flow through the shared `BattleEngine` (they will, unless Nez components are touched)
 
-- [ ] `EnhancedAttackResolver` paths reachable in virtual context
-- [ ] Damage formula identical (no shortcuts)
-- [ ] Elemental multipliers computed via `BalanceConfig.GetElementalDamageMultiplier`
-- [ ] Death detection (`HP == 0`) propagates to GOAP world state
+## 6. Battle — ✅ mirrored (shared engine)
+
+- [x] The SAME `PitHero.Combat.BattleEngine` runs live (via `LiveBattleAdapter` coroutine) and virtual (via `HeadlessCoroutineRunner`) — damage formulas, elements, buffs, DoT, counter/deflect/crit are identical by construction
+- [x] Death propagates: monsters removed from `VirtualWorldState`, hero death ends the level run (`Wiped`)
+- [ ] **New battle mechanics MUST go into `BattleEngine` (or skills/`BattleReactionHelper`), never into `LiveBattleAdapter` display code** — engine changes are automatically mirrored; adapter changes are live-only
+- [ ] ⚠ Respect the RNG-call-order contract documented in `VirtualGameLogicLayer.md` — do not add/remove/reorder `Nez.Random` calls in the engine without accepting a live-behavior change
 
 ## 7. GOAP Action Dual Execution
 
@@ -49,15 +50,20 @@ For each GOAP action exercised by the feature:
 
 - [ ] Action implements both `Execute(HeroComponent)` and `Execute(IGoapContext)`
 - [ ] `IGoapContext` exposes everything the action needs (no hidden live-layer dependencies)
+- [ ] Any new per-level hero flag is reset in `VirtualGameSimulation.RunPitLevel` (or persistent runs will skip levels — see Known Gotchas in `VirtualGameLogicLayer.md`)
+
+## Known Remaining Gaps (record additions here / in the doc's "Still Unmirrored" table)
+
+Walking/travel time, seed-crop chest contents, shop purchases, night sleep,
+`SecondChanceMerchantVault` recovery, analytics JSONL emission (metrics are aggregated
+instead), tavern seat management.
 
 ## Priority Order When Filling Gaps
-
-When the feature touches multiple subsystems, implement in this order to unblock dependent work:
 
 1. **Pit Generation** (everything else depends on a valid pit)
 2. **Monsters** (combat needs enemies)
 3. **Equipment & Items** (combat needs gear; items influence GOAP)
-4. **Battle** (combat resolution)
+4. **Battle** (combat resolution — usually free via the shared engine)
 5. **Mercenaries** (multi-actor coordination)
 6. **GOAP dual execution** (last — actions wire everything together)
 
@@ -71,4 +77,5 @@ For each new virtual component added:
 
 1. Write a focused unit test under `PitHero.Tests/` that exercises only the new component.
 2. Run `dotnet test PitHero.Tests/` and confirm the new test passes.
-3. Confirm existing virtual-layer tests still pass (regression check).
+3. Confirm existing virtual-layer tests still pass — the baseline is **12 known pre-existing failures**; anything above that is a regression.
+4. For combat-adjacent changes, also run `--filter "TestCategory=BalanceTraversal"` and confirm the same-seed reproducibility test still passes.

--- a/PitHero/docs/VirtualGameLogicLayer.md
+++ b/PitHero/docs/VirtualGameLogicLayer.md
@@ -2,408 +2,222 @@
 
 ## Overview
 
-The Virtual Game Logic Layer is a complete simulation system that allows testing and verification of the PitHero GOAP workflow without requiring graphics or the full Nez environment. This addresses the need for GitHub Copilot to test and verify game logic independently.
+The Virtual Game Logic Layer (`PitHero/VirtualGame/`, namespace `PitHero.VirtualGame`) is a
+complete headless simulation of the game loop: pit generation, fog-of-war exploration, GOAP
+planning, **real combat** (shared `BattleEngine`), traps, chest loot with auto-equip, and a
+spendable gold economy (inn rest + mercenary hiring). It runs with no graphics, no Nez
+`Core` instance, and no wall-clock time, and is the engine behind automated balance testing
+(see the `pit-balance-test` skill).
+
+Everything that affects combat balance is mirrored from the live layer as of issue #296
+(PR #297). The simulation operates on **real** RPG-framework objects — `Hero`, `Mercenary`,
+`IEnemy` via `EnemyFactory`, `IItem`/`IGear`, `ItemBag` — not stand-ins, so stat math, skills,
+buffs, DoT, elements, and rewards are identical to live play by construction.
+
+## Quick Start — Balance Runs
+
+### Single pit level
+
+```csharp
+var sim = new VirtualGameSimulation(rngSeed: 12345);           // seeded => reproducible
+sim.ConfigureHero(new Knight(), level: 8, new StatBlock(10, 8, 10, 4), crystal);
+var metrics = sim.RunPitLevel(5);                              // explore, fight, loot, boss gate, orb
+```
+
+### Persistent full-game run (recommended for balance curves)
+
+```csharp
+var sim = new VirtualGameSimulation(rngSeed: 12345);
+sim.ConfigureHero(new Knight(), level: 1, new StatBlock(10, 8, 10, 4), crystal);
+// Wallet defaults to GameConfig.NewGameStartingGold; potions default to none — stock them:
+for (int i = 0; i < 5; i++) sim.Bag.TryAdd(PotionItems.HPPotion());
+var perLevel = sim.RunLevelRange(1, 25);                       // hires mercs + inn rests between levels
+```
+
+`RunLevelRange` reuses the same hero/mercs/bag/wallet across levels; between levels it
+prunes dead mercenaries, hires random mercenaries while affordable (max 2), and takes an
+inn rest when the party isn't at full HP/MP. It stops early on a party wipe.
+
+### ⚠ Fully-equipped party — REQUIRED for representative results
+
+Freshly constructed characters are **not** representative of live play. Without the steps
+below, traversals show `healing=0`, understate survivability, and misstate difficulty:
+
+1. **Hero skills** — a bare `new Hero(...)` can never learn skills. Bind a JP-loaded
+   `HeroCrystal` and purchase the job kit:
+   ```csharp
+   var crystal = new HeroCrystal("RefCrystal", new Knight(), level, baseStats);
+   crystal.EarnJP(1_000_000);
+   sim.ConfigureHero(new Knight(), level, baseStats, crystal);
+   var hero = sim.Hero.LinkedHero;
+   for (int i = 0; i < hero.Job.Skills.Count; i++) hero.TryPurchaseSkill(hero.Job.Skills[i]);
+   ```
+2. **Mercenary skills** — call `merc.LearnAllJobSkills()` on any manually-constructed
+   `Mercenary` (live `MercenaryManager` does this on every tavern spawn).
+   Mercs hired via `TryHireRandomMercenary()` already have their skills.
+3. **Potions** — stock `sim.Bag` (a live new game grants HP Potions).
+4. **Hero level** — `BalanceConfig.EstimatePlayerLevelForPitLevel(pitLevel)` gives the
+   expected level for a pit; stats scale with level automatically via
+   `GrowthCurveCalculator`, so a fixed base `StatBlock` is fine at any level.
+
+The canonical working example is `PitHero.Tests/VirtualBalanceTraversalTests.cs`
+(`[TestCategory("BalanceTraversal")]`): solo, party, and persistent-run CSV tables plus the
+same-seed reproducibility contract. Run it with:
+
+```bash
+dotnet test PitHero.Tests/PitHero.Tests.csproj --filter "TestCategory=BalanceTraversal"
+```
+
+## Determinism Model
+
+Two independent RNG streams — both reproducible, by different mechanisms:
+
+| Stream | Source | Determinism |
+|--------|--------|-------------|
+| Pit layout + loot contents | local `new Random(level)` inside `VirtualPitGenerator` | Deterministic **per pit level**, always |
+| Combat rolls (turn order, evasion/variance, target picks, crit/deflect) + hire rolls | global `Nez.Random` | Deterministic when constructed via `VirtualGameSimulation(rngSeed)`; the default ctor captures the ambient seed |
+
+The seed is recorded in `VirtualRunMetrics.RngSeed`; cite it in every balance report.
+Same seed ⇒ byte-identical metrics CSV (pinned by test). Note: live play uses unseeded
+`Nez.Random` for pit generation, so virtual layouts intentionally differ from any specific
+live session while following the same formulas.
 
 ## Architecture
 
-### Core Components
-
-1. **IVirtualWorld**: Interface for world representation without graphics
-2. **VirtualWorldState**: Console-based world implementation that tracks:
-   - Hero position and state
-   - Pit layout and dynamic sizing
-   - Wizard orb location and activation status
-   - Fog of war status across the map
-   - Entity positions and collision detection
-
-3. **VirtualHero**: Hero simulation that maintains:
-   - All GOAP state flags (matching HeroComponent)
-   - Position-based state detection
-   - Movement pathfinding and execution
-   - World state generation for GOAP planning
-
-4. **VirtualGameSimulation**: Main orchestrator that executes:
-   - Complete pit generation at specified levels
-   - Full GOAP action sequences
-   - State transitions and validation
-   - Console visualization and logging
-
-## Complete Workflow Simulation
-
-The system simulates the exact workflow described in the GitHub issue:
-
-1. **Pit Generation**: Creates pit at level 40 with dynamic width calculation
-2. **MoveToPitAction**: Hero moves from spawn to pit edge
-3. **JumpIntoPitAction**: Hero enters pit interior
-4. **WanderAction**: Complete exploration until all fog is cleared
-5. **Wizard Orb Workflow**:
-   - MoveToWizardOrbAction → ActivateWizardOrbAction
-   - MovingToInsidePitEdgeAction → JumpOutOfPitAction
-   - MoveToPitGenPointAction → Pit regeneration
-6. **Cycle Restart**: New pit ready for next iteration
-
-## Usage
-
-### Running Tests
-
-```bash
-# Run all virtual game simulation tests
-dotnet test PitHero.Tests/ --filter VirtualGameSimulationTests
-
-# Run the complete workflow demonstration
-dotnet test PitHero.Tests/ --filter CompleteVirtualGameWorkflow_Demonstration
-```
-
-### Console Simulation
-
-```csharp
-// Create and run a complete simulation
-var simulation = new VirtualGameSimulation();
-simulation.RunCompleteSimulation();
-```
-
-### Testing Specific Scenarios
-
-```csharp
-// Test pit generation at different levels
-var world = new VirtualWorldState();
-world.RegeneratePit(40); // Level 40 pit with wider bounds
-
-// Test hero state management
-var hero = new VirtualHero(world);
-hero.MoveTo(new Point(2, 3)); // Move inside pit
-var worldState = hero.GetWorldState(); // Get GOAP states
-```
-
-## Console Output
-
-The simulation provides detailed logging:
-
-```
-=== Starting Virtual Game Simulation ===
-STEP 1: Generating pit at level 40
-[VirtualWorld] Regenerated pit at level 40, bounds: (1,2,16,9)
-
-STEP 2: Hero spawns and begins MoveToPitAction  
-[MoveToPitAction] Moving from (33,6) to (0,5)
-[MoveToPitAction] Completed. Hero adjacent to pit: True
-
-STEP 3: Hero jumps into pit
-[JumpIntoPitAction] Jumping from (0,5) to (3,4)
-[JumpIntoPitAction] Completed. Hero inside pit: True
-
-STEP 4: Hero wanders and explores pit completely
-[WanderAction] Starting systematic exploration of pit interior
-[WanderAction] Tick 50: Explored (8,7), fog remaining: 12
-[WanderAction] Completed. Fog remaining: 0, MapExplored: True
-
-STEP 5: Execute complete wizard orb workflow
-[MoveToWizardOrbAction] Moving from (8,7) to wizard orb at (9,6)
-[ActivateWizardOrbAction] Activating wizard orb and queuing next pit level
-[MovingToInsidePitEdgeAction] Moving to inside pit edge at (1,5)
-[JumpOutOfPitAction] Jumping out of pit to (0,5)
-[MoveToPitGenPointAction] Moving to pit generation point (34,6)
-[MoveToPitGenPointAction] Regenerated pit at level 50
-```
-
-## Visual Representation
-
-The system provides ASCII visualization of the world state:
-
-```
-=== Virtual World - Pit Level 40 ===
-Hero: (34,6), Wizard Orb: (9,6) [ACTIVATED]
-Pit Bounds: (1,2,16,9)
-
-   01234567890123456789
-02 ....████████████....
-03 ...█..........█.....
-04 ...█..........█.....
-05 ...█....w.....█.....
-06 ...█..........█.....
-07 ...█..........█.....
-08 ...█..........█.....
-09 ...█..........█.....
-10 ....████████████....
-
-Legend: H=Hero, w=Wizard Orb, W=Activated Orb, #=Obstacle, █=Wall, ?=Fog, .=Empty
-```
-
-## Benefits for Development
-
-### For GitHub Copilot
-- **Independent Testing**: Verify game logic without graphics setup
-- **Rapid Iteration**: Test changes instantly in console environment
-- **Debug Visibility**: See exact state changes and action execution
-- **Regression Prevention**: Catch logic errors before they reach the full game
-
-### For Developers
-- **Unit Testing**: Test individual GOAP actions in isolation
-- **Integration Testing**: Verify complete workflow sequences
-- **Performance Testing**: Measure action execution times
-- **State Validation**: Confirm proper state transitions
-
-## Integration with Existing Code
-
-The virtual layer integrates seamlessly with existing systems:
-
-- **GOAP Actions**: All existing actions work without modification
-- **State Management**: Uses identical state flags as HeroComponent
-- **Pathfinding**: Reuses AStar algorithms for movement
-- **Service Layer**: Compatible with existing service patterns
-
-## Test Coverage
-
-The virtual game simulation includes comprehensive tests for:
-
-- ✅ World state initialization and pit generation
-- ✅ Hero movement and state detection
-- ✅ GOAP world state generation
-- ✅ Complete workflow execution
-- ✅ Pit level progression and regeneration
-- ✅ Wizard orb discovery and activation
-- ✅ Visual representation rendering
-- ✅ Edge cases and error handling
-
-## Delta Plan — Phase B: Combat + Traps Mirrored (issue #296)
-
-Phase B wires up the headless `BattleEngine` (extracted in Phase A) to the virtual
-exploration loop so that pit traversal is now a complete simulation: monsters are
-fought, traps are triggered or disarmed, and aggregated metrics are exported for
-balance analysis.
-
-### New files added (all in `PitHero.VirtualGame`)
-
-| File | Responsibility |
-|------|---------------|
-| `VirtualBattleAlly.cs` | `IBattleAlly` over a real `Hero` or `Mercenary`; `IsPresent` always true (mirrors `LiveHeroAlly`) |
-| `VirtualBattlePartyView.cs` | `IBattlePartyView` replicating `HeroComponent` burst/critical-HP math using the same `GameConfig` constants |
-| `VirtualBattleSink.cs` | `BattleEventSinkBase` that accumulates `VirtualBattleMetrics` and removes defeated monsters from `VirtualWorldState` in `ShowMonsterDeath` |
-| `VirtualBattleRunner.cs` | Owns `BattleEngine` + `VirtualBattleSink` + a persistent `ActionQueue`; exposes `RunAdjacentBattle()`, `ApplyTrapDamageToHero()`, `PartyHasTrapSense()` |
-| `VirtualBattleMetrics.cs` | Per-battle: rounds, damageDealt/Taken, healing, potions, heroDied, mercDeaths, monstersDefeated, XP/gold |
-| `VirtualRunMetrics.cs` | Per-pit-level aggregate with `WriteCsv(TextWriter)` for balance reporting |
-
-### Key modifications
-
-- **`VirtualWorldState`** — adds `Dictionary<Point, IEnemy>` + reverse map, `HashSet<Point> TrapTiles`, `AddMonster(Point, IEnemy)` overload (auto-routes to `AddBossMonster` when `IsBoss=true`), adjacency query, `HasLivingBoss/Monsters`, trap methods `AddTrapTile / TriggerTrap / DisarmTrap`.  `ClearAllEntities()` clears the new collections.
-
-- **`VirtualPitGenerator`** — boss mapping fixed to live `PitGenerator.cs` (5=StoneGuardian, 10=EarthElemental, 15=AncientWyrm, 20=PitLord, 25=MoltenTitan).  All monsters are created via `EnemyFactory.Create()` as real `IEnemy` instances, then stored through the new `AddMonster(Point, IEnemy)` overload.  Traps spawned per `GameConfig.TrapMin/MaxPerFloor`.
-
-- **`VirtualHero`** — exposes `LinkedHero` and `ConfigureHero(IJob, int, StatBlock)`.  `AreAllMonstersDefeated` now checks `VirtualWorldState.HasLivingMonsters()`.
-
-- **`VirtualHeroController.BossDefeated`** — computed from `!world.HasLivingBoss()` (was hardcoded `true`).
-
-- **`VirtualHeroStateMachine`** — `BattleRunner` property; after each `TeleportTo` in wander/connectivity phases, `HandleTrapAtTile` + `RunAdjacentBattlesIfAny` are called.  A third wander phase sweeps any remaining living monsters (teleport adjacent + battle) before exploration is declared complete, mirroring the live Battle priority.  `ExecuteActivateWizardOrbAction` gates on `!HasLivingBoss()` and navigates to any surviving boss before the gate check.
-
-- **`VirtualGameSimulation`** — `ConfigureHero`, `ConfigureMercenaries`, `RunPitLevel(int)`, `World`, `Metrics` properties. `RunPitLevel` uses `VirtualPitGenerator` to populate real `IEnemy` instances, builds a `VirtualBattleRunner`, runs the state machine, and accumulates battle metrics into `VirtualRunMetrics`.
-
-- **`VirtualGoapContext`** — `BattleRunner { get; set; }` property.
-
-- **`AttackMonsterAction.Execute(IGoapContext)`** — stub replaced: if context is `VirtualGoapContext` with a `BattleRunner`, calls `RunAdjacentBattle()` and logs results; otherwise falls through to the original exploration-only no-op.
-
-### Boss-mapping fix side-effect
-
-`CaveBiomeBalanceTests.CaveBiome_BossEncounters_ValidateAllFiveBosses` expected old wrong display strings.  Updated to MonsterTextKey values matching live mapping.
-
-## Deterministic Seeding (Phase C, issue #296)
-
-- `new VirtualGameSimulation(rngSeed)` calls `Nez.Random.SetSeed(rngSeed)` so **all combat
-  rolls** (turn order, evasion/variance, target picks, crit/deflect) are reproducible.
-  The default constructor captures the ambient `Nez.Random.GetSeed()` instead.
-- The seed is recorded in `VirtualRunMetrics.RngSeed` so every balance report can cite it.
-- Pit **layout** randomness is separate and already deterministic per level
-  (`VirtualPitGenerator`/`VirtualWorldState` use a local `Random(level)`).
-- `VirtualRunMetrics.HpLossPercent` = damage taken ÷ party max-HP pool at level start.
-- `PitHero.Tests/VirtualBalanceTraversalTests.cs` (`[TestCategory("BalanceTraversal")]`)
-  runs a seeded sampled traversal over levels 1/5/10/15/20/25 (all Cave boss floors),
-  prints the per-level CSV table, and pins the same-seed ⇒ identical-CSV contract.
-
-## Future Enhancements
-
-Potential extensions to the virtual layer:
-
-- **Multiple Heroes**: Support for testing multi-hero scenarios
-- **Custom Scenarios**: Scripted test scenarios for specific edge cases
-- **Performance Metrics**: Detailed timing and efficiency analysis
-- **Save/Load States**: Checkpoint and restore world states
-- **Interactive Mode**: Step-by-step execution for debugging
-
-This virtual game logic layer provides GitHub Copilot with the exact testing capability requested, enabling independent verification of the complete GOAP workflow without graphics dependencies.
-
-## Delta Plan — Phase C: Chest loot + auto-equip (issue #296 follow-up)
-
-Phase C gives virtual chest positions real `IItem` instances, opens them during
-traversal, adds items to the party bag, and auto-equips gear exactly like the live
-`OpenChestAction` flow.
-
-### New APIs
-
-**`VirtualWorldState`** — Phase C adds a `Dictionary<Point, IItem> _treasureInstances`
-running in parallel with the string-based parity lists
-(`LastGeneratedTreasureLevels` / `LastGeneratedEquipmentTypes`):
-
-| Method | Behaviour |
-|--------|-----------|
-| `AddTreasure(Point, IItem)` | Stores the real item; infers treasure level from rarity (Normal→1, Uncommon→2, Rare→3, Epic→4, Legendary→5); calls the string-based overload for parity-list parity |
-| `TryGetTreasureAt(Point, out IItem)` | Non-destructive lookup |
-| `RemoveTreasure(Point)` | Clears both `_treasureInstances` and the `_entities["Treasures"]` position list |
-| `HasUnopenedTreasures()` | True when any chest remains unvisited |
-| `GetNearestTreasurePosition(Point)` | Manhattan-distance nearest chest |
-
-**`VirtualBattleRunner`** — new chest-loot surface:
-
-| Member | Behaviour |
-|--------|-----------|
-| `AutoEquipHero` (`bool`, default `true`) | Mirrors `HeroComponent.AutoEquipHero` |
-| `AutoEquipMercenaries` (`bool`, default `true`) | Mirrors `HeroComponent.AutoEquipMercenaries` |
-| `TreasuresOpened` (`int`) | Incremented by each `CollectChestItem` call |
-| `GearEquipped` (`int`) | Incremented each time a piece of gear is slotted |
-| `BagCount()` | Returns current `Bag.Count` for test observability |
-| `CollectChestItem(IItem)` | Adds to bag → if gear: `TryAutoEquipOnHero` → per-merc with hand-me-down cascade |
-
-**`VirtualHeroStateMachine`** — new fourth wander phase:
-1. Fog sweep (existing phase 1)
-2. Connectivity sweep (existing phase 2)
-3. Monster sweep (existing phase 3)
-4. **Chest sweep** — teleports to each remaining chest one at a time (one per tick);
-   calls `CollectChestItem` + `RemoveTreasure` on the hero's tile, then
-   `CollectAdjacentTreasures()` for Chebyshev-1 neighbours.
-   Only returns `true` (action complete) once `HasUnopenedTreasures()` is false.
-
-`CollectAdjacentTreasures()` is also called after every `TeleportTo` in the fog,
-connectivity, and monster phases so nearby chests are collected opportunistically.
-
-### Deterministic item generation
-
-`TreasureComponent` gains `internal static` deterministic overloads:
-
-- `GenerateCaveItemForTreasureLevelDeterministic(int treasureLevel, System.Random rng)` — mirrors `GenerateCaveItemForTreasureLevel` but uses `rng.NextDouble()` / `rng.Next()` instead of `Nez.Random`.  Pool-selection switch bodies are shared via private `Get*ItemAtIndex(int)` helpers.
-- `GenerateItemForTreasureLevelDeterministic(int treasureLevel, System.Random rng)` — for non-cave levels (Normal/Mid/Full potions by treasure level).
-
-`VirtualPitGenerator.RegenerateForLevel` now calls these overloads with the per-level
-`new Random(level)` instance, so loot is deterministic per level just like mob spawns.
-
-### Metrics
-
-`VirtualRunMetrics` adds `TreasuresOpened` and `GearEquipped` fields; both are written
-to the CSV export (`treasures,gearEquipped` columns).  `VirtualGameSimulation.RunPitLevel`
-copies them from the runner after the state machine completes.
-
-### Test coverage
-
-Three new tests in `VirtualBattleSimulationTests`:
-
-| Test | Assertion |
-|------|-----------|
-| `ChestAdjacentToHero_WhenCollected_ItemLandsInBag` | Bag grows by 1 after `CollectChestItem`; `TreasuresOpened` = 1 |
-| `GearChestItem_BetterThanHeroSlot_GetsAutoEquipped` | `GearEquipped` = 1; `hero.WeaponShield1` is non-null after auto-equip |
-| `RunPitLevel1_AllChestsCollected_MetricsMatch` | `HasUnopenedTreasures()` false; `metrics.TreasuresOpened == LastGeneratedTreasureLevels.Count` |
-
-## Gold Economy (issue #296 persistent-run phase)
-
-This section documents the spendable-gold layer added in the persistent-run phase, which
-enables realistic multi-level balance runs without re-creating the simulation per level.
-
-### Wallet
-
-`VirtualGameSimulation.Gold` starts at `GameConfig.NewGameStartingGold` (200 gold) — the
-same amount the live game grants via `GameStateService.Funds` on a fresh save
-(`MainGameScene.cs` line ~120).  Override with `ConfigureStartingGold(int)` to mirror a
-mid-game save state.
-
-After each `RunPitLevel` call, `Gold` is credited with the level's total `GoldEarned`
-(summed from `VirtualBattleMetrics.GoldEarned` per battle via
-`VirtualBattleSink.OnEnemyDefeated → enemy.GoldYield`).  The end-of-level balance is
-recorded in `VirtualRunMetrics.Wallet`.
-
-### Inn Rest
-
-`TryInnRest()` mirrors `SleepInBedAction` (lines ~255–500):
-
-| Live action | Virtual mirror |
-|-------------|----------------|
-| `gameState.Funds >= GameConfig.InnCostGold` (10 g) | `Gold >= GameConfig.InnCostGold` |
-| `gameState.Funds -= GameConfig.InnCostGold` | `Gold -= GameConfig.InnCostGold` |
-| `hero.RestoreHP(MaxHP − CurrentHP)` | `hero.RestoreHP(hero.MaxHP)` |
-| `hero.RestoreMP(-1)` (full restore) | `hero.RestoreMP(-1)` |
-| `mercComp.LinkedMercenary.RestoreHP(MaxHP)` | `merc.RestoreHP(merc.MaxHP)` |
-| `mercComp.LinkedMercenary.RestoreMP(maxMP − currentMP)` | `merc.RestoreMP(merc.MaxMP)` |
-| `hero.HealingItemExhausted = false` | `_lastPartyView.HealingItemExhausted = false` |
-| `hero.HealingSkillExhausted = false` | `_lastPartyView.HealingSkillExhausted = false` |
-
-Walking animations and coroutine delay are skipped (virtual: instant).
-
-Returns `false` when `Gold < InnCostGold`, mirroring the live `InnExhausted` flag set in
-`JumpOutOfPitForInnAction.Execute` (line ~103).
-
-### Mercenary Hiring
-
-`TryHireRandomMercenary()` mirrors `MercenaryManager.SpawnMercenary` + `HireMercenary`:
-
-| Live | Virtual |
-|------|---------|
-| `DetermineMercenaryLevel(heroLevel)` using `Nez.Random` | Identical copy in `VirtualMercenaryLevelRoller` |
-| `GetRandomJob()` → 6 jobs, `Nez.Random.Range(0, 6)` | `VirtualMercenaryLevelRoller.GetRandomJob()` (switch, not `Activator.CreateInstance`, for AOT) |
-| `new StatBlock(4, 3, 5, 1)` | Same |
-| `mercenary.LearnAllJobSkills()` | Same |
-| `BalanceConfig.CalculateMercenaryHireCost(mercLevel)` | Same |
-| `MaxHiredMercenaries = 2` | Constant 2 (same value) |
-
-Mercenary names are deterministic (`"Merc1"`, `"Merc2"`, …) instead of random names since
-the virtual layer has no `NameGenerator` dependency.
-
-The `_mercenaries` field (previously `IReadOnlyList`) was changed to `List<Mercenary>` so
-`TryHireRandomMercenary` can append and `RunLevelRange` can prune dead entries.
-
-### `RunLevelRange` Policy
-
-`RunLevelRange(fromLevel, toLevel)` runs a persistent traversal, sharing the same hero,
-merc roster, bag, and wallet across all levels.  Between levels the surface policy is:
-
-1. **Prune dead mercs** — any `Mercenary` with `CurrentHP <= 0` is removed (the
-   `BattleEngine` removes the `IBattleAlly` wrapper in-place; the RPG object's HP lands
-   at 0).
-2. **Hire** — `TryHireRandomMercenary()` until roster has 2 members or gold runs out.
-3. **Inn rest** — `TryInnRest()` when any party member is below full HP or MP.
-
-The number of mercs hired and whether inn rest occurred are written into the **next** level's
-`VirtualRunMetrics.MercsHired` / `VirtualRunMetrics.InnRested` (since they happen before
-that level starts).  Traversal stops early on a wipe; the wipe level's metrics are included.
-
-### New CSV columns
-
-`VirtualRunMetrics.WriteCsvHeader` / `WriteRow` now emit four additional columns:
-
-| Column | Source |
-|--------|--------|
-| `goldEarned` | Sum of `enemy.GoldYield` over all battles on this level |
-| `wallet` | `Gold` balance after crediting `goldEarned` (before next-level spending) |
-| `innRested` | 1 if inn rest was taken before this level (`RunLevelRange` only) |
-| `mercsHired` | Count of mercs hired before this level (`RunLevelRange` only) |
-
-### What is still unmirrored
-
-| Live feature | Gap |
-|--------------|-----|
-| Walking time (hero → tavern → inn) | Skipped; inn/hire is instant in virtual layer |
-| Mercenary walk-to-tavern animation / leave animation | No entity system headlessly |
-| Night sleep (free rest at specific time-of-day) | No `InGameTimeService` headlessly |
-| `SecondChanceMerchantVault` on merc dismissal | Dismissed mercs drop their gear silently |
-| Analytics events (`LogInnSleep`, `LogMercArrived`) | Skipped (no analytics service headlessly) |
-| Tavern seat management / `_occupiedTavernPositions` | Not needed (no entity system) |
-| `DeferredMercenary` (hired while sleeping) | Not applicable in virtual layer |
-
-## Delta Plan — Unmirrored features
-
-All previously listed gaps are now closed:
-
-- **Combat** — mirrored as of issue #296 Phase B (see "Delta Plan — Phase B" above).
-- **Traps (Phase 6)** — mirrored as of issue #296 Phase B: `VirtualWorldState.TrapTiles`
-  spawned by `VirtualPitGenerator`, `TriggerTrap` chip damage (`5 + pitLevel * 2`,
-  1-HP floor, live `TrapComponent` parity) applied via
-  `VirtualBattleRunner.ApplyTrapDamageToHero`, TrapSense auto-disarm via `DisarmTrap`.
-  Covered by `VirtualBattleSimulationTests`.
-- **Chest loot + auto-equip** — mirrored as of issue #296 Phase C (see above).
-
-New live-layer features should be checked against this document and added here when
-they lack a virtual counterpart.
+### Simulation components (`PitHero/VirtualGame/`)
+
+| Component | Responsibility |
+|-----------|---------------|
+| `VirtualGameSimulation` | Top-level harness: `ConfigureHero/ConfigureMercenaries/ConfigureStartingGold`, `RunPitLevel`, `RunLevelRange`, `TryInnRest`, `TryHireRandomMercenary`, `Gold`, `Bag`, `Metrics`, `RngSeed` |
+| `VirtualWorldState` | Tile grid, fog, collision, entity positions **plus instances**: `Dictionary<Point, IEnemy>` monsters, `Dictionary<Point, IItem>` treasures, `HashSet<Point>` traps; queries (`GetLivingMonstersAdjacentTo`, `HasLivingBoss`, `GetNearestTreasurePosition`, …) |
+| `VirtualPitGenerator` | Live-parity content: `EnemyFactory` monsters with `CaveBiomeConfig` level scaling, boss floors (5=StoneGuardian, 10=EarthElemental, 15=AncientWyrm, 20=PitLord, 25=MoltenTitan), real chest items with live treasure formulas **and party-job loot weighting** (`LootContext`), traps |
+| `VirtualHero` | GOAP flags + position + `LinkedHero` (real `Hero`) via `ConfigureHero` |
+| `VirtualHeroStateMachine` | Idle→GoTo→PerformAction mirror; wander phases: fog sweep → connectivity sweep → **monster sweep** → **chest sweep**; per-tile trap handling; boss-gated orb activation |
+| `VirtualBattleRunner` | Drives `BattleEngine` headlessly: `RunAdjacentBattle()`, `CollectChestItem()` (bag + auto-equip cascade), `ApplyTrapDamageToHero()`, counters (`TreasuresOpened`, `GearEquipped`) |
+| `VirtualBattlePartyView` | `IBattlePartyView` — replicates `HeroComponent` critical-HP/burst thresholds with the same `GameConfig` constants |
+| `VirtualBattleSink` | `IBattleEventSink` — aggregates `VirtualBattleMetrics`, removes dead monsters from world state, credits gold |
+| `VirtualBattleMetrics` / `VirtualRunMetrics` | Per-battle / per-level aggregates + CSV export |
+| `VirtualMercenaryLevelRoller` | Mirrors `MercenaryManager`'s hire-level distribution + six-job pool (via `Nez.Random`, AOT-safe switch) |
+| `VirtualGoapContext` + `Virtual*Manager/Service` | `IGoapContext` wiring so GOAP actions run dual-path (`Execute(IGoapContext)`) |
+
+### The headless BattleEngine (`PitHero/Combat/`)
+
+The battle round loop lives in `PitHero.Combat.BattleEngine`, extracted from
+`AttackMonsterAction` (which is now only the live Nez adapter). One code path serves both
+layers:
+
+- The engine is a coroutine (`IEnumerator Run(hero, mercs, monsters, heroActionQueue)`).
+  Every yield is either an enumerator returned by the `IBattleEventSink` (display/pacing)
+  or null. **Live**: `Core.StartCoroutine` via `LiveBattleAdapter` — real pacing/animations.
+  **Virtual**: `HeadlessCoroutineRunner.RunToCompletion` — the virtual sink returns null
+  everywhere, so battles resolve instantly.
+- `IBattlePartyView` supplies party settings (tactic, bag, heal priorities, critical/burst
+  checks); `IBattleAlly` wraps combatants (`IsPresent` = in-pit, deliberately WITHOUT an
+  HP check — see contract below); monsters are plain `IEnemy`.
+- Pure reward math (XP/JP/SP, merc XP) is applied inside the engine; side effects
+  (gold, services, analytics, display) go through the sink.
+
+**⚠ Behavior-preservation contract:** the engine is a verbatim retype of the original live
+loop. The **sequence of `Nez.Random` calls is a compatibility contract** — adding, removing,
+or reordering any RNG call (turn values, target picks, crit/deflect rolls, resolver
+evasion/variance) changes live gameplay outcomes. Preserved quirks that must not be
+"fixed" casually: a hero who dies mid-round still takes their queued turn that round
+(hero turn-skip is pit-presence only); mercenary heals use `UseMP` while the hero uses
+`SpendMP`; merc kills award rewards with `heroKill=false` (no `InnExhausted` reset);
+`DEBUG_DAMAGE_MULT` applies to monster→ally damage only. `BattleEngineTests` pins a
+same-seed ⇒ identical-event-stream determinism test that catches accidental drift.
+
+## Gold Economy
+
+- **Wallet**: `Gold` starts at `GameConfig.NewGameStartingGold`; battle gold credits it
+  after each level; `ConfigureStartingGold` overrides for mid-game scenarios.
+- **`TryInnRest()`** mirrors `SleepInBedAction`: `GameConfig.InnCostGold` (10 g) deducted;
+  hero + all mercenaries restored to full HP **and MP**; `HealingItemExhausted` /
+  `HealingSkillExhausted` reset. Instant — walking is not simulated. Returns false when
+  unaffordable (live `InnExhausted` semantics).
+- **`TryHireRandomMercenary()`** mirrors `MercenaryManager.SpawnMercenary` + hire:
+  weighted level distribution around the hero's level, random job from the six primary
+  jobs, `StatBlock(4, 3, 5, 1)`, `LearnAllJobSkills()`, cost via
+  `BalanceConfig.CalculateMercenaryHireCost`, max 2 hired. Rolls use seeded `Nez.Random`.
+  Names are deterministic (`"Merc1"`, `"Merc2"`, …).
+
+## Chest Loot + Auto-Equip
+
+- Chest **items are real `IItem`s** generated at pit-gen time with the live treasure-level
+  formulas (`CaveBiomeConfig.DetermineCaveTreasureLevel` routing) and the live
+  **party-job loot weighting** (`TreasureComponent.SelectWeightedPoolIndexDeterministic`
+  with a `LootJobContext` built from the configured party).
+- During traversal the hero collects chests adjacent to each landing tile; the chest-sweep
+  wander phase guarantees every chest is opened before a level completes.
+- `VirtualBattleRunner.CollectChestItem` mirrors live `OpenChestAction`: bag insert with
+  consumable stacking, `HealingItemExhausted` reset on healing pickups, auto-equip hero
+  first then mercenaries (`GearAutoEquipService`), with the recursive hand-me-down cascade
+  for displaced gear. Toggles: `AutoEquipHero` / `AutoEquipMercenaries` (default true).
+
+## Metrics & CSV Reference
+
+`VirtualRunMetrics.WriteCsvHeader/WriteRow` emit one row per pit level:
+
+| Column | Meaning |
+|--------|---------|
+| `pitLevel` | Level this row covers |
+| `battles` | Battles fought |
+| `rounds` | Total combat rounds |
+| `dmgDealt` / `dmgTaken` | Ally→monster / monster→ally damage totals |
+| `hpLossPct` | `dmgTaken ÷ party max-HP pool` at level start |
+| `healing` | HP restored by skills + consumables |
+| `deaths` | Party deaths (hero + mercs) |
+| `wiped` | 1 when the hero died before completing the level |
+| `treasures` / `gearEquipped` | Chests opened / gear pieces auto-equipped |
+| `goldEarned` / `wallet` | Gold from kills this level / balance after crediting |
+| `innRested` / `mercsHired` | Between-level actions taken **before** this level (`RunLevelRange` only) |
+
+Run-level fields: `RngSeed`, `JobName`, `LevelRangeMin/Max`.
+
+## Known Gotchas (learned the hard way)
+
+1. **Per-level GOAP flags**: `RunPitLevel` resets `ExploredPit` / `FoundWizardOrb` /
+   `ActivatedWizardOrb` at level start. Any new per-level flag must be reset the same way,
+   or persistent runs will silently skip levels 2+ (guarded by per-level `BattleCount > 0`
+   assertions in `VirtualBalanceTraversalTests`).
+2. **Headless text lookups**: `Core.Services` throws without a game instance;
+   `GetTextService()` in `Consumable`/`Gear`/`BaseJob`/`BaseSkill`/`CompositeJob` guards on
+   `Core.Instance` and falls back to raw text keys. New localized-name lookups in
+   RolePlayingFramework must follow the same pattern or headless runs crash.
+3. **Fully-equipped party**: see Quick Start — bare heroes/mercs know no skills.
+4. **No inn between manually-chained `RunPitLevel` calls**: HP/MP/bag/wallet persist;
+   use `RunLevelRange` (or call `TryInnRest` yourself) for realistic multi-level runs.
+
+## What Is Still Unmirrored
+
+| Live feature | Status |
+|--------------|--------|
+| Walking/travel time (pit↔tavern↔inn), animations | Intentionally skipped — instant in virtual |
+| Seed-crop chest contents (farming) | Level-2 chests never roll seeds virtually |
+| Shop purchases (buying potions/gear) | No virtual shop; stock `Bag` manually |
+| Night sleep (free time-of-day rest) | No `InGameTimeService` headlessly |
+| `SecondChanceMerchantVault` on merc death/dismissal | Gear is not recovered virtually |
+| Analytics JSONL (`AnalyticsService`) | Virtual sink aggregates metrics instead — same event payloads, comparable columns |
+| Tavern seat management, `DeferredMercenary` | Not applicable headlessly |
+
+New live-layer features should be checked against this document (see the
+`virtual-game-layer` skill) and added here when they lack a virtual counterpart.
+
+## Test Map
+
+| Test file | Covers |
+|-----------|--------|
+| `BattleEngineTests` | Headless engine: rewards, turn ordering, Untargetable anti-stall, deflect/counter, Quickdraw crit, DoT, buff-leak guard, same-seed determinism |
+| `VirtualBattleSimulationTests` | Traversal combat, boss orb-gating, wipes, merc participation, traps + TrapSense, chest collection/auto-equip, inn rest, hiring, `RunLevelRange` |
+| `VirtualBalanceTraversalTests` | Balance curves (solo / party / persistent run), CSV output, same-seed reproducibility |
+| `VirtualGameSimulationTests`, `VirtualWorldStateTests`, `CaveBiomeBalanceTests`, `InterfaceBased*Tests` | Exploration, world state, generation parity, GOAP dual execution |
+
+Full suite: `dotnet test PitHero.Tests/PitHero.Tests.csproj`. Baseline: **12 known
+pre-existing failures** (environment-dependent tests) — anything above that is a regression.
+
+## Legacy Exploration Harness
+
+`RunCompleteSimulation()` and the ASCII visualization (`GetVisualRepresentation()`)
+predate the combat integration: a scripted level-40 explore→orb→regenerate cycle used by
+`CompleteWorkflowDemonstrationTests`. They still work and are useful for debugging
+exploration/GOAP issues, but balance work should use `RunPitLevel`/`RunLevelRange`.


### PR DESCRIPTION
VirtualGameLogicLayer.md is rewritten from its accreted per-phase delta sections into a coherent current-state reference: quick-start recipes (single level + persistent RunLevelRange), the mandatory fully-equipped party setup (crystal-purchased hero skills, LearnAllJobSkills for mercs, stocked bag), the two-stream determinism model, an architecture map covering the shared PitHero.Combat BattleEngine, the RNG-call-order behavior-preservation contract and preserved quirks, the full metrics/ CSV column reference, known gotchas (per-level GOAP flag resets, headless GetTextService guard), the remaining-unmirrored table, and a test map with the 12-failure baseline.

The virtual-game-layer skill's coverage checklist is updated to the post-#296 baseline (all six systems mirrored; stale VirtualEnemy / VirtualMercenaryStateMachine references removed; new-mechanics-go-in- BattleEngine rule added), its architecture reference reflects the sanctioned RNG streams and the HeadlessCoroutineRunner pattern, and the pit-balance-test runner reference gains the RunLevelRange/gold-economy recipe and the current test baseline.