### PR TITLE
Particle effects for magic and other things (#301)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,7 @@ Design docs under `PitHero/docs/` (kept as standalone references — don't dupli
 
 **Architecture / subsystems:**
 - `PitHero/docs/RenderingSystem.md` — render layer stack, Y-sort, MultiSpriteAnimator / StaticSpriteCompositor / YSortSpriteRenderer
+- `PitHero/docs/ParticleEffects.md` — ParticleEffectManager, .pex authoring quirks, sizing rules, effect patterns (attached/projectile/AoE), battle + out-of-battle wiring map
 - `PitHero/docs/RolePlayingFramework.md`
 - `PitHero/docs/VirtualGameLogicLayer.md`
 - `PitHero/docs/JpSystem.md` — Job Points, skill purchase flow, mastery

--- a/PitHero.Tests/ParticleEffectManagerTests.cs
+++ b/PitHero.Tests/ParticleEffectManagerTests.cs
@@ -1,0 +1,40 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Util;
+
+namespace PitHero.Tests
+{
+    [TestClass]
+    public class ParticleEffectManagerTests
+    {
+        [TestMethod]
+        public void SpawnEffect_BeforeInit_ReturnsNull()
+        {
+            var manager = new ParticleEffectManager();
+
+            var emitter = manager.SpawnEffect(ParticleEffectType.Heal, new Nez.Entity("target"));
+
+            Assert.IsNull(emitter);
+        }
+
+        [TestMethod]
+        public void SpawnEffect_NullTarget_ReturnsNull()
+        {
+            var manager = new ParticleEffectManager();
+
+            var emitter = manager.SpawnEffect(ParticleEffectType.Heal, null);
+
+            Assert.IsNull(emitter);
+        }
+
+        [TestMethod]
+        public void SpawnEffectAtPosition_BeforeInit_ReturnsNull()
+        {
+            var manager = new ParticleEffectManager();
+
+            var emitter = manager.SpawnEffectAtPosition(
+                ParticleEffectType.Heal, Microsoft.Xna.Framework.Vector2.Zero, null);
+
+            Assert.IsNull(emitter);
+        }
+    }
+}

--- a/PitHero/AI/LiveBattleAdapter.cs
+++ b/PitHero/AI/LiveBattleAdapter.cs
@@ -350,6 +350,25 @@ namespace PitHero.AI
         }
 
         /// <inheritdoc/>
+        public IEnumerator ShowItemHealOnAlly(IBattleAlly ally, int amount, RolePlayingFramework.Equipment.Consumable consumable)
+        {
+            var entity = GetEntityForAlly(ally);
+            if (entity == null) return null;
+            Core.GetGlobalManager<ParticleEffectManager>()?.SpawnEffect(
+                ParticleEffectType.HealPotion, entity, densityScale: GetPotionEffectDensity(consumable));
+            return ShowDamageDigitOnEntity(entity, amount, Color.Green);
+        }
+
+        /// <summary>Stronger potions emit denser particles: base potions (100 HP) 1x,
+        /// mid potions (500 HP) 2x, full-restore potions (negative amount) 3x.</summary>
+        private static float GetPotionEffectDensity(RolePlayingFramework.Equipment.Consumable consumable)
+        {
+            if (consumable.HPRestoreAmount < 0) return 3f;
+            if (consumable.HPRestoreAmount >= 500) return 2f;
+            return 1f;
+        }
+
+        /// <inheritdoc/>
         public IEnumerator ShowBuffOnAlly(IBattleAlly ally, string label)
         {
             var entity = GetEntityForAlly(ally);

--- a/PitHero/AI/LiveBattleAdapter.cs
+++ b/PitHero/AI/LiveBattleAdapter.cs
@@ -344,26 +344,73 @@ namespace PitHero.AI
         /// <summary>World-space pixels per second a skill projectile travels.</summary>
         private const float SkillProjectileSpeed = 340f;
 
-        /// <summary>Attack skills with a projectile visual. Adding one = pex file + enum
-        /// member + Init load line in ParticleEffectManager + an entry here.</summary>
-        private static readonly Dictionary<string, ParticleEffectType> _skillProjectileEffects
-            = new Dictionary<string, ParticleEffectType>
-            {
-                { "mage.fire", ParticleEffectType.Fireball }
-            };
+        /// <summary>How far above the enemy group's center an area rain effect spawns.</summary>
+        private const float AreaRainSpawnHeight = 70f;
+
+        /// <summary>How long the engine waits on an area rain effect before damage shows.</summary>
+        private const float AreaRainImpactDelay = 0.5f;
 
         /// <inheritdoc/>
-        public IEnumerator ShowSkillProjectileOnMonster(ICombatant caster, ISkill skill, IEnemy target)
+        /// <remarks>Adding a skill visual = pex file + enum member + Init load line in
+        /// ParticleEffectManager + a case here.</remarks>
+        public IEnumerator ShowSkillEffectOnMonsters(ICombatant caster, ISkill skill,
+            IEnemy primaryTarget, List<IEnemy> surroundingTargets)
         {
-            if (!_skillProjectileEffects.TryGetValue(skill.Id, out var effectType))
-                return null;
+            switch (skill.Id)
+            {
+                case "mage.fire":
+                {
+                    var casterEntity = GetEntityForCombatant(caster);
+                    var targetEntity = GetEntityForEnemy(primaryTarget);
+                    if (casterEntity == null || targetEntity == null)
+                        return null;
+                    return FlyProjectileEffect(ParticleEffectType.Fireball,
+                        casterEntity.Position, targetEntity.Position);
+                }
 
-            var casterEntity = GetEntityForCombatant(caster);
-            var targetEntity = GetEntityForEnemy(target);
-            if (casterEntity == null || targetEntity == null)
-                return null;
+                case "mage.firestorm":
+                {
+                    var center = GetCenterOfEnemyGroup(primaryTarget, surroundingTargets);
+                    if (center == null)
+                        return null;
+                    return RainEffectOverPosition(ParticleEffectType.Firestorm, center.Value);
+                }
 
-            return FlyProjectileEffect(effectType, casterEntity.Position, targetEntity.Position);
+                default:
+                    return null;
+            }
+        }
+
+        /// <summary>Averages the entity positions of the primary and surrounding targets;
+        /// null when no target has a live entity.</summary>
+        private Vector2? GetCenterOfEnemyGroup(IEnemy primaryTarget, List<IEnemy> surroundingTargets)
+        {
+            var sum = Vector2.Zero;
+            int count = 0;
+
+            var primaryEntity = GetEntityForEnemy(primaryTarget);
+            if (primaryEntity != null) { sum += primaryEntity.Position; count++; }
+
+            if (surroundingTargets != null)
+            {
+                for (int i = 0; i < surroundingTargets.Count; i++)
+                {
+                    var e = GetEntityForEnemy(surroundingTargets[i]);
+                    if (e != null) { sum += e.Position; count++; }
+                }
+            }
+
+            return count > 0 ? sum / count : (Vector2?)null;
+        }
+
+        private IEnumerator RainEffectOverPosition(ParticleEffectType type, Vector2 groundCenter)
+        {
+            var spawnPos = groundCenter - new Vector2(0f, AreaRainSpawnHeight);
+            Core.GetGlobalManager<ParticleEffectManager>()?.SpawnEffectAtPosition(type, spawnPos, Core.Scene);
+
+            // Let the rain visibly fall onto the group before damage digits appear;
+            // the emitter finishes and cleans itself up on its own after this returns.
+            yield return WaitForSecondsRespectingPause(AreaRainImpactDelay);
         }
 
         private Entity GetEntityForCombatant(ICombatant combatant)

--- a/PitHero/AI/LiveBattleAdapter.cs
+++ b/PitHero/AI/LiveBattleAdapter.cs
@@ -345,6 +345,7 @@ namespace PitHero.AI
         {
             var entity = GetEntityForAlly(ally);
             if (entity == null) return null;
+            Core.GetGlobalManager<ParticleEffectManager>()?.SpawnEffect(ParticleEffectType.Heal, entity);
             return ShowDamageDigitOnEntity(entity, amount, Color.Green);
         }
 

--- a/PitHero/AI/LiveBattleAdapter.cs
+++ b/PitHero/AI/LiveBattleAdapter.cs
@@ -354,18 +354,8 @@ namespace PitHero.AI
         {
             var entity = GetEntityForAlly(ally);
             if (entity == null) return null;
-            Core.GetGlobalManager<ParticleEffectManager>()?.SpawnEffect(
-                ParticleEffectType.HealPotion, entity, densityScale: GetPotionEffectDensity(consumable));
+            Core.GetGlobalManager<ParticleEffectManager>()?.SpawnPotionHealEffect(consumable, entity);
             return ShowDamageDigitOnEntity(entity, amount, Color.Green);
-        }
-
-        /// <summary>Stronger potions emit denser particles: base potions (100 HP) 1x,
-        /// mid potions (500 HP) 2x, full-restore potions (negative amount) 3x.</summary>
-        private static float GetPotionEffectDensity(RolePlayingFramework.Equipment.Consumable consumable)
-        {
-            if (consumable.HPRestoreAmount < 0) return 3f;
-            if (consumable.HPRestoreAmount >= 500) return 2f;
-            return 1f;
         }
 
         /// <inheritdoc/>

--- a/PitHero/AI/LiveBattleAdapter.cs
+++ b/PitHero/AI/LiveBattleAdapter.cs
@@ -12,6 +12,7 @@ using RolePlayingFramework.Equipment;
 using RolePlayingFramework.Heroes;
 using RolePlayingFramework.Inventory;
 using RolePlayingFramework.Mercenaries;
+using RolePlayingFramework.Skills;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -338,6 +339,63 @@ namespace PitHero.AI
         {
             var entity = GetEntityForEnemy(enemy);
             return entity != null ? ShowTextOnEntity(entity, "Crit", Color.Yellow) : null;
+        }
+
+        /// <summary>World-space pixels per second a skill projectile travels.</summary>
+        private const float SkillProjectileSpeed = 340f;
+
+        /// <summary>Attack skills with a projectile visual. Adding one = pex file + enum
+        /// member + Init load line in ParticleEffectManager + an entry here.</summary>
+        private static readonly Dictionary<string, ParticleEffectType> _skillProjectileEffects
+            = new Dictionary<string, ParticleEffectType>
+            {
+                { "mage.fire", ParticleEffectType.Fireball }
+            };
+
+        /// <inheritdoc/>
+        public IEnumerator ShowSkillProjectileOnMonster(ICombatant caster, ISkill skill, IEnemy target)
+        {
+            if (!_skillProjectileEffects.TryGetValue(skill.Id, out var effectType))
+                return null;
+
+            var casterEntity = GetEntityForCombatant(caster);
+            var targetEntity = GetEntityForEnemy(target);
+            if (casterEntity == null || targetEntity == null)
+                return null;
+
+            return FlyProjectileEffect(effectType, casterEntity.Position, targetEntity.Position);
+        }
+
+        private Entity GetEntityForCombatant(ICombatant combatant)
+        {
+            if (combatant is Hero)
+                return _heroComponent.Entity;
+            if (combatant is Mercenary merc && _mercMap.TryGetValue(merc, out var m))
+                return m.e;
+            return null;
+        }
+
+        private IEnumerator FlyProjectileEffect(ParticleEffectType type, Vector2 from, Vector2 to)
+        {
+            var emitter = Core.GetGlobalManager<ParticleEffectManager>()
+                ?.SpawnEffectAtPosition(type, from, Core.Scene);
+            if (emitter == null)
+                yield break;
+
+            var projectile = emitter.Entity;
+            float duration = Mathf.Clamp(Vector2.Distance(from, to) / SkillProjectileSpeed, 0.15f, 0.6f);
+            float elapsed = 0f;
+            while (elapsed < duration)
+            {
+                elapsed += Time.DeltaTime;
+                projectile.SetPosition(Vector2.Lerp(from, to, Mathf.Clamp01(elapsed / duration)));
+                yield return null;
+            }
+
+            // Impact: stop emitting and let the trail fade; the entity destroys itself via
+            // the OnAllParticlesExpired handler subscribed at spawn. The config's finite
+            // duration is the leak-safe fallback if this coroutine is torn down mid-flight.
+            emitter.PauseEmission();
         }
 
         /// <inheritdoc/>

--- a/PitHero/AI/UseHealingItemAction.cs
+++ b/PitHero/AI/UseHealingItemAction.cs
@@ -94,7 +94,7 @@ namespace PitHero.AI
                     hero.Bag, currentHP, maxHP, currentMP, maxMP,
                     out bestConsumable, out bestIndex))
                 {
-                    bool success = UseHealingItemFromBag(bestConsumable, bestIndex, target, isHero, hero);
+                    bool success = UseHealingItemFromBag(bestConsumable, bestIndex, target, isHero, hero, targetEntity);
                     if (success)
                     {
                         Debug.Log($"[UseHealingItemAction] Successfully used {bestConsumable.Name} on {targetName} from inventory");
@@ -186,7 +186,7 @@ namespace PitHero.AI
         /// Use the healing item from bag on the target (hero or mercenary)
         /// Similar to InventoryGrid.UseConsumable but works for both Hero and Mercenary targets
         /// </summary>
-        private bool UseHealingItemFromBag(Consumable consumable, int bagIndex, object target, bool isHero, HeroComponent heroComponent)
+        private bool UseHealingItemFromBag(Consumable consumable, int bagIndex, object target, bool isHero, HeroComponent heroComponent, Entity targetEntity)
         {
             if (consumable == null || target == null || bagIndex < 0) return false;
 
@@ -225,6 +225,8 @@ namespace PitHero.AI
 
                 if (hpRestored > 0)
                 {
+                    Core.GetGlobalManager<ParticleEffectManager>()?.SpawnPotionHealEffect(consumable, targetEntity);
+
                     Core.Services.GetService<GameEventService>()?.EmitLocalized(UITextKey.ConsoleOutBattleHealConsumable,
                         (targetName, GameConfig.ConsoleColorHeroName),
                         (consumable.Name, RarityUtils.GetRarityColor(consumable.Rarity)),

--- a/PitHero/AI/UseHealingSkillAction.cs
+++ b/PitHero/AI/UseHealingSkillAction.cs
@@ -4,6 +4,7 @@ using PitHero;
 using PitHero.AI.Interfaces;
 using PitHero.ECS.Components;
 using PitHero.Services;
+using PitHero.Util;
 using RolePlayingFramework.Skills;
 using System;
 using System.Collections.Generic;
@@ -83,7 +84,7 @@ namespace PitHero.AI
             }
 
             // Use the healing skill (caster spends MP, target gets healed)
-            bool success = UseHealingSkillOnTarget(healingSkill, caster, isCasterHero, target, isTargetHero);
+            bool success = UseHealingSkillOnTarget(healingSkill, caster, isCasterHero, target, isTargetHero, targetEntity);
             if (!success)
             {
                 Debug.Warn("[UseHealingSkillAction] Failed to use healing skill");
@@ -285,7 +286,7 @@ namespace PitHero.AI
         /// <summary>
         /// Use the healing skill: caster spends their own MP, target gets healed
         /// </summary>
-        private bool UseHealingSkillOnTarget(ISkill skill, object caster, bool isCasterHero, object target, bool isTargetHero)
+        private bool UseHealingSkillOnTarget(ISkill skill, object caster, bool isCasterHero, object target, bool isTargetHero, Entity targetEntity)
         {
             if (skill == null || caster == null || target == null) return false;
 
@@ -349,6 +350,8 @@ namespace PitHero.AI
 
             if (healed)
             {
+                Core.GetGlobalManager<ParticleEffectManager>()?.SpawnEffect(ParticleEffectType.Heal, targetEntity);
+
                 int casterMP = isCasterHero ? ((RolePlayingFramework.Heroes.Hero)caster).CurrentMP : ((RolePlayingFramework.Mercenaries.Mercenary)caster).CurrentMP;
                 int casterMaxMP = isCasterHero ? ((RolePlayingFramework.Heroes.Hero)caster).MaxMP : ((RolePlayingFramework.Mercenaries.Mercenary)caster).MaxMP;
                 Debug.Log($"[UseHealingSkillAction] {casterName} healed {targetName} for {healAmount} HP using {skill.Name}. Target HP: {currentHP}/{maxHP}, Caster MP: {casterMP}/{casterMaxMP}");

--- a/PitHero/Combat/BattleEngine.cs
+++ b/PitHero/Combat/BattleEngine.cs
@@ -1180,7 +1180,7 @@ namespace PitHero.Combat
                     var targetAlly = FindAllyForTarget(target, targetsHero);
                     if (targetAlly != null)
                     {
-                        var rh = _sink.ShowHealOnAlly(targetAlly, healAmount);
+                        var rh = _sink.ShowItemHealOnAlly(targetAlly, healAmount, consumable);
                         if (rh != null) yield return rh;
                     }
                 }

--- a/PitHero/Combat/BattleEngine.cs
+++ b/PitHero/Combat/BattleEngine.cs
@@ -817,8 +817,8 @@ namespace PitHero.Combat
             // Phase 4: MarkActed AFTER Execute
             battleContext.MarkActed(caster);
 
-            // Skill cast/projectile visual (e.g. mage fireball) flies before any damage shows
-            var rproj = _sink.ShowSkillProjectileOnMonster(caster, skill, primaryTarget);
+            // Skill cast visual (mage fireball projectile, firestorm rain) plays before any damage shows
+            var rproj = _sink.ShowSkillEffectOnMonsters(caster, skill, primaryTarget, _surroundingTargets);
             if (rproj != null) yield return rproj;
 
             // Display damage and handle deaths for all affected monsters

--- a/PitHero/Combat/BattleEngine.cs
+++ b/PitHero/Combat/BattleEngine.cs
@@ -817,6 +817,10 @@ namespace PitHero.Combat
             // Phase 4: MarkActed AFTER Execute
             battleContext.MarkActed(caster);
 
+            // Skill cast/projectile visual (e.g. mage fireball) flies before any damage shows
+            var rproj = _sink.ShowSkillProjectileOnMonster(caster, skill, primaryTarget);
+            if (rproj != null) yield return rproj;
+
             // Display damage and handle deaths for all affected monsters
             bool critTextShown = false;
             for (int i = _tempLivingEnemies.Count - 1; i >= 0; i--)

--- a/PitHero/Combat/BattleEventSinkBase.cs
+++ b/PitHero/Combat/BattleEventSinkBase.cs
@@ -63,6 +63,9 @@ namespace PitHero.Combat
         public virtual IEnumerator ShowHealOnAlly(IBattleAlly ally, int amount) { return null; }
 
         /// <inheritdoc/>
+        public virtual IEnumerator ShowItemHealOnAlly(IBattleAlly ally, int amount, RolePlayingFramework.Equipment.Consumable consumable) { return null; }
+
+        /// <inheritdoc/>
         public virtual IEnumerator ShowBuffOnAlly(IBattleAlly ally, string label) { return null; }
 
         /// <inheritdoc/>

--- a/PitHero/Combat/BattleEventSinkBase.cs
+++ b/PitHero/Combat/BattleEventSinkBase.cs
@@ -57,8 +57,8 @@ namespace PitHero.Combat
         public virtual IEnumerator ShowDeflectOnAlly(IBattleAlly ally) { return null; }
 
         /// <inheritdoc/>
-        public virtual IEnumerator ShowSkillProjectileOnMonster(RolePlayingFramework.Combat.ICombatant caster,
-            RolePlayingFramework.Skills.ISkill skill, IEnemy target) { return null; }
+        public virtual IEnumerator ShowSkillEffectOnMonsters(RolePlayingFramework.Combat.ICombatant caster,
+            RolePlayingFramework.Skills.ISkill skill, IEnemy primaryTarget, List<IEnemy> surroundingTargets) { return null; }
 
         /// <inheritdoc/>
         public virtual IEnumerator ShowCritOnMonster(IEnemy enemy) { return null; }

--- a/PitHero/Combat/BattleEventSinkBase.cs
+++ b/PitHero/Combat/BattleEventSinkBase.cs
@@ -57,6 +57,10 @@ namespace PitHero.Combat
         public virtual IEnumerator ShowDeflectOnAlly(IBattleAlly ally) { return null; }
 
         /// <inheritdoc/>
+        public virtual IEnumerator ShowSkillProjectileOnMonster(RolePlayingFramework.Combat.ICombatant caster,
+            RolePlayingFramework.Skills.ISkill skill, IEnemy target) { return null; }
+
+        /// <inheritdoc/>
         public virtual IEnumerator ShowCritOnMonster(IEnemy enemy) { return null; }
 
         /// <inheritdoc/>

--- a/PitHero/Combat/IBattleEventSink.cs
+++ b/PitHero/Combat/IBattleEventSink.cs
@@ -78,6 +78,14 @@ namespace PitHero.Combat
         /// <summary>Shows a "Deflect" label over an ally.</summary>
         IEnumerator ShowDeflectOnAlly(IBattleAlly ally);
 
+        /// <summary>
+        /// Plays a projectile/cast visual for an attack skill travelling from the caster to
+        /// the primary target (e.g. the mage's fireball), yielded by the engine BEFORE damage
+        /// digits appear so the impact lands first. Return null when the skill has no visual.
+        /// </summary>
+        IEnumerator ShowSkillProjectileOnMonster(RolePlayingFramework.Combat.ICombatant caster,
+            RolePlayingFramework.Skills.ISkill skill, IEnemy target);
+
         /// <summary>Shows a "Crit" label over a monster.</summary>
         IEnumerator ShowCritOnMonster(IEnemy enemy);
 

--- a/PitHero/Combat/IBattleEventSink.cs
+++ b/PitHero/Combat/IBattleEventSink.cs
@@ -81,8 +81,13 @@ namespace PitHero.Combat
         /// <summary>Shows a "Crit" label over a monster.</summary>
         IEnumerator ShowCritOnMonster(IEnemy enemy);
 
-        /// <summary>Shows a heal number over an ally.</summary>
+        /// <summary>Shows a heal number over an ally (skill/spell heals).</summary>
         IEnumerator ShowHealOnAlly(IBattleAlly ally, int amount);
+
+        /// <summary>Shows a heal number over an ally for a consumable heal; the consumable
+        /// lets the live sink pick a potion-specific visual (e.g. denser particles for
+        /// stronger potions).</summary>
+        IEnumerator ShowItemHealOnAlly(IBattleAlly ally, int amount, RolePlayingFramework.Equipment.Consumable consumable);
 
         /// <summary>Shows a buff label (e.g. "DEF+1") over an ally.</summary>
         IEnumerator ShowBuffOnAlly(IBattleAlly ally, string label);

--- a/PitHero/Combat/IBattleEventSink.cs
+++ b/PitHero/Combat/IBattleEventSink.cs
@@ -79,12 +79,13 @@ namespace PitHero.Combat
         IEnumerator ShowDeflectOnAlly(IBattleAlly ally);
 
         /// <summary>
-        /// Plays a projectile/cast visual for an attack skill travelling from the caster to
-        /// the primary target (e.g. the mage's fireball), yielded by the engine BEFORE damage
-        /// digits appear so the impact lands first. Return null when the skill has no visual.
+        /// Plays a cast visual for an attack skill — a projectile from caster to the primary
+        /// target (mage Fire) or an area effect over the enemy group (mage Firestorm).
+        /// Yielded by the engine BEFORE damage digits appear so the impact lands first.
+        /// Return null when the skill has no visual.
         /// </summary>
-        IEnumerator ShowSkillProjectileOnMonster(RolePlayingFramework.Combat.ICombatant caster,
-            RolePlayingFramework.Skills.ISkill skill, IEnemy target);
+        IEnumerator ShowSkillEffectOnMonsters(RolePlayingFramework.Combat.ICombatant caster,
+            RolePlayingFramework.Skills.ISkill skill, IEnemy primaryTarget, List<IEnemy> surroundingTargets);
 
         /// <summary>Shows a "Crit" label over a monster.</summary>
         IEnumerator ShowCritOnMonster(IEnemy enemy);

--- a/PitHero/Content/Particles/fireball.pex
+++ b/PitHero/Content/Particles/fireball.pex
@@ -1,0 +1,40 @@
+<particleEmitterConfig>
+  <yCoordFlipped value="1" />
+  <sourcePosition x="0" y="0" />
+  <sourcePositionVariance x="0" y="0" />
+  <speed value="0.00" />
+  <speedVariance value="0.00" />
+  <particleLifeSpan value="0.3000" />
+  <particleLifespanVariance value="0.1000" />
+  <angle value="0" />
+  <angleVariance value="360" />
+  <gravity x="0" y="0" />
+  <radialAcceleration value="0.00" />
+  <radialAccelVariance value="0.00" />
+  <tangentialAcceleration value="0.00" />
+  <tangentialAccelVariance value="0.00" />
+  <startColor red="1.00" green="0.65" blue="0.15" alpha="1.00" />
+  <startColorVariance red="0.00" green="0.15" blue="0.10" alpha="0.00" />
+  <finishColor red="0.85" green="0.15" blue="0.00" alpha="0.00" />
+  <finishColorVariance red="0.00" green="0.00" blue="0.00" alpha="0.00" />
+  <maxParticles value="40" />
+  <startParticleSize value="7.00" />
+  <startParticleSizeVariance value="2.00" />
+  <finishParticleSize value="3.00" />
+  <finishParticleSizeVariance value="0.00" />
+  <duration value="1.0" />
+  <emitterType value="1" />
+  <maxRadius value="6.00" />
+  <maxRadiusVariance value="2.00" />
+  <minRadius value="0.00" />
+  <minRadiusVariance value="0.00" />
+  <rotatePerSecond value="720.00" />
+  <rotatePerSecondVariance value="180.00" />
+  <blendFuncSource value="770" />
+  <blendFuncDestination value="1" />
+  <rotationStart value="0.00" />
+  <rotationStartVariance value="0.00" />
+  <rotationEnd value="0.00" />
+  <rotationEndVariance value="0.00" />
+  <texture name="texture.png" data="H4sIAAAAAAAEABVWa1hTZxL+zklCLiQh3GKEkISLFSQgCCLRoCcI4aYVUTCKdRMuCkopROoaUDkJYEBEDgUjKtpUvLaUDVhRpNZAUA8IAoot6OKiRKRbvJSkLKjVxR8z82ee5515Z+aZtyz+8ygGzYUGAGDEREckzEXkk1Fs5vz3mblPAKDpYiIkG/duS03TE2Y+flwVMx2wZMmHC9VtnAwHsFe8Bl/ZwLuQiIKRmBvA+Cwz6/SChSAeLjmhlhwFiCW0mZzbJLnkGiboT+Udrzy6tgLVe4OcvdzxwPDgRiHTImwKJiyAIBpgJ9i6eoiZU2Il0FsUSR2D8nIFxqEXDXperjr1nj/OUxI0ZwEyJW7hHFTVcFySr3kWnGC5frEqVIBTidKUDYDZV1+go2bwoumnbrO9vQOpZrnFuupi6PKKRrYuNrrbISIdEsbwRNNNKo7XQcYYjbiVR1a5uAWlUFmHmolPhEhEQ31BzfwJF4yzvKKByWYNJYDr2o+ws7qzP1N6MZSQ0N1OoaQ0EwPTgfKwiVvZOyZYV5/K/gmof1/NLP4Y3fTWrtdUiL6/GV1LLWMEjfET5AFIr+ack0042AFGo98a3jPK09PsinrgPyXBS6R2TrIWSVmgV6VnAccJ4Byv/5FdLgZ8HbD7g/t8SuNm5ICghmawAVvua0uCeyx4l+t4ZpL+uSCkVLo91ZZi3gjKmwozIHTy9/8gIhY/4uPBfF5EkIeKc/uDlj1G3EU+DAT3LUPiezY/cc2qPBe2ICCsGB61O6EthGYFdqYEh9I+SiJhavGSk5ALhj9Fl7Fy0iFrf+Q9C35aq+KYM1nbyY8OrzHBBBHrDQmE9BWJ3ztm+OPbWBWN/PHN2DZZPS3pyw54YhWBadSwN07wtAsKreJPvPTtBr2pUaYJNbgbHtCGHCk6asVj3MZza19IsiMXR1SNlD85ExHyLbRJhfqR9C9UtecMMFPXN4yJaVOhlN3wrVAsQBiA3bWpjeongLBpCY/8lI9Y5D6UTX4ah0qEqYxFuxRrSW/ATKUoQ819h/uAs2RRV5G4gmGCYZ0fki8fJo/bY2OYLRIvQFN47HdzTZ3jmrcQW+1LfryClzpxZBugfBpyZD/LVTR9/LtAKO6DwctuSjwvnnlQsc88CGwDsP3FCUAIkNPadL4MisYthslibsC1ZmpoOkoA6yZNMNR6IOrIflkzWXXaNcNj2RbECKvrgHx17FsDQPpChk7cxVMMlJKFhdZmICKxDu03O6HcdwaOlgTyBUaaVCZC/8UqfvjXqgFxJc8ywYvKFqt7tF2mBPjeRiTLvXQrSImDcLWxSEfDqUD2nbbu9Xz97PxNcfa/xhZ3FcEMJxbnEgpRDVi/ueT5P7Ax+bkVSjbiT5ZfAjrSENVrR2294qFAqaCWh2X9GGlN8ojm4/R4o7qn04WCDwMdLP+OaOvK4Sc7l56G5Wp0G0cDE1vpyJFEjFBlCVICuUX8SwvszUKyNel86yNYNOv5mDrt+8sWMGKZYz3NXbkIYRKti+yTGGcW7rLCDF1xWaZ3+04aNnwTS5jXU2FgOjZMGo8zSv0IiI37MQKe6N6ARGQD96tQqJ7Z+Wut+vku2dRt3YuB5DJDCKw0pvgG9Yf1oQwBGQhrsEzrHjAHkW3vscNW1o2WtcO2EfUL11kB4v9ywDVa78X83g3rjfxKoem5oyNhfxNfLyqiJbJtJtEaBBWVMnzOb24yVFlCHE9cCeh71s0egk869QWNwoIo93lo51lYloSes0k74Rx3oFjFFe3BXhJvUZbzz5I3fqa/EJq1JyWIHzZb/87eiTdag6yhgcyD6aQ0FzYLh2CL15KKtYuvaxV+S1kVp19ivRoSaB6Z6YlqIe/yQBYTMOencYwhYaQd1/wzpXr1MseRlXm7ByzB7gVNrfNHmDXb3Bu3gPNl9t3I+QE/SEQ7eWtIXC6UHnLrfERd4jjSi6fMjbZMUUzIgtC6CMzyWcMo8mpnyh8Hztw1zUy8VUgqG3jHPiU/qFxTf3n9Ga7I9n1UHH1IrHlia7qlXfrlwHNJl+O3YdfyVZ2Pynt78SfhV09Cm/xQv84mETMkF3K9F/7qksKWaG0mim7/+XVu1TsavkfT2URiXn83PweKB8ZwEnvFNXHlpKhWO5Ap0xI3c5Mf88L+aBerX6235oZvnfZoY2xnNw6idQvKYqFrXLJF2JAKu97UlplcvA1bYPZjPNFjDX2YWXsgKzikrX8DvwUYT8IGZ6kh3sOswjyr3Eq+9CKzHwuCJGrNYtCvvVWlvS3ZPkbLSoGhBeOSDduNuVCDDxD9LnixWPZPZ9F4lbZx4M4bLJUnEjSlUzFx8yxe36FvX59HvzxP9LC92yZtmec70q5F8vYNU54rXESv21NOyfqKuJBFoGxzSxJozFWWlT37sAs3CSPaIwq1mkfBsyP8uX/awEKA2YZnLQjKnxTcYSnJpfGTDq7AQLXHXtyE3Igmg3Fu0WUtgMTNX4TETCO7+2fpwv6fUa5rp7lwKM95CiEqH/Nbc4pIPKH+DclBWPCUBswoIMFCZ6PYzhb87ANU3dzkFSB5PloHYwWFeCDNQUvyyp+GRNh9MENbS8UvgVZ55zH4w9gusuA3GM/CFiI8WMXbqFdnYAsElRqh9PVx9wse1nDGWd7GaA1MT3LU/6B9rpB9I/UnyAMrfVlyH3KSbjQW4kDQ51DGMJg7Zv9PlatczMi+03eS9O3SimgGkAn2FbEPDjUDoRH7oaMwetbt1oMJX6nhITyTAHmflQRqn5CkfRbDIOwrrCKAGw1In3+AXXs3tO8KJLTVXwC1xz/mkog91W+AsZqGXYZxix6TvvrWs4CXvJ950kntXFvcDJSSUi7FgBqTCKO+7+UHbl0/yNrkTnlgtetGj5Lo0eDGOFqyvGEp+VDMvtW/zXTTrS02ypOE1g8XsldT4o6Wctvo0WooNfWHQLnKfpxqVSeEr1Vs7VXI9mjS7dP66ucdwF/Bbc6/7QzM8gHjmVYOXGaaA41FnWsmuviqWm7SjPuLwjxL1V/1ZFgYUJVZ6yJzZsSpDTBL9A0nBzoMkFjSROLtVV6rEZ3JrGB3iIEvkBwpUXFbbyAXl1EsLGVsOJOVV2n6XsypWP/mabJv6VISy56CqwmXWSIbyXgHDJz+wDmt1cXcOBwq3Xq0A4aT+t3n7Q34OjRufzM7VvNgec6Yw/1BUbO2agOsnCKXFYlp5RJZub1ZYT5bubWko9n1usgw1Dm+OW9dqkX8ZF9lnZuMQyFgY8iscxirv9qlx11A7hDTp0CL1NHzxBX8EkW0uH7hVxx+2E3PNhL7Ir0TSMMP2QwrVeYpG91OuT3BlngmlR8s6MARL4RGqeWxKo4oulxP3T7PHt5uHSyu88DCaLYg7683sh1eij73GAi0QE06loiFJAyJS9fRkw2fBNKzuaddR+PE/DsnZk6XkeCesYngOYOKGpjH/+b7BPdXB61cqQTYlYLDDQAVseOGUV/EUBY0CnCedFrgn3voaq/9FzajeYH/dUhOs+Q0DWyAY9eEv2zXLYofDExQFAZG+oAwJKchJHKT1Nv4MZWa4RQoXZTdcH4nEKx4v+rVyDMzERA8K/ZUPxCC0mg3+gzwdLvaRwCExJm8c7OjvnNCFcREfh7RGC7X/B+u20U3zwoAAA==" />
+</particleEmitterConfig>

--- a/PitHero/Content/Particles/firestorm.pex
+++ b/PitHero/Content/Particles/firestorm.pex
@@ -1,0 +1,40 @@
+<particleEmitterConfig>
+  <yCoordFlipped value="1" />
+  <sourcePosition x="0" y="0" />
+  <sourcePositionVariance x="56" y="6" />
+  <speed value="100.00" />
+  <speedVariance value="30.00" />
+  <particleLifeSpan value="0.5500" />
+  <particleLifespanVariance value="0.1500" />
+  <angle value="90" />
+  <angleVariance value="6" />
+  <gravity x="0" y="120" />
+  <radialAcceleration value="0.00" />
+  <radialAccelVariance value="0.00" />
+  <tangentialAcceleration value="0.00" />
+  <tangentialAccelVariance value="0.00" />
+  <startColor red="1.00" green="0.60" blue="0.12" alpha="1.00" />
+  <startColorVariance red="0.00" green="0.18" blue="0.10" alpha="0.00" />
+  <finishColor red="0.90" green="0.20" blue="0.00" alpha="0.00" />
+  <finishColorVariance red="0.00" green="0.00" blue="0.00" alpha="0.00" />
+  <maxParticles value="56" />
+  <startParticleSize value="12.00" />
+  <startParticleSizeVariance value="4.00" />
+  <finishParticleSize value="6.00" />
+  <finishParticleSizeVariance value="0.00" />
+  <duration value="0.8" />
+  <emitterType value="0" />
+  <maxRadius value="0.00" />
+  <maxRadiusVariance value="0.00" />
+  <minRadius value="0.00" />
+  <minRadiusVariance value="0.00" />
+  <rotatePerSecond value="0.00" />
+  <rotatePerSecondVariance value="0.00" />
+  <blendFuncSource value="770" />
+  <blendFuncDestination value="1" />
+  <rotationStart value="0.00" />
+  <rotationStartVariance value="0.00" />
+  <rotationEnd value="0.00" />
+  <rotationEndVariance value="0.00" />
+  <texture name="texture.png" data="H4sIAAAAAAAEABVWa1hTZxL+zklCLiQh3GKEkISLFSQgCCLRoCcI4aYVUTCKdRMuCkopROoaUDkJYEBEDgUjKtpUvLaUDVhRpNZAUA8IAoot6OKiRKRbvJSkLKjVxR8z82ee5515Z+aZtyz+8ygGzYUGAGDEREckzEXkk1Fs5vz3mblPAKDpYiIkG/duS03TE2Y+flwVMx2wZMmHC9VtnAwHsFe8Bl/ZwLuQiIKRmBvA+Cwz6/SChSAeLjmhlhwFiCW0mZzbJLnkGiboT+Udrzy6tgLVe4OcvdzxwPDgRiHTImwKJiyAIBpgJ9i6eoiZU2Il0FsUSR2D8nIFxqEXDXperjr1nj/OUxI0ZwEyJW7hHFTVcFySr3kWnGC5frEqVIBTidKUDYDZV1+go2bwoumnbrO9vQOpZrnFuupi6PKKRrYuNrrbISIdEsbwRNNNKo7XQcYYjbiVR1a5uAWlUFmHmolPhEhEQ31BzfwJF4yzvKKByWYNJYDr2o+ws7qzP1N6MZSQ0N1OoaQ0EwPTgfKwiVvZOyZYV5/K/gmof1/NLP4Y3fTWrtdUiL6/GV1LLWMEjfET5AFIr+ack0042AFGo98a3jPK09PsinrgPyXBS6R2TrIWSVmgV6VnAccJ4Byv/5FdLgZ8HbD7g/t8SuNm5ICghmawAVvua0uCeyx4l+t4ZpL+uSCkVLo91ZZi3gjKmwozIHTy9/8gIhY/4uPBfF5EkIeKc/uDlj1G3EU+DAT3LUPiezY/cc2qPBe2ICCsGB61O6EthGYFdqYEh9I+SiJhavGSk5ALhj9Fl7Fy0iFrf+Q9C35aq+KYM1nbyY8OrzHBBBHrDQmE9BWJ3ztm+OPbWBWN/PHN2DZZPS3pyw54YhWBadSwN07wtAsKreJPvPTtBr2pUaYJNbgbHtCGHCk6asVj3MZza19IsiMXR1SNlD85ExHyLbRJhfqR9C9UtecMMFPXN4yJaVOhlN3wrVAsQBiA3bWpjeongLBpCY/8lI9Y5D6UTX4ah0qEqYxFuxRrSW/ATKUoQ819h/uAs2RRV5G4gmGCYZ0fki8fJo/bY2OYLRIvQFN47HdzTZ3jmrcQW+1LfryClzpxZBugfBpyZD/LVTR9/LtAKO6DwctuSjwvnnlQsc88CGwDsP3FCUAIkNPadL4MisYthslibsC1ZmpoOkoA6yZNMNR6IOrIflkzWXXaNcNj2RbECKvrgHx17FsDQPpChk7cxVMMlJKFhdZmICKxDu03O6HcdwaOlgTyBUaaVCZC/8UqfvjXqgFxJc8ywYvKFqt7tF2mBPjeRiTLvXQrSImDcLWxSEfDqUD2nbbu9Xz97PxNcfa/xhZ3FcEMJxbnEgpRDVi/ueT5P7Ax+bkVSjbiT5ZfAjrSENVrR2294qFAqaCWh2X9GGlN8ojm4/R4o7qn04WCDwMdLP+OaOvK4Sc7l56G5Wp0G0cDE1vpyJFEjFBlCVICuUX8SwvszUKyNel86yNYNOv5mDrt+8sWMGKZYz3NXbkIYRKti+yTGGcW7rLCDF1xWaZ3+04aNnwTS5jXU2FgOjZMGo8zSv0IiI37MQKe6N6ARGQD96tQqJ7Z+Wut+vku2dRt3YuB5DJDCKw0pvgG9Yf1oQwBGQhrsEzrHjAHkW3vscNW1o2WtcO2EfUL11kB4v9ywDVa78X83g3rjfxKoem5oyNhfxNfLyqiJbJtJtEaBBWVMnzOb24yVFlCHE9cCeh71s0egk869QWNwoIo93lo51lYloSes0k74Rx3oFjFFe3BXhJvUZbzz5I3fqa/EJq1JyWIHzZb/87eiTdag6yhgcyD6aQ0FzYLh2CL15KKtYuvaxV+S1kVp19ivRoSaB6Z6YlqIe/yQBYTMOencYwhYaQd1/wzpXr1MseRlXm7ByzB7gVNrfNHmDXb3Bu3gPNl9t3I+QE/SEQ7eWtIXC6UHnLrfERd4jjSi6fMjbZMUUzIgtC6CMzyWcMo8mpnyh8Hztw1zUy8VUgqG3jHPiU/qFxTf3n9Ga7I9n1UHH1IrHlia7qlXfrlwHNJl+O3YdfyVZ2Pynt78SfhV09Cm/xQv84mETMkF3K9F/7qksKWaG0mim7/+XVu1TsavkfT2URiXn83PweKB8ZwEnvFNXHlpKhWO5Ap0xI3c5Mf88L+aBerX6235oZvnfZoY2xnNw6idQvKYqFrXLJF2JAKu97UlplcvA1bYPZjPNFjDX2YWXsgKzikrX8DvwUYT8IGZ6kh3sOswjyr3Eq+9CKzHwuCJGrNYtCvvVWlvS3ZPkbLSoGhBeOSDduNuVCDDxD9LnixWPZPZ9F4lbZx4M4bLJUnEjSlUzFx8yxe36FvX59HvzxP9LC92yZtmec70q5F8vYNU54rXESv21NOyfqKuJBFoGxzSxJozFWWlT37sAs3CSPaIwq1mkfBsyP8uX/awEKA2YZnLQjKnxTcYSnJpfGTDq7AQLXHXtyE3Igmg3Fu0WUtgMTNX4TETCO7+2fpwv6fUa5rp7lwKM95CiEqH/Nbc4pIPKH+DclBWPCUBswoIMFCZ6PYzhb87ANU3dzkFSB5PloHYwWFeCDNQUvyyp+GRNh9MENbS8UvgVZ55zH4w9gusuA3GM/CFiI8WMXbqFdnYAsElRqh9PVx9wse1nDGWd7GaA1MT3LU/6B9rpB9I/UnyAMrfVlyH3KSbjQW4kDQ51DGMJg7Zv9PlatczMi+03eS9O3SimgGkAn2FbEPDjUDoRH7oaMwetbt1oMJX6nhITyTAHmflQRqn5CkfRbDIOwrrCKAGw1In3+AXXs3tO8KJLTVXwC1xz/mkog91W+AsZqGXYZxix6TvvrWs4CXvJ950kntXFvcDJSSUi7FgBqTCKO+7+UHbl0/yNrkTnlgtetGj5Lo0eDGOFqyvGEp+VDMvtW/zXTTrS02ypOE1g8XsldT4o6Wctvo0WooNfWHQLnKfpxqVSeEr1Vs7VXI9mjS7dP66ucdwF/Bbc6/7QzM8gHjmVYOXGaaA41FnWsmuviqWm7SjPuLwjxL1V/1ZFgYUJVZ6yJzZsSpDTBL9A0nBzoMkFjSROLtVV6rEZ3JrGB3iIEvkBwpUXFbbyAXl1EsLGVsOJOVV2n6XsypWP/mabJv6VISy56CqwmXWSIbyXgHDJz+wDmt1cXcOBwq3Xq0A4aT+t3n7Q34OjRufzM7VvNgec6Yw/1BUbO2agOsnCKXFYlp5RJZub1ZYT5bubWko9n1usgw1Dm+OW9dqkX8ZF9lnZuMQyFgY8iscxirv9qlx11A7hDTp0CL1NHzxBX8EkW0uH7hVxx+2E3PNhL7Ir0TSMMP2QwrVeYpG91OuT3BlngmlR8s6MARL4RGqeWxKo4oulxP3T7PHt5uHSyu88DCaLYg7683sh1eij73GAi0QE06loiFJAyJS9fRkw2fBNKzuaddR+PE/DsnZk6XkeCesYngOYOKGpjH/+b7BPdXB61cqQTYlYLDDQAVseOGUV/EUBY0CnCedFrgn3voaq/9FzajeYH/dUhOs+Q0DWyAY9eEv2zXLYofDExQFAZG+oAwJKchJHKT1Nv4MZWa4RQoXZTdcH4nEKx4v+rVyDMzERA8K/ZUPxCC0mg3+gzwdLvaRwCExJm8c7OjvnNCFcREfh7RGC7X/B+u20U3zwoAAA==" />
+</particleEmitterConfig>

--- a/PitHero/Content/Particles/heal.pex
+++ b/PitHero/Content/Particles/heal.pex
@@ -1,0 +1,40 @@
+<particleEmitterConfig>
+  <yCoordFlipped value="1" />
+  <sourcePosition x="150" y="50" />
+  <sourcePositionVariance x="0" y="0" />
+  <speed value="64.00" />
+  <speedVariance value="32.00" />
+  <particleLifeSpan value="0.5000" />
+  <particleLifespanVariance value="0.3000" />
+  <angle value="0" />
+  <angleVariance value="360" />
+  <gravity x="0" y="0" />
+  <radialAcceleration value="0.00" />
+  <radialAccelVariance value="0.00" />
+  <tangentialAcceleration value="0.00" />
+  <tangentialAccelVariance value="8.00" />
+  <startColor red="0.10" green="0.80" blue="0.20" alpha="1.00" />
+  <startColorVariance red="0.00" green="0.20" blue="0.20" alpha="0.50" />
+  <finishColor red="0.00" green="0.55" blue="0.12" alpha="0.00" />
+  <finishColorVariance red="0.00" green="0.00" blue="0.00" alpha="0.00" />
+  <maxParticles value="59" />
+  <startParticleSize value="5.00" />
+  <startParticleSizeVariance value="3.00" />
+  <finishParticleSize value="8.00" />
+  <finishParticleSizeVariance value="0.00" />
+  <duration value="0.5" />
+  <emitterType value="0" />
+  <maxRadius value="0.00" />
+  <maxRadiusVariance value="0.00" />
+  <minRadius value="300.00" />
+  <minRadiusVariance value="0.00" />
+  <rotatePerSecond value="360.00" />
+  <rotatePerSecondVariance value="0.00" />
+  <blendFuncSource value="770" />
+  <blendFuncDestination value="1" />
+  <rotationStart value="0.00" />
+  <rotationStartVariance value="0.00" />
+  <rotationEnd value="0.00" />
+  <rotationEndVariance value="0.00" />
+  <texture name="texture.png" data="H4sIAAAAAAAEABVWa1hTZxL+zklCLiQh3GKEkISLFSQgCCLRoCcI4aYVUTCKdRMuCkopROoaUDkJYEBEDgUjKtpUvLaUDVhRpNZAUA8IAoot6OKiRKRbvJSkLKjVxR8z82ee5515Z+aZtyz+8ygGzYUGAGDEREckzEXkk1Fs5vz3mblPAKDpYiIkG/duS03TE2Y+flwVMx2wZMmHC9VtnAwHsFe8Bl/ZwLuQiIKRmBvA+Cwz6/SChSAeLjmhlhwFiCW0mZzbJLnkGiboT+Udrzy6tgLVe4OcvdzxwPDgRiHTImwKJiyAIBpgJ9i6eoiZU2Il0FsUSR2D8nIFxqEXDXperjr1nj/OUxI0ZwEyJW7hHFTVcFySr3kWnGC5frEqVIBTidKUDYDZV1+go2bwoumnbrO9vQOpZrnFuupi6PKKRrYuNrrbISIdEsbwRNNNKo7XQcYYjbiVR1a5uAWlUFmHmolPhEhEQ31BzfwJF4yzvKKByWYNJYDr2o+ws7qzP1N6MZSQ0N1OoaQ0EwPTgfKwiVvZOyZYV5/K/gmof1/NLP4Y3fTWrtdUiL6/GV1LLWMEjfET5AFIr+ack0042AFGo98a3jPK09PsinrgPyXBS6R2TrIWSVmgV6VnAccJ4Byv/5FdLgZ8HbD7g/t8SuNm5ICghmawAVvua0uCeyx4l+t4ZpL+uSCkVLo91ZZi3gjKmwozIHTy9/8gIhY/4uPBfF5EkIeKc/uDlj1G3EU+DAT3LUPiezY/cc2qPBe2ICCsGB61O6EthGYFdqYEh9I+SiJhavGSk5ALhj9Fl7Fy0iFrf+Q9C35aq+KYM1nbyY8OrzHBBBHrDQmE9BWJ3ztm+OPbWBWN/PHN2DZZPS3pyw54YhWBadSwN07wtAsKreJPvPTtBr2pUaYJNbgbHtCGHCk6asVj3MZza19IsiMXR1SNlD85ExHyLbRJhfqR9C9UtecMMFPXN4yJaVOhlN3wrVAsQBiA3bWpjeongLBpCY/8lI9Y5D6UTX4ah0qEqYxFuxRrSW/ATKUoQ819h/uAs2RRV5G4gmGCYZ0fki8fJo/bY2OYLRIvQFN47HdzTZ3jmrcQW+1LfryClzpxZBugfBpyZD/LVTR9/LtAKO6DwctuSjwvnnlQsc88CGwDsP3FCUAIkNPadL4MisYthslibsC1ZmpoOkoA6yZNMNR6IOrIflkzWXXaNcNj2RbECKvrgHx17FsDQPpChk7cxVMMlJKFhdZmICKxDu03O6HcdwaOlgTyBUaaVCZC/8UqfvjXqgFxJc8ywYvKFqt7tF2mBPjeRiTLvXQrSImDcLWxSEfDqUD2nbbu9Xz97PxNcfa/xhZ3FcEMJxbnEgpRDVi/ueT5P7Ax+bkVSjbiT5ZfAjrSENVrR2294qFAqaCWh2X9GGlN8ojm4/R4o7qn04WCDwMdLP+OaOvK4Sc7l56G5Wp0G0cDE1vpyJFEjFBlCVICuUX8SwvszUKyNel86yNYNOv5mDrt+8sWMGKZYz3NXbkIYRKti+yTGGcW7rLCDF1xWaZ3+04aNnwTS5jXU2FgOjZMGo8zSv0IiI37MQKe6N6ARGQD96tQqJ7Z+Wut+vku2dRt3YuB5DJDCKw0pvgG9Yf1oQwBGQhrsEzrHjAHkW3vscNW1o2WtcO2EfUL11kB4v9ywDVa78X83g3rjfxKoem5oyNhfxNfLyqiJbJtJtEaBBWVMnzOb24yVFlCHE9cCeh71s0egk869QWNwoIo93lo51lYloSes0k74Rx3oFjFFe3BXhJvUZbzz5I3fqa/EJq1JyWIHzZb/87eiTdag6yhgcyD6aQ0FzYLh2CL15KKtYuvaxV+S1kVp19ivRoSaB6Z6YlqIe/yQBYTMOencYwhYaQd1/wzpXr1MseRlXm7ByzB7gVNrfNHmDXb3Bu3gPNl9t3I+QE/SEQ7eWtIXC6UHnLrfERd4jjSi6fMjbZMUUzIgtC6CMzyWcMo8mpnyh8Hztw1zUy8VUgqG3jHPiU/qFxTf3n9Ga7I9n1UHH1IrHlia7qlXfrlwHNJl+O3YdfyVZ2Pynt78SfhV09Cm/xQv84mETMkF3K9F/7qksKWaG0mim7/+XVu1TsavkfT2URiXn83PweKB8ZwEnvFNXHlpKhWO5Ap0xI3c5Mf88L+aBerX6235oZvnfZoY2xnNw6idQvKYqFrXLJF2JAKu97UlplcvA1bYPZjPNFjDX2YWXsgKzikrX8DvwUYT8IGZ6kh3sOswjyr3Eq+9CKzHwuCJGrNYtCvvVWlvS3ZPkbLSoGhBeOSDduNuVCDDxD9LnixWPZPZ9F4lbZx4M4bLJUnEjSlUzFx8yxe36FvX59HvzxP9LC92yZtmec70q5F8vYNU54rXESv21NOyfqKuJBFoGxzSxJozFWWlT37sAs3CSPaIwq1mkfBsyP8uX/awEKA2YZnLQjKnxTcYSnJpfGTDq7AQLXHXtyE3Igmg3Fu0WUtgMTNX4TETCO7+2fpwv6fUa5rp7lwKM95CiEqH/Nbc4pIPKH+DclBWPCUBswoIMFCZ6PYzhb87ANU3dzkFSB5PloHYwWFeCDNQUvyyp+GRNh9MENbS8UvgVZ55zH4w9gusuA3GM/CFiI8WMXbqFdnYAsElRqh9PVx9wse1nDGWd7GaA1MT3LU/6B9rpB9I/UnyAMrfVlyH3KSbjQW4kDQ51DGMJg7Zv9PlatczMi+03eS9O3SimgGkAn2FbEPDjUDoRH7oaMwetbt1oMJX6nhITyTAHmflQRqn5CkfRbDIOwrrCKAGw1In3+AXXs3tO8KJLTVXwC1xz/mkog91W+AsZqGXYZxix6TvvrWs4CXvJ950kntXFvcDJSSUi7FgBqTCKO+7+UHbl0/yNrkTnlgtetGj5Lo0eDGOFqyvGEp+VDMvtW/zXTTrS02ypOE1g8XsldT4o6Wctvo0WooNfWHQLnKfpxqVSeEr1Vs7VXI9mjS7dP66ucdwF/Bbc6/7QzM8gHjmVYOXGaaA41FnWsmuviqWm7SjPuLwjxL1V/1ZFgYUJVZ6yJzZsSpDTBL9A0nBzoMkFjSROLtVV6rEZ3JrGB3iIEvkBwpUXFbbyAXl1EsLGVsOJOVV2n6XsypWP/mabJv6VISy56CqwmXWSIbyXgHDJz+wDmt1cXcOBwq3Xq0A4aT+t3n7Q34OjRufzM7VvNgec6Yw/1BUbO2agOsnCKXFYlp5RJZub1ZYT5bubWko9n1usgw1Dm+OW9dqkX8ZF9lnZuMQyFgY8iscxirv9qlx11A7hDTp0CL1NHzxBX8EkW0uH7hVxx+2E3PNhL7Ir0TSMMP2QwrVeYpG91OuT3BlngmlR8s6MARL4RGqeWxKo4oulxP3T7PHt5uHSyu88DCaLYg7683sh1eij73GAi0QE06loiFJAyJS9fRkw2fBNKzuaddR+PE/DsnZk6XkeCesYngOYOKGpjH/+b7BPdXB61cqQTYlYLDDQAVseOGUV/EUBY0CnCedFrgn3voaq/9FzajeYH/dUhOs+Q0DWyAY9eEv2zXLYofDExQFAZG+oAwJKchJHKT1Nv4MZWa4RQoXZTdcH4nEKx4v+rVyDMzERA8K/ZUPxCC0mg3+gzwdLvaRwCExJm8c7OjvnNCFcREfh7RGC7X/B+u20U3zwoAAA==" />
+</particleEmitterConfig>

--- a/PitHero/Content/Particles/heal_potion.pex
+++ b/PitHero/Content/Particles/heal_potion.pex
@@ -1,14 +1,14 @@
 <particleEmitterConfig>
   <yCoordFlipped value="1" />
   <sourcePosition x="0" y="0" />
-  <sourcePositionVariance x="6" y="3" />
-  <speed value="30.00" />
-  <speedVariance value="12.00" />
-  <particleLifeSpan value="0.7000" />
+  <sourcePositionVariance x="10" y="4" />
+  <speed value="40.00" />
+  <speedVariance value="15.00" />
+  <particleLifeSpan value="0.8000" />
   <particleLifespanVariance value="0.2500" />
   <angle value="270" />
   <angleVariance value="10" />
-  <gravity x="0" y="-18" />
+  <gravity x="0" y="-30" />
   <radialAcceleration value="0.00" />
   <radialAccelVariance value="0.00" />
   <tangentialAcceleration value="0.00" />
@@ -17,12 +17,12 @@
   <startColorVariance red="0.00" green="0.15" blue="0.15" alpha="0.30" />
   <finishColor red="0.10" green="0.60" blue="0.20" alpha="0.00" />
   <finishColorVariance red="0.00" green="0.00" blue="0.00" alpha="0.00" />
-  <maxParticles value="24" />
-  <startParticleSize value="3.00" />
-  <startParticleSizeVariance value="1.50" />
-  <finishParticleSize value="4.00" />
+  <maxParticles value="36" />
+  <startParticleSize value="8.00" />
+  <startParticleSizeVariance value="3.00" />
+  <finishParticleSize value="12.00" />
   <finishParticleSizeVariance value="0.00" />
-  <duration value="0.6" />
+  <duration value="0.7" />
   <emitterType value="0" />
   <maxRadius value="0.00" />
   <maxRadiusVariance value="0.00" />

--- a/PitHero/Content/Particles/heal_potion.pex
+++ b/PitHero/Content/Particles/heal_potion.pex
@@ -1,0 +1,40 @@
+<particleEmitterConfig>
+  <yCoordFlipped value="1" />
+  <sourcePosition x="0" y="0" />
+  <sourcePositionVariance x="6" y="3" />
+  <speed value="30.00" />
+  <speedVariance value="12.00" />
+  <particleLifeSpan value="0.7000" />
+  <particleLifespanVariance value="0.2500" />
+  <angle value="270" />
+  <angleVariance value="10" />
+  <gravity x="0" y="-18" />
+  <radialAcceleration value="0.00" />
+  <radialAccelVariance value="0.00" />
+  <tangentialAcceleration value="0.00" />
+  <tangentialAccelVariance value="0.00" />
+  <startColor red="0.20" green="0.85" blue="0.30" alpha="1.00" />
+  <startColorVariance red="0.00" green="0.15" blue="0.15" alpha="0.30" />
+  <finishColor red="0.10" green="0.60" blue="0.20" alpha="0.00" />
+  <finishColorVariance red="0.00" green="0.00" blue="0.00" alpha="0.00" />
+  <maxParticles value="24" />
+  <startParticleSize value="3.00" />
+  <startParticleSizeVariance value="1.50" />
+  <finishParticleSize value="4.00" />
+  <finishParticleSizeVariance value="0.00" />
+  <duration value="0.6" />
+  <emitterType value="0" />
+  <maxRadius value="0.00" />
+  <maxRadiusVariance value="0.00" />
+  <minRadius value="0.00" />
+  <minRadiusVariance value="0.00" />
+  <rotatePerSecond value="0.00" />
+  <rotatePerSecondVariance value="0.00" />
+  <blendFuncSource value="770" />
+  <blendFuncDestination value="1" />
+  <rotationStart value="0.00" />
+  <rotationStartVariance value="0.00" />
+  <rotationEnd value="0.00" />
+  <rotationEndVariance value="0.00" />
+  <texture name="texture.png" data="H4sIAAAAAAAEABVWa1hTZxL+zklCLiQh3GKEkISLFSQgCCLRoCcI4aYVUTCKdRMuCkopROoaUDkJYEBEDgUjKtpUvLaUDVhRpNZAUA8IAoot6OKiRKRbvJSkLKjVxR8z82ee5515Z+aZtyz+8ygGzYUGAGDEREckzEXkk1Fs5vz3mblPAKDpYiIkG/duS03TE2Y+flwVMx2wZMmHC9VtnAwHsFe8Bl/ZwLuQiIKRmBvA+Cwz6/SChSAeLjmhlhwFiCW0mZzbJLnkGiboT+Udrzy6tgLVe4OcvdzxwPDgRiHTImwKJiyAIBpgJ9i6eoiZU2Il0FsUSR2D8nIFxqEXDXperjr1nj/OUxI0ZwEyJW7hHFTVcFySr3kWnGC5frEqVIBTidKUDYDZV1+go2bwoumnbrO9vQOpZrnFuupi6PKKRrYuNrrbISIdEsbwRNNNKo7XQcYYjbiVR1a5uAWlUFmHmolPhEhEQ31BzfwJF4yzvKKByWYNJYDr2o+ws7qzP1N6MZSQ0N1OoaQ0EwPTgfKwiVvZOyZYV5/K/gmof1/NLP4Y3fTWrtdUiL6/GV1LLWMEjfET5AFIr+ack0042AFGo98a3jPK09PsinrgPyXBS6R2TrIWSVmgV6VnAccJ4Byv/5FdLgZ8HbD7g/t8SuNm5ICghmawAVvua0uCeyx4l+t4ZpL+uSCkVLo91ZZi3gjKmwozIHTy9/8gIhY/4uPBfF5EkIeKc/uDlj1G3EU+DAT3LUPiezY/cc2qPBe2ICCsGB61O6EthGYFdqYEh9I+SiJhavGSk5ALhj9Fl7Fy0iFrf+Q9C35aq+KYM1nbyY8OrzHBBBHrDQmE9BWJ3ztm+OPbWBWN/PHN2DZZPS3pyw54YhWBadSwN07wtAsKreJPvPTtBr2pUaYJNbgbHtCGHCk6asVj3MZza19IsiMXR1SNlD85ExHyLbRJhfqR9C9UtecMMFPXN4yJaVOhlN3wrVAsQBiA3bWpjeongLBpCY/8lI9Y5D6UTX4ah0qEqYxFuxRrSW/ATKUoQ819h/uAs2RRV5G4gmGCYZ0fki8fJo/bY2OYLRIvQFN47HdzTZ3jmrcQW+1LfryClzpxZBugfBpyZD/LVTR9/LtAKO6DwctuSjwvnnlQsc88CGwDsP3FCUAIkNPadL4MisYthslibsC1ZmpoOkoA6yZNMNR6IOrIflkzWXXaNcNj2RbECKvrgHx17FsDQPpChk7cxVMMlJKFhdZmICKxDu03O6HcdwaOlgTyBUaaVCZC/8UqfvjXqgFxJc8ywYvKFqt7tF2mBPjeRiTLvXQrSImDcLWxSEfDqUD2nbbu9Xz97PxNcfa/xhZ3FcEMJxbnEgpRDVi/ueT5P7Ax+bkVSjbiT5ZfAjrSENVrR2294qFAqaCWh2X9GGlN8ojm4/R4o7qn04WCDwMdLP+OaOvK4Sc7l56G5Wp0G0cDE1vpyJFEjFBlCVICuUX8SwvszUKyNel86yNYNOv5mDrt+8sWMGKZYz3NXbkIYRKti+yTGGcW7rLCDF1xWaZ3+04aNnwTS5jXU2FgOjZMGo8zSv0IiI37MQKe6N6ARGQD96tQqJ7Z+Wut+vku2dRt3YuB5DJDCKw0pvgG9Yf1oQwBGQhrsEzrHjAHkW3vscNW1o2WtcO2EfUL11kB4v9ywDVa78X83g3rjfxKoem5oyNhfxNfLyqiJbJtJtEaBBWVMnzOb24yVFlCHE9cCeh71s0egk869QWNwoIo93lo51lYloSes0k74Rx3oFjFFe3BXhJvUZbzz5I3fqa/EJq1JyWIHzZb/87eiTdag6yhgcyD6aQ0FzYLh2CL15KKtYuvaxV+S1kVp19ivRoSaB6Z6YlqIe/yQBYTMOencYwhYaQd1/wzpXr1MseRlXm7ByzB7gVNrfNHmDXb3Bu3gPNl9t3I+QE/SEQ7eWtIXC6UHnLrfERd4jjSi6fMjbZMUUzIgtC6CMzyWcMo8mpnyh8Hztw1zUy8VUgqG3jHPiU/qFxTf3n9Ga7I9n1UHH1IrHlia7qlXfrlwHNJl+O3YdfyVZ2Pynt78SfhV09Cm/xQv84mETMkF3K9F/7qksKWaG0mim7/+XVu1TsavkfT2URiXn83PweKB8ZwEnvFNXHlpKhWO5Ap0xI3c5Mf88L+aBerX6235oZvnfZoY2xnNw6idQvKYqFrXLJF2JAKu97UlplcvA1bYPZjPNFjDX2YWXsgKzikrX8DvwUYT8IGZ6kh3sOswjyr3Eq+9CKzHwuCJGrNYtCvvVWlvS3ZPkbLSoGhBeOSDduNuVCDDxD9LnixWPZPZ9F4lbZx4M4bLJUnEjSlUzFx8yxe36FvX59HvzxP9LC92yZtmec70q5F8vYNU54rXESv21NOyfqKuJBFoGxzSxJozFWWlT37sAs3CSPaIwq1mkfBsyP8uX/awEKA2YZnLQjKnxTcYSnJpfGTDq7AQLXHXtyE3Igmg3Fu0WUtgMTNX4TETCO7+2fpwv6fUa5rp7lwKM95CiEqH/Nbc4pIPKH+DclBWPCUBswoIMFCZ6PYzhb87ANU3dzkFSB5PloHYwWFeCDNQUvyyp+GRNh9MENbS8UvgVZ55zH4w9gusuA3GM/CFiI8WMXbqFdnYAsElRqh9PVx9wse1nDGWd7GaA1MT3LU/6B9rpB9I/UnyAMrfVlyH3KSbjQW4kDQ51DGMJg7Zv9PlatczMi+03eS9O3SimgGkAn2FbEPDjUDoRH7oaMwetbt1oMJX6nhITyTAHmflQRqn5CkfRbDIOwrrCKAGw1In3+AXXs3tO8KJLTVXwC1xz/mkog91W+AsZqGXYZxix6TvvrWs4CXvJ950kntXFvcDJSSUi7FgBqTCKO+7+UHbl0/yNrkTnlgtetGj5Lo0eDGOFqyvGEp+VDMvtW/zXTTrS02ypOE1g8XsldT4o6Wctvo0WooNfWHQLnKfpxqVSeEr1Vs7VXI9mjS7dP66ucdwF/Bbc6/7QzM8gHjmVYOXGaaA41FnWsmuviqWm7SjPuLwjxL1V/1ZFgYUJVZ6yJzZsSpDTBL9A0nBzoMkFjSROLtVV6rEZ3JrGB3iIEvkBwpUXFbbyAXl1EsLGVsOJOVV2n6XsypWP/mabJv6VISy56CqwmXWSIbyXgHDJz+wDmt1cXcOBwq3Xq0A4aT+t3n7Q34OjRufzM7VvNgec6Yw/1BUbO2agOsnCKXFYlp5RJZub1ZYT5bubWko9n1usgw1Dm+OW9dqkX8ZF9lnZuMQyFgY8iscxirv9qlx11A7hDTp0CL1NHzxBX8EkW0uH7hVxx+2E3PNhL7Ir0TSMMP2QwrVeYpG91OuT3BlngmlR8s6MARL4RGqeWxKo4oulxP3T7PHt5uHSyu88DCaLYg7683sh1eij73GAi0QE06loiFJAyJS9fRkw2fBNKzuaddR+PE/DsnZk6XkeCesYngOYOKGpjH/+b7BPdXB61cqQTYlYLDDQAVseOGUV/EUBY0CnCedFrgn3voaq/9FzajeYH/dUhOs+Q0DWyAY9eEv2zXLYofDExQFAZG+oAwJKchJHKT1Nv4MZWa4RQoXZTdcH4nEKx4v+rVyDMzERA8K/ZUPxCC0mg3+gzwdLvaRwCExJm8c7OjvnNCFcREfh7RGC7X/B+u20U3zwoAAA==" />
+</particleEmitterConfig>

--- a/PitHero/Game1.cs
+++ b/PitHero/Game1.cs
@@ -49,6 +49,10 @@ namespace PitHero
             soundEffectManager.Init(Content);
             RegisterGlobalManager(soundEffectManager);
 
+            ParticleEffectManager particleEffectManager = new ParticleEffectManager();
+            particleEffectManager.Init(Content);
+            RegisterGlobalManager(particleEffectManager);
+
 #if DEBUG
             // Analytics for game balancing (issue #289) - debug builds only
             RegisterGlobalManager(new Services.Analytics.AnalyticsManager());

--- a/PitHero/UI/InventoryGrid.cs
+++ b/PitHero/UI/InventoryGrid.cs
@@ -7,6 +7,7 @@ using Nez.Sprites;
 using Nez.UI;
 using PitHero.ECS.Components;
 using PitHero.Services;
+using PitHero.Util;
 using RolePlayingFramework.Equipment;
 using RolePlayingFramework.Mercenaries;
 using RolePlayingFramework.Synergies;
@@ -789,9 +790,13 @@ namespace PitHero.UI
             }
 
             // Try to consume the item
+            int hpBefore = hero.CurrentHP;
             if (consumable.Consume(hero))
             {
                 Debug.Log($"Used {item.Name}");
+
+                if (hero.CurrentHP > hpBefore)
+                    Core.GetGlobalManager<ParticleEffectManager>()?.SpawnPotionHealEffect(consumable, _heroComponent.Entity);
 
                 // Reset HealingSkillExhausted if MP restoration item is used
                 if (_heroComponent != null && consumable.MPRestoreAmount > 0)

--- a/PitHero/UI/ShortcutBar.cs
+++ b/PitHero/UI/ShortcutBar.cs
@@ -5,6 +5,7 @@ using Nez.Textures;
 using Nez.UI;
 using PitHero.ECS.Components;
 using PitHero.Services;
+using PitHero.Util;
 using RolePlayingFramework.Equipment;
 using RolePlayingFramework.Skills;
 using System.Collections.Generic;
@@ -656,18 +657,28 @@ namespace PitHero.UI
             // Determine the target: most critical party member when the option is enabled,
             // otherwise always the hero.
             object target = hero;
+            Entity targetEntity = _heroComponent.Entity;
             if (_heroComponent.UseConsumablesOnMercenaries)
             {
-                target = FindMostCriticalTargetForConsumable(consumable);
+                target = FindMostCriticalTargetForConsumable(consumable, out targetEntity);
             }
 
             // Try to consume the item immediately (out of battle)
+            int hpBefore = target is RolePlayingFramework.Heroes.Hero preHero
+                ? preHero.CurrentHP
+                : ((RolePlayingFramework.Mercenaries.Mercenary)target).CurrentHP;
             if (consumable.Consume(target))
             {
                 string targetName = target is RolePlayingFramework.Heroes.Hero h
                     ? h.Name
                     : ((RolePlayingFramework.Mercenaries.Mercenary)target).Name;
                 Debug.Log($"[ShortcutBar] Used {item.Name} on {targetName}");
+
+                int hpAfter = target is RolePlayingFramework.Heroes.Hero postHero
+                    ? postHero.CurrentHP
+                    : ((RolePlayingFramework.Mercenaries.Mercenary)target).CurrentHP;
+                if (hpAfter > hpBefore)
+                    Core.GetGlobalManager<ParticleEffectManager>()?.SpawnPotionHealEffect(consumable, targetEntity);
 
                 // Reset HealingSkillExhausted if MP restoration item is used
                 if (_heroComponent != null && consumable.MPRestoreAmount > 0)
@@ -700,12 +711,13 @@ namespace PitHero.UI
         /// potions), restricted to targets the potion can actually help. Falls back to the
         /// hero if nobody has any missing resources of the relevant type.
         /// </summary>
-        private object FindMostCriticalTargetForConsumable(Consumable consumable)
+        private object FindMostCriticalTargetForConsumable(Consumable consumable, out Entity targetEntity)
         {
             bool restoresHP = consumable.HPRestoreAmount != 0;
             bool restoresMP = consumable.MPRestoreAmount != 0;
 
             object bestTarget = null;
+            targetEntity = _heroComponent.Entity;
             float lowestPercent = 1f;
 
             // Evaluate hero
@@ -721,6 +733,7 @@ namespace PitHero.UI
                     if (relevantPct < lowestPercent)
                     {
                         bestTarget = heroObj;
+                        targetEntity = _heroComponent.Entity;
                         lowestPercent = relevantPct;
                     }
                 }
@@ -748,6 +761,7 @@ namespace PitHero.UI
                         if (relevantPct < lowestPercent)
                         {
                             bestTarget = mercenary;
+                            targetEntity = merc;
                             lowestPercent = relevantPct;
                         }
                     }
@@ -755,6 +769,8 @@ namespace PitHero.UI
             }
 
             // Fall back to hero — Consume() will return false gracefully if at full HP/MP
+            if (bestTarget == null)
+                targetEntity = _heroComponent.Entity;
             return bestTarget ?? _heroComponent.LinkedHero;
         }
 

--- a/PitHero/Util/ParticleEffectManager.cs
+++ b/PitHero/Util/ParticleEffectManager.cs
@@ -9,8 +9,12 @@ namespace PitHero.Util
     /// <summary>Particle effects that can be spawned via ParticleEffectManager.</summary>
     public enum ParticleEffectType
     {
-        /// <summary>Green clump spreading outward while fading; plays on heal targets.</summary>
-        Heal
+        /// <summary>Green clump spreading outward while fading; plays on heal-spell targets.</summary>
+        Heal,
+
+        /// <summary>Green particles rising vertically while fading; plays on potion-heal targets.
+        /// Density scales with potion strength via SpawnEffect's densityScale.</summary>
+        HealPotion
     }
 
     /// <summary>
@@ -18,7 +22,8 @@ namespace PitHero.Util
     /// To add a new effect: drop a .pex in Content/Particles, add a ParticleEffectType member,
     /// load it in Init, then call SpawnEffect at the trigger site.
     /// Registry configs are shared instances — never mutate one at spawn time; a per-spawn
-    /// variant needs its own enum member and .pex file.
+    /// variant needs its own enum member and .pex file, or a CloneConfig-based knob like
+    /// SpawnEffect's densityScale.
     /// Only finite-duration configs belong here: a Duration of -1 never fires
     /// OnAllParticlesExpired, so the emitter would never clean itself up.
     /// </summary>
@@ -34,7 +39,8 @@ namespace PitHero.Util
             {
                 _configs = new Dictionary<ParticleEffectType, ParticleEmitterConfig>
                 {
-                    { ParticleEffectType.Heal, content.LoadParticleEmitterConfig("Content/Particles/heal.pex") }
+                    { ParticleEffectType.Heal, content.LoadParticleEmitterConfig("Content/Particles/heal.pex") },
+                    { ParticleEffectType.HealPotion, content.LoadParticleEmitterConfig("Content/Particles/heal_potion.pex") }
                 };
 
                 Initialized = true;
@@ -44,12 +50,21 @@ namespace PitHero.Util
         /// <summary>
         /// Fire-and-forget effect attached to an entity; the emitter removes itself
         /// once all particles expire. Returns null if uninitialized or target is null.
+        /// densityScale multiplies particle count and emission rate (1 = as authored);
+        /// values != 1 spawn from a private clone so the shared registry config stays pristine.
         /// </summary>
         public ParticleEmitter SpawnEffect(ParticleEffectType type, Entity target,
-            int renderLayer = GameConfig.RenderLayerLowest)
+            int renderLayer = GameConfig.RenderLayerLowest, float densityScale = 1f)
         {
             if (_configs == null || target == null || !_configs.TryGetValue(type, out var config))
                 return null;
+
+            if (densityScale != 1f)
+            {
+                config = CloneConfig(config);
+                config.MaxParticles = (uint)(config.MaxParticles * densityScale);
+                config.EmissionRate *= densityScale;
+            }
 
             var emitter = target.AddComponent(new ParticleEmitter(config));
             emitter.SimulateInWorldSpace = true;
@@ -76,6 +91,56 @@ namespace PitHero.Util
             emitter.RenderLayer = renderLayer;
             emitter.OnAllParticlesExpired += DestroyEmitterEntity;
             return emitter;
+        }
+
+        /// <summary>
+        /// Field-by-field copy so per-spawn tweaks never touch the shared registry config.
+        /// The Sprite reference is shared intentionally — clones must never be disposed.
+        /// </summary>
+        private static ParticleEmitterConfig CloneConfig(ParticleEmitterConfig source)
+        {
+            return new ParticleEmitterConfig
+            {
+                Sprite = source.Sprite,
+                SimulateInWorldSpace = source.SimulateInWorldSpace,
+                BlendFuncSource = source.BlendFuncSource,
+                BlendFuncDestination = source.BlendFuncDestination,
+                SourcePosition = source.SourcePosition,
+                SourcePositionVariance = source.SourcePositionVariance,
+                Speed = source.Speed,
+                SpeedVariance = source.SpeedVariance,
+                ParticleLifespan = source.ParticleLifespan,
+                ParticleLifespanVariance = source.ParticleLifespanVariance,
+                Angle = source.Angle,
+                AngleVariance = source.AngleVariance,
+                Gravity = source.Gravity,
+                RadialAcceleration = source.RadialAcceleration,
+                RadialAccelVariance = source.RadialAccelVariance,
+                TangentialAcceleration = source.TangentialAcceleration,
+                TangentialAccelVariance = source.TangentialAccelVariance,
+                StartColor = source.StartColor,
+                StartColorVariance = source.StartColorVariance,
+                FinishColor = source.FinishColor,
+                FinishColorVariance = source.FinishColorVariance,
+                MaxParticles = source.MaxParticles,
+                StartParticleSize = source.StartParticleSize,
+                StartParticleSizeVariance = source.StartParticleSizeVariance,
+                FinishParticleSize = source.FinishParticleSize,
+                FinishParticleSizeVariance = source.FinishParticleSizeVariance,
+                Duration = source.Duration,
+                EmitterType = source.EmitterType,
+                RotationStart = source.RotationStart,
+                RotationStartVariance = source.RotationStartVariance,
+                RotationEnd = source.RotationEnd,
+                RotationEndVariance = source.RotationEndVariance,
+                EmissionRate = source.EmissionRate,
+                MaxRadius = source.MaxRadius,
+                MaxRadiusVariance = source.MaxRadiusVariance,
+                MinRadius = source.MinRadius,
+                MinRadiusVariance = source.MinRadiusVariance,
+                RotatePerSecond = source.RotatePerSecond,
+                RotatePerSecondVariance = source.RotatePerSecondVariance
+            };
         }
 
         private static void RemoveEmitterComponent(ParticleEmitter emitter)

--- a/PitHero/Util/ParticleEffectManager.cs
+++ b/PitHero/Util/ParticleEffectManager.cs
@@ -74,6 +74,22 @@ namespace PitHero.Util
         }
 
         /// <summary>
+        /// Spawns the potion-heal effect (rising green particles) on the target, denser
+        /// for stronger potions: base potions 1x, mid potions (500+ HP) 2x, full-restore
+        /// potions (negative amount) 3x. Shared by battle and out-of-battle potion paths.
+        /// </summary>
+        public ParticleEmitter SpawnPotionHealEffect(RolePlayingFramework.Equipment.Consumable consumable, Entity target)
+        {
+            if (consumable == null)
+                return null;
+
+            float densityScale = consumable.HPRestoreAmount < 0 ? 3f
+                : consumable.HPRestoreAmount >= 500 ? 2f
+                : 1f;
+            return SpawnEffect(ParticleEffectType.HealPotion, target, densityScale: densityScale);
+        }
+
+        /// <summary>
         /// Fire-and-forget effect at a world position for effects not tied to an actor
         /// (e.g. dust when jumping into the pit). Creates a throwaway entity that is
         /// destroyed once all particles expire.

--- a/PitHero/Util/ParticleEffectManager.cs
+++ b/PitHero/Util/ParticleEffectManager.cs
@@ -18,7 +18,11 @@ namespace PitHero.Util
 
         /// <summary>Spinning ball of fire; launched from caster to target as a projectile
         /// (spawn via SpawnEffectAtPosition, move the entity, PauseEmission on impact).</summary>
-        Fireball
+        Fireball,
+
+        /// <summary>Wide band of large fire particles raining down; spawned above the
+        /// enemy group's center for the mage Firestorm AoE.</summary>
+        Firestorm
     }
 
     /// <summary>
@@ -45,7 +49,8 @@ namespace PitHero.Util
                 {
                     { ParticleEffectType.Heal, content.LoadParticleEmitterConfig("Content/Particles/heal.pex") },
                     { ParticleEffectType.HealPotion, content.LoadParticleEmitterConfig("Content/Particles/heal_potion.pex") },
-                    { ParticleEffectType.Fireball, content.LoadParticleEmitterConfig("Content/Particles/fireball.pex") }
+                    { ParticleEffectType.Fireball, content.LoadParticleEmitterConfig("Content/Particles/fireball.pex") },
+                    { ParticleEffectType.Firestorm, content.LoadParticleEmitterConfig("Content/Particles/firestorm.pex") }
                 };
 
                 Initialized = true;

--- a/PitHero/Util/ParticleEffectManager.cs
+++ b/PitHero/Util/ParticleEffectManager.cs
@@ -14,7 +14,11 @@ namespace PitHero.Util
 
         /// <summary>Green particles rising vertically while fading; plays on potion-heal targets.
         /// Density scales with potion strength via SpawnEffect's densityScale.</summary>
-        HealPotion
+        HealPotion,
+
+        /// <summary>Spinning ball of fire; launched from caster to target as a projectile
+        /// (spawn via SpawnEffectAtPosition, move the entity, PauseEmission on impact).</summary>
+        Fireball
     }
 
     /// <summary>
@@ -40,7 +44,8 @@ namespace PitHero.Util
                 _configs = new Dictionary<ParticleEffectType, ParticleEmitterConfig>
                 {
                     { ParticleEffectType.Heal, content.LoadParticleEmitterConfig("Content/Particles/heal.pex") },
-                    { ParticleEffectType.HealPotion, content.LoadParticleEmitterConfig("Content/Particles/heal_potion.pex") }
+                    { ParticleEffectType.HealPotion, content.LoadParticleEmitterConfig("Content/Particles/heal_potion.pex") },
+                    { ParticleEffectType.Fireball, content.LoadParticleEmitterConfig("Content/Particles/fireball.pex") }
                 };
 
                 Initialized = true;

--- a/PitHero/Util/ParticleEffectManager.cs
+++ b/PitHero/Util/ParticleEffectManager.cs
@@ -1,0 +1,93 @@
+using Microsoft.Xna.Framework;
+using Nez;
+using Nez.Particles;
+using Nez.Systems;
+using System.Collections.Generic;
+
+namespace PitHero.Util
+{
+    /// <summary>Particle effects that can be spawned via ParticleEffectManager.</summary>
+    public enum ParticleEffectType
+    {
+        /// <summary>Green clump spreading outward while fading; plays on heal targets.</summary>
+        Heal
+    }
+
+    /// <summary>
+    /// Global registry of particle effects loaded from .pex files in Content/Particles.
+    /// To add a new effect: drop a .pex in Content/Particles, add a ParticleEffectType member,
+    /// load it in Init, then call SpawnEffect at the trigger site.
+    /// Registry configs are shared instances — never mutate one at spawn time; a per-spawn
+    /// variant needs its own enum member and .pex file.
+    /// Only finite-duration configs belong here: a Duration of -1 never fires
+    /// OnAllParticlesExpired, so the emitter would never clean itself up.
+    /// </summary>
+    public class ParticleEffectManager : GlobalManager
+    {
+        public bool Initialized = false;
+
+        private Dictionary<ParticleEffectType, ParticleEmitterConfig> _configs;
+
+        public void Init(NezContentManager content)
+        {
+            if (!Initialized)
+            {
+                _configs = new Dictionary<ParticleEffectType, ParticleEmitterConfig>
+                {
+                    { ParticleEffectType.Heal, content.LoadParticleEmitterConfig("Content/Particles/heal.pex") }
+                };
+
+                Initialized = true;
+            }
+        }
+
+        /// <summary>
+        /// Fire-and-forget effect attached to an entity; the emitter removes itself
+        /// once all particles expire. Returns null if uninitialized or target is null.
+        /// </summary>
+        public ParticleEmitter SpawnEffect(ParticleEffectType type, Entity target,
+            int renderLayer = GameConfig.RenderLayerLowest)
+        {
+            if (_configs == null || target == null || !_configs.TryGetValue(type, out var config))
+                return null;
+
+            var emitter = target.AddComponent(new ParticleEmitter(config));
+            emitter.SimulateInWorldSpace = true;
+            emitter.RenderLayer = renderLayer;
+            emitter.OnAllParticlesExpired += RemoveEmitterComponent;
+            return emitter;
+        }
+
+        /// <summary>
+        /// Fire-and-forget effect at a world position for effects not tied to an actor
+        /// (e.g. dust when jumping into the pit). Creates a throwaway entity that is
+        /// destroyed once all particles expire.
+        /// </summary>
+        public ParticleEmitter SpawnEffectAtPosition(ParticleEffectType type, Vector2 worldPosition,
+            Scene scene, int renderLayer = GameConfig.RenderLayerLowest)
+        {
+            if (_configs == null || scene == null || !_configs.TryGetValue(type, out var config))
+                return null;
+
+            var entity = scene.CreateEntity("particle-effect");
+            entity.SetPosition(worldPosition);
+            var emitter = entity.AddComponent(new ParticleEmitter(config));
+            emitter.SimulateInWorldSpace = true;
+            emitter.RenderLayer = renderLayer;
+            emitter.OnAllParticlesExpired += DestroyEmitterEntity;
+            return emitter;
+        }
+
+        private static void RemoveEmitterComponent(ParticleEmitter emitter)
+        {
+            emitter.Clear();
+            emitter.Entity?.RemoveComponent(emitter);
+        }
+
+        private static void DestroyEmitterEntity(ParticleEmitter emitter)
+        {
+            emitter.Clear();
+            emitter.Entity?.Destroy();
+        }
+    }
+}

--- a/PitHero/docs/ParticleEffects.md
+++ b/PitHero/docs/ParticleEffects.md
@@ -1,0 +1,65 @@
+# Particle Effects
+
+How PitHero uses Nez's built-in particle system, and how to add a new effect. Introduced in issue #301 / PR #302.
+
+## Architecture
+
+- **`PitHero/Util/ParticleEffectManager.cs`** — a Nez `GlobalManager` (registered in `Game1.Initialize`, fetched via `Core.GetGlobalManager<ParticleEffectManager>()`). Holds an enum-keyed registry (`ParticleEffectType` → `ParticleEmitterConfig`) loaded once from `.pex` files in `PitHero/Content/Particles/`.
+- **`.pex` files** are ParticleDesigner XML loaded at startup by `Core.Content.LoadParticleEmitterConfig` — raw file loading, no content pipeline. `PitHero.csproj` already copies `Content/**/*` to output; dropping a file in the folder is enough.
+- **Battle visuals** flow through `IBattleEventSink`. Live effects are triggered only from `LiveBattleAdapter`; `VirtualBattleSink` and headless tests inherit no-ops from `BattleEventSinkBase`. Never touch particles from `BattleEngine` logic or the virtual layer, and never change RNG call order (it is a save/replay contract).
+- **Cleanup is automatic**: spawn methods subscribe static handlers to `ParticleEmitter.OnAllParticlesExpired` that remove the component (or destroy the throwaway entity). Static handlers only — no captures (AOT safety).
+
+## Adding a new effect (the recipe)
+
+1. Copy an existing `.pex` in `PitHero/Content/Particles/` (keep the embedded `<texture data="...">` — it's a 64×64 soft radial glow) and edit the fields.
+2. Add a `ParticleEffectType` enum member with a doc comment describing the look and pattern.
+3. Add one load line in `ParticleEffectManager.Init`.
+4. Call it at the trigger site:
+   - `SpawnEffect(type, entity)` — attach to an actor (heals, buffs).
+   - `SpawnEffectAtPosition(type, worldPos, scene)` — free-standing (dust, impacts, projectiles).
+   - For battle skills, add a `case` in `LiveBattleAdapter.ShowSkillEffectOnMonsters` (see patterns below).
+
+## Rules (violating these caused real bugs)
+
+- **Never mutate a registry config at spawn time** — configs are shared instances; an edit bleeds into every later spawn. Per-spawn variation clones the config: see `SpawnEffect`'s `densityScale` (scales `MaxParticles` + `EmissionRate` via `CloneConfig`). New knobs should follow the same clone pattern.
+- **Sizing: particle sizes are world pixels.** Tiles are 32px; the shared texture is a soft glow whose bright core is a fraction of the sprite. **Anything under ~5px is effectively invisible** — the first potion effect shipped at 3px and read as "no effect at all". Working references: heal burst 5–8px ×59 particles, potion rise 8–12px ×36, firestorm rain 12–16px ×56.
+- **Fire-and-forget spawns need a finite `duration`** — a `-1` (infinite) config never fires `OnAllParticlesExpired` and leaks the emitter. Manually-driven effects (projectiles) still use a finite duration as a leak-safe cap in case the driving coroutine is torn down mid-effect.
+
+## .pex quirks (what Nez actually reads)
+
+- `sourcePosition` and `yCoordFlipped` are **ignored**. Particles spawn at the emitter entity's position ± `sourcePositionVariance`.
+- Angles are **screen-space**: `angle=270` moves up, `90` down, `0` right. Negative `gravity y` accelerates upward.
+- `emitterType 0` (Gravity) = ballistic motion from `speed`/`angle`/`gravity`. `emitterType 1` (Radial) = particles orbit the emitter from `maxRadius` toward `minRadius` at `rotatePerSecond` deg/s — this is how the fireball's "spinning ball" look works; `speed`/`gravity` are ignored.
+- `EmissionRate` is not a `.pex` field — the loader computes `MaxParticles / ParticleLifespan`. If you ever build a `ParticleEmitterConfig` in code, you must set it yourself or nothing emits.
+- Keep `particleLifespanVariance` **below** `particleLifeSpan`, or some particles roll a negative lifetime and die instantly (thins the effect).
+- `blendFuncSource=770, blendFuncDestination=1` = additive glow (used by all current effects).
+- All effects render at `GameConfig.RenderLayerLowest` (0) by default — above actors and fog, same as battle digits.
+
+## Effect patterns in use
+
+| Pattern | Example | How |
+|---|---|---|
+| Attached burst | Heal spell | `SpawnEffect(Heal, targetEntity)` fire-and-forget alongside the digit coroutine |
+| Attached, intensity-scaled | Heal potion | `SpawnPotionHealEffect` → `densityScale` 1×/2×/3× by `HPRestoreAmount` (base / ≥500 / negative=full) |
+| Projectile | Fire (`mage.fire`) | `SpawnEffectAtPosition` at caster, lerp entity to target (`SkillProjectileSpeed`, 0.15–0.6s clamp), `PauseEmission()` on impact; engine yields the coroutine so damage digits appear on landing |
+| Area rain | Firestorm (`mage.firestorm`) | Average affected enemies' positions, spawn `AreaRainSpawnHeight` above, `WaitForSecondsRespectingPause(AreaRainImpactDelay)` before damage shows |
+
+Skill visuals hook `ShowSkillEffectOnMonsters(caster, skill, primaryTarget, surroundingTargets)`, which `BattleEngine.ExecuteCombatantAttackSkill` yields **before** damage digits. Caster entity resolution works for hero and mercenaries via `GetEntityForCombatant`.
+
+## Wiring map — battle sink is NOT enough
+
+Heals and item use have paths that bypass `BattleEngine` entirely. If an effect should play "whenever X happens", check all of:
+
+| Trigger | In battle | Out of battle |
+|---|---|---|
+| Skill heal | `LiveBattleAdapter.ShowHealOnAlly` | `UseHealingSkillAction.UseHealingSkillOnTarget` (GOAP) |
+| Potion heal | `LiveBattleAdapter.ShowItemHealOnAlly` | `InventoryGrid.UseConsumable`, `ShortcutBar.UseConsumable`, `UseHealingItemAction.UseHealingItemFromBag` |
+| Attack skill | `LiveBattleAdapter.ShowSkillEffectOnMonsters` | n/a (skills can't be cast outside battle) |
+
+Out-of-battle potion/heal paths guard on "HP actually restored" so MP-only potions and full-HP sips show nothing.
+
+## Caveats
+
+- The embedded-texture decode path uses `System.Drawing` — **Windows-only** under .NET 7+. If cross-platform ever ships, delete the `data` attribute and place a `texture.png` next to the `.pex` (the loader falls back to `Texture2D.FromStream`).
+- Multiple emitters on one entity are fine; each cleans up independently.
+- Headless tests can construct `ParticleEffectManager` and exercise the null-safe pre-`Init` paths (`PitHero.Tests/ParticleEffectManagerTests.cs`), but `Init` needs a GraphicsDevice — don't call it in tests.


### PR DESCRIPTION
Closes #301

## Summary

Integrates Nez's built-in particle system into PitHero via a new `ParticleEffectManager` (GlobalManager) with an enum-keyed registry of `.pex`-based effects, and ships four effects:

- **Heal spell** — green radial burst on the target; plays in battle (`ShowHealOnAlly`) and out of battle (`UseHealingSkillAction`).
- **Heal potion** — green particles rising vertically; density scales with potion strength (base 1x, mid 2x, full-restore 3x). Wired into all four potion paths: battle sink, inventory grid, shortcut bar, and the auto-heal GOAP action. Only plays when HP was actually restored.
- **Fire (mage)** — spinning ball of fire (radial emitter, world-space trail) launched from caster to target at 340 px/s; the engine yields the flight coroutine so damage digits appear on impact.
- **Firestorm (mage)** — wide band of large fire particles raining down over the enemy group's center, held 0.5s before damage shows.

## Architecture

- All battle visuals flow through `IBattleEventSink`; two new methods (`ShowItemHealOnAlly`, `ShowSkillEffectOnMonsters`) have no-op defaults in `BattleEventSinkBase`, so `VirtualBattleSink` and headless tests are untouched. No RNG-order changes.
- Adding a new effect = drop a `.pex` in `Content/Particles/`, add an enum member + `Init` load line, and one call at the trigger site (or a case in the skill-effect switch).
- Emitters self-clean via `OnAllParticlesExpired` (static handlers, AOT-safe). Per-spawn variation clones the config — shared registry configs are never mutated. Finite `.pex` durations guarantee cleanup even if a coroutine is torn down mid-effect.

## Notes

- Particle sizes are world-pixels against a 64x64 soft-glow texture; sub-5px particles are effectively invisible on 32px tiles (the initial potion effect shipped too small and was rewritten).
- The embedded-texture `.pex` decode path uses System.Drawing (Windows-only under .NET 7+); if cross-platform ever ships, swap the `data` attribute for an external `texture.png`.

## Testing

- `dotnet test`: 1393 passed, 12 pre-existing baseline failures (unchanged), including 3 new `ParticleEffectManagerTests`.
- Visually verified in-game: priest heal, potion heals (all potion tiers/paths), fireball flight and impact timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)