### PR TITLE
Pit tier progression + honor enemy spawn levels (#291)

### DIFF
--- a/PitHero.Tests/BalanceProbeTests.cs
+++ b/PitHero.Tests/BalanceProbeTests.cs
@@ -1,0 +1,91 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.VirtualGame;
+using RolePlayingFramework.Equipment;
+using RolePlayingFramework.Heroes;
+using RolePlayingFramework.Jobs.Primary;
+using RolePlayingFramework.Stats;
+using System.IO;
+using System.Text;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Balance data-gathering probes for issue #291 (pit tier system).
+    /// These runs print CSVs consumed by the balance report; they assert only
+    /// structural properties, not balance verdicts (the report interprets the data).
+    /// </summary>
+    [TestClass]
+    [DoNotParallelize]
+    public class BalanceProbeTests
+    {
+        /// <summary>Standard fully-equipped hero setup mirroring VirtualBalanceTraversalTests.</summary>
+        private static VirtualGameSimulation CreateSim(int seed, int heroLevel, int startingGold = -1)
+        {
+            var sim = new VirtualGameSimulation(seed);
+            var crystal = new HeroCrystal("ProbeCrystal", new Knight(), heroLevel, new StatBlock(10, 8, 10, 4));
+            crystal.EarnJP(1_000_000);
+            sim.ConfigureHero(new Knight(), heroLevel, new StatBlock(10, 8, 10, 4), crystal);
+
+            var hero = sim.Hero.LinkedHero;
+            var jobSkills = hero.Job.Skills;
+            for (int i = 0; i < jobSkills.Count; i++)
+                hero.TryPurchaseSkill(jobSkills[i]);
+
+            for (int i = 0; i < 5; i++)
+                sim.Bag.TryAdd(PotionItems.HPPotion());
+
+            if (startingGold >= 0)
+                sim.ConfigureStartingGold(startingGold);
+
+            return sim;
+        }
+
+        private static string ToCsv(string title, System.Collections.Generic.List<VirtualRunMetrics> rows)
+        {
+            var sb = new StringBuilder(1024);
+            using (var writer = new StringWriter(sb))
+            {
+                writer.WriteLine(title);
+                VirtualRunMetrics.WriteCsvHeader(writer);
+                for (int i = 0; i < rows.Count; i++)
+                    rows[i].WriteRow(writer);
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// A level-appropriate Knight (curve level for pit 20) with gold to hire mercs
+        /// runs depths 20→30, crossing the 25→1(2) tier boundary. Prints the CSV so the
+        /// balance report can evaluate boundary smoothness and crossing survivability.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("BalanceProbe")]
+        public void Probe_TierCrossing_LevelAppropriateParty_Depths20To30()
+        {
+            int heroLevel = RolePlayingFramework.Balance.BalanceConfig.EstimatePlayerLevelForPitLevel(20);
+            var sim = CreateSim(12345, heroLevel, startingGold: 5000);
+            var rows = sim.RunLevelRange(20, 30);
+            System.Console.WriteLine(ToCsv($"# crossing probe: Knight L{heroLevel} start, depths 20-30, 5000g", rows));
+            Assert.IsTrue(rows.Count > 0, "Crossing probe must traverse at least one depth");
+        }
+
+        /// <summary>
+        /// Natural-pacing persistent runs (level-1 Knight, default economy) from depth 1
+        /// to 50 across three seeds — characterizes where natural leveling pace falls
+        /// behind the monster curve (wipe depth distribution).
+        /// </summary>
+        [TestMethod]
+        [TestCategory("BalanceProbe")]
+        public void Probe_PersistentNaturalPacing_ThreeSeeds()
+        {
+            int[] seeds = { 12345, 777, 424242 };
+            for (int s = 0; s < seeds.Length; s++)
+            {
+                var sim = CreateSim(seeds[s], heroLevel: 1);
+                var rows = sim.RunLevelRange(1, 50);
+                System.Console.WriteLine(ToCsv($"# natural pacing probe: seed {seeds[s]}, level-1 Knight, depths 1-50", rows));
+                Assert.IsTrue(rows.Count > 0, $"Seed {seeds[s]}: must traverse at least one depth");
+            }
+        }
+    }
+}

--- a/PitHero.Tests/BiomeProgressionConfigTests.cs
+++ b/PitHero.Tests/BiomeProgressionConfigTests.cs
@@ -1,0 +1,185 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Config;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Unit tests for BiomeProgressionConfig helper methods:
+    /// round-trips between (pitLevel, pitTier) and cumulative depth, boundary values,
+    /// and tier-cap behaviour.
+    /// </summary>
+    [TestClass]
+    public class BiomeProgressionConfigTests
+    {
+        // MaxBiomeLevel is derived from CaveBiomeConfig.CaveEndLevel = 25.
+        private const int MaxLevel = 25;
+
+        // ── GetEffectiveDepth ─────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetEffectiveDepth_Level1_Tier1_Returns1()
+        {
+            Assert.AreEqual(1, BiomeProgressionConfig.GetEffectiveDepth(1, 1));
+        }
+
+        [TestMethod]
+        public void GetEffectiveDepth_Level25_Tier1_Returns25()
+        {
+            Assert.AreEqual(25, BiomeProgressionConfig.GetEffectiveDepth(25, 1));
+        }
+
+        [TestMethod]
+        public void GetEffectiveDepth_Level1_Tier2_Returns26()
+        {
+            Assert.AreEqual(26, BiomeProgressionConfig.GetEffectiveDepth(1, 2));
+        }
+
+        [TestMethod]
+        public void GetEffectiveDepth_Level19_Tier5_Returns119()
+        {
+            Assert.AreEqual(119, BiomeProgressionConfig.GetEffectiveDepth(19, 5));
+        }
+
+        [TestMethod]
+        public void GetEffectiveDepth_ClampsLowTier()
+        {
+            // Tier 0 and below should be treated as tier 1.
+            Assert.AreEqual(BiomeProgressionConfig.GetEffectiveDepth(5, 1),
+                            BiomeProgressionConfig.GetEffectiveDepth(5, 0));
+            Assert.AreEqual(BiomeProgressionConfig.GetEffectiveDepth(5, 1),
+                            BiomeProgressionConfig.GetEffectiveDepth(5, -99));
+        }
+
+        [TestMethod]
+        public void GetEffectiveDepth_ClampsAtMaxTier()
+        {
+            int depth99 = BiomeProgressionConfig.GetEffectiveDepth(1, 99);
+            int depth100 = BiomeProgressionConfig.GetEffectiveDepth(1, 100);
+            Assert.AreEqual(depth99, depth100);
+        }
+
+        // ── GetDisplayedLevelForDepth ─────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetDisplayedLevelForDepth_Depth1_Returns1()
+        {
+            Assert.AreEqual(1, BiomeProgressionConfig.GetDisplayedLevelForDepth(1));
+        }
+
+        [TestMethod]
+        public void GetDisplayedLevelForDepth_Depth25_Returns25()
+        {
+            Assert.AreEqual(25, BiomeProgressionConfig.GetDisplayedLevelForDepth(25));
+        }
+
+        [TestMethod]
+        public void GetDisplayedLevelForDepth_Depth26_Returns1()
+        {
+            Assert.AreEqual(1, BiomeProgressionConfig.GetDisplayedLevelForDepth(26));
+        }
+
+        [TestMethod]
+        public void GetDisplayedLevelForDepth_Depth119_Returns19()
+        {
+            Assert.AreEqual(19, BiomeProgressionConfig.GetDisplayedLevelForDepth(119));
+        }
+
+        [TestMethod]
+        public void GetDisplayedLevelForDepth_GuardDepthLessThan1_Returns1()
+        {
+            Assert.AreEqual(1, BiomeProgressionConfig.GetDisplayedLevelForDepth(0));
+            Assert.AreEqual(1, BiomeProgressionConfig.GetDisplayedLevelForDepth(-5));
+        }
+
+        // ── GetTierForDepth ───────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetTierForDepth_Depth1_ReturnsTier1()
+        {
+            Assert.AreEqual(1, BiomeProgressionConfig.GetTierForDepth(1));
+        }
+
+        [TestMethod]
+        public void GetTierForDepth_Depth25_ReturnsTier1()
+        {
+            Assert.AreEqual(1, BiomeProgressionConfig.GetTierForDepth(25));
+        }
+
+        [TestMethod]
+        public void GetTierForDepth_Depth26_ReturnsTier2()
+        {
+            Assert.AreEqual(2, BiomeProgressionConfig.GetTierForDepth(26));
+        }
+
+        [TestMethod]
+        public void GetTierForDepth_Depth119_ReturnsTier5()
+        {
+            Assert.AreEqual(5, BiomeProgressionConfig.GetTierForDepth(119));
+        }
+
+        [TestMethod]
+        public void GetTierForDepth_CapAt99()
+        {
+            // Depth 2475 = 99 * 25; depth 2476 = 100 * 25 + 1 — both should return 99.
+            Assert.AreEqual(99, BiomeProgressionConfig.GetTierForDepth(2475));
+            Assert.AreEqual(99, BiomeProgressionConfig.GetTierForDepth(2476));
+            Assert.AreEqual(99, BiomeProgressionConfig.GetTierForDepth(99999));
+        }
+
+        [TestMethod]
+        public void GetTierForDepth_GuardDepthLessThan1_Returns1()
+        {
+            Assert.AreEqual(1, BiomeProgressionConfig.GetTierForDepth(0));
+            Assert.AreEqual(1, BiomeProgressionConfig.GetTierForDepth(-1));
+        }
+
+        // ── Round-trip ────────────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void RoundTrip_Depth25_Tier1_Level25()
+        {
+            int depth = 25;
+            Assert.AreEqual(25, BiomeProgressionConfig.GetDisplayedLevelForDepth(depth));
+            Assert.AreEqual(1,  BiomeProgressionConfig.GetTierForDepth(depth));
+        }
+
+        [TestMethod]
+        public void RoundTrip_Depth26_Tier2_Level1()
+        {
+            int depth = 26;
+            Assert.AreEqual(1, BiomeProgressionConfig.GetDisplayedLevelForDepth(depth));
+            Assert.AreEqual(2, BiomeProgressionConfig.GetTierForDepth(depth));
+        }
+
+        [TestMethod]
+        public void RoundTrip_Depth119_Tier5_Level19()
+        {
+            int depth = 119;
+            Assert.AreEqual(19, BiomeProgressionConfig.GetDisplayedLevelForDepth(depth));
+            Assert.AreEqual(5,  BiomeProgressionConfig.GetTierForDepth(depth));
+        }
+
+        [TestMethod]
+        public void GetEffectiveDepth_ReconstitutesDepth()
+        {
+            // GetEffectiveDepth(GetDisplayedLevel(d), GetTier(d)) == d for valid depths.
+            int[] testDepths = { 1, 25, 26, 50, 119, 200, 2475 };
+            for (int i = 0; i < testDepths.Length; i++)
+            {
+                int d = testDepths[i];
+                int level = BiomeProgressionConfig.GetDisplayedLevelForDepth(d);
+                int tier  = BiomeProgressionConfig.GetTierForDepth(d);
+                int reconstructed = BiomeProgressionConfig.GetEffectiveDepth(level, tier);
+                Assert.AreEqual(d, reconstructed, $"Round-trip failed for depth {d}");
+            }
+        }
+
+        // ── MaxBiomeLevel derivation ──────────────────────────────────────────────
+
+        [TestMethod]
+        public void MaxBiomeLevel_MatchesCaveEndLevel()
+        {
+            Assert.AreEqual(CaveBiomeConfig.CaveEndLevel, BiomeProgressionConfig.MaxBiomeLevel);
+        }
+    }
+}

--- a/PitHero.Tests/EnemyLevelSystemIntegrationTests.cs
+++ b/PitHero.Tests/EnemyLevelSystemIntegrationTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RolePlayingFramework.Balance;
 using RolePlayingFramework.Enemies;
 using PitHero.Config;
 
@@ -66,6 +67,89 @@ namespace PitHero.Tests
 
             // Assert
             Assert.AreEqual(1, slimeLevel, "Slimes should always be level 1 according to the design requirements");
+        }
+
+        // -----------------------------------------------------------------------
+        // Tests for the 9 previously-broken enemies (issue #291)
+        // -----------------------------------------------------------------------
+
+        [TestMethod]
+        public void AllPreviouslyBrokenEnemies_HonorRequestedLevel()
+        {
+            // Arrange – request a level well above each enemy's preset to confirm it is used.
+            const int requested = 30;
+
+            // Act
+            var bat      = new Bat(requested);
+            var goblin   = new Goblin(requested);
+            var orc      = new Orc(requested);
+            var pitLord  = new PitLord(requested);
+            var rat      = new Rat(requested);
+            var skeleton = new Skeleton(requested);
+            var snake    = new Snake(requested);
+            var spider   = new Spider(requested);
+            var wraith   = new Wraith(requested);
+
+            // Assert – Level must equal the requested value.
+            Assert.AreEqual(requested, bat.Level,      "Bat should honour requested level");
+            Assert.AreEqual(requested, goblin.Level,   "Goblin should honour requested level");
+            Assert.AreEqual(requested, orc.Level,      "Orc should honour requested level");
+            Assert.AreEqual(requested, pitLord.Level,  "PitLord should honour requested level");
+            Assert.AreEqual(requested, rat.Level,      "Rat should honour requested level");
+            Assert.AreEqual(requested, skeleton.Level, "Skeleton should honour requested level");
+            Assert.AreEqual(requested, snake.Level,    "Snake should honour requested level");
+            Assert.AreEqual(requested, spider.Level,   "Spider should honour requested level");
+            Assert.AreEqual(requested, wraith.Level,   "Wraith should honour requested level");
+
+            // Assert – MaxHP must be consistent with BalanceConfig at that level/archetype.
+            Assert.AreEqual(BalanceConfig.CalculateMonsterHP(requested, BalanceConfig.MonsterArchetype.FastFragile), bat.MaxHP,      "Bat MaxHP should match BalanceConfig at requested level");
+            Assert.AreEqual(BalanceConfig.CalculateMonsterHP(requested, BalanceConfig.MonsterArchetype.Balanced),    goblin.MaxHP,   "Goblin MaxHP should match BalanceConfig at requested level");
+            Assert.AreEqual(BalanceConfig.CalculateMonsterHP(requested, BalanceConfig.MonsterArchetype.Tank),        orc.MaxHP,      "Orc MaxHP should match BalanceConfig at requested level");
+            Assert.AreEqual(BalanceConfig.CalculateMonsterHP(requested, BalanceConfig.MonsterArchetype.Tank),        pitLord.MaxHP,  "PitLord MaxHP should match BalanceConfig at requested level");
+            Assert.AreEqual(BalanceConfig.CalculateMonsterHP(requested, BalanceConfig.MonsterArchetype.Balanced),    rat.MaxHP,      "Rat MaxHP should match BalanceConfig at requested level");
+            Assert.AreEqual(BalanceConfig.CalculateMonsterHP(requested, BalanceConfig.MonsterArchetype.Tank),        skeleton.MaxHP, "Skeleton MaxHP should match BalanceConfig at requested level");
+            Assert.AreEqual(BalanceConfig.CalculateMonsterHP(requested, BalanceConfig.MonsterArchetype.FastFragile), snake.MaxHP,    "Snake MaxHP should match BalanceConfig at requested level");
+            Assert.AreEqual(BalanceConfig.CalculateMonsterHP(requested, BalanceConfig.MonsterArchetype.FastFragile), spider.MaxHP,   "Spider MaxHP should match BalanceConfig at requested level");
+            Assert.AreEqual(BalanceConfig.CalculateMonsterHP(requested, BalanceConfig.MonsterArchetype.FastFragile), wraith.MaxHP,   "Wraith MaxHP should match BalanceConfig at requested level");
+        }
+
+        [TestMethod]
+        public void AllPreviouslyBrokenEnemies_FallBackToPreset_WhenLevelIsZero()
+        {
+            // Act – level 0 signals "use preset".
+            var bat      = new Bat(0);
+            var goblin   = new Goblin(0);
+            var orc      = new Orc(0);
+            var pitLord  = new PitLord(0);
+            var rat      = new Rat(0);
+            var skeleton = new Skeleton(0);
+            var snake    = new Snake(0);
+            var spider   = new Spider(0);
+            var wraith   = new Wraith(0);
+
+            // Assert – each enemy should be at its configured preset level.
+            Assert.AreEqual(EnemyLevelConfig.GetPresetLevel(EnemyId.Bat),      bat.Level,      "Bat(0) should use preset level");
+            Assert.AreEqual(EnemyLevelConfig.GetPresetLevel(EnemyId.Goblin),   goblin.Level,   "Goblin(0) should use preset level");
+            Assert.AreEqual(EnemyLevelConfig.GetPresetLevel(EnemyId.Orc),      orc.Level,      "Orc(0) should use preset level");
+            Assert.AreEqual(EnemyLevelConfig.GetPresetLevel(EnemyId.PitLord),  pitLord.Level,  "PitLord(0) should use preset level");
+            Assert.AreEqual(EnemyLevelConfig.GetPresetLevel(EnemyId.Rat),      rat.Level,      "Rat(0) should use preset level");
+            Assert.AreEqual(EnemyLevelConfig.GetPresetLevel(EnemyId.Skeleton), skeleton.Level, "Skeleton(0) should use preset level");
+            Assert.AreEqual(EnemyLevelConfig.GetPresetLevel(EnemyId.Snake),    snake.Level,    "Snake(0) should use preset level");
+            Assert.AreEqual(EnemyLevelConfig.GetPresetLevel(EnemyId.Spider),   spider.Level,   "Spider(0) should use preset level");
+            Assert.AreEqual(EnemyLevelConfig.GetPresetLevel(EnemyId.Wraith),   wraith.Level,   "Wraith(0) should use preset level");
+        }
+
+        [TestMethod]
+        public void EnemyFactory_CreateWithNoLevel_ReturnsPresetLevel()
+        {
+            // Calling EnemyFactory.Create with no level argument must yield each enemy's preset.
+            var skeleton = EnemyFactory.Create(EnemyId.Skeleton);
+            var pitLord  = EnemyFactory.Create(EnemyId.PitLord);
+
+            Assert.AreEqual(EnemyLevelConfig.GetPresetLevel(EnemyId.Skeleton), skeleton.Level,
+                "EnemyFactory.Create(Skeleton) with no level should return preset level 6");
+            Assert.AreEqual(EnemyLevelConfig.GetPresetLevel(EnemyId.PitLord), pitLord.Level,
+                "EnemyFactory.Create(PitLord) with no level should return preset level 10");
         }
     }
 }

--- a/PitHero.Tests/GearTierScalingTests.cs
+++ b/PitHero.Tests/GearTierScalingTests.cs
@@ -1,0 +1,335 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Config;
+using PitHero.ECS.Components;
+using PitHero.VirtualGame;
+using RolePlayingFramework.Balance;
+using RolePlayingFramework.Combat;
+using RolePlayingFramework.Equipment;
+using RolePlayingFramework.Stats;
+using System;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Tests for gear tier scaling: Gear.CreateTierScaledCopy, ItemRegistry "+N" round-trip,
+    /// and TreasureComponent deterministic drops at tier 2.
+    /// </summary>
+    [TestClass]
+    public class GearTierScalingTests
+    {
+        // ── Helpers ───────────────────────────────────────────────────────────────────
+
+        private static Gear MakeBaseGear(
+            int atk = 10, int def = 5, int price = 100,
+            ItemRarity rarity = ItemRarity.Normal)
+        {
+            var stats = new StatBlock(strength: 2, agility: 1, vitality: 1, magic: 0);
+            return new Gear(
+                "TestSword",
+                ItemKind.WeaponSword,
+                rarity,
+                "TestDesc",
+                price,
+                in stats,
+                atk: atk,
+                def: def);
+        }
+
+        // ── Tier-1 pass-through ───────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void CreateTierScaledCopy_Tier1_ReturnsSameInstance()
+        {
+            var gear = MakeBaseGear();
+            var result = Gear.CreateTierScaledCopy(gear, 1, 25);
+            Assert.AreSame(gear, result, "Tier 1 should return the original instance unchanged");
+        }
+
+        [TestMethod]
+        public void CreateTierScaledCopy_Tier0_ReturnsSameInstance()
+        {
+            var gear = MakeBaseGear();
+            var result = Gear.CreateTierScaledCopy(gear, 0, 25);
+            Assert.AreSame(gear, result, "Tier <= 1 should return the original instance unchanged");
+        }
+
+        // ── Tier-2 stat scaling ───────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void CreateTierScaledCopy_Tier2_AttackIsHigherThanBase()
+        {
+            var gear = MakeBaseGear(atk: 10, rarity: ItemRarity.Normal);
+            int depthDelta = 1 * BiomeProgressionConfig.MaxBiomeLevel; // 25
+
+            var scaled = Gear.CreateTierScaledCopy(gear, 2, depthDelta);
+
+            Assert.IsTrue(scaled.AttackBonus > gear.AttackBonus,
+                $"Tier-2 atk ({scaled.AttackBonus}) should exceed tier-1 atk ({gear.AttackBonus})");
+        }
+
+        [TestMethod]
+        public void CreateTierScaledCopy_Tier2_DefenseIsHigherThanBase()
+        {
+            var gear = MakeBaseGear(def: 5, rarity: ItemRarity.Normal);
+            int depthDelta = 1 * BiomeProgressionConfig.MaxBiomeLevel; // 25
+
+            var scaled = Gear.CreateTierScaledCopy(gear, 2, depthDelta);
+
+            Assert.IsTrue(scaled.DefenseBonus > gear.DefenseBonus,
+                $"Tier-2 def ({scaled.DefenseBonus}) should exceed tier-1 def ({gear.DefenseBonus})");
+        }
+
+        [TestMethod]
+        public void CreateTierScaledCopy_Tier2_PriceIsDoubled()
+        {
+            var gear = MakeBaseGear(price: 100);
+            var scaled = Gear.CreateTierScaledCopy(gear, 2, 25);
+            Assert.AreEqual(gear.Price * 2, scaled.Price,
+                "Tier-2 price should be source.Price * tier");
+        }
+
+        [TestMethod]
+        public void CreateTierScaledCopy_Tier2_TierPropertyIs2()
+        {
+            var gear = MakeBaseGear();
+            var scaled = Gear.CreateTierScaledCopy(gear, 2, 25);
+            Assert.AreEqual(2, scaled.Tier);
+        }
+
+        [TestMethod]
+        public void CreateTierScaledCopy_Tier1Base_TierPropertyIs1()
+        {
+            var gear = MakeBaseGear();
+            Assert.AreEqual(1, gear.Tier, "Default gear should have Tier = 1");
+        }
+
+        [TestMethod]
+        public void CreateTierScaledCopy_Tier2_NameContainsPlusTwoSuffix()
+        {
+            var gear = MakeBaseGear();
+            var scaled = Gear.CreateTierScaledCopy(gear, 2, 25);
+            // In headless context, Name resolves to _nameKey. Tier-2 appends "+2".
+            Assert.IsTrue(scaled.Name.EndsWith("+2"),
+                $"Tier-2 name '{scaled.Name}' should end with '+2'");
+        }
+
+        [TestMethod]
+        public void CreateTierScaledCopy_Tier3_NameContainsPlusThreeSuffix()
+        {
+            var gear = MakeBaseGear();
+            var scaled = Gear.CreateTierScaledCopy(gear, 3, 50);
+            Assert.IsTrue(scaled.Name.EndsWith("+3"),
+                $"Tier-3 name '{scaled.Name}' should end with '+3'");
+        }
+
+        [TestMethod]
+        public void CreateTierScaledCopy_SpriteName_UnchangedFromSource()
+        {
+            var gear = MakeBaseGear();
+            string baseSprite = gear.SpriteName;
+            var scaled = Gear.CreateTierScaledCopy(gear, 2, 25);
+            Assert.AreEqual(baseSprite, scaled.SpriteName,
+                "SpriteName must remain the same as the source so atlas lookup succeeds");
+        }
+
+        [TestMethod]
+        public void CreateTierScaledCopy_Rarity_UnchangedFromSource()
+        {
+            var gear = MakeBaseGear(rarity: ItemRarity.Rare);
+            var scaled = Gear.CreateTierScaledCopy(gear, 2, 25);
+            Assert.AreEqual(ItemRarity.Rare, scaled.Rarity);
+        }
+
+        [TestMethod]
+        public void CreateTierScaledCopy_Kind_UnchangedFromSource()
+        {
+            var gear = MakeBaseGear();
+            var scaled = Gear.CreateTierScaledCopy(gear, 2, 25);
+            Assert.AreEqual(ItemKind.WeaponSword, scaled.Kind);
+        }
+
+        // ── Delta formula verification ────────────────────────────────────────────────
+
+        [TestMethod]
+        public void CalculateEquipmentAttackBonusDelta_Normal_DepthDelta25_Equals12()
+        {
+            // (25 / 2f) * 1.0 = 12.5 → (int) = 12
+            int delta = BalanceConfig.CalculateEquipmentAttackBonusDelta(25, ItemRarity.Normal);
+            Assert.AreEqual(12, delta,
+                "Attack delta for depthDelta=25, Normal rarity should be 12 (25/2 = 12.5 → 12)");
+        }
+
+        [TestMethod]
+        public void CalculateEquipmentDefenseBonusDelta_Normal_DepthDelta25_Equals8()
+        {
+            // (25 / 3f) * 1.0 = 8.33 → (int) = 8
+            int delta = BalanceConfig.CalculateEquipmentDefenseBonusDelta(25, ItemRarity.Normal);
+            Assert.AreEqual(8, delta,
+                "Defense delta for depthDelta=25, Normal rarity should be 8 (25/3 = 8.33 → 8)");
+        }
+
+        [TestMethod]
+        public void CalculateEquipmentStatBonusDelta_Normal_DepthDelta25_Equals5()
+        {
+            // (25 / 5f) * 1.0 = 5.0 → (int) = 5
+            int delta = BalanceConfig.CalculateEquipmentStatBonusDelta(25, ItemRarity.Normal);
+            Assert.AreEqual(5, delta,
+                "Stat delta for depthDelta=25, Normal rarity should be 5 (25/5 = 5)");
+        }
+
+        // ── ItemRegistry "+N" round-trip ─────────────────────────────────────────────
+
+        [TestMethod]
+        public void ItemRegistry_TryCreateItem_TierScaledName_RoundTrips()
+        {
+            // Get a known base gear name via the registry (headless: Name = _nameKey)
+            Assert.IsTrue(ItemRegistry.TryCreateItem("Inv_RustyBlade_Name", out var baseItem),
+                "Base item 'Inv_RustyBlade_Name' must exist in registry");
+            Assert.IsInstanceOfType(baseItem, typeof(Gear));
+
+            var baseGear = (Gear)baseItem;
+            var tier2Name = baseGear.Name + "+2"; // e.g. "Inv_RustyBlade_Name+2" in headless
+
+            ItemRegistry.TierDepthStride = BiomeProgressionConfig.MaxBiomeLevel; // ensure stride is set
+            bool found = ItemRegistry.TryCreateItem(tier2Name, out var tier2Item);
+
+            Assert.IsTrue(found, $"TryCreateItem('{tier2Name}') should succeed via +N parsing");
+            Assert.IsInstanceOfType(tier2Item, typeof(Gear));
+
+            var tier2Gear = (Gear)tier2Item;
+            Assert.AreEqual(2, tier2Gear.Tier, "Round-tripped item should have Tier = 2");
+            Assert.IsTrue(tier2Gear.AttackBonus >= baseGear.AttackBonus,
+                "Round-tripped tier-2 atk should be >= base atk");
+        }
+
+        [TestMethod]
+        public void ItemRegistry_TryCreateItem_NonExistentName_ReturnsFalse()
+        {
+            bool found = ItemRegistry.TryCreateItem("NonExistentSword+2", out _);
+            Assert.IsFalse(found, "Unknown base name with +N suffix should return false");
+        }
+
+        [TestMethod]
+        public void ItemRegistry_TryCreateItem_PotionWithPlusSuffix_ReturnsFalse()
+        {
+            // Potions are not Gear so the +N branch should not produce a result even if base exists.
+            // "Inv_HPPotion_Name+2" — base "Inv_HPPotion_Name" exists but is a Potion, not Gear.
+            ItemRegistry.TryCreateItem("Inv_HPPotion_Name", out var potionItem);
+            if (potionItem == null) return; // potion not in registry under that key — skip
+
+            string potionTier2Name = potionItem.Name + "+2";
+            bool found = ItemRegistry.TryCreateItem(potionTier2Name, out var result);
+            // Either not found (no base), or found but not Gear (so falls through to false)
+            if (found) Assert.IsNotInstanceOfType(result, typeof(Gear),
+                "Non-gear items should not be tier-scaled via +N lookup");
+        }
+
+        // ── TreasureComponent deterministic tier-2 vs tier-1 comparison ──────────────
+
+        [TestMethod]
+        public void TreasureComponent_Deterministic_Tier2CaveGear_StrongerThanTier1()
+        {
+            // Use a non-boss, non-trivial cave level where gear can drop (level >= 11 for Uncommon gear).
+            // Use level 11 which yields Uncommon gear (level 2 treasure) for rolls < 0.35f.
+            // Seed the RNG to a known state so DetermineCaveTreasureLevel returns level 2.
+            Nez.Random.SetSeed(12345);
+
+            // Tier 1 drop at displayed level 11
+            var tier1Chest = new TreasureComponent();
+            LootJobContext emptyCtx = LootJobContext.Empty;
+            tier1Chest.InitializeForPitLevel(11, emptyCtx, pitTier: 1);
+
+            Nez.Random.SetSeed(12345);
+
+            // Tier 2 drop at displayed level 11 (same RNG state = same base item, then scaled)
+            var tier2Chest = new TreasureComponent();
+            tier2Chest.InitializeForPitLevel(11, emptyCtx, pitTier: 2);
+
+            // If both drops produced Gear, tier-2 should be strictly stronger.
+            if (tier1Chest.ContainedItem is Gear t1 && tier2Chest.ContainedItem is Gear t2)
+            {
+                Assert.IsTrue(t2.AttackBonus + t2.DefenseBonus >= t1.AttackBonus + t1.DefenseBonus,
+                    $"Tier-2 gear stats (atk={t2.AttackBonus} def={t2.DefenseBonus}) should be >= tier-1 (atk={t1.AttackBonus} def={t1.DefenseBonus})");
+                Assert.AreEqual(2, t2.Tier, "Tier-2 chest item should have Tier = 2");
+                Assert.AreEqual(1, t1.Tier, "Tier-1 chest item should have Tier = 1");
+            }
+            // If seeds produced a potion/seed drop, skip rather than fail — the test is best-effort.
+        }
+
+        // ── VirtualPitGenerator depth-decomposition ───────────────────────────────────
+
+        [TestMethod]
+        public void VirtualPitGenerator_Depth40_IsTier2CaveLevel15()
+        {
+            // depth 40 = displayedLevel 15, tier 2
+            int displayedLevel = BiomeProgressionConfig.GetDisplayedLevelForDepth(40);
+            int tier = BiomeProgressionConfig.GetTierForDepth(40);
+            Assert.AreEqual(15, displayedLevel, "Depth 40 should map to displayed level 15");
+            Assert.AreEqual(2, tier, "Depth 40 should be tier 2");
+        }
+
+        [TestMethod]
+        public void VirtualPitGenerator_RegenerateForLevel40_GeneratesAncientWyrmBoss()
+        {
+            // depth 40 → displayed 15 → AncientWyrm boss floor
+            var world = new VirtualWorldState();
+            var context = new VirtualGoapContext(world);
+            context.PitWidthManager.Initialize();
+
+            context.PitGenerator.RegenerateForLevel(40);
+
+            // Boss floor 15 (AncientWyrm) should produce exactly 1 boss marker
+            Assert.AreEqual(1, world.LastGeneratedBossMonsterCount,
+                "Depth 40 (cave boss floor 15) should generate exactly 1 boss monster (AncientWyrm)");
+        }
+
+        [TestMethod]
+        public void VirtualPitGenerator_RegenerateForLevel26_IsTier2CaveLevel1()
+        {
+            // depth 26 = displayedLevel 1, tier 2 (first level of tier-2 loop)
+            int displayedLevel = BiomeProgressionConfig.GetDisplayedLevelForDepth(26);
+            int tier = BiomeProgressionConfig.GetTierForDepth(26);
+            Assert.AreEqual(1, displayedLevel, "Depth 26 should map to displayed level 1");
+            Assert.AreEqual(2, tier, "Depth 26 should be tier 2");
+        }
+
+        [TestMethod]
+        public void VirtualPitGenerator_RegenerateForLevel25_IsTier1CaveLevel25()
+        {
+            // depth 25 = displayedLevel 25, tier 1 (unchanged boundary)
+            int displayedLevel = BiomeProgressionConfig.GetDisplayedLevelForDepth(25);
+            int tier = BiomeProgressionConfig.GetTierForDepth(25);
+            Assert.AreEqual(25, displayedLevel, "Depth 25 should map to displayed level 25 (tier 1)");
+            Assert.AreEqual(1, tier, "Depth 25 should be tier 1");
+        }
+
+        [TestMethod]
+        public void CaveBiomeConfig_GetScaledEnemyLevel_Tier2_IsHigherThanTier1()
+        {
+            // At any cave level, tier-2 enemy level should exceed tier-1.
+            for (int level = 1; level <= 25; level++)
+            {
+                if (CaveBiomeConfig.IsBossFloor(level))
+                    continue; // Boss levels have +2 bonus; still check that tier-2 >= tier-1
+
+                int t1Level = CaveBiomeConfig.GetScaledEnemyLevelForPitLevel(level, pitTier: 1);
+                int t2Level = CaveBiomeConfig.GetScaledEnemyLevelForPitLevel(level, pitTier: 2);
+                Assert.IsTrue(t2Level >= t1Level,
+                    $"Tier-2 enemy level ({t2Level}) at cave level {level} should be >= tier-1 ({t1Level})");
+            }
+        }
+
+        [TestMethod]
+        public void CaveBiomeConfig_GetScaledEnemyLevel_DefaultTier_BehaviourMatchesTier1()
+        {
+            // The default pitTier=1 signature should produce identical results to explicit pitTier=1.
+            for (int level = 1; level <= 25; level++)
+            {
+                int defaultResult  = CaveBiomeConfig.GetScaledEnemyLevelForPitLevel(level);
+                int explicit1Result = CaveBiomeConfig.GetScaledEnemyLevelForPitLevel(level, pitTier: 1);
+                Assert.AreEqual(defaultResult, explicit1Result,
+                    $"Default pitTier and explicit pitTier=1 should produce the same result at level {level}");
+            }
+        }
+    }
+}

--- a/PitHero.Tests/MercenaryLevelFloorTests.cs
+++ b/PitHero.Tests/MercenaryLevelFloorTests.cs
@@ -1,0 +1,145 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Services;
+using PitHero.VirtualGame;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Tests that DetermineMercenaryLevel (live and virtual) respects the minLevel floor
+    /// introduced by the pit-tier feature (step 3b), and that the default minLevel=1 is
+    /// unchanged from previous behaviour.
+    /// </summary>
+    [TestClass]
+    public class MercenaryLevelFloorTests
+    {
+        // Run N seeded trials and assert all results are within bounds.
+        private const int TrialCount = 200;
+
+        private static void SeedRng(int seed)
+        {
+            Nez.Random.SetSeed(seed);
+        }
+
+        // ── Live MercenaryManager.DetermineMercenaryLevel ─────────────────────────
+
+        [TestMethod]
+        public void DetermineMercenaryLevel_WithMinLevel1_ResultAlwaysAtLeast1()
+        {
+            SeedRng(42);
+            int heroLevel = 40;
+            for (int i = 0; i < TrialCount; i++)
+            {
+                int level = MercenaryManager.DetermineMercenaryLevel(heroLevel, minLevel: 1);
+                Assert.IsTrue(level >= 1, $"Level {level} below minLevel=1 on trial {i}");
+            }
+        }
+
+        [TestMethod]
+        public void DetermineMercenaryLevel_WithMinLevel20_ResultAlwaysAtLeast20()
+        {
+            SeedRng(1337);
+            int heroLevel = 40;
+            int minLevel = 20;
+            for (int i = 0; i < TrialCount; i++)
+            {
+                int level = MercenaryManager.DetermineMercenaryLevel(heroLevel, minLevel);
+                Assert.IsTrue(level >= minLevel,
+                    $"Level {level} below minLevel={minLevel} on trial {i}");
+            }
+        }
+
+        [TestMethod]
+        public void DetermineMercenaryLevel_MinLevel1_MatchesOldBehaviour()
+        {
+            // With minLevel=1, the default, at least some results should be below 20
+            // (the distribution is not entirely floored).
+            SeedRng(99);
+            int heroLevel = 40;
+            bool sawLow = false;
+            for (int i = 0; i < TrialCount; i++)
+            {
+                // Reset seed consistently so we compare against known rolls.
+                int level = MercenaryManager.DetermineMercenaryLevel(heroLevel, minLevel: 1);
+                if (level < 20)
+                    sawLow = true;
+            }
+            Assert.IsTrue(sawLow, "With minLevel=1, some results should be below 20 for heroLevel=40");
+        }
+
+        [TestMethod]
+        public void DetermineMercenaryLevel_MinLevelEqualToHeroLevel_ResultIsHeroLevel()
+        {
+            // When minLevel == heroLevel, every result is clamped to heroLevel.
+            SeedRng(7777);
+            int heroLevel = 35;
+            for (int i = 0; i < TrialCount; i++)
+            {
+                int level = MercenaryManager.DetermineMercenaryLevel(heroLevel, minLevel: heroLevel);
+                Assert.AreEqual(heroLevel, level,
+                    $"With minLevel==heroLevel, result should be heroLevel on trial {i}");
+            }
+        }
+
+        // ── Virtual VirtualMercenaryLevelRoller ───────────────────────────────────
+
+        [TestMethod]
+        public void VirtualRoller_WithMinLevel1_ResultAlwaysAtLeast1()
+        {
+            SeedRng(42);
+            int heroLevel = 40;
+            for (int i = 0; i < TrialCount; i++)
+            {
+                int level = VirtualMercenaryLevelRoller.DetermineMercenaryLevel(heroLevel, minLevel: 1);
+                Assert.IsTrue(level >= 1, $"Virtual level {level} below 1 on trial {i}");
+            }
+        }
+
+        [TestMethod]
+        public void VirtualRoller_WithMinLevel20_ResultAlwaysAtLeast20()
+        {
+            SeedRng(1337);
+            int heroLevel = 40;
+            int minLevel = 20;
+            for (int i = 0; i < TrialCount; i++)
+            {
+                int level = VirtualMercenaryLevelRoller.DetermineMercenaryLevel(heroLevel, minLevel);
+                Assert.IsTrue(level >= minLevel,
+                    $"Virtual level {level} below {minLevel} on trial {i}");
+            }
+        }
+
+        [TestMethod]
+        public void VirtualRoller_DefaultMinLevel1_IsUnchanged()
+        {
+            // Calling with no minLevel argument must produce the same distribution as minLevel=1.
+            SeedRng(555);
+            int heroLevel = 30;
+            for (int i = 0; i < TrialCount; i++)
+            {
+                int levelDefault = VirtualMercenaryLevelRoller.DetermineMercenaryLevel(heroLevel);
+                Assert.IsTrue(levelDefault >= 1,
+                    $"Default minLevel=1 result {levelDefault} below 1 on trial {i}");
+            }
+        }
+
+        // ── Live/Virtual parity ───────────────────────────────────────────────────
+
+        [TestMethod]
+        public void LiveAndVirtual_ProduceSameResultForSameSeed()
+        {
+            // Both implementations consume Nez.Random in the same order, so they must
+            // match exactly when seeded identically before each call.
+            int heroLevel = 50;
+            int minLevel = 15;
+            for (int i = 0; i < 50; i++)
+            {
+                SeedRng(i * 31 + 7);
+                int live = MercenaryManager.DetermineMercenaryLevel(heroLevel, minLevel);
+                SeedRng(i * 31 + 7);
+                int virt = VirtualMercenaryLevelRoller.DetermineMercenaryLevel(heroLevel, minLevel);
+                Assert.AreEqual(live, virt,
+                    $"Live ({live}) and virtual ({virt}) differ for seed {i * 31 + 7}");
+            }
+        }
+    }
+}

--- a/PitHero.Tests/PitGeneratorTests.cs
+++ b/PitHero.Tests/PitGeneratorTests.cs
@@ -1,6 +1,9 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using PitHero;
+using PitHero.Config;
+using RolePlayingFramework.Balance;
+using RolePlayingFramework.Enemies;
 
 namespace PitHero.Tests
 {
@@ -159,6 +162,50 @@ namespace PitHero.Tests
                         $"Level {level} should generate enemies between level 1 and scaled level {expected}");
                 }
             }
+        }
+
+        /// <summary>
+        /// Validates that CreateEnemyForPitLevel with a tier argument produces a monster whose
+        /// level is within ±2 of EstimatePlayerLevelForPitLevel(effectiveDepth).  This covers
+        /// both tier-1 and tier-2 samples.  The ±2 window accommodates the boss-floor +2 spike.
+        /// </summary>
+        [TestMethod]
+        public void CreateEnemyForPitLevel_Tier2Samples_MonsterLevelWithinRange()
+        {
+            var generator = new PitGenerator((Nez.Scene)null!);
+
+            // Samples: (displayedLevel, tier, isBoss)
+            int[] displayedLevels = { 7, 16, 24,  1, 15, 20, 25 };
+            int[] tiers           = { 1,  1,  1,  2,  2,  2,  2 };
+
+            for (int s = 0; s < displayedLevels.Length; s++)
+            {
+                int pitLevel   = displayedLevels[s];
+                int pitTier    = tiers[s];
+                int effectiveDepth = BiomeProgressionConfig.GetEffectiveDepth(pitLevel, pitTier);
+                int expectedPlayerLevel = BalanceConfig.EstimatePlayerLevelForPitLevel(effectiveDepth);
+
+                var result = generator.CreateEnemyForPitLevel(pitLevel, pitTier);
+
+                Assert.IsTrue(
+                    Math.Abs(result.enemy.Level - expectedPlayerLevel) <= 2,
+                    $"(pitLevel={pitLevel}, tier={pitTier}): enemy level {result.enemy.Level} " +
+                    $"should be within ±2 of expectedPlayerLevel {expectedPlayerLevel} " +
+                    $"(effectiveDepth={effectiveDepth})");
+            }
+        }
+
+        /// <summary>
+        /// Validates that CreateEnemyForPitLevel(20, 2) returns a PitLord — the boss keyed
+        /// to displayed level 20 is the same regardless of tier.
+        /// </summary>
+        [TestMethod]
+        public void CreateEnemyForPitLevel_Tier2BossFloor20_ReturnsPitLord()
+        {
+            var generator = new PitGenerator((Nez.Scene)null!);
+            var result = generator.CreateEnemyForPitLevel(pitLevel: 20, pitTier: 2);
+            Assert.IsTrue(result.enemy is PitLord,
+                $"Tier-2 boss floor 20 must spawn PitLord; got {result.enemy.GetType().Name}");
         }
 
         [TestMethod]

--- a/PitHero.Tests/PitResetOnHeroDeathTests.cs
+++ b/PitHero.Tests/PitResetOnHeroDeathTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Config;
 using PitHero.VirtualGame;
 
 namespace PitHero.Tests
@@ -73,6 +74,95 @@ namespace PitHero.Tests
 
             pitManager.SetPitLevel(1);
             Assert.AreEqual(1, pitManager.CurrentPitLevel, "Pit level should be 1 after reset");
+        }
+
+        // ── Tier state ────────────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void TierAndBaseLevel_SurviveSetPitLevel1()
+        {
+            // Tier and base level must NOT reset when the pit resets to level 1 on hero death.
+            var pitManager = CreatePitManager();
+            pitManager.Initialize();
+            pitManager.SetPitTier(3);
+            pitManager.SetTierBaseLevel(20);
+
+            pitManager.SetPitLevel(1);
+
+            Assert.AreEqual(3, pitManager.CurrentPitTier, "PitTier must survive death reset");
+            Assert.AreEqual(20, pitManager.TierBaseLevel, "TierBaseLevel must survive death reset");
+            Assert.AreEqual(1, pitManager.CurrentPitLevel, "PitLevel should be 1 after reset");
+        }
+
+        [TestMethod]
+        public void IncrementPitTier_IncreasesCounterAndSetsBaseLevel()
+        {
+            var pitManager = CreatePitManager();
+            pitManager.Initialize();
+
+            Assert.AreEqual(1, pitManager.CurrentPitTier);
+            Assert.AreEqual(1, pitManager.TierBaseLevel);
+
+            pitManager.IncrementPitTier(heroLevelAtEntry: 30);
+
+            Assert.AreEqual(2, pitManager.CurrentPitTier);
+            Assert.AreEqual(30, pitManager.TierBaseLevel);
+        }
+
+        [TestMethod]
+        public void IncrementPitTier_Monotonic_BaseLevelNeverDecreases()
+        {
+            var pitManager = CreatePitManager();
+            pitManager.Initialize();
+            pitManager.IncrementPitTier(heroLevelAtEntry: 40);
+            Assert.AreEqual(40, pitManager.TierBaseLevel);
+
+            // Incrementing again with a LOWER hero level must not decrease base level.
+            pitManager.IncrementPitTier(heroLevelAtEntry: 20);
+            Assert.AreEqual(40, pitManager.TierBaseLevel, "TierBaseLevel must never decrease");
+            Assert.AreEqual(3, pitManager.CurrentPitTier);
+        }
+
+        [TestMethod]
+        public void IncrementPitTier_CapsAt99()
+        {
+            var pitManager = CreatePitManager();
+            pitManager.Initialize();
+            pitManager.SetPitTier(BiomeProgressionConfig.MaxPitTier); // 99
+
+            pitManager.IncrementPitTier(heroLevelAtEntry: 1);
+
+            Assert.AreEqual(BiomeProgressionConfig.MaxPitTier, pitManager.CurrentPitTier, "Tier must not exceed 99");
+        }
+
+        [TestMethod]
+        public void SetTierBaseLevel_IsMonotonicNonDecreasing()
+        {
+            var pitManager = CreatePitManager();
+            pitManager.Initialize();
+            pitManager.SetTierBaseLevel(50);
+            Assert.AreEqual(50, pitManager.TierBaseLevel);
+
+            // Lower value is silently ignored.
+            pitManager.SetTierBaseLevel(30);
+            Assert.AreEqual(50, pitManager.TierBaseLevel, "Lower base level should be ignored");
+
+            // Higher value is accepted.
+            pitManager.SetTierBaseLevel(60);
+            Assert.AreEqual(60, pitManager.TierBaseLevel);
+        }
+
+        [TestMethod]
+        public void SetPitTier_ClampsToValidRange()
+        {
+            var pitManager = CreatePitManager();
+            pitManager.Initialize();
+
+            pitManager.SetPitTier(0);
+            Assert.AreEqual(1, pitManager.CurrentPitTier, "Tier below 1 should clamp to 1");
+
+            pitManager.SetPitTier(200);
+            Assert.AreEqual(BiomeProgressionConfig.MaxPitTier, pitManager.CurrentPitTier, "Tier above 99 should clamp to 99");
         }
     }
 }

--- a/PitHero.Tests/PitTierProgressionTests.cs
+++ b/PitHero.Tests/PitTierProgressionTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Config;
+using PitHero.VirtualGame;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Unit tests for pit-tier progression mechanics: tier-2 treasure scaling via
+    /// <see cref="VirtualPitGenerator"/> and related tier-decomposition helpers.
+    /// These are plain unit tests — not BalanceTraversal — and run in the default test suite.
+    /// </summary>
+    [TestClass]
+    public class PitTierProgressionTests
+    {
+        /// <summary>
+        /// Verifies that regenerating tier-2 depths (36–50) via <see cref="VirtualPitGenerator"/>
+        /// produces at least one treasure whose item name ends with "+2" — the tier-2 suffix
+        /// that <see cref="RolePlayingFramework.Equipment.Gear"/> appends in headless mode.
+        ///
+        /// <para>
+        /// The generator applies <see cref="RolePlayingFramework.Equipment.Gear.CreateTierScaledCopy"/>
+        /// to all Gear drops at tier ≥ 2.  Cave displayed levels 11+ (depths 36–50 in tier 2)
+        /// produce loot level 2 (Uncommon) and level 3 (Rare) drops, which generate Gear items.
+        /// Across several depth samples we must see at least one tier-scaled Gear.
+        /// </para>
+        ///
+        /// <para>
+        /// In headless mode (no TextService) <c>Gear.Name</c> returns <c>nameKey + "+2"</c>,
+        /// and <see cref="VirtualWorldState.LastGeneratedEquipmentTypes"/> stores this name
+        /// string, so checking for the "+2" suffix is equivalent to checking <c>Gear.Tier == 2</c>.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        public void Tier2_CaveChest_ContainsTierScaledGear()
+        {
+            // Sample depths in tier-2 range where loot level ≥ 2 gear can appear
+            // (displayed levels 11+ have ≥35 % chance for Uncommon+ loot that becomes Gear).
+            // Depth 36 = displayed 11, depth 40 = displayed 15 (boss), depth 45 = displayed 20 (boss),
+            // depth 50 = displayed 25 (boss — highest loot table, 20 % level-3 chance).
+            int[] tier2Depths = { 36, 40, 45, 50 };
+
+            bool foundTier2Gear = false;
+
+            for (int d = 0; d < tier2Depths.Length; d++)
+            {
+                int depth = tier2Depths[d];
+
+                var world = new VirtualWorldState();
+                world.RegeneratePit(depth);
+
+                var tiledMapService = new VirtualTiledMapService(world);
+                var pitWidthManager = new VirtualPitWidthManager(tiledMapService);
+                var generator = new VirtualPitGenerator(world, tiledMapService, pitWidthManager);
+                generator.RegenerateForLevel(depth);
+
+                // LastGeneratedEquipmentTypes stores item.Name for each chest.
+                // In headless mode a tier-2 Gear has name "Inv_XXX_Name+2".
+                var equipmentTypes = world.LastGeneratedEquipmentTypes;
+                for (int e = 0; e < equipmentTypes.Count; e++)
+                {
+                    if (equipmentTypes[e].EndsWith("+2"))
+                    {
+                        foundTier2Gear = true;
+                    }
+                }
+
+                // Verify the tier is correct for these depths.
+                Assert.AreEqual(2, BiomeProgressionConfig.GetTierForDepth(depth),
+                    $"Depth {depth} must be tier 2");
+            }
+
+            Assert.IsTrue(foundTier2Gear,
+                "Across tier-2 depth samples {36,40,45,50} at least one Gear item with '+2' name " +
+                "(= Tier == 2 in headless mode) must appear in chest loot");
+        }
+    }
+}

--- a/PitHero.Tests/SaveLoadTests.cs
+++ b/PitHero.Tests/SaveLoadTests.cs
@@ -490,5 +490,110 @@ namespace PitHero.Tests
                     Directory.Delete(tempDir, true);
             }
         }
+
+        /// <summary>Verifies PitTier and TierBaseLevel round-trip through save v13.</summary>
+        [TestMethod]
+        public void SaveData_V13_PitTier_RoundTrip()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "pithero_tier_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var dataStore = new FileDataStore(tempDir);
+
+                var original = new SaveData();
+                original.PitLevel = 7;
+                original.PitTier = 5;
+                original.TierBaseLevel = 30;
+
+                dataStore.Save("tier_save.bin", original);
+
+                var loaded = new SaveData();
+                dataStore.Load("tier_save.bin", loaded);
+
+                Assert.AreEqual(7, loaded.PitLevel, "PitLevel should round-trip");
+                Assert.AreEqual(5, loaded.PitTier, "PitTier should round-trip");
+                Assert.AreEqual(30, loaded.TierBaseLevel, "TierBaseLevel should round-trip");
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a SaveData with default tier values (tier=1, base=1) round-trips correctly.
+        /// </summary>
+        [TestMethod]
+        public void SaveData_V13_DefaultTierValues_RoundTrip()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "pithero_defaulttier_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var dataStore = new FileDataStore(tempDir);
+
+                var original = new SaveData();
+                // Default values: PitTier = 1, TierBaseLevel = 1.
+                Assert.AreEqual(1, original.PitTier, "Default PitTier should be 1");
+                Assert.AreEqual(1, original.TierBaseLevel, "Default TierBaseLevel should be 1");
+
+                dataStore.Save("default_tier.bin", original);
+
+                var loaded = new SaveData();
+                dataStore.Load("default_tier.bin", loaded);
+
+                Assert.AreEqual(1, loaded.PitTier, "Loaded PitTier should default to 1");
+                Assert.AreEqual(1, loaded.TierBaseLevel, "Loaded TierBaseLevel should default to 1");
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
+            }
+        }
+
+        /// <summary>
+        /// Migration test: saves created before v13 (where PitLevel was cumulative depth) are
+        /// decoded into the correct tier + displayed level.  We simulate a v12-era save whose
+        /// PitLevel field holds cumulative depth 119 (tier 5, displayed level 19).
+        /// </summary>
+        [TestMethod]
+        public void SaveData_Migration_PitLevel119_DecodesAsTier5_Level19()
+        {
+            // SaveData.Recover normalises PitLevel from cumulative depth to biome-local when
+            // fileVersion < 13.  We can't write a true v12 binary from a unit test without
+            // down-grading CurrentVersion, so we validate the helper logic directly.
+            var data = new SaveData();
+            data.PitLevel = 119;
+            data.Level = 40; // hero level used for TierBaseLevel migration
+
+            // Apply the same migration formula as Recover does for fileVersion < 13:
+            int rawPitLevel = data.PitLevel;
+            int migratedTier = PitHero.Config.BiomeProgressionConfig.GetTierForDepth(rawPitLevel);
+            int migratedBaseLevel = migratedTier >= 2 ? (data.Level > 0 ? data.Level : 1) : 1;
+            int migratedLevel = PitHero.Config.BiomeProgressionConfig.GetDisplayedLevelForDepth(rawPitLevel);
+
+            Assert.AreEqual(5, migratedTier, "Depth 119 should decode to tier 5");
+            Assert.AreEqual(19, migratedLevel, "Depth 119 should decode to level 19");
+            Assert.AreEqual(40, migratedBaseLevel, "TierBaseLevel should equal saved hero level when tier >= 2");
+        }
+
+        /// <summary>
+        /// Migration: a v12 save with PitLevel ≤ 25 (already a normal level) should decode to tier 1.
+        /// </summary>
+        [TestMethod]
+        public void SaveData_Migration_PitLevel7_DecodesAsTier1()
+        {
+            int rawPitLevel = 7;
+            int migratedTier = PitHero.Config.BiomeProgressionConfig.GetTierForDepth(rawPitLevel);
+            int migratedLevel = PitHero.Config.BiomeProgressionConfig.GetDisplayedLevelForDepth(rawPitLevel);
+
+            Assert.AreEqual(1, migratedTier, "PitLevel 7 should map to tier 1");
+            Assert.AreEqual(7, migratedLevel, "PitLevel 7 should remain 7 after migration");
+        }
     }
 }

--- a/PitHero.Tests/VirtualBalanceTraversalTests.cs
+++ b/PitHero.Tests/VirtualBalanceTraversalTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Config;
 using PitHero.VirtualGame;
 using RolePlayingFramework.Balance;
 using RolePlayingFramework.Equipment;
@@ -225,6 +226,245 @@ namespace PitHero.Tests
             string second = RunTraversalCsv(Seed);
             Assert.AreEqual(first, second,
                 "Same seed must reproduce the exact same balance metrics CSV");
+        }
+
+        // ── Tier-2 tests (issue #291, step 8) ────────────────────────────────────────
+
+        /// <summary>Cumulative depths in tier-2, with their displayed levels noted.</summary>
+        /// <remarks>
+        /// 26 → displayed 1 (tier 2), 30 → displayed 5 (boss, tier 2),
+        /// 40 → displayed 15 (boss, tier 2), 45 → displayed 20 (boss, tier 2),
+        /// 50 → displayed 25 (boss, tier 2).
+        /// </remarks>
+        private static readonly int[] Tier2SampleDepths = { 26, 30, 40, 45, 50 };
+
+        /// <summary>
+        /// Runs a single tier-2 pit depth with a fresh seeded sim and a level-appropriate
+        /// Knight whose level tracks the expected player level for that cumulative depth.
+        /// </summary>
+        private static VirtualRunMetrics RunTier2Level(int seed, int depth)
+        {
+            var sim = new VirtualGameSimulation(seed);
+            int heroLevel = BalanceConfig.EstimatePlayerLevelForPitLevel(depth);
+
+            var crystal = new HeroCrystal("RefCrystal", new Knight(), heroLevel, new StatBlock(10, 8, 10, 4));
+            crystal.EarnJP(1_000_000);
+            sim.ConfigureHero(new Knight(), heroLevel, new StatBlock(10, 8, 10, 4), crystal);
+
+            var hero      = sim.Hero.LinkedHero;
+            var jobSkills = hero.Job.Skills;
+            for (int i = 0; i < jobSkills.Count; i++)
+                hero.TryPurchaseSkill(jobSkills[i]);
+
+            for (int i = 0; i < 5; i++)
+                sim.Bag.TryAdd(PotionItems.HPPotion());
+
+            return sim.RunPitLevel(depth);
+        }
+
+        /// <summary>
+        /// Runs tier-2 depths {26, 30, 40, 45, 50} with a level-appropriate solo Knight
+        /// and verifies each traversal produces battles and that PitTier/DisplayedLevel
+        /// columns are correctly populated in the returned metrics.
+        /// CSV output is printed so balance reports can consume it.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("BalanceTraversal")]
+        public void BalanceTraversal_Tier2SampledFloors_ProducesMetrics()
+        {
+            var sb = new StringBuilder(512);
+            using (var writer = new StringWriter(sb))
+            {
+                writer.WriteLine("# tier-2 sampled floors: solo Knight");
+                VirtualRunMetrics.WriteCsvHeader(writer);
+
+                for (int i = 0; i < Tier2SampleDepths.Length; i++)
+                {
+                    int depth    = Tier2SampleDepths[i];
+                    int displayed = BiomeProgressionConfig.GetDisplayedLevelForDepth(depth);
+                    int tier      = BiomeProgressionConfig.GetTierForDepth(depth);
+                    var metrics  = RunTier2Level(Seed, depth);
+                    metrics.WriteRow(writer);
+
+                    Assert.AreEqual(2, metrics.PitTier,
+                        $"Depth {depth}: PitTier column must be 2");
+                    Assert.AreEqual(displayed, metrics.DisplayedLevel,
+                        $"Depth {depth}: DisplayedLevel must be {displayed}");
+                    Assert.AreEqual(Seed, metrics.RngSeed,
+                        $"Depth {depth}: metrics must record the run seed");
+                    Assert.IsTrue(metrics.BattleCount > 0,
+                        $"Depth {depth} (displayed {displayed}, tier {tier}): must fight at least one battle");
+                    Assert.IsTrue(metrics.DamageDealt > 0,
+                        $"Depth {depth} (displayed {displayed}, tier {tier}): allies must deal damage");
+                }
+            }
+
+            System.Console.WriteLine(sb.ToString());
+        }
+
+        /// <summary>
+        /// Runs a persistent pit traversal from depth 1 to 50 (two full biome loops) using
+        /// the standard level-1 Knight setup with the gold-economy policy.
+        /// Asserts: if the hero was not wiped, exactly 50 rows are present; rows for depth ≥ 26
+        /// carry PitTier == 2; full CSV is emitted to test output.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("BalanceTraversal")]
+        public void BalanceTraversal_PersistentRun1To50_TierCrossingRecorded()
+        {
+            // Same setup as RunPersistentRange but extending to depth 50 (tier 2).
+            var sim = new VirtualGameSimulation(Seed);
+
+            var crystal = new HeroCrystal("RefCrystal", new Knight(), 1, new StatBlock(10, 8, 10, 4));
+            crystal.EarnJP(1_000_000);
+            sim.ConfigureHero(new Knight(), 1, new StatBlock(10, 8, 10, 4), crystal);
+
+            var hero      = sim.Hero.LinkedHero;
+            var jobSkills = hero.Job.Skills;
+            for (int i = 0; i < jobSkills.Count; i++)
+                hero.TryPurchaseSkill(jobSkills[i]);
+
+            for (int i = 0; i < 5; i++)
+                sim.Bag.TryAdd(PotionItems.HPPotion());
+
+            var results = sim.RunLevelRange(1, 50);
+
+            // Emit full CSV so balance reports can consume it.
+            var sb = new StringBuilder(2048);
+            using (var writer = new StringWriter(sb))
+            {
+                writer.WriteLine("# persistent run 1-50: Knight, auto-hire + inn");
+                VirtualRunMetrics.WriteCsvHeader(writer);
+                for (int i = 0; i < results.Count; i++)
+                    results[i].WriteRow(writer);
+            }
+            System.Console.WriteLine(sb.ToString());
+
+            Assert.IsTrue(results.Count >= 1,
+                "Persistent 1-50 run must traverse at least one depth");
+
+            var last = results[results.Count - 1];
+            if (!last.Wiped)
+            {
+                Assert.AreEqual(50, results.Count,
+                    "If not wiped, all 50 depth rows must be present");
+            }
+
+            // Rows for depth >= 26 must have PitTier == 2.
+            for (int i = 0; i < results.Count; i++)
+            {
+                int depth = results[i].PitLevel;
+                int expectedTier = BiomeProgressionConfig.GetTierForDepth(depth);
+                Assert.AreEqual(expectedTier, results[i].PitTier,
+                    $"Depth {depth}: PitTier column must equal {expectedTier}");
+                Assert.AreEqual(
+                    BiomeProgressionConfig.GetDisplayedLevelForDepth(depth),
+                    results[i].DisplayedLevel,
+                    $"Depth {depth}: DisplayedLevel column must match BiomeProgressionConfig");
+            }
+
+            // All traversed depths must have fought at least one battle.
+            for (int i = 0; i < results.Count; i++)
+            {
+                Assert.IsTrue(results[i].BattleCount > 0,
+                    $"Persistent depth {results[i].PitLevel}: must fight at least one battle");
+            }
+        }
+
+        /// <summary>
+        /// Simulates a hero respawning at the tier-base level after death in tier 2.
+        /// A crossing sim with a level-appropriate hero establishes the TierBaseLevel;
+        /// then a fresh sim at that level (with full Knight skills and potions) runs the
+        /// first three non-boss floors of tier 2 (depths 26–28) and must not wipe.
+        /// This validates the game-design contract: a hero at the tier-base level can
+        /// re-progress through early tier-2 content.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("BalanceTraversal")]
+        public void BalanceTraversal_RespawnAtTierBaseLevel_SurvivesEarlyTier2()
+        {
+            // ── Part 1: establish TierBaseLevel via a crossing sim ────────────────────
+            // Use a hero at the expected level when *entering* tier 2 (depth 26 = pit 26
+            // equivalent).  This represents the hero's level at the crossing point and is
+            // the value IncrementPitTier will record as TierBaseLevel.  Configuring at
+            // EstimatePlayerLevelForPitLevel(26) ensures the respawn hero's level closely
+            // matches depth-26 content and the test remains balance-valid.
+            int crossingHeroLevel = BalanceConfig.EstimatePlayerLevelForPitLevel(26);
+            var crossingSim = new VirtualGameSimulation(Seed);
+            var crossingCrystal = new HeroCrystal("CrossRef", new Knight(), crossingHeroLevel, new StatBlock(10, 8, 10, 4));
+            crossingCrystal.EarnJP(1_000_000);
+            crossingSim.ConfigureHero(new Knight(), crossingHeroLevel, new StatBlock(10, 8, 10, 4), crossingCrystal);
+            var crossingHero   = crossingSim.Hero.LinkedHero;
+            var crossingSkills = crossingHero.Job.Skills;
+            for (int i = 0; i < crossingSkills.Count; i++)
+                crossingHero.TryPurchaseSkill(crossingSkills[i]);
+            for (int i = 0; i < 5; i++)
+                crossingSim.Bag.TryAdd(PotionItems.HPPotion());
+
+            // Running pit 25 then depth 26 triggers IncrementPitTier, recording TierBaseLevel.
+            crossingSim.RunLevelRange(25, 26);
+            int tierBaseLevel = crossingSim.TierBaseLevel;
+
+            Assert.IsTrue(tierBaseLevel >= 1,
+                "TierBaseLevel must be set (≥ 1) after crossing into tier 2");
+
+            // ── Part 2: respawn sim — hero at TierBaseLevel with a tier-appropriate party ──
+            // A player respawning in tier 2 would rehire mercs at the tier-base level
+            // (the live MercenaryManager enforces the minLevel floor).  We mirror that here
+            // via ConfigureMercenaries with a Priest (healing) and Archer (damage) at the
+            // same tierBaseLevel, following the withParty=true convention in RunLevel.
+            var respawnSim = new VirtualGameSimulation(Seed);
+            var respawnCrystal = new HeroCrystal("RespawnRef", new Knight(), tierBaseLevel, new StatBlock(10, 8, 10, 4));
+            respawnCrystal.EarnJP(1_000_000);
+            respawnSim.ConfigureHero(new Knight(), tierBaseLevel, new StatBlock(10, 8, 10, 4), respawnCrystal);
+            var respawnHero   = respawnSim.Hero.LinkedHero;
+            var respawnSkills = respawnHero.Job.Skills;
+            for (int i = 0; i < respawnSkills.Count; i++)
+                respawnHero.TryPurchaseSkill(respawnSkills[i]);
+            for (int i = 0; i < 5; i++)
+                respawnSim.Bag.TryAdd(PotionItems.HPPotion());
+
+            // Restore the tier state so the manager knows the correct minLevel for any
+            // additional hires that RunLevelRange may attempt between levels.
+            respawnSim.ConfigurePitTier(2, tierBaseLevel);
+
+            // Pre-configure a Priest + Archer at tierBaseLevel (mirrors live tavern spawn
+            // where LearnAllJobSkills is called on every new mercenary).
+            var cleric = new Mercenary("Cleric", new Priest(), tierBaseLevel, new StatBlock(6, 8, 8, 12));
+            cleric.LearnAllJobSkills();
+            var scout = new Mercenary("Scout", new Archer(), tierBaseLevel, new StatBlock(9, 12, 8, 5));
+            scout.LearnAllJobSkills();
+            respawnSim.ConfigureMercenaries(new List<Mercenary> { cleric, scout });
+
+            // Run the first non-boss floor of tier 2 (depth 26; displayed 1).
+            // This is the minimum viable re-progression check: a base-level party must
+            // clear the very first floor of tier 2 after respawning.
+            var respawnResults = respawnSim.RunLevelRange(26, 26);
+
+            // Emit CSV for visibility.
+            var sb = new StringBuilder(512);
+            using (var writer = new StringWriter(sb))
+            {
+                writer.WriteLine($"# respawn-at-tier-base scenario: tierBaseLevel={tierBaseLevel}, depth 26");
+                VirtualRunMetrics.WriteCsvHeader(writer);
+                for (int i = 0; i < respawnResults.Count; i++)
+                    respawnResults[i].WriteRow(writer);
+            }
+            System.Console.WriteLine(sb.ToString());
+
+            Assert.IsTrue(respawnResults.Count > 0,
+                "Respawn run must attempt at least one depth");
+
+            // All traversed depths must have PitTier == 2.
+            for (int i = 0; i < respawnResults.Count; i++)
+            {
+                Assert.AreEqual(2, respawnResults[i].PitTier,
+                    $"Respawn depth {respawnResults[i].PitLevel}: PitTier must be 2");
+            }
+
+            var lastRespawn = respawnResults[respawnResults.Count - 1];
+            Assert.IsFalse(lastRespawn.Wiped,
+                $"A 3-member party at tier-base level {tierBaseLevel} must survive depth 26 (displayed 1, tier 2)");
         }
 
         /// <summary>

--- a/PitHero/AI/ActivateWizardOrbAction.cs
+++ b/PitHero/AI/ActivateWizardOrbAction.cs
@@ -5,6 +5,7 @@ using PitHero.Config;
 using PitHero.ECS.Components;
 using PitHero.Services;
 using PitHero.Util;
+using PitHero.VirtualGame;
 using System.Collections;
 
 namespace PitHero.AI
@@ -53,8 +54,9 @@ namespace PitHero.AI
             ClearAllFogOfWarInPit();
 
             int pitLevelBeforeOrb = Core.Services.GetService<PitWidthManager>()?.CurrentPitLevel ?? 0;
+            int heroLevel = hero.LinkedHero?.Level ?? 1;
 
-            QueueNextPitLevel();
+            QueueNextPitLevel(heroLevel);
 
             // Regenerate the queued pit level immediately
             if (!RegenerateQueuedPitLevel())
@@ -106,8 +108,22 @@ namespace PitHero.AI
             var nextLevel = context.PitLevelManager.DequeueLevel();
             if (nextLevel.HasValue)
             {
-                context.PitGenerator.RegenerateForLevel(nextLevel.Value);
-                context.LogDebug($"[ActivateWizardOrbAction] Generated pit level {nextLevel.Value}");
+                // Normalize tier state when the depth exceeds the single-biome boundary.
+                // The level value itself is passed through unchanged for now (step 4 will
+                // teach RegenerateForLevel to interpret it as cumulative depth).
+                int dequeued = nextLevel.Value;
+                if (dequeued > BiomeProgressionConfig.MaxBiomeLevel)
+                {
+                    int newTier = BiomeProgressionConfig.GetTierForDepth(dequeued);
+                    if (newTier > context.PitWidthManager.CurrentPitTier)
+                    {
+                        var vManager = context.PitWidthManager as VirtualPitWidthManager;
+                        vManager?.SetPitTier(newTier);
+                        context.LogDebug($"[ActivateWizardOrbAction] Tier advanced to {newTier} for depth {dequeued}");
+                    }
+                }
+                context.PitGenerator.RegenerateForLevel(dequeued);
+                context.LogDebug($"[ActivateWizardOrbAction] Generated pit level {dequeued}");
             }
             else
             {
@@ -170,8 +186,8 @@ namespace PitHero.AI
             return wizardOrbEntities[0]; // Should only be one wizard orb
         }
 
-        /// <summary>Queue next pit level for regeneration.</summary>
-        private void QueueNextPitLevel()
+        /// <summary>Queue next pit level for regeneration, wrapping to tier 1 when past MaxBiomeLevel.</summary>
+        private void QueueNextPitLevel(int heroLevel)
         {
             var pitWidthManager = Core.Services.GetService<PitWidthManager>();
             if (pitWidthManager == null)
@@ -180,8 +196,14 @@ namespace PitHero.AI
                 return;
             }
 
-            // Queue the next level (current level + 1)
             var nextLevel = pitWidthManager.CurrentPitLevel + 1;
+            if (nextLevel > BiomeProgressionConfig.MaxBiomeLevel)
+            {
+                // Wrap: increment tier then queue level 1. IncrementPitTier is idempotent at tier cap 99.
+                pitWidthManager.IncrementPitTier(heroLevel);
+                nextLevel = 1;
+                Debug.Log($"[ActivateWizardOrb] Pit wrapped — tier now {pitWidthManager.CurrentPitTier}, queuing level 1");
+            }
             QueuePitLevel(nextLevel);
 
             Debug.Log($"[ActivateWizardOrb] Queued pit level {nextLevel} for regeneration");

--- a/PitHero/AI/Interfaces/IPitWidthManager.cs
+++ b/PitHero/AI/Interfaces/IPitWidthManager.cs
@@ -13,6 +13,16 @@ namespace PitHero.AI.Interfaces
         int CurrentPitLevel { get; }
 
         /// <summary>
+        /// Current pit tier (1–99, permanent, never decreases).
+        /// </summary>
+        int CurrentPitTier { get; }
+
+        /// <summary>
+        /// Hero level recorded when the tier first incremented; respawned heroes start here.
+        /// </summary>
+        int TierBaseLevel { get; }
+
+        /// <summary>
         /// Current pit right edge X coordinate
         /// </summary>
         int CurrentPitRightEdge { get; }

--- a/PitHero/Config/BiomeProgressionConfig.cs
+++ b/PitHero/Config/BiomeProgressionConfig.cs
@@ -1,0 +1,52 @@
+namespace PitHero.Config
+{
+    /// <summary>
+    /// Biome progression rules for pit tier rollover and effective cumulative depth calculations.
+    /// The pit loops back to level 1 when it would exceed MaxBiomeLevel; each loop increments
+    /// the pit tier (1–99, permanent, survives hero death).
+    /// </summary>
+    public static class BiomeProgressionConfig
+    {
+        /// <summary>
+        /// Maximum pit level within a single biome loop (derived from CaveBiomeConfig, not hardcoded).
+        /// </summary>
+        public static int MaxBiomeLevel => CaveBiomeConfig.CaveEndLevel;
+
+        /// <summary>Maximum pit tier. Tier is permanent and never decreases.</summary>
+        public const int MaxPitTier = 99;
+
+        /// <summary>
+        /// Returns the effective cumulative depth for a given displayed pit level and pit tier.
+        /// Tier is clamped to [1, MaxPitTier].
+        /// Example: level=1, tier=1 → 1; level=1, tier=2 → 26; level=25, tier=1 → 25; level=19, tier=5 → 119.
+        /// </summary>
+        public static int GetEffectiveDepth(int pitLevel, int pitTier)
+        {
+            int clampedTier = pitTier < 1 ? 1 : (pitTier > MaxPitTier ? MaxPitTier : pitTier);
+            return (clampedTier - 1) * MaxBiomeLevel + pitLevel;
+        }
+
+        /// <summary>
+        /// Returns the displayed (biome-local) pit level for a cumulative depth value.
+        /// Guard: depth less than 1 returns 1.
+        /// Example: depth=25 → 25 (tier 1); depth=26 → 1 (tier 2); depth=119 → 19 (tier 5).
+        /// </summary>
+        public static int GetDisplayedLevelForDepth(int depth)
+        {
+            if (depth < 1) return 1;
+            return ((depth - 1) % MaxBiomeLevel) + 1;
+        }
+
+        /// <summary>
+        /// Returns the pit tier for a cumulative depth value.
+        /// Guard: depth less than 1 returns 1. Result is capped at MaxPitTier.
+        /// Example: depth=25 → 1; depth=26 → 2; depth=119 → 5; depth=2475 → 99 (cap).
+        /// </summary>
+        public static int GetTierForDepth(int depth)
+        {
+            if (depth < 1) return 1;
+            int tier = (depth - 1) / MaxBiomeLevel + 1;
+            return tier > MaxPitTier ? MaxPitTier : tier;
+        }
+    }
+}

--- a/PitHero/Config/CaveBiomeConfig.cs
+++ b/PitHero/Config/CaveBiomeConfig.cs
@@ -56,9 +56,13 @@ namespace PitHero.Config
         /// <summary>
         /// Gets enemy spawn level for Cave progression, with a boss bonus on boss floors.
         /// </summary>
-        public static int GetScaledEnemyLevelForPitLevel(int pitLevel)
+        /// <param name="pitLevel">Displayed pit level (1–25, biome-local).</param>
+        /// <param name="pitTier">Pit tier (1 = first loop; default keeps all existing call sites at tier 1).</param>
+        public static int GetScaledEnemyLevelForPitLevel(int pitLevel, int pitTier = 1)
         {
-            int baseLevel = BalanceConfig.EstimatePlayerLevelForPitLevel(pitLevel);
+            // Use effective cumulative depth so tier-2+ enemies are stronger than tier-1 at the same displayed level.
+            int effectiveDepth = BiomeProgressionConfig.GetEffectiveDepth(pitLevel, pitTier);
+            int baseLevel = BalanceConfig.EstimatePlayerLevelForPitLevel(effectiveDepth);
             // Boss floors get a small +2 spike to preserve milestone difficulty without changing the base curve.
             int bossBonus = IsBossFloor(pitLevel) ? 2 : 0;
             // Clamp keeps levels in the global 1-99 bounds for safety at all call sites.

--- a/PitHero/ECS/Components/TreasureComponent.cs
+++ b/PitHero/ECS/Components/TreasureComponent.cs
@@ -848,13 +848,17 @@ namespace PitHero.ECS.Components
         }
 
         /// <summary>
-        /// Initialize this treasure chest for a specific pit level
+        /// Initialize this treasure chest for a specific pit level.
         /// </summary>
-        public void InitializeForPitLevel(int pitLevel, LootJobContext jobContext = default)
+        /// <param name="pitLevel">Displayed pit level (1–25, biome-local).</param>
+        /// <param name="jobContext">Party job composition for biased loot.</param>
+        /// <param name="pitTier">Pit tier — gear drops at tier ≥ 2 are upgraded via <see cref="RolePlayingFramework.Equipment.Gear.CreateTierScaledCopy"/>.</param>
+        public void InitializeForPitLevel(int pitLevel, LootJobContext jobContext = default, int pitTier = 1)
         {
             Level = DetermineTreasureLevel(pitLevel);
 
             // Seed drop: any uncommon (level-2) chest has a chance to yield seeds instead of normal loot.
+            // Seeds are not tier-scaled (they are consumables, not gear).
             if (Level == 2 && Nez.Random.NextFloat() < BalanceConfig.SeedChestDropRate)
             {
                 ContainedSeedType  = (CropType)Nez.Random.NextInt(CropTypeInfo.Count);
@@ -866,10 +870,18 @@ namespace PitHero.ECS.Components
             if (CaveBiomeConfig.IsCaveLevel(pitLevel))
             {
                 ContainedItem = GenerateCaveItemForTreasureLevel(Level, jobContext);
-                return;
+            }
+            else
+            {
+                ContainedItem = GenerateItemForTreasureLevel(Level);
             }
 
-            ContainedItem = GenerateItemForTreasureLevel(Level);
+            // Apply tier scaling to gear drops.  Potions/consumables are not Gear and pass through untouched.
+            if (pitTier >= 2 && ContainedItem is RolePlayingFramework.Equipment.Gear g)
+            {
+                int depthDelta = (pitTier - 1) * BiomeProgressionConfig.MaxBiomeLevel;
+                ContainedItem = RolePlayingFramework.Equipment.Gear.CreateTierScaledCopy(g, pitTier, depthDelta);
+            }
         }
     }
 }

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -33,6 +33,7 @@ namespace PitHero.ECS.Scenes
         private Label _fundsLabel; // UI label showing total funds
         private Label _clockLabel; // UI label showing in-game time
         private int _lastDisplayedPitLevel = -1; // Track last displayed level to avoid string churn
+        private int _lastDisplayedPitTier = -1; // Track last displayed tier to avoid string churn
         private int _lastDisplayedFunds = -1; // Track last displayed funds to avoid string churn
         private ShortcutBar _shortcutBar; // Shortcut bar displayed at bottom center
         private GraphicalHUD _graphicalHUD; // Graphical HUD component for HP/MP/Level display
@@ -222,7 +223,12 @@ namespace PitHero.ECS.Scenes
             // ClearExistingPitEntities cannot find, producing a conflicting dual-state pit.
             var pitWidthManager = Core.Services.GetService<PitWidthManager>();
             if (pitWidthManager != null && SaveLoadService.PendingLoadData == null)
+            {
+                // New game — ensure tier state is clean before setting the initial level.
+                pitWidthManager.SetPitTier(1);
+                pitWidthManager.SetTierBaseLevel(1);
                 pitWidthManager.SetPitLevel(1);
+            }
 
             SpawnHero();
             SpawnHeroStatue();
@@ -531,12 +537,13 @@ namespace PitHero.ECS.Scenes
             heroComp.UseConsumablesOnMercenaries = pendingData.UseConsumablesOnMercenaries;
             heroComp.MercenariesCanUseConsumables = pendingData.MercenariesCanUseConsumables;
             
-            // Restore pit level (always call SetPitLevel so the pit is generated once
-            // from saved state; the initial SetPitLevel(1) in Begin is skipped when
-            // pending load data exists to prevent a conflicting dual-state pit)
+            // Restore pit tier and base level BEFORE pit level so that width-regen uses
+            // the correct effective depth (tier 1 behaviour is identical to before).
             var pitManager = Core.Services.GetService<PitWidthManager>();
             if (pitManager != null)
             {
+                pitManager.SetPitTier(pendingData.PitTier);
+                pitManager.SetTierBaseLevel(pendingData.TierBaseLevel);
                 pitManager.SetPitLevel(Math.Max(1, pendingData.PitLevel));
             }
             
@@ -1527,7 +1534,7 @@ namespace PitHero.ECS.Scenes
         }
 
         /// <summary>
-        /// Update pit level label text when the pit level changes
+        /// Update pit level label text when the pit level or tier changes
         /// </summary>
         private void UpdatePitLevelLabel()
         {
@@ -1539,10 +1546,15 @@ namespace PitHero.ECS.Scenes
                 return;
 
             var currentLevel = pitWidthManager.CurrentPitLevel;
-            if (currentLevel != _lastDisplayedPitLevel)
+            var currentTier = pitWidthManager.CurrentPitTier;
+            if (currentLevel != _lastDisplayedPitLevel || currentTier != _lastDisplayedPitTier)
             {
-                _pitLevelLabel.SetText($"Pit Lv. {currentLevel}");
+                if (currentTier >= 2)
+                    _pitLevelLabel.SetText($"Pit Lv. {currentLevel}({currentTier})");
+                else
+                    _pitLevelLabel.SetText($"Pit Lv. {currentLevel}");
                 _lastDisplayedPitLevel = currentLevel;
+                _lastDisplayedPitTier = currentTier;
             }
         }
 

--- a/PitHero/Game1.cs
+++ b/PitHero/Game1.cs
@@ -1,9 +1,11 @@
 using Microsoft.Xna.Framework;
 using Nez;
 using Nez.Persistence.Binary;
+using PitHero.Config;
 using PitHero.ECS.Scenes;
 using PitHero.Services;
 using PitHero.Util;
+using RolePlayingFramework.Equipment;
 
 namespace PitHero
 {
@@ -18,6 +20,10 @@ namespace PitHero
         protected override void Initialize()
         {
             base.Initialize();
+
+            // Synchronize ItemRegistry tier stride with the biome loop length so that
+            // tier-scaled gear names ("Item+2", "Item+3", …) resolve correctly on load.
+            ItemRegistry.TierDepthStride = BiomeProgressionConfig.MaxBiomeLevel;
 
             Graphics.Instance.BitmapFont = Content.LoadBitmapFont(GameConfig.FontMainUI);
 

--- a/PitHero/PitGenerator.cs
+++ b/PitHero/PitGenerator.cs
@@ -99,12 +99,17 @@ namespace PitHero
         /// <summary>
         /// Create a random enemy appropriate for the given pit level.
         /// Cave levels 1-25 use explicit mapping with boss floors at 5/10/15/20/25.
+        /// Biome pool selection uses the displayed pitLevel; enemy scaling uses the effective depth via pitTier.
         /// </summary>
-        public (IEnemy enemy, Color color) CreateEnemyForPitLevel(int pitLevel)
+        /// <param name="pitLevel">Displayed pit level (1–25, biome-local).</param>
+        /// <param name="pitTier">Pit tier (default 1 keeps all existing call sites at tier-1 behaviour).</param>
+        public (IEnemy enemy, Color color) CreateEnemyForPitLevel(int pitLevel, int pitTier = 1)
         {
             if (CaveBiomeConfig.IsCaveLevel(pitLevel))
             {
-                int scaledLevel = CaveBiomeConfig.GetScaledEnemyLevelForPitLevel(pitLevel);
+                // Pool keying and boss checks use the DISPLAYED pitLevel (biome-local 1–25).
+                // Enemy level scaling uses the effective cumulative depth so tier-2+ enemies are stronger.
+                int scaledLevel = CaveBiomeConfig.GetScaledEnemyLevelForPitLevel(pitLevel, pitTier);
                 if (CaveBiomeConfig.IsBossFloor(pitLevel))
                 {
                     // Spawn unique boss for each boss floor
@@ -129,11 +134,11 @@ namespace PitHero
                 return CreateEnemyById(enemyPool[choice], scaledLevel);
             }
 
-            // Fallback mapping outside cave
+            // Fallback mapping outside cave — uses effective depth for enemy level.
+            int effectiveDepth = Math.Clamp(BiomeProgressionConfig.GetEffectiveDepth(pitLevel, pitTier), 1, 99);
             if (pitLevel % 5 == 0)
             {
-                int bossLevel = Math.Clamp(pitLevel, 1, 99);
-                return (new PitLord(bossLevel), Color.Red);
+                return (new PitLord(effectiveDepth), Color.Red);
             }
 
             if (pitLevel >= 7)
@@ -141,9 +146,9 @@ namespace PitHero
                 int choice = Nez.Random.Range(0, 3);
                 return choice switch
                 {
-                    0 => (new Skeleton(Math.Clamp(pitLevel, 1, 99)), Color.White),
-                    1 => (new Orc(Math.Clamp(pitLevel, 1, 99)), Color.DarkGreen),
-                    _ => (new Wraith(Math.Clamp(pitLevel, 1, 99)), Color.Blue)
+                    0 => (new Skeleton(effectiveDepth), Color.White),
+                    1 => (new Orc(effectiveDepth), Color.DarkGreen),
+                    _ => (new Wraith(effectiveDepth), Color.Blue)
                 };
             }
 
@@ -153,9 +158,9 @@ namespace PitHero
                 int choice = Nez.Random.Range(0, 3);
                 return choice switch
                 {
-                    0 => (new Goblin(Math.Clamp(pitLevel, 1, 99)), Color.Green),
-                    1 => (new Spider(Math.Clamp(pitLevel, 1, 99)), Color.DarkGray),
-                    _ => (new Snake(Math.Clamp(pitLevel, 1, 99)), Color.Yellow)
+                    0 => (new Goblin(effectiveDepth), Color.Green),
+                    1 => (new Spider(effectiveDepth), Color.DarkGray),
+                    _ => (new Snake(effectiveDepth), Color.Yellow)
                 };
             }
 
@@ -163,9 +168,9 @@ namespace PitHero
             int lowLevelChoice = Nez.Random.Range(0, 3);
             return lowLevelChoice switch
             {
-                0 => (new Slime(Math.Clamp(pitLevel, 1, 99)), Color.LightGreen),
-                1 => (new Bat(Math.Clamp(pitLevel, 1, 99)), Color.Purple),
-                _ => (new Rat(Math.Clamp(pitLevel, 1, 99)), Color.Brown)
+                0 => (new Slime(effectiveDepth), Color.LightGreen),
+                1 => (new Bat(effectiveDepth), Color.Purple),
+                _ => (new Rat(effectiveDepth), Color.Brown)
             };
         }
 
@@ -332,6 +337,9 @@ namespace PitHero
         {
             var pitWidthManager = Core.Services?.GetService<PitWidthManager>();
 
+            // Read current pit tier for enemy/loot scaling.
+            int currentPitTier = pitWidthManager?.CurrentPitTier ?? 1;
+
             // Calculate pit bounds using PitWidthManager if available
             int validMinX, validMinY, validMaxX, validMaxY;
 
@@ -413,11 +421,11 @@ namespace PitHero
                     var trapPositions = GenerateEntityPositions(trapCount, validMinX, validMinY, validMaxX, validMaxY, usedPositions, "traps");
 
                     var wizardOrbColor = isBossFloor ? Color.Red : Color.White;
-                    CreateEntitiesAtPositions(validObstacles, GameConfig.TAG_OBSTACLE, Color.Gray, "obstacle", level);
-                    CreateEntitiesAtPositions(treasures, GameConfig.TAG_TREASURE, Color.Yellow, "treasure", level);
-                    CreateEntitiesAtPositions(monsters, GameConfig.TAG_MONSTER, Color.White, "monster", level);
-                    CreateEntitiesAtPositions(wizardOrbs, GameConfig.TAG_WIZARD_ORB, wizardOrbColor, "wizard_orb", level);
-                    CreateTrapEntitiesAtPositions(trapPositions, level);
+                    CreateEntitiesAtPositions(validObstacles, GameConfig.TAG_OBSTACLE, Color.Gray, "obstacle", level, currentPitTier);
+                    CreateEntitiesAtPositions(treasures, GameConfig.TAG_TREASURE, Color.Yellow, "treasure", level, currentPitTier);
+                    CreateEntitiesAtPositions(monsters, GameConfig.TAG_MONSTER, Color.White, "monster", level, currentPitTier);
+                    CreateEntitiesAtPositions(wizardOrbs, GameConfig.TAG_WIZARD_ORB, wizardOrbColor, "wizard_orb", level, currentPitTier);
+                    CreateTrapEntitiesAtPositions(trapPositions, level, currentPitTier);
 
                     validLayoutGenerated = true;
                     Debug.Log($"[PitGenerator] Valid layout generated on attempt {attempt}");
@@ -691,7 +699,7 @@ namespace PitHero
             return positions;
         }
 
-        private void CreateEntitiesAtPositions(List<Point> positions, int tag, Color color, string entityTypeName, int pitLevel = 1)
+        private void CreateEntitiesAtPositions(List<Point> positions, int tag, Color color, string entityTypeName, int pitLevel = 1, int pitTier = 1)
         {
             for (int i = 0; i < positions.Count; i++)
             {
@@ -795,7 +803,8 @@ namespace PitHero
 
                     var treasureComponent = entity.AddComponent(new TreasureComponent());
                     var lootCtx = BuildLootJobContext();
-                    treasureComponent.InitializeForPitLevel(currentPitLevel, lootCtx);
+                    // Pass pitTier so gear drops in tier-2+ are upgraded via CreateTierScaledCopy.
+                    treasureComponent.InitializeForPitLevel(currentPitLevel, lootCtx, pitTier);
 
                     var collider = entity.AddComponent(new BoxCollider(GameConfig.TileSize, GameConfig.TileSize));
                     collider.IsTrigger = true;
@@ -845,8 +854,8 @@ namespace PitHero
                     collider.IsTrigger = true;
                     Flags.SetFlagExclusive(ref collider.PhysicsLayer, GameConfig.PhysicsHeroWorldLayer);
 
-                    // Create appropriate enemy for pit level
-                    var (enemy, enemyColor) = CreateEnemyForPitLevel(pitLevel);
+                    // Create appropriate enemy for pit level — pass pitTier for effective-depth scaling.
+                    var (enemy, enemyColor) = CreateEnemyForPitLevel(pitLevel, pitTier);
 
                     var enemyComponent = entity.AddComponent(new EnemyComponent(enemy, isStationary: enemy.IsBoss));
                     Debug.Log($"[PitGenerator] Created {enemy.Name} enemy (Level {enemy.Level}, HP {enemy.CurrentHP}, IsBoss {enemy.IsBoss}) at tile ({tilePos.X},{tilePos.Y})");
@@ -1036,9 +1045,13 @@ namespace PitHero
         /// Creates hidden trap entities at the given tile positions.
         /// Traps use a trigger collider on PhysicsHeroWorldLayer so the hero's trigger system
         /// detects them. They are invisible (no renderer) — the hero encounters them by stepping on them.
+        /// Trap damage scales with effective cumulative depth (not just the displayed pit level) so
+        /// tier-2+ traps hit proportionally harder than tier-1 traps at the same displayed level.
         /// </summary>
-        private void CreateTrapEntitiesAtPositions(List<Point> positions, int pitLevel)
+        private void CreateTrapEntitiesAtPositions(List<Point> positions, int pitLevel, int pitTier = 1)
         {
+            // Effective depth drives the TrapComponent damage formula (5 + effectiveDepth * 2).
+            int effectiveDepth = BiomeProgressionConfig.GetEffectiveDepth(pitLevel, pitTier);
             for (int i = 0; i < positions.Count; i++)
             {
                 var tilePos = positions[i];
@@ -1051,13 +1064,13 @@ namespace PitHero
                 entity.SetTag(GameConfig.TAG_TRAP);
                 entity.SetPosition(worldPos);
 
-                entity.AddComponent(new ECS.Components.TrapComponent(pitLevel));
+                entity.AddComponent(new ECS.Components.TrapComponent(effectiveDepth));
 
                 var collider = entity.AddComponent(new BoxCollider(GameConfig.TileSize, GameConfig.TileSize));
                 collider.IsTrigger = true;
                 Flags.SetFlagExclusive(ref collider.PhysicsLayer, GameConfig.PhysicsHeroWorldLayer);
 
-                Debug.Log($"[PitGenerator] Created trap at tile ({tilePos.X},{tilePos.Y}), damage={5 + pitLevel * 2}");
+                Debug.Log($"[PitGenerator] Created trap at tile ({tilePos.X},{tilePos.Y}), damage={5 + effectiveDepth * 2}");
             }
         }
 

--- a/PitHero/PitWidthManager.cs
+++ b/PitHero/PitWidthManager.cs
@@ -1,6 +1,7 @@
 using Microsoft.Xna.Framework;
 using Nez;
 using PitHero.AI.Interfaces;
+using PitHero.Config;
 using PitHero.ECS.Scenes;
 using PitHero.Util;
 using System;
@@ -42,6 +43,8 @@ namespace PitHero
 
         // Track current pit state
         private int _currentPitLevel = 1;
+        private int _currentPitTier = 1;
+        private int _tierBaseLevel = 1;
         private int _currentPitRightEdge; // The rightmost x coordinate of the current pit
         private bool _isInitialized = false;
 
@@ -49,6 +52,8 @@ namespace PitHero
         private ITiledMapService _tiledMapService;
 
         public int CurrentPitLevel => _currentPitLevel;
+        public int CurrentPitTier => _currentPitTier;
+        public int TierBaseLevel => _tierBaseLevel;
         public int CurrentPitRightEdge => _currentPitRightEdge;
 
         public PitWidthManager(ITiledMapService tiledMapService = null)
@@ -211,6 +216,43 @@ namespace PitHero
         }
 
         /// <summary>
+        /// Sets the pit tier, clamped to [1, MaxPitTier]. Called on save load or explicit tier override.
+        /// </summary>
+        public void SetPitTier(int tier)
+        {
+            int clamped = tier < 1 ? 1 : (tier > BiomeProgressionConfig.MaxPitTier ? BiomeProgressionConfig.MaxPitTier : tier);
+            _currentPitTier = clamped;
+            Debug.Log($"[PitWidthManager] PitTier set to {_currentPitTier}");
+        }
+
+        /// <summary>
+        /// Sets the tier base level (clamped to ≥1, monotonic non-decreasing — lower values are ignored).
+        /// </summary>
+        public void SetTierBaseLevel(int heroLevel)
+        {
+            int clamped = heroLevel < 1 ? 1 : heroLevel;
+            if (clamped > _tierBaseLevel)
+            {
+                _tierBaseLevel = clamped;
+                Debug.Log($"[PitWidthManager] TierBaseLevel updated to {_tierBaseLevel}");
+            }
+        }
+
+        /// <summary>
+        /// Increments the pit tier by 1 (clamped at MaxPitTier) and records the hero level as the new tier base level.
+        /// Called when the pit level wraps from MaxBiomeLevel back to 1.
+        /// </summary>
+        public void IncrementPitTier(int heroLevelAtEntry)
+        {
+            int newTier = _currentPitTier + 1;
+            if (newTier > BiomeProgressionConfig.MaxPitTier)
+                newTier = BiomeProgressionConfig.MaxPitTier;
+            _currentPitTier = newTier;
+            SetTierBaseLevel(heroLevelAtEntry);
+            Debug.Log($"[PitWidthManager] PitTier incremented to {_currentPitTier}, TierBaseLevel={_tierBaseLevel}");
+        }
+
+        /// <summary>
         /// Set the pit level and regenerate the pit width accordingly
         /// </summary>
         public void SetPitLevel(int newLevel)
@@ -235,8 +277,9 @@ namespace PitHero
 
             // Calculate new right edge
             int initialRightEdge = GameConfig.PitRectX + GameConfig.PitRectWidth;
-            // Cap expansion at level 100 - pit stops expanding beyond level 100
-            int expansionLevel = Math.Min(_currentPitLevel, 100);
+            // Cap expansion at effective depth 100 - pit stops expanding beyond effective depth 100.
+            // Tier 1 behaviour is identical to before (effectiveDepth == pitLevel).
+            int expansionLevel = Math.Min(BiomeProgressionConfig.GetEffectiveDepth(_currentPitLevel, _currentPitTier), 100);
             int innerFloorTilesToExtend = ((int)(expansionLevel / 10)) * 2;
             int newRightEdge = initialRightEdge + innerFloorTilesToExtend + (innerFloorTilesToExtend > 0 ? 2 : 0); // +2 for inner wall and outer floor
 
@@ -325,15 +368,16 @@ namespace PitHero
                 return;
             }
 
-            // Calculate how many inner floor tiles to extend
-            // Cap expansion at level 100 - pit stops expanding beyond level 100
-            int expansionLevel = Math.Min(_currentPitLevel, 100);
+            // Calculate how many inner floor tiles to extend.
+            // Use effective depth so expansion continues across tiers, capped at depth 100.
+            int effectiveDepth = BiomeProgressionConfig.GetEffectiveDepth(_currentPitLevel, _currentPitTier);
+            int expansionLevel = Math.Min(effectiveDepth, 100);
             int innerFloorTilesToExtend = ((int)(expansionLevel / 10)) * 2;
-            Debug.Log($"[PitWidthManager] Level {_currentPitLevel}: extending pit by {innerFloorTilesToExtend} inner floor tiles");
+            Debug.Log($"[PitWidthManager] Level {_currentPitLevel} Tier {_currentPitTier} (effectiveDepth={effectiveDepth}): extending pit by {innerFloorTilesToExtend} inner floor tiles");
 
-            if (_currentPitLevel > 100)
+            if (effectiveDepth > 100)
             {
-                Debug.Log("[PitWidthManager] Expansion capped at level 100. No further width increases beyond level 100.");
+                Debug.Log("[PitWidthManager] Expansion capped at effective depth 100. No further width increases.");
             }
 
             if (innerFloorTilesToExtend <= 0)

--- a/PitHero/RolePlayingFramework/Balance/BalanceConfig.cs
+++ b/PitHero/RolePlayingFramework/Balance/BalanceConfig.cs
@@ -550,6 +550,39 @@ namespace RolePlayingFramework.Balance
             return (int)(baseStat * rarityMultiplier);
         }
 
+        // ── Tier-scaling delta helpers ─────────────────────────────────────────────────
+        // These produce the ADDITIONAL stat bonus a piece of gear gains when promoted to
+        // a higher pit tier.  The divisors match the base Calculate* functions so a +25
+        // depth delta ≈ the difference between the base formula at (pitLevel) and at
+        // (pitLevel + 25).  Rounding is truncated (int cast) for parity with the base formulas.
+
+        /// <summary>
+        /// Additional attack bonus per depthDelta levels of effective depth (mirrors CalculateEquipmentAttackBonus divisor = 2).
+        /// </summary>
+        public static int CalculateEquipmentAttackBonusDelta(int depthDelta, ItemRarity rarity)
+        {
+            float rarityMultiplier = GetRarityMultiplier(rarity);
+            return (int)((depthDelta / 2f) * rarityMultiplier);
+        }
+
+        /// <summary>
+        /// Additional defense bonus per depthDelta levels of effective depth (mirrors CalculateEquipmentDefenseBonus divisor = 3).
+        /// </summary>
+        public static int CalculateEquipmentDefenseBonusDelta(int depthDelta, ItemRarity rarity)
+        {
+            float rarityMultiplier = GetRarityMultiplier(rarity);
+            return (int)((depthDelta / 3f) * rarityMultiplier);
+        }
+
+        /// <summary>
+        /// Additional stat bonus per depthDelta levels of effective depth (mirrors CalculateEquipmentStatBonus divisor = 5).
+        /// </summary>
+        public static int CalculateEquipmentStatBonusDelta(int depthDelta, ItemRarity rarity)
+        {
+            float rarityMultiplier = GetRarityMultiplier(rarity);
+            return (int)((depthDelta / 5f) * rarityMultiplier);
+        }
+
         #endregion
 
         #region Elemental Damage Multipliers

--- a/PitHero/RolePlayingFramework/Enemies/Bat.cs
+++ b/PitHero/RolePlayingFramework/Enemies/Bat.cs
@@ -29,9 +29,8 @@ namespace RolePlayingFramework.Enemies
 
         public Bat(int level = 1)
         {
-            // Always use the preset level for Bats regardless of requested level
             var presetLevel = PitHero.Config.EnemyLevelConfig.GetPresetLevel(EnemyId.Bat);
-            Level = presetLevel;
+            Level = StatConstants.ClampLevel(level > 0 ? level : presetLevel);
 
             // Use BalanceConfig for stats
             var archetype = BalanceConfig.MonsterArchetype.FastFragile;

--- a/PitHero/RolePlayingFramework/Enemies/EnemyFactory.cs
+++ b/PitHero/RolePlayingFramework/Enemies/EnemyFactory.cs
@@ -9,40 +9,46 @@ namespace RolePlayingFramework.Enemies
     /// </summary>
     public static class EnemyFactory
     {
-        /// <summary>Creates an enemy instance for the given id. Level is clamped to 1–99.</summary>
-        public static IEnemy Create(EnemyId enemyId, int level = 1)
+        /// <summary>
+        /// Creates an enemy instance for the given id.
+        /// When <paramref name="level"/> is 0 or negative the constructor falls back to its
+        /// configured preset level.  Positive values are clamped to 1–99 and honoured directly.
+        /// </summary>
+        public static IEnemy Create(EnemyId enemyId, int level = 0)
         {
-            int clampedLevel = Math.Clamp(level, 1, 99);
+            // Pass 0 through unchanged so constructors can detect "no level specified" and
+            // fall back to their preset.  Only clamp positive requests.
+            int levelToPass = level > 0 ? Math.Clamp(level, 1, 99) : 0;
 
             return enemyId switch
             {
-                EnemyId.Slime => new Slime(clampedLevel),
-                EnemyId.Bat => new Bat(clampedLevel),
-                EnemyId.Rat => new Rat(clampedLevel),
-                EnemyId.CaveMushroom => new CaveMushroom(clampedLevel),
-                EnemyId.StoneBeetle => new StoneBeetle(clampedLevel),
-                EnemyId.Goblin => new Goblin(clampedLevel),
-                EnemyId.Spider => new Spider(clampedLevel),
-                EnemyId.Snake => new Snake(clampedLevel),
-                EnemyId.ShadowImp => new ShadowImp(clampedLevel),
-                EnemyId.TunnelWorm => new TunnelWorm(clampedLevel),
-                EnemyId.FireLizard => new FireLizard(clampedLevel),
-                EnemyId.Skeleton => new Skeleton(clampedLevel),
-                EnemyId.Orc => new Orc(clampedLevel),
-                EnemyId.Wraith => new Wraith(clampedLevel),
-                EnemyId.MagmaOoze => new MagmaOoze(clampedLevel),
-                EnemyId.CrystalGolem => new CrystalGolem(clampedLevel),
-                EnemyId.CaveTroll => new CaveTroll(clampedLevel),
-                EnemyId.GhostMiner => new GhostMiner(clampedLevel),
-                EnemyId.ShadowBeast => new ShadowBeast(clampedLevel),
-                EnemyId.LavaDrake => new LavaDrake(clampedLevel),
-                EnemyId.StoneWyrm => new StoneWyrm(clampedLevel),
-                EnemyId.StoneGuardian => new StoneGuardian(clampedLevel),
-                EnemyId.EarthElemental => new EarthElemental(clampedLevel),
-                EnemyId.MoltenTitan => new MoltenTitan(clampedLevel),
-                EnemyId.AncientWyrm => new AncientWyrm(clampedLevel),
-                EnemyId.PitLord => new PitLord(clampedLevel),
-                _ => new Slime(clampedLevel)
+                EnemyId.Slime => new Slime(levelToPass),
+                EnemyId.Bat => new Bat(levelToPass),
+                EnemyId.Rat => new Rat(levelToPass),
+                EnemyId.CaveMushroom => new CaveMushroom(levelToPass),
+                EnemyId.StoneBeetle => new StoneBeetle(levelToPass),
+                EnemyId.Goblin => new Goblin(levelToPass),
+                EnemyId.Spider => new Spider(levelToPass),
+                EnemyId.Snake => new Snake(levelToPass),
+                EnemyId.ShadowImp => new ShadowImp(levelToPass),
+                EnemyId.TunnelWorm => new TunnelWorm(levelToPass),
+                EnemyId.FireLizard => new FireLizard(levelToPass),
+                EnemyId.Skeleton => new Skeleton(levelToPass),
+                EnemyId.Orc => new Orc(levelToPass),
+                EnemyId.Wraith => new Wraith(levelToPass),
+                EnemyId.MagmaOoze => new MagmaOoze(levelToPass),
+                EnemyId.CrystalGolem => new CrystalGolem(levelToPass),
+                EnemyId.CaveTroll => new CaveTroll(levelToPass),
+                EnemyId.GhostMiner => new GhostMiner(levelToPass),
+                EnemyId.ShadowBeast => new ShadowBeast(levelToPass),
+                EnemyId.LavaDrake => new LavaDrake(levelToPass),
+                EnemyId.StoneWyrm => new StoneWyrm(levelToPass),
+                EnemyId.StoneGuardian => new StoneGuardian(levelToPass),
+                EnemyId.EarthElemental => new EarthElemental(levelToPass),
+                EnemyId.MoltenTitan => new MoltenTitan(levelToPass),
+                EnemyId.AncientWyrm => new AncientWyrm(levelToPass),
+                EnemyId.PitLord => new PitLord(levelToPass),
+                _ => new Slime(levelToPass)
             };
         }
     }

--- a/PitHero/RolePlayingFramework/Enemies/Goblin.cs
+++ b/PitHero/RolePlayingFramework/Enemies/Goblin.cs
@@ -29,9 +29,8 @@ namespace RolePlayingFramework.Enemies
 
         public Goblin(int level = 3)
         {
-            // Always use the preset level for Goblins regardless of requested level
             var presetLevel = PitHero.Config.EnemyLevelConfig.GetPresetLevel(EnemyId.Goblin);
-            Level = presetLevel;
+            Level = StatConstants.ClampLevel(level > 0 ? level : presetLevel);
 
             // Use BalanceConfig for stats
             var archetype = BalanceConfig.MonsterArchetype.Balanced;

--- a/PitHero/RolePlayingFramework/Enemies/Orc.cs
+++ b/PitHero/RolePlayingFramework/Enemies/Orc.cs
@@ -29,9 +29,8 @@ namespace RolePlayingFramework.Enemies
 
         public Orc(int level = 6)
         {
-            // Always use the preset level for Orcs regardless of requested level
             var presetLevel = PitHero.Config.EnemyLevelConfig.GetPresetLevel(EnemyId.Orc);
-            Level = presetLevel;
+            Level = StatConstants.ClampLevel(level > 0 ? level : presetLevel);
 
             // Use BalanceConfig for stats
             var archetype = BalanceConfig.MonsterArchetype.Tank;

--- a/PitHero/RolePlayingFramework/Enemies/PitLord.cs
+++ b/PitHero/RolePlayingFramework/Enemies/PitLord.cs
@@ -29,9 +29,8 @@ namespace RolePlayingFramework.Enemies
 
         public PitLord(int level = 10)
         {
-            // Always use the preset level for Pit Lords regardless of requested level
             var presetLevel = PitHero.Config.EnemyLevelConfig.GetPresetLevel(EnemyId.PitLord);
-            Level = presetLevel;
+            Level = StatConstants.ClampLevel(level > 0 ? level : presetLevel);
 
             // Use BalanceConfig for stats
             var archetype = BalanceConfig.MonsterArchetype.Tank;

--- a/PitHero/RolePlayingFramework/Enemies/Rat.cs
+++ b/PitHero/RolePlayingFramework/Enemies/Rat.cs
@@ -29,9 +29,8 @@ namespace RolePlayingFramework.Enemies
 
         public Rat(int level = 1)
         {
-            // Always use the preset level for Rats regardless of requested level
             var presetLevel = PitHero.Config.EnemyLevelConfig.GetPresetLevel(EnemyId.Rat);
-            Level = presetLevel;
+            Level = StatConstants.ClampLevel(level > 0 ? level : presetLevel);
 
             // Use BalanceConfig for stats
             var archetype = BalanceConfig.MonsterArchetype.Balanced;

--- a/PitHero/RolePlayingFramework/Enemies/Skeleton.cs
+++ b/PitHero/RolePlayingFramework/Enemies/Skeleton.cs
@@ -29,9 +29,8 @@ namespace RolePlayingFramework.Enemies
 
         public Skeleton(int level = 6)
         {
-            // Always use the preset level for Skeletons regardless of requested level
             var presetLevel = PitHero.Config.EnemyLevelConfig.GetPresetLevel(EnemyId.Skeleton);
-            Level = presetLevel;
+            Level = StatConstants.ClampLevel(level > 0 ? level : presetLevel);
 
             // Use BalanceConfig for stats
             var archetype = BalanceConfig.MonsterArchetype.Tank;

--- a/PitHero/RolePlayingFramework/Enemies/Snake.cs
+++ b/PitHero/RolePlayingFramework/Enemies/Snake.cs
@@ -29,9 +29,8 @@ namespace RolePlayingFramework.Enemies
 
         public Snake(int level = 3)
         {
-            // Always use the preset level for Snakes regardless of requested level
             var presetLevel = PitHero.Config.EnemyLevelConfig.GetPresetLevel(EnemyId.Snake);
-            Level = presetLevel;
+            Level = StatConstants.ClampLevel(level > 0 ? level : presetLevel);
 
             // Use BalanceConfig for stats
             var archetype = BalanceConfig.MonsterArchetype.FastFragile;

--- a/PitHero/RolePlayingFramework/Enemies/Spider.cs
+++ b/PitHero/RolePlayingFramework/Enemies/Spider.cs
@@ -29,9 +29,8 @@ namespace RolePlayingFramework.Enemies
 
         public Spider(int level = 3)
         {
-            // Always use the preset level for Spiders regardless of requested level
             var presetLevel = PitHero.Config.EnemyLevelConfig.GetPresetLevel(EnemyId.Spider);
-            Level = presetLevel;
+            Level = StatConstants.ClampLevel(level > 0 ? level : presetLevel);
 
             // Use BalanceConfig for stats
             var archetype = BalanceConfig.MonsterArchetype.FastFragile;

--- a/PitHero/RolePlayingFramework/Enemies/Wraith.cs
+++ b/PitHero/RolePlayingFramework/Enemies/Wraith.cs
@@ -29,9 +29,8 @@ namespace RolePlayingFramework.Enemies
 
         public Wraith(int level = 6)
         {
-            // Always use the preset level for Wraiths regardless of requested level
             var presetLevel = PitHero.Config.EnemyLevelConfig.GetPresetLevel(EnemyId.Wraith);
-            Level = presetLevel;
+            Level = StatConstants.ClampLevel(level > 0 ? level : presetLevel);
 
             // Use BalanceConfig for stats
             var archetype = BalanceConfig.MonsterArchetype.FastFragile;

--- a/PitHero/RolePlayingFramework/Equipment/Gear.cs
+++ b/PitHero/RolePlayingFramework/Equipment/Gear.cs
@@ -1,6 +1,7 @@
 using Nez;
 using PitHero;
 using PitHero.Services;
+using RolePlayingFramework.Balance;
 using RolePlayingFramework.Combat;
 using RolePlayingFramework.Jobs;
 using RolePlayingFramework.Stats;
@@ -10,6 +11,7 @@ namespace RolePlayingFramework.Equipment
     /// <summary>
     /// Simple gear item with stat and flat bonuses.
     /// Supports elemental types and resistances for integration with the elemental combat system.
+    /// Supports pit-tier scaling: a tier-N copy has higher stats and a "+N" suffix on its display name.
     /// </summary>
     /// <remarks>
     /// Elemental System Integration:
@@ -18,24 +20,24 @@ namespace RolePlayingFramework.Equipment
     /// - Defensive gear (armor/shields/helms) can have custom resistances
     /// - Resistances are percentage-based (0.25 = 25% damage reduction, -0.15 = 15% extra damage)
     /// - Defensive gear typically resists its own element and is weak to opposing element
-    /// 
+    ///
     /// Current Equipment Elemental Assignments:
     /// Weapons:
     ///   - ShortSword: Neutral
     ///   - LongSword: Fire
-    /// 
+    ///
     /// Armor:
     ///   - LeatherArmor: Neutral
     ///   - IronArmor: Earth (25% Earth resist, -15% Wind weakness)
-    /// 
+    ///
     /// Shields:
     ///   - WoodenShield: Neutral
     ///   - IronShield: Water (30% Water resist, -15% Fire weakness)
-    /// 
+    ///
     /// Helms:
     ///   - SquireHelm: Neutral
     ///   - IronHelm: Earth (20% Earth resist, -10% Wind weakness)
-    /// 
+    ///
     /// Accessories:
     ///   - RingOfPower: Neutral
     ///   - NecklaceOfHealth: Light
@@ -49,6 +51,14 @@ namespace RolePlayingFramework.Equipment
         private readonly string _spriteName;
         private TextService _textService;
 
+        // ── Tier-scaling state ────────────────────────────────────────────────────────
+        private readonly int _tier;
+        // Tier suffix cached at construction ("" for tier 1, "+2" for tier 2, etc.)
+        private readonly string _tierSuffix;
+        // Fully composed "BaseName+N" string cached once TextService resolves.
+        // null = not yet resolved; assigned on first Name access when tier >= 2.
+        private string _cachedTieredName;
+
         private TextService GetTextService()
         {
             // Core.Instance is null in headless hosts (unit tests, virtual balance runs);
@@ -58,7 +68,22 @@ namespace RolePlayingFramework.Equipment
             return _textService;
         }
 
-        public string Name => GetTextService()?.DisplayText(TextType.Inventory, _nameKey) ?? _nameKey;
+        public string Name
+        {
+            get
+            {
+                if (_tier <= 1)
+                    return GetTextService()?.DisplayText(TextType.Inventory, _nameKey) ?? _nameKey;
+
+                // Tier >= 2: compose once and cache to avoid per-frame allocation.
+                if (_cachedTieredName != null)
+                    return _cachedTieredName;
+
+                string baseName = GetTextService()?.DisplayText(TextType.Inventory, _nameKey) ?? _nameKey;
+                _cachedTieredName = baseName + _tierSuffix;
+                return _cachedTieredName;
+            }
+        }
 
         /// <summary>Sprite name used to look up the item's sprite in the Items atlas. Derived from the item class name.</summary>
         public string SpriteName => _spriteName;
@@ -76,6 +101,11 @@ namespace RolePlayingFramework.Equipment
         public JobType AllowedJobs { get; }
 
         /// <summary>
+        /// Pit tier this gear belongs to.  1 = base; 2+ = tier-scaled copy with bonus stats and a "+N" name suffix.
+        /// </summary>
+        public int Tier => _tier;
+
+        /// <summary>
         /// Creates a new Gear item with specified properties.
         /// </summary>
         /// <param name="name">Display name of the gear item</param>
@@ -90,7 +120,8 @@ namespace RolePlayingFramework.Equipment
         /// <param name="mp">Flat MP bonus</param>
         /// <param name="elementalProps">Elemental properties with type and optional resistances. Defaults to Neutral if not specified.</param>
         /// <param name="allowedJobs">Bitflag of job classes that can equip this gear. Defaults based on ItemKind if not specified.</param>
-        public Gear(string name, ItemKind kind, ItemRarity rarity, string description, int price, in StatBlock stats, int atk = 0, int def = 0, int hp = 0, int mp = 0, ElementalProperties elementalProps = null, JobType? allowedJobs = null)
+        /// <param name="tier">Pit tier (1 = base, 2+ = scaled copy). Default 1 keeps all existing call sites unchanged.</param>
+        public Gear(string name, ItemKind kind, ItemRarity rarity, string description, int price, in StatBlock stats, int atk = 0, int def = 0, int hp = 0, int mp = 0, ElementalProperties elementalProps = null, JobType? allowedJobs = null, int tier = 1)
         {
             _nameKey = name;
             _descKey = description;
@@ -109,6 +140,47 @@ namespace RolePlayingFramework.Equipment
             MPBonus = mp;
             ElementalProps = elementalProps ?? new ElementalProperties(ElementType.Neutral);
             AllowedJobs = allowedJobs ?? GetDefaultAllowedJobs(kind);
+            _tier = tier < 1 ? 1 : tier;
+            _tierSuffix = _tier >= 2 ? ("+" + _tier) : string.Empty;
+        }
+
+        /// <summary>
+        /// Returns a new Gear with stats scaled for the given pit tier and depth delta.
+        /// For tier ≤ 1 returns source unchanged (no allocation).
+        /// </summary>
+        /// <param name="source">Base gear to scale from.</param>
+        /// <param name="tier">Target pit tier (must be ≥ 2 to produce a new instance).</param>
+        /// <param name="depthDelta">Additional effective depth beyond tier-1 baseline (e.g. (tier-1) * MaxBiomeLevel).</param>
+        public static Gear CreateTierScaledCopy(Gear source, int tier, int depthDelta)
+        {
+            if (source == null) return null;
+            if (tier <= 1) return source;
+
+            int atkDelta  = BalanceConfig.CalculateEquipmentAttackBonusDelta(depthDelta, source.Rarity);
+            int defDelta  = BalanceConfig.CalculateEquipmentDefenseBonusDelta(depthDelta, source.Rarity);
+            int statDelta = BalanceConfig.CalculateEquipmentStatBonusDelta(depthDelta, source.Rarity);
+
+            var scaledStats = new StatBlock(
+                source.StatBonus.Strength  + statDelta,
+                source.StatBonus.Agility   + statDelta,
+                source.StatBonus.Vitality  + statDelta,
+                source.StatBonus.Magic     + statDelta);
+
+            // HP/MP: no dedicated delta formula — scale linearly with tier.
+            return new Gear(
+                source._nameKey,
+                source.Kind,
+                source.Rarity,
+                source._descKey,
+                source.Price * tier,
+                in scaledStats,
+                atk:          source.AttackBonus  + atkDelta,
+                def:          source.DefenseBonus + defDelta,
+                hp:           source.HPBonus  * tier,
+                mp:           source.MPBonus  * tier,
+                elementalProps: source.ElementalProps,
+                allowedJobs:  source.AllowedJobs,
+                tier:         tier);
         }
 
         /// <summary>Returns the default allowed jobs for a given ItemKind.</summary>

--- a/PitHero/RolePlayingFramework/Equipment/ItemRegistry.cs
+++ b/PitHero/RolePlayingFramework/Equipment/ItemRegistry.cs
@@ -9,6 +9,15 @@ namespace RolePlayingFramework.Equipment
         private static Dictionary<string, Func<IItem>> _registry;
         private static bool _initialized;
 
+        /// <summary>
+        /// Depth stride per pit tier — used when reconstructing tier-scaled gear names of the
+        /// form "BaseName+N" (N = tier).  Defaults to 25; overridden at game startup from
+        /// BiomeProgressionConfig.MaxBiomeLevel so the value stays in sync with the biome loop.
+        /// Assign this from the PitHero side before any TryCreateItem call that may encounter
+        /// a tier-scaled name; RolePlayingFramework must not reference PitHero.Config directly.
+        /// </summary>
+        public static int TierDepthStride = 25;
+
         /// <summary>Returns the registry, initializing on first access.</summary>
         private static Dictionary<string, Func<IItem>> Registry
         {
@@ -203,13 +212,36 @@ namespace RolePlayingFramework.Equipment
 
         }
 
-        /// <summary>Attempts to create an item by name. Returns true if found.</summary>
+        /// <summary>
+        /// Attempts to create an item by name.  Returns true if found.
+        /// Also handles tier-scaled names of the form "BaseName+N" (N &gt; 1):
+        /// strips the suffix, looks up the base item, and if found as Gear returns a
+        /// tier-scaled copy via <see cref="Gear.CreateTierScaledCopy"/>.
+        /// </summary>
         public static bool TryCreateItem(string name, out IItem item)
         {
             if (Registry.TryGetValue(name, out var factory))
             {
                 item = factory();
                 return true;
+            }
+
+            // ── Tier-scaled name parsing ("BaseName+N", N > 1) ───────────────────────
+            int plusIdx = name.LastIndexOf('+');
+            if (plusIdx > 0)
+            {
+                string suffix  = name.Substring(plusIdx + 1);
+                string baseName = name.Substring(0, plusIdx);
+                if (int.TryParse(suffix, out int tier) && tier > 1
+                    && Registry.TryGetValue(baseName, out var baseFactory))
+                {
+                    IItem baseItem = baseFactory();
+                    if (baseItem is Gear baseGear)
+                    {
+                        item = Gear.CreateTierScaledCopy(baseGear, tier, (tier - 1) * TierDepthStride);
+                        return true;
+                    }
+                }
             }
 
             item = null;

--- a/PitHero/Services/Analytics/AnalyticsService.cs
+++ b/PitHero/Services/Analytics/AnalyticsService.cs
@@ -170,6 +170,7 @@ namespace PitHero.Services.Analytics
             if (!BeginEvent("pit_generated"))
                 return;
             _json.Field("pitLevel", pitLevel);
+            _json.Field("pitTier", GetCurrentPitTier());
             _json.Field("isBossFloor", isBossFloor);
             _json.Field("monsterCount", monsterCount);
             _json.Field("chestCount", chestCount);
@@ -187,6 +188,7 @@ namespace PitHero.Services.Analytics
             if (!BeginEvent("chest_spawned"))
                 return;
             _json.Field("pitLevel", pitLevel);
+            _json.Field("pitTier", GetCurrentPitTier());
             _json.Field("x", x);
             _json.Field("y", y);
             _json.Field("chestLevel", chestLevel);
@@ -212,6 +214,7 @@ namespace PitHero.Services.Analytics
             if (!BeginEvent("monster_spawned"))
                 return;
             _json.Field("pitLevel", pitLevel);
+            _json.Field("pitTier", GetCurrentPitTier());
             _json.Field("x", x);
             _json.Field("y", y);
             _json.Field("name", enemy.Name);
@@ -234,6 +237,7 @@ namespace PitHero.Services.Analytics
                 return;
             _json.Field("fromPitLevel", fromPitLevel);
             _json.Field("toPitLevel", toPitLevel);
+            _json.Field("pitTier", GetCurrentPitTier());
             _json.Field("heroLevel", heroLevel);
             EndEvent();
 #endif
@@ -471,6 +475,7 @@ namespace PitHero.Services.Analytics
             _json.Field("level", enemy.Level);
             _json.Field("isBoss", enemy.IsBoss);
             _json.Field("pitLevel", GetCurrentPitLevel());
+            _json.Field("pitTier", GetCurrentPitTier());
             _json.Field("xp", enemy.ExperienceYield);
             _json.Field("jp", enemy.JPYield);
             _json.Field("gold", enemy.GoldYield);
@@ -604,6 +609,15 @@ namespace PitHero.Services.Analytics
                 return 0;
             var pitWidthManager = Core.Services.GetService<PitWidthManager>();
             return pitWidthManager?.CurrentPitLevel ?? 0;
+        }
+
+        /// <summary>Writes the current pit tier fetched from the PitWidthManager service (1 when unavailable).</summary>
+        private static int GetCurrentPitTier()
+        {
+            if (Core.Instance == null)
+                return 1;
+            var pitWidthManager = Core.Services.GetService<PitWidthManager>();
+            return pitWidthManager?.CurrentPitTier ?? 1;
         }
 
         /// <summary>Writes name/job/level/stats/skills/gear fields for a hero into the current object.</summary>

--- a/PitHero/Services/HeroPromotionService.cs
+++ b/PitHero/Services/HeroPromotionService.cs
@@ -131,15 +131,19 @@ namespace PitHero.Services
             var heroName = heroComponent.LinkedHero?.Name
                 ?? Core.Services.GetService<HeroDesignService>()?.GetDesign().Name
                 ?? "Hero";
+            // When tier ≥ 2 the hero starts at least at the recorded tier base level.
+            var pitWidthManagerForSpawn = Core.Services.GetService<PitWidthManager>();
+            int tierBaseLevel = pitWidthManagerForSpawn?.TierBaseLevel ?? 1;
+            int spawnLevel = nextCrystal.Level > tierBaseLevel ? nextCrystal.Level : tierBaseLevel;
             heroComponent.LinkedHero = new RolePlayingFramework.Heroes.Hero(
                 heroName,
                 nextCrystal.Job,
-                nextCrystal.Level,
+                spawnLevel,
                 nextCrystal.BaseStats,
                 nextCrystal
             );
 
-            Debug.Log($"[HeroPromotionService] Hero granted crystal: {nextCrystal.Job.Name} Level {nextCrystal.Level}");
+            Debug.Log($"[HeroPromotionService] Hero granted crystal: {nextCrystal.Job.Name} Level {spawnLevel} (crystal={nextCrystal.Level}, tierBase={tierBaseLevel})");
 
             Core.Services.GetService<GameEventService>()?.EmitLocalized(UITextKey.ConsoleCrystalPromotion,
                 (heroComponent.LinkedHero.Name, GameConfig.ConsoleColorHeroName),
@@ -476,15 +480,19 @@ namespace PitHero.Services
 
             // Get next crystal for hero (from pending, queue, or random)
             var nextCrystal = GetNextCrystalForHero();
+            // When tier ≥ 2 the promoted hero starts at least at the recorded tier base level.
+            var pitWidthManagerForPromotion = Core.Services.GetService<PitWidthManager>();
+            int promotionTierBase = pitWidthManagerForPromotion?.TierBaseLevel ?? 1;
+            int promotionSpawnLevel = nextCrystal.Level > promotionTierBase ? nextCrystal.Level : promotionTierBase;
             heroComponent.LinkedHero = new RolePlayingFramework.Heroes.Hero(
                 mercComponent.LinkedMercenary.Name,
                 nextCrystal.Job,
-                nextCrystal.Level,
+                promotionSpawnLevel,
                 nextCrystal.BaseStats,
                 nextCrystal
             );
 
-            Debug.Log($"[HeroPromotionService] Created new hero {heroComponent.LinkedHero.Name} with Level {heroComponent.LinkedHero.Level}, HP {heroComponent.LinkedHero.CurrentHP}/{heroComponent.LinkedHero.MaxHP}");
+            Debug.Log($"[HeroPromotionService] Created new hero {heroComponent.LinkedHero.Name} with Level {heroComponent.LinkedHero.Level} (crystal={nextCrystal.Level}, tierBase={promotionTierBase}), HP {heroComponent.LinkedHero.CurrentHP}/{heroComponent.LinkedHero.MaxHP}");
 
             Core.Services.GetService<GameEventService>()?.EmitLocalized(UITextKey.ConsoleCrystalPromotion,
                 (heroComponent.LinkedHero.Name, GameConfig.ConsoleColorHeroName),

--- a/PitHero/Services/MercenaryManager.cs
+++ b/PitHero/Services/MercenaryManager.cs
@@ -175,8 +175,15 @@ namespace PitHero.Services
             var heroComponent = heroEntity?.GetComponent<HeroComponent>();
             var heroLevel = heroComponent?.LinkedHero?.Level ?? 1;
 
+            // Tier ≥ 2: tavern mercenaries are floored at the tier base level so they stay
+            // relevant for the hero's current progression loop.
+            var pitWidthManagerForMerc = Core.Services.GetService<PitWidthManager>();
+            int mercMinLevel = pitWidthManagerForMerc != null && pitWidthManagerForMerc.CurrentPitTier >= 2
+                ? pitWidthManagerForMerc.TierBaseLevel
+                : 1;
+
             // Determine mercenary level from distribution
-            var mercLevel = DetermineMercenaryLevel(heroLevel);
+            var mercLevel = DetermineMercenaryLevel(heroLevel, mercMinLevel);
 
             // Generate random job
             var job = GetRandomJob();
@@ -655,7 +662,9 @@ namespace PitHero.Services
         }
 
         /// <summary>Determines mercenary level using a weighted distribution based on hero level.</summary>
-        public static int DetermineMercenaryLevel(int heroLevel)
+        /// <param name="heroLevel">Current hero level (distribution anchor).</param>
+        /// <param name="minLevel">Minimum level floor — tier base level when tier ≥ 2, otherwise 1.</param>
+        public static int DetermineMercenaryLevel(int heroLevel, int minLevel = 1)
         {
             if (heroLevel < 1) heroLevel = 1;
 
@@ -695,7 +704,8 @@ namespace PitHero.Services
                 level = heroLevel;
             }
 
-            return level < 1 ? 1 : level;
+            int raw = level < 1 ? 1 : level;
+            return raw < minLevel ? minLevel : raw;
         }
 
         /// <summary>Hires a mercenary</summary>

--- a/PitHero/Services/SaveData.cs
+++ b/PitHero/Services/SaveData.cs
@@ -1,5 +1,6 @@
 using Microsoft.Xna.Framework;
 using Nez.Persistence.Binary;
+using PitHero.Config;
 using RolePlayingFramework.Heroes;
 using RolePlayingFramework.Jobs;
 using RolePlayingFramework.Stats;
@@ -243,7 +244,7 @@ namespace PitHero.Services
     public class SaveData : IPersistable
     {
         /// <summary>Current save file version.</summary>
-        public const int CurrentVersion = 12;
+        public const int CurrentVersion = 13;
 
         // Total Time
         /// <summary>Total time played in seconds.</summary>
@@ -352,8 +353,14 @@ namespace PitHero.Services
         public Dictionary<string, int> DiscoveredStencils;
 
         // Pit State
-        /// <summary>Current pit level.</summary>
+        /// <summary>Current pit level (biome-local, 1–MaxBiomeLevel).</summary>
         public int PitLevel;
+
+        /// <summary>Current pit tier (1–99, permanent, never decreases). Version 13+.</summary>
+        public int PitTier = 1;
+
+        /// <summary>Hero level at which the tier first incremented; respawned heroes start here. Version 13+.</summary>
+        public int TierBaseLevel = 1;
 
         // Priorities (stored as ints, cast from HeroPitPriority / HeroHealPriority)
         /// <summary>First pit priority.</summary>
@@ -800,6 +807,10 @@ namespace PitHero.Services
                 writer.Write(DroppedCrops[i].TileX);
                 writer.Write(DroppedCrops[i].TileY);
             }
+
+            // 29. Pit tier (version 13+)
+            writer.Write(PitTier);
+            writer.Write(TierBaseLevel);
         }
 
         /// <summary>Reads all game state from the persistence reader.</summary>
@@ -1224,6 +1235,24 @@ namespace PitHero.Services
             else
             {
                 DroppedCrops = new List<SavedDroppedCrop>();
+            }
+
+            // 29. Pit tier (version 13+)
+            // Migration: old saves whose PitLevel exceeded MaxBiomeLevel (e.g. pit 119) are
+            // decoded into the correct tier and displayed level so the game never sees a raw
+            // depth value in PitLevel. Level (hero level) is read earlier in section 4.
+            if (fileVersion >= 13)
+            {
+                PitTier = reader.ReadInt();
+                TierBaseLevel = reader.ReadInt();
+            }
+            else
+            {
+                // Infer tier from the raw pit level (which may be cumulative depth on old saves).
+                PitTier = BiomeProgressionConfig.GetTierForDepth(PitLevel);
+                TierBaseLevel = PitTier >= 2 ? (Level > 0 ? Level : 1) : 1;
+                // Normalise PitLevel to biome-local range so the rest of the game sees [1..MaxBiomeLevel].
+                PitLevel = BiomeProgressionConfig.GetDisplayedLevelForDepth(PitLevel);
             }
         }
 

--- a/PitHero/Services/SaveLoadService.cs
+++ b/PitHero/Services/SaveLoadService.cs
@@ -299,10 +299,14 @@ namespace PitHero.Services
                 stencilEnumerator.Dispose();
             }
 
-            // Pit level
+            // Pit level, tier, and base level
             var pitManager = Core.Services.GetService<PitWidthManager>();
             if (pitManager != null)
+            {
                 data.PitLevel = pitManager.CurrentPitLevel;
+                data.PitTier = pitManager.CurrentPitTier;
+                data.TierBaseLevel = pitManager.TierBaseLevel;
+            }
 
             // Allied monsters
             var alliedManager = Core.Services.GetService<AlliedMonsterManager>();

--- a/PitHero/VirtualGame/VirtualGameSimulation.cs
+++ b/PitHero/VirtualGame/VirtualGameSimulation.cs
@@ -1,5 +1,6 @@
 using Microsoft.Xna.Framework;
 using PitHero.AI;
+using PitHero.Config;
 using RolePlayingFramework.Balance;
 using RolePlayingFramework.Heroes;
 using RolePlayingFramework.Inventory;
@@ -32,6 +33,13 @@ namespace PitHero.VirtualGame
         // Mutable roster: ConfigureMercenaries copies in; TryHireRandomMercenary appends;
         // RunLevelRange prunes dead mercs between levels.
         private readonly List<Mercenary> _mercenaries = new List<Mercenary>(2);
+
+        // ── Pit-tier state ─────────────────────────────────────────────────────────
+        // Persistent VirtualPitWidthManager used by the sim to track tier and tierBaseLevel
+        // across RunPitLevel calls (separate from the per-level generator manager which
+        // handles layout only).  TiledMapService is null since we only need tier tracking,
+        // not actual pit-width extension in the headless context.
+        private readonly VirtualPitWidthManager _simPitWidthManager = new VirtualPitWidthManager(null);
 
         // ── Gold economy state ─────────────────────────────────────────────────────
         // Counter for deterministic virtual merc names ("Merc1", "Merc2", ...)
@@ -74,6 +82,33 @@ namespace PitHero.VirtualGame
         /// <see cref="VirtualRunMetrics.RngSeed"/> so every balance report can cite it.
         /// </summary>
         public int RngSeed { get; }
+
+        /// <summary>
+        /// Current pit tier tracked by this simulation's persistent pit-width manager.
+        /// Starts at 1; increments automatically in <see cref="RunLevelRange"/> when the
+        /// cumulative depth crosses a tier boundary.
+        /// </summary>
+        public int CurrentPitTier => _simPitWidthManager.CurrentPitTier;
+
+        /// <summary>
+        /// Hero level recorded at the most recent tier increment.  Stays at 1 until the
+        /// simulation first crosses into tier 2.  Used by <see cref="TryHireRandomMercenary"/>
+        /// as the minimum level floor for newly hired mercenaries in higher tiers.
+        /// </summary>
+        public int TierBaseLevel => _simPitWidthManager.TierBaseLevel;
+
+        /// <summary>
+        /// Seeds the internal pit-width manager with the specified tier and tier base level.
+        /// Call this before <see cref="RunLevelRange"/> to restore a save-loaded mid-game
+        /// state (e.g. hero respawning in tier 2 after a wipe).
+        /// </summary>
+        /// <param name="tier">Pit tier to restore (≥ 1, clamped to <see cref="Config.BiomeProgressionConfig.MaxPitTier"/>).</param>
+        /// <param name="tierBaseLevel">Hero level recorded at the tier entry (≥ 1).</param>
+        public void ConfigurePitTier(int tier, int tierBaseLevel)
+        {
+            _simPitWidthManager.SetPitTier(tier);
+            _simPitWidthManager.SetTierBaseLevel(tierBaseLevel);
+        }
 
         /// <summary>Public access to the hero for tests.</summary>
         public VirtualHero Hero => _hero;
@@ -177,7 +212,11 @@ namespace PitHero.VirtualGame
             if (_mercenaries.Count >= maxHiredMercenaries) return null;
 
             int heroLevel = _hero.LinkedHero?.Level ?? 1;
-            int mercLevel = VirtualMercenaryLevelRoller.DetermineMercenaryLevel(heroLevel);
+            // Tier ≥ 2: pass the tier base level as minLevel, mirroring live MercenaryManager.SpawnMercenary.
+            // This ensures mercenaries hired in higher tiers are at least as strong as the party entered with.
+            int currentTier = _simPitWidthManager.CurrentPitTier;
+            int minLevel    = currentTier >= 2 ? _simPitWidthManager.TierBaseLevel : 1;
+            int mercLevel = VirtualMercenaryLevelRoller.DetermineMercenaryLevel(heroLevel, minLevel: minLevel);
             int hireCost  = BalanceConfig.CalculateMercenaryHireCost(mercLevel);
 
             if (Gold < hireCost) return null;
@@ -227,6 +266,17 @@ namespace PitHero.VirtualGame
 
             for (int level = fromLevel; level <= toLevel; level++)
             {
+                // ── Tier boundary detection (before surface policy so hiring uses the updated tier) ─
+                // The tier for a cumulative depth is purely deterministic from the depth value.
+                int depthTier = BiomeProgressionConfig.GetTierForDepth(level);
+                if (depthTier > _simPitWidthManager.CurrentPitTier)
+                {
+                    // Crossed into a new tier — record the current hero level as the tier base level
+                    // so mercenary hiring in this tier is floored at a sensible minimum.
+                    int heroLevelAtEntry = _hero.LinkedHero?.Level ?? 1;
+                    _simPitWidthManager.IncrementPitTier(heroLevelAtEntry);
+                }
+
                 // ── Between-level surface policy (skip for the very first level) ─────
                 if (level > fromLevel)
                 {
@@ -354,11 +404,13 @@ namespace PitHero.VirtualGame
 
             _runMetrics = new VirtualRunMetrics
             {
-                PitLevel      = pitLevel,
-                JobName       = jobName,
-                LevelRangeMin = _hero.LinkedHero.Level,
-                LevelRangeMax = _hero.LinkedHero.Level,
-                RngSeed       = RngSeed
+                PitLevel       = pitLevel,
+                DisplayedLevel = BiomeProgressionConfig.GetDisplayedLevelForDepth(pitLevel),
+                PitTier        = BiomeProgressionConfig.GetTierForDepth(pitLevel),
+                JobName        = jobName,
+                LevelRangeMin  = _hero.LinkedHero.Level,
+                LevelRangeMax  = _hero.LinkedHero.Level,
+                RngSeed        = RngSeed
             };
 
             // Party max-HP pool at level start, for the HP-loss percentage
@@ -429,6 +481,7 @@ namespace PitHero.VirtualGame
             // InnRested / MercsHired are 0/false here; RunLevelRange stamps them after.
             Gold                  += _runMetrics.GoldEarned;
             _runMetrics.Wallet     = Gold;
+            _runMetrics.HeroLevel  = _hero.LinkedHero.Level;
 
             _currentAction = "RunPitLevel_Complete";
             return _runMetrics;
@@ -563,8 +616,8 @@ namespace PitHero.VirtualGame
             _world.ActivateWizardOrb();
             _hero.ActivatedWizardOrb = true;
 
-            // Queue next pit level (current + 10)
-            var nextLevel = _world.PitLevel + 10;
+            // Queue next pit level (current + 1; wrap to level 1 and increment tier when past MaxBiomeLevel)
+            var nextLevel = _world.PitLevel + 1;
             _pitQueue.QueueLevel(nextLevel);
 
             _tickCount++;

--- a/PitHero/VirtualGame/VirtualMercenaryLevelRoller.cs
+++ b/PitHero/VirtualGame/VirtualMercenaryLevelRoller.cs
@@ -15,7 +15,7 @@ namespace PitHero.VirtualGame
     /// dependencies.
     /// </para>
     /// </summary>
-    internal static class VirtualMercenaryLevelRoller
+    public static class VirtualMercenaryLevelRoller
     {
         /// <summary>
         /// Mirrors <c>MercenaryManager.DetermineMercenaryLevel</c> exactly:
@@ -27,7 +27,9 @@ namespace PitHero.VirtualGame
         ///   <item>10 % — heroLevel</item>
         /// </list>
         /// </summary>
-        public static int DetermineMercenaryLevel(int heroLevel)
+        /// <param name="heroLevel">Current hero level (distribution anchor).</param>
+        /// <param name="minLevel">Minimum level floor — tier base level when tier ≥ 2, otherwise 1.</param>
+        public static int DetermineMercenaryLevel(int heroLevel, int minLevel = 1)
         {
             if (heroLevel < 1) heroLevel = 1;
 
@@ -62,7 +64,8 @@ namespace PitHero.VirtualGame
                 level = heroLevel;
             }
 
-            return level < 1 ? 1 : level;
+            int raw = level < 1 ? 1 : level;
+            return raw < minLevel ? minLevel : raw;
         }
 
         /// <summary>

--- a/PitHero/VirtualGame/VirtualPitGenerator.cs
+++ b/PitHero/VirtualGame/VirtualPitGenerator.cs
@@ -35,13 +35,23 @@ namespace PitHero.VirtualGame
 
         public void RegenerateForCurrentLevel()
         {
-            var currentLevel = _pitWidthManager.CurrentPitLevel;
-            RegenerateForLevel(currentLevel);
+            // Convert displayed level + tier to cumulative depth so RegenerateForLevel
+            // receives the same contract as RunPitLevel does.
+            int displayedLevel = _pitWidthManager.CurrentPitLevel;
+            int tier           = _pitWidthManager.CurrentPitTier;
+            int depth          = BiomeProgressionConfig.GetEffectiveDepth(displayedLevel, tier);
+            RegenerateForLevel(depth);
         }
 
         public void RegenerateForLevel(int level)
         {
-            Console.WriteLine($"[VirtualPitGenerator] Regenerating pit content for level {level}");
+            // level is the CUMULATIVE DEPTH (1-N across all tiers).
+            // Decompose into biome-local displayed level and tier for content selection;
+            // retain the original depth for seeding and entity-count formulas.
+            int displayedLevel = BiomeProgressionConfig.GetDisplayedLevelForDepth(level);
+            int tier           = BiomeProgressionConfig.GetTierForDepth(level);
+
+            Console.WriteLine($"[VirtualPitGenerator] Regenerating pit content for depth {level} (displayed={displayedLevel}, tier={tier})");
 
             // Clear existing entities
             _worldState.ClearAllEntities();
@@ -67,24 +77,24 @@ namespace PitHero.VirtualGame
             Console.WriteLine($"[VirtualPitGenerator] Valid placement area for level {level}: tiles ({validMinX},{validMinY}) to ({validMaxX},{validMaxY})");
 
             // Generate entities using same logic as real PitGenerator
-            GenerateEntitiesForLevel(level, validMinX, validMinY, validMaxX, validMaxY);
+            GenerateEntitiesForLevel(level, displayedLevel, tier, validMinX, validMinY, validMaxX, validMaxY);
         }
 
-        private void GenerateEntitiesForLevel(int level, int minX, int minY, int maxX, int maxY)
+        private void GenerateEntitiesForLevel(int depth, int displayedLevel, int tier, int minX, int minY, int maxX, int maxY)
         {
-            // Calculate entity counts based on level (same as real PitGenerator)
-            int maxMonsters = Math.Clamp((int)Math.Round(2 + 8 * Math.Max(level - 10, 0) / 90.0), 2, 10);
-            int maxChests = Math.Clamp((int)Math.Round(2 + 8 * Math.Max(level - 10, 0) / 90.0), 2, 10);
-            int minObstacles = Math.Clamp((int)Math.Round(5 + 35 * Math.Max(level - 10, 0) / 90.0), 5, 40);
-            int maxObstacles = Math.Clamp((int)Math.Round(10 + 40 * Math.Max(level - 10, 0) / 90.0), 10, 50);
+            // Entity count formulas scale with cumulative depth so tier-2+ floors have more content.
+            int maxMonsters = Math.Clamp((int)Math.Round(2 + 8 * Math.Max(depth - 10, 0) / 90.0), 2, 10);
+            int maxChests = Math.Clamp((int)Math.Round(2 + 8 * Math.Max(depth - 10, 0) / 90.0), 2, 10);
+            int minObstacles = Math.Clamp((int)Math.Round(5 + 35 * Math.Max(depth - 10, 0) / 90.0), 5, 40);
+            int maxObstacles = Math.Clamp((int)Math.Round(10 + 40 * Math.Max(depth - 10, 0) / 90.0), 10, 50);
 
-            // Calculate actual entity counts with variance
-            var random = new Random(level); // Deterministic based on level
+            // Seed with cumulative depth so tier-2 floors differ from tier-1 at same displayed level.
+            var random = new Random(depth); // Deterministic based on cumulative depth
             int obstacleCount = random.Next(minObstacles, maxObstacles + 1);
             int chestCount = random.Next(maxChests / 2, maxChests + 1);
             int monsterCount = random.Next(maxMonsters / 2, maxMonsters + 1);
 
-            Console.WriteLine($"[VirtualPitGenerator] Level {level} calculated amounts:");
+            Console.WriteLine($"[VirtualPitGenerator] Level {depth} calculated amounts:");
             Console.WriteLine($"[VirtualPitGenerator]   Max Monsters: {maxMonsters}, Actual: {monsterCount}");
             Console.WriteLine($"[VirtualPitGenerator]   Max Chests: {maxChests}, Actual: {chestCount}");
             Console.WriteLine($"[VirtualPitGenerator]   Min Obstacles: {minObstacles}");
@@ -115,8 +125,9 @@ namespace PitHero.VirtualGame
             }
 
             // Generate treasures with Cave Biome progression.
+            // Biome keying uses displayedLevel; tier scaling is applied after item generation.
             // Live code uses Nez.Random (global); here we use the local deterministic
-            // Random(level) so pit layout and loot are both reproducible per level,
+            // Random(depth) so pit layout and loot are both reproducible per cumulative depth,
             // independent of the combat RNG seed passed to VirtualGameSimulation.
             for (int i = 0; i < chestCount; i++)
             {
@@ -125,26 +136,35 @@ namespace PitHero.VirtualGame
                 {
                     usedPositions.Add(pos.Value);
                     IItem item;
-                    if (CaveBiomeConfig.IsCaveLevel(level))
+                    if (CaveBiomeConfig.IsCaveLevel(displayedLevel))
                     {
                         float roll = (float)random.NextDouble();
-                        int treasureLevel = CaveBiomeConfig.DetermineCaveTreasureLevel(level, roll);
+                        int treasureLevel = CaveBiomeConfig.DetermineCaveTreasureLevel(displayedLevel, roll);
                         var lootCtx = LootContext;
                         item = TreasureComponent.GenerateCaveItemForTreasureLevelDeterministic(treasureLevel, in lootCtx, random);
                     }
                     else
                     {
                         float roll = (float)random.NextDouble();
-                        int treasureLevel = DetermineNonCaveTreasureLevelDeterministic(level, roll);
+                        int treasureLevel = DetermineNonCaveTreasureLevelDeterministic(displayedLevel, roll);
                         item = TreasureComponent.GenerateItemForTreasureLevelDeterministic(treasureLevel, random);
                     }
+
+                    // Apply tier scaling to gear drops.  Potions pass through unchanged.
+                    if (tier >= 2 && item is RolePlayingFramework.Equipment.Gear gearItem)
+                    {
+                        int depthDelta = (tier - 1) * BiomeProgressionConfig.MaxBiomeLevel;
+                        item = RolePlayingFramework.Equipment.Gear.CreateTierScaledCopy(gearItem, tier, depthDelta);
+                    }
+
                     // AddTreasure(Point, IItem) stores the instance and keeps parity lists in sync.
                     _worldState.AddTreasure(pos.Value, item);
                 }
             }
 
-            int caveScaledEnemyLevel = CaveBiomeConfig.GetScaledEnemyLevelForPitLevel(level);
-            bool isCaveBossFloor = CaveBiomeConfig.IsBossFloor(level);
+            // Enemy level uses effective depth so tier-2+ enemies are stronger than tier-1 at the same displayed level.
+            int caveScaledEnemyLevel = CaveBiomeConfig.GetScaledEnemyLevelForPitLevel(displayedLevel, tier);
+            bool isCaveBossFloor = CaveBiomeConfig.IsBossFloor(displayedLevel);
 
             // Generate boss marker first on cave boss floors
             if (isCaveBossFloor && monsterCount > 0)
@@ -153,19 +173,19 @@ namespace PitHero.VirtualGame
                 if (bossPos.HasValue)
                 {
                     usedPositions.Add(bossPos.Value);
-                    EnemyId bossId = GetBossEnemyIdForLevel(level);
+                    EnemyId bossId = GetBossEnemyIdForLevel(displayedLevel);
                     IEnemy bossEnemy = EnemyFactory.Create(bossId, caveScaledEnemyLevel);
                     // AddMonster(Point, IEnemy) routes to AddBossMonster internally when IsBoss=true
                     _worldState.AddMonster(bossPos.Value, bossEnemy);
                     monsterCount--;
-                    Console.WriteLine($"[VirtualPitGenerator] Cave boss floor at level {level} with {bossEnemy.Name} (scaled level {caveScaledEnemyLevel})");
+                    Console.WriteLine($"[VirtualPitGenerator] Cave boss floor at displayed level {displayedLevel} (depth={depth}) with {bossEnemy.Name} (scaled level {caveScaledEnemyLevel})");
                 }
             }
 
             // Generate monsters from Cave Biome pool if in cave range
-            if (CaveBiomeConfig.IsCaveLevel(level) && !isCaveBossFloor)
+            if (CaveBiomeConfig.IsCaveLevel(displayedLevel) && !isCaveBossFloor)
             {
-                EnemyId[] enemyPool = CaveBiomeConfig.GetEnemyPoolForLevel(level);
+                EnemyId[] enemyPool = CaveBiomeConfig.GetEnemyPoolForLevel(displayedLevel);
                 for (int i = 0; i < monsterCount; i++)
                 {
                     var pos = GetRandomPosition(minX, minY, maxX, maxY, usedPositions, random);
@@ -182,7 +202,7 @@ namespace PitHero.VirtualGame
             }
             else if (!isCaveBossFloor)
             {
-                // Non-cave levels use generic monster spawning
+                // Non-cave fallback (unreachable when all displayed levels are 1-25, kept for safety)
                 for (int i = 0; i < monsterCount; i++)
                 {
                     var pos = GetRandomPosition(minX, minY, maxX, maxY, usedPositions, random);
@@ -209,7 +229,7 @@ namespace PitHero.VirtualGame
                         _worldState.AddTrapTile(pos.Value);
                     }
                 }
-                Console.WriteLine($"[VirtualPitGenerator] Spawned {trapCount} trap(s) for level {level}");
+                Console.WriteLine($"[VirtualPitGenerator] Spawned {trapCount} trap(s) for depth {depth}");
             }
 
             Console.WriteLine($"[VirtualPitGenerator] Generated {obstacles.Count} obstacles, {chestCount} treasures, {monsterCount} monsters, and 1 wizard orb");

--- a/PitHero/VirtualGame/VirtualPitWidthManager.cs
+++ b/PitHero/VirtualGame/VirtualPitWidthManager.cs
@@ -1,5 +1,6 @@
 using Microsoft.Xna.Framework;
 using PitHero.AI.Interfaces;
+using PitHero.Config;
 using PitHero.Util;
 using System;
 using System.Collections.Generic;
@@ -16,6 +17,8 @@ namespace PitHero.VirtualGame
 
         // State tracking (same as real PitWidthManager)
         private int _currentPitLevel = 1;
+        private int _currentPitTier = 1;
+        private int _tierBaseLevel = 1;
         private int _currentPitRightEdge;
         private bool _isInitialized = false;
 
@@ -35,6 +38,8 @@ namespace PitHero.VirtualGame
         }
 
         public int CurrentPitLevel => _currentPitLevel;
+        public int CurrentPitTier => _currentPitTier;
+        public int TierBaseLevel => _tierBaseLevel;
         public int CurrentPitRightEdge => _currentPitRightEdge;
 
         public int CurrentPitRectWidthTiles => _isInitialized
@@ -125,6 +130,42 @@ namespace PitHero.VirtualGame
             Console.WriteLine($"[VirtualPitWidthManager] {patternName} total: {dictionary.Count} tiles, {nonZeroCount} non-zero");
         }
 
+        /// <summary>
+        /// Sets the pit tier, clamped to [1, MaxPitTier].
+        /// </summary>
+        public void SetPitTier(int tier)
+        {
+            int clamped = tier < 1 ? 1 : (tier > BiomeProgressionConfig.MaxPitTier ? BiomeProgressionConfig.MaxPitTier : tier);
+            _currentPitTier = clamped;
+            Console.WriteLine($"[VirtualPitWidthManager] PitTier set to {_currentPitTier}");
+        }
+
+        /// <summary>
+        /// Sets the tier base level (clamped to ≥1, monotonic non-decreasing — lower values are ignored).
+        /// </summary>
+        public void SetTierBaseLevel(int heroLevel)
+        {
+            int clamped = heroLevel < 1 ? 1 : heroLevel;
+            if (clamped > _tierBaseLevel)
+            {
+                _tierBaseLevel = clamped;
+                Console.WriteLine($"[VirtualPitWidthManager] TierBaseLevel updated to {_tierBaseLevel}");
+            }
+        }
+
+        /// <summary>
+        /// Increments the pit tier by 1 (clamped at MaxPitTier) and records the hero level as the new tier base level.
+        /// </summary>
+        public void IncrementPitTier(int heroLevelAtEntry)
+        {
+            int newTier = _currentPitTier + 1;
+            if (newTier > BiomeProgressionConfig.MaxPitTier)
+                newTier = BiomeProgressionConfig.MaxPitTier;
+            _currentPitTier = newTier;
+            SetTierBaseLevel(heroLevelAtEntry);
+            Console.WriteLine($"[VirtualPitWidthManager] PitTier incremented to {_currentPitTier}, TierBaseLevel={_tierBaseLevel}");
+        }
+
         public void SetPitLevel(int newLevel)
         {
             if (!_isInitialized)
@@ -156,11 +197,12 @@ namespace PitHero.VirtualGame
                 return;
             }
 
-            // Calculate how many inner floor tiles to extend (same logic as real PitWidthManager)
-            // Cap expansion at level 100 - pit stops expanding beyond level 100
-            int expansionLevel = Math.Min(_currentPitLevel, 100);
+            // Calculate how many inner floor tiles to extend (same logic as real PitWidthManager).
+            // Use effective depth so expansion continues across tiers, capped at depth 100.
+            int effectiveDepth = BiomeProgressionConfig.GetEffectiveDepth(_currentPitLevel, _currentPitTier);
+            int expansionLevel = Math.Min(effectiveDepth, 100);
             int innerFloorTilesToExtend = ((int)(expansionLevel / 10)) * 2;
-            Console.WriteLine($"[VirtualPitWidthManager] Level {_currentPitLevel}: extending pit by {innerFloorTilesToExtend} inner floor tiles");
+            Console.WriteLine($"[VirtualPitWidthManager] Level {_currentPitLevel} Tier {_currentPitTier} (effectiveDepth={effectiveDepth}): extending pit by {innerFloorTilesToExtend} inner floor tiles");
 
             if (innerFloorTilesToExtend <= 0)
             {

--- a/PitHero/VirtualGame/VirtualRunMetrics.cs
+++ b/PitHero/VirtualGame/VirtualRunMetrics.cs
@@ -70,6 +70,26 @@ namespace PitHero.VirtualGame
         /// </summary>
         public int MercsHired;
 
+        /// <summary>
+        /// Pit tier this level belongs to (1 = first loop, 2 = second, …).
+        /// Derived from <see cref="PitLevel"/> via <see cref="Config.BiomeProgressionConfig.GetTierForDepth"/>.
+        /// </summary>
+        public int PitTier;
+
+        /// <summary>
+        /// Biome-local displayed pit level (1–25) for this row.
+        /// For tier-1 runs this equals <see cref="PitLevel"/>; for tier-2+ it wraps back to 1 at each loop.
+        /// Derived from <see cref="PitLevel"/> via <see cref="Config.BiomeProgressionConfig.GetDisplayedLevelForDepth"/>.
+        /// </summary>
+        public int DisplayedLevel;
+
+        /// <summary>
+        /// Hero level at the end of this pit level (after battle XP is applied).
+        /// Lets balance reports compare natural leveling pace against the
+        /// <see cref="RolePlayingFramework.Balance.BalanceConfig.EstimatePlayerLevelForPitLevel"/> curve.
+        /// </summary>
+        public int HeroLevel;
+
         // ── Run summary fields (populated once per simulation run) ──────────────────
 
         /// <summary>RNG seed used for this run (placeholder for Phase C).</summary>
@@ -110,7 +130,7 @@ namespace PitHero.VirtualGame
         /// </summary>
         public static void WriteCsvHeader(TextWriter writer)
         {
-            writer.WriteLine("pitLevel,battles,rounds,dmgDealt,dmgTaken,hpLossPct,healing,deaths,wiped,treasures,gearEquipped,goldEarned,wallet,innRested,mercsHired");
+            writer.WriteLine("pitLevel,battles,rounds,dmgDealt,dmgTaken,hpLossPct,healing,deaths,wiped,treasures,gearEquipped,goldEarned,wallet,innRested,mercsHired,pitTier,displayedLevel,heroLevel");
         }
 
         /// <summary>
@@ -121,7 +141,8 @@ namespace PitHero.VirtualGame
             writer.WriteLine(
                 $"{PitLevel},{BattleCount},{TotalRounds},{DamageDealt},{DamageTaken}," +
                 $"{HpLossPercent:F4},{HealingConsumed},{PartyDeaths},{(Wiped ? 1 : 0)}," +
-                $"{TreasuresOpened},{GearEquipped},{GoldEarned},{Wallet},{(InnRested ? 1 : 0)},{MercsHired}");
+                $"{TreasuresOpened},{GearEquipped},{GoldEarned},{Wallet},{(InnRested ? 1 : 0)},{MercsHired}," +
+                $"{PitTier},{DisplayedLevel},{HeroLevel}");
         }
 
         /// <summary>

--- a/PitHero/VirtualGame/VirtualWorldState.cs
+++ b/PitHero/VirtualGame/VirtualWorldState.cs
@@ -218,6 +218,12 @@ namespace PitHero.VirtualGame
                 list.Remove(position);
         }
 
+        /// <summary>
+        /// Read-only view of all treasure items currently placed in the world, keyed by tile position.
+        /// Use this in tests to inspect item types and tier-scaling without consuming treasures.
+        /// </summary>
+        public IReadOnlyDictionary<Point, IItem> TreasureInstances => _treasureInstances;
+
         /// <summary>Returns true when at least one unopened treasure chest remains.</summary>
         public bool HasUnopenedTreasures()
         {

--- a/PitHero/docs/AnalyticsSchema.md
+++ b/PitHero/docs/AnalyticsSchema.md
@@ -45,12 +45,12 @@ interpretation caveats that are not obvious from the raw data.
 ### Pit
 | `e` | Fields | Notes |
 |---|---|---|
-| `pit_generated` | `pitLevel`, `isBossFloor`, `monsterCount`, `chestCount` | Fires on every pit (re)generation, including the initial load-time generation. `isBossFloor` comes from `CaveBiomeConfig.IsBossFloor` — see caveat below. |
-| `chest_spawned` | `pitLevel`, `x`, `y`, `chestLevel` (1–5), `item`, `kind`, `rarity`, optional `seedType` + `seedCount` | Contents decided at spawn time. `item` is `null` for seed chests. |
-| `monster_spawned` | `pitLevel`, `x`, `y`, `name`, `enemyId`, `level`, `maxHP`, `isBoss` | `level` is the enemy's own level (often a per-type preset — see caveats). |
-| `trap_triggered` | `pitLevel`, `x`, `y`, `damage` | Hero stepped on a hidden trap. `damage` is the clamped value actually applied (hero's HP is never reduced below 1 out-of-battle). Formula: `5 + pitLevel * 2` before clamping. |
+| `pit_generated` | `pitLevel`, `pitTier`, `isBossFloor`, `monsterCount`, `chestCount` | Fires on every pit (re)generation, including the initial load-time generation. `isBossFloor` comes from `CaveBiomeConfig.IsBossFloor` — see caveat below. `pitTier` is 1 until the player completes pit 25, after which it increments and `pitLevel` resets to 1 for the new tier. |
+| `chest_spawned` | `pitLevel`, `pitTier`, `x`, `y`, `chestLevel` (1–5), `item`, `kind`, `rarity`, optional `seedType` + `seedCount` | Contents decided at spawn time. `item` is `null` for seed chests. |
+| `monster_spawned` | `pitLevel`, `pitTier`, `x`, `y`, `name`, `enemyId`, `level`, `maxHP`, `isBoss` | `level` is the enemy's own level (often a per-type preset — see caveats). |
+| `trap_triggered` | `pitLevel`, `x`, `y`, `damage` | Hero stepped on a hidden trap. `damage` is the clamped value actually applied (hero's HP is never reduced below 1 out-of-battle). Formula: `5 + (tier-1)*25*2 + pitLevel * 2` (effective depth scaling) before clamping. |
 | `trap_disarmed` | `pitLevel`, `x`, `y` | A party member with the TrapSense passive auto-disarmed a trap when fog was cleared over it. No damage dealt. |
-| `orb_activated` | `fromPitLevel`, `toPitLevel`, `heroLevel` | Wizard orb → next pit level. Followed by a `party_snapshot` with `reason:"orb"`. |
+| `orb_activated` | `fromPitLevel`, `toPitLevel`, `pitTier`, `heroLevel` | Wizard orb → next pit level. `pitTier` is the tier **at the moment of activation** (i.e. the tier about to be left when the orb advances into a new tier). Followed by a `party_snapshot` with `reason:"orb"`. |
 | `pit_jump` | `pitLevel`, `heroLevel`, `heroHP`, `heroMaxHP` | Hero jumped into the pit. Followed by a `party_snapshot` with `reason:"pit_jump"`. |
 | `party_snapshot` | `reason`, `members[]` | Each member: `name`, `type` (`"hero"`/`"merc"`), `job`, `level`, `str/agi/vit/mag` (total stats incl. gear/synergy), `maxHP`, `curHP`, `maxMP`, `skills[]` (skill ids), `gear{}` (slot→item name; keys `weapon`, `armor`, `hat`, `shield`, `acc1`, `acc2`; empty slots omitted). |
 
@@ -73,7 +73,7 @@ interpretation caveats that are not obvious from the raw data.
 |---|---|---|
 | `attack` | `actor`, `actorType` (`"hero"`/`"merc"`/`"monster"`), `action`, `target`, `targetType`, `dmg`, `hpBefore`, `hpAfter`, `killed` | `action` is `"physical"`, a skill id (e.g. `knight.heavy_strike`), `"counter"` (hero/merc retaliation after taking a hit — requires monk.counter passive), or `"<skillId>.dot"` (end-of-round damage-over-time tick from a skill such as `synergy.poison_arrow.dot`). `hpBefore`/`hpAfter` are the **target's** HP; `hpBefore − dmg = hpAfter` (floored at 0). AoE skills emit one line per target hit. Misses are not logged. Monsters only have physical attacks. Counter attacks and DoT ticks never produce miss events. |
 | `heal` | `actor`, `source` (skill id or item name), `target`, `amount`, `hpAfter` | Battle heals (skills and consumables). |
-| `monster_defeated` | `name`, `enemyId`, `level`, `isBoss`, `pitLevel`, `xp`, `jp`, `gold` | One per kill regardless of killer; the matching `gold_gained` (`source:"battle"`) follows. |
+| `monster_defeated` | `name`, `enemyId`, `level`, `isBoss`, `pitLevel`, `pitTier`, `xp`, `jp`, `gold` | One per kill regardless of killer; the matching `gold_gained` (`source:"battle"`) follows. |
 | `char_killed` | full victim snapshot (same shape as a `party_snapshot` member) + `killer{name, enemyId, level, str/agi/vit/mag, maxHP}` | Hero or mercenary killed by a monster. |
 
 ## Interpretation caveats
@@ -83,9 +83,11 @@ interpretation caveats that are not obvious from the raw data.
   localized display names (English by default). Strip the prefixes for readability.
 - **Damage is post-mitigation.** `dmg` is the applied damage (includes the debug
   `DEBUG_DAMAGE_MULT` multiplier in `AttackMonsterAction`, normally 1).
-- **Enemy `level` may not track `pitLevel`.** Enemy constructors use per-type preset levels
-  (`EnemyLevelConfig.GetPresetLevel`) outside the Cave biome — see issues #290/#291 for the
-  known post-cave flattening this exposes.
+- **Enemy `level` tracks effective depth inside the Cave biome.** As of issue #291, enemy
+  constructors honour `pitLevel` passed by `CaveBiomeConfig`; the per-type preset path
+  (`EnemyLevelConfig.GetPresetLevel`) is still used for non-Cave content. Use `pitTier` and
+  `pitLevel` together to recover effective depth: `effectiveDepth = (pitTier-1)*25 + pitLevel`.
+  Trap damage scales with this same depth formula: `5 + effectiveDepth * 2` before clamping.
 - **Load-time replay:** on `mode:"load"`, the pit is regenerated, so the first
   `pit_generated`/`chest_spawned`/`monster_spawned` burst right after `session_start`
   reflects the restored pit, and one `merc_arrived` fires for the initial tavern spawn.

--- a/PitHero/docs/VirtualGameLogicLayer.md
+++ b/PitHero/docs/VirtualGameLogicLayer.md
@@ -215,6 +215,26 @@ New live-layer features should be checked against this document (see the
 Full suite: `dotnet test PitHero.Tests/PitHero.Tests.csproj`. Baseline: **12 known
 pre-existing failures** (environment-dependent tests) — anything above that is a regression.
 
+## Depth Semantics and Pit Tiers (issue #291)
+
+`VirtualPitGenerator.RegenerateForLevel` and `VirtualGameSimulation.RunPitLevel` /
+`RunLevelRange` accept a **cumulative depth** argument — the absolute depth since the start of
+the game, not a per-tier counter.
+
+- Depths **≤ 25** are tier 1 and behave identically to the pre-#291 behaviour.
+- Crossing depth 25 (i.e. the argument is 26) causes the simulation to auto-increment its
+  internal tier counter and record the tier base level (`TierBaseLevel = 26`). Subsequent
+  levels continue counting up, with enemy scaling derived from the full cumulative depth.
+- `RunLevelRange(1, 50)` therefore spans tier 1 (depths 1–25) and tier 2 (depths 26–50)
+  without any special configuration.
+- The mercenary hire floor activates at tier ≥ 2: `RunLevelRange` will attempt to hire
+  mercenaries from depth 26 onward even if the party is already full from tier 1, because
+  mercenaries from earlier tiers may have died or been dismissed.
+
+The effective depth formula used for balance joins is `(tier-1)*25 + pitLevel`, where
+`pitLevel` is the within-tier counter (1–25). Both values are present in analytics events
+(see `AnalyticsSchema.md`).
+
 ## Legacy Exploration Harness
 
 `RunCompleteSimulation()` and the ASCII visualization (`GetVisualRepresentation()`)

--- a/features/reports/feature_pit_tier_progression_balance_report.md
+++ b/features/reports/feature_pit_tier_progression_balance_report.md
@@ -1,0 +1,89 @@
+# Balance Report — Pit Tier Progression (issue #291)
+
+**Date:** 2026-07-12
+**Seeds:** 12345 (primary), 777, 424242 (natural-pacing probes)
+**Jobs tested:** Knight (solo + Knight/Priest/Archer party)
+**Pit-level range:** depths 1–50 (tier 1 pits 1–25, tier 2 pits 1(2)–25(2))
+**Tested-by:** Pit Balance Tester (skill)
+
+---
+
+## 1. Test Scope
+
+Issue #291 changed three things that this report validates:
+
+1. **Enemy constructors honor requested levels** — 9 previously-frozen types (Bat, Goblin, Orc, PitLord, Rat, Skeleton, Snake, Spider, Wraith) now spawn at the floor's scaled level instead of preset L1–L10. This restores intended difficulty at pits 7–24 and the pit-20 boss.
+2. **Pit tier system** — after pit 25 the pit loops to 1 and the tier increments (permanent). Monster levels follow the continuous-depth curve `EstimatePlayerLevelForPitLevel((tier−1)×25 + pitLevel)`; gear drops at tier ≥ 2 get scaled stats and a `+N` name suffix; tavern mercenaries get a `TierBaseLevel` floor at tier ≥ 2; respawned heroes start at `TierBaseLevel`.
+3. **Tier-2 loot** — chests at tier 2 use the cave gear pools (previously: potions only past pit 25).
+
+## 2. Methodology
+
+- Entry points: `VirtualGameSimulation.RunPitLevel(depth)` (fresh level-appropriate hero per floor) and `RunLevelRange(from, to)` (persistent run, natural XP, gold economy, auto-hire + inn rest). Fully-equipped convention throughout: JP-loaded crystal + full skill kit, mercs with `LearnAllJobSkills()`, 5 HP potions.
+- Sampled floors: tier 1 {1, 5, 10, 15, 20, 25}, tier 2 depths {26, 30, 40, 45, 50} (displayed 1(2), 5(2), 15(2), 20(2), 25(2)).
+- Persistent runs: depths 1–50 from a level-1 Knight (seeds 12345, 777, 424242); crossing probe depths 20–30 from a curve-level (L36) Knight with 5000g.
+- Respawn scenario: crossing sim records `TierBaseLevel` (46); fresh party (Knight+Priest+Archer, all L46) re-runs depth 26.
+- New metrics columns used: `pitTier`, `displayedLevel`, `heroLevel` (hero level at end of each floor).
+- Unit tests: full suite 1367 passed / **12 failed = exactly the pre-existing baseline** (no regressions). BalanceTraversal: 6/6 pass. New coverage: monster level within ±2 of curve at 7 (pit, tier) samples; tier-2 boss identity; tier-2 chest gear; save v13 round-trip + migration; merc floor distribution.
+
+## 3. Findings
+
+### Critical Issues
+
+None.
+
+### Major Issues
+
+| Pit Level | Job | Issue | Notes |
+|---|---|---|---|
+| 16–23 (tier 1) | All (natural pacing) | Greedy single-pass descent wipes at pit 23 in 2/3 seeds (depth 33 in the third) | `heroLevel` column shows the gap: natural XP pace reaches L11–13 by pit 23 while monsters follow the curve at L41. Level-appropriate parties clear these floors comfortably (sampled runs), so floors are beatable as designed — but a hero descending every floor without farming falls ~30 levels behind by pit 23. Pre-#291 this was masked because half the spawns were frozen at L6. This is an XP-pacing characteristic of the grind loop, not a tier-system defect — see recommendation 1. |
+| 22→23 (tier 1) | All | hpLossPct jump 0.04–0.45 → 1.24–2.85 (>2×) across all seeds | Depth-23's deterministic layout produces the hardest tier-1 encounter cluster (2 back-to-back multi-monster battles, 13–18 rounds). Same-layout-every-run is by design (layout seeds on depth); combined with the pacing gap above it is the consistent wipe point. |
+
+### Minor Issues
+
+| Pit Level | Job | Issue | Notes |
+|---|---|---|---|
+| 26 = 1(2) | Solo Knight | Curve-level (L46) solo Knight wipes at tier-2 entry | The same floor is cleared by a 3-member L46 party (respawn scenario: wiped=0, battles=3, healing=463). Tier 2 is party-gated — consistent with the tavern + tier-base-level respawn design, but a solo idle hero will stall here. |
+
+### What passed
+
+- **Tier crossing is smooth (the core #291 acceptance).** Seed 424242's natural run: pit 25 boss hpLoss 0.06 → depth 26 hpLoss 0.43 → progressed to depth 33 (displayed 8, tier 2). No difficulty cliff or reset at the boundary; monster levels are monotonic across the crossing (unit-verified ±2 of curve).
+- **Tier-2 sampled floors (level-appropriate hero):** depths 30/40/45/50 all cleared solo, including three tier-2 boss floors; boss identity stays keyed to the displayed floor (pit 20(2) is still PitLord, at the scaled level).
+- **Tier-2 loot:** chests yield cave gear with `+2` scaled stats (no more potion-only chests); auto-equip picked up 3–4 pieces per floor in tier-2 runs (`gearEquipped` column).
+- **Respawn-at-TierBaseLevel:** a wiped tier-2 party restarting at TierBaseLevel 46 with floor-46 mercenaries re-clears depth 26 — the permanent-tier death loop is viable.
+- **Rewards scale again:** pit-23 kills yield 128–384g per floor vs the flat 23g/58xp of the frozen-level bug.
+
+## 4. Elemental Matchup Matrix
+
+Not re-tested. This change does not touch elemental properties, resistances, or damage multipliers; monster elemental assignments are unchanged (see `PitHero/docs/CaveBiomeBalanceReport.md` for the standing matchup validation). Tier-scaled gear preserves the source item's element and resistances (`CreateTierScaledCopy` copies `ElementalProps`).
+
+## 5. Equipment Tier Utilization
+
+Observed across the persistent and sampled runs (auto-equip decisions):
+
+| Depth range | Drops seen | Equipped | Notes |
+|---|---|---|---|
+| 1–15 (tier 1) | Normal cave gear | 0–1 per floor | Unchanged from pre-#291 behavior |
+| 16–25 (tier 1) | Normal/Uncommon cave gear | 1–6 per floor | Higher equip rate — better gear now matters against correctly-leveled monsters |
+| 26–50 (tier 2) | Cave gear `+2` (tier-scaled) | 2–4 per floor | `+2` gear strictly upgrades same-slot tier-1 gear (atk +12, def +8, stat +5 at Normal rarity for the 25-depth delta); no tier is skipped |
+
+## 6. Verdict
+
+**Pass-with-caveats.**
+
+The #291 core is validated: monster levels, rewards, and loot now scale continuously through the tier boundary with no flat spots and no discontinuity at 25→1(2); the tier-base-level respawn loop works. The caveats are pacing, not scaling: a greedily-descending natural-pace party hits a wall around pit 16–23 of tier 1 (hero ~L11 vs curve L41), and tier-2 entry requires a party. Both are grind-loop tuning questions, not defects in the tier system — every floor is beatable by a level-appropriate party, which is the design contract.
+
+## 7. Prioritized Rebalance Recommendations
+
+| Priority | Change | Affected | Rationale |
+|---|---|---|---|
+| 1 (Major, follow-up issue suggested) | Close the natural-pacing gap at pits 16–25. Concrete options, pick one: (a) raise monster XP yield `10 + L*8` → `10 + L*12` so curve-level kills close the level gap faster; (b) floor tier-1 mercenary rolls at `EstimatePlayerLevelForPitLevel(currentPit)/2` (mirrors the tier-≥2 TierBaseLevel floor); (c) soften `EstimatePlayerLevelForPitLevel` for pits 21–25 from `36+(p−20)*1.75` → `36+(p−20)*1.25`. Re-run `TestCategory=BalanceProbe` after any change — wipe depth should move from 23 to ≥25. | Tier-1 pits 16–25 | 2/3 natural-pacing seeds wipe at pit 23 with hero 30 levels under curve |
+| 2 (Minor) | If solo play should remain viable into tier 2, floor `DetermineMercenaryLevel`'s tier-1 rolls (option 1b) so a depth-26 hero can field a credible party for ~200–600g | Tier-2 entry | Solo L46 Knight wipes at depth 26; L46 party clears it |
+| 3 (Info) | Keep `BalanceProbeTests` (TestCategory=BalanceProbe) as the standing pacing probe; it prints seed-stamped 1–50 CSVs with the `heroLevel` column for before/after comparison | Balance workflow | Deterministic, <1s, reusable for the follow-up tuning |
+
+---
+
+## Handoff Summary
+
+- Report path: `features/reports/feature_pit_tier_progression_balance_report.md`
+- Verdict: **Pass-with-caveats**
+- Prioritized recommendations: 3 (1 major pacing follow-up, 1 minor solo-viability option, 1 workflow note)


### PR DESCRIPTION
Closes #291.

## Root-cause fix: enemy constructors honor spawn levels

9 of 26 enemy classes (Skeleton, Orc, Wraith, PitLord, Rat, Bat, Goblin, Snake, Spider) discarded the requested level in favor of `EnemyLevelConfig` presets — breaking scaling both past pit 25 *and inside the cave biome* (pits 7–24 mixed L6 spawns into L28–45 floors; the pit-20 boss had pit-5-boss HP). They now use the same pattern as the other 17 classes (`Level = ClampLevel(level > 0 ? level : presetLevel)`); `EnemyFactory.Create` defaults to `level = 0` so preset fallback is preserved for callers like AddMonsterDialog. Stats/HP/XP/JP/gold all derive from `Level`, so rewards scale again (no more flat 23g/58xp).

## Pit tier system

- Past the max biome level (derived via new `BiomeProgressionConfig` from `CaveBiomeConfig.CaveEndLevel` — not hardcoded, future biomes extend it), the pit loops to level 1 and the **tier** increments: 1–99, permanent, survives death (death still resets the pit *level* to 1).
- **Continuous-depth scaling**: monster levels, trap damage, and pit-width growth follow effective depth `(tier−1)×25 + pitLevel`; enemy pools, boss floors, and treasure bands stay keyed to the displayed level (1–25), so tier 2+ always uses cave content — fixing the potion-only chests and the tiny fallback enemy pool.
- **TierBaseLevel**: the hero's level on first tier entry is recorded; respawned heroes start there (crystal ceremony + merc promotion paths), and tavern mercenaries get it as a minimum hire level at tier ≥ 2.
- Tier-scaled gear drops carry the delta of the equipment curves (atk +Δ/2, def +Δ/3, stats +Δ/5 × rarity) and a `+N` name suffix; `ItemRegistry.TryCreateItem` parses the suffix so name-based persistence (inventory/vault/equipped) round-trips.
- HUD: `Pit Lv. 7(2)` from tier 2 onward; analytics events gain `pitTier`.
- Save v13 (`PitTier`, `TierBaseLevel`) with migration: legacy saves past pit 25 decompose (pit 119 → level 19, tier 5, base = saved hero level).

## Virtual-layer validation

Everything is mirrored headless (`VirtualPitGenerator`/`RunPitLevel`/`RunLevelRange` treat arguments as cumulative depth) and validated per the pit-balance-test skill — report: `features/reports/feature_pit_tier_progression_balance_report.md`.

- Full suite: **1367 passed / 12 failed = exactly the pre-existing baseline**; BalanceTraversal 6/6.
- Tier crossing is smooth: a natural run cleared pit 25, entered tier 2 with no difficulty cliff, equipped `+2` gear, and progressed 7 floors; monster levels unit-verified within ±2 of the curve in both tiers; a TierBaseLevel-46 party re-clears tier-2 entry after a wipe.
- New metrics columns (`pitTier`, `displayedLevel`, `heroLevel`) + deterministic `BalanceProbeTests` for future tuning.

**Verdict: pass-with-caveats** — greedy no-farming descent now wipes ~pit 23 of tier 1 (hero L11 vs curve L41; previously masked by the frozen-level bug). Every floor is beatable by a level-appropriate party, so this is an XP-pacing follow-up; the report lists three concrete tuning options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)