### PR TITLE
Permanent crop plans, auto seed purchases, and shop coverage highlight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ Game1 (Nez.Core)
 - Use `Nez.Time.DeltaTime` for all timing (respects `timeScale` for pausing); use `Time.TotalTime` or `Time.UnscaledDeltaTime` for absolute time
 - Use `Nez.Random` instead of `System.Random`
 - Register/retrieve services: `Core.Services.AddService<T>()` / `Core.Services.GetService<T>()`
+- **Every service registered in `MainGameScene` (`Begin()` or `LoadMap`) needs a matching `RemoveService` in `MainGameScene.Unload()`** — loading a save tears down the scene and re-runs `Begin()`; a missing removal crashes `AddService` with a duplicate-key `ArgumentException`. Also mind registration order within `Begin()`: a service that captures another in its constructor must be registered after its dependency (e.g. `AutoSeedPurchaseService` after `FarmTaskCoordinator`)
 - Add GOAP conditions to `GoapConstants` for strong typing
 - Keep `Program.cs` as standard Nez boilerplate
 - Components inherit from `Nez.Component`; rendering via `Nez.RenderableComponent` (or custom)

--- a/PitHero.Tests/AutoSeedPurchaseServiceTests.cs
+++ b/PitHero.Tests/AutoSeedPurchaseServiceTests.cs
@@ -158,6 +158,26 @@ namespace PitHero.Tests
         }
 
         [TestMethod]
+        public void TryPurchasePass_StopsAtSeedInventoryCap()
+        {
+            // Planned demand exceeds the per-crop cap while owned sits 2 below it — only the
+            // 2 seeds of headroom may be bought; the rest would be clamped away and waste gold.
+            _service.GoldBuffer = 0;
+            int plans = GameConfig.SeedInventoryMaxPerCrop + 6;
+            for (int i = 0; i < plans; i++)
+                _cropPlanting.AddPlan(new PlacedCropPlan { Type = CropType.Wheat, TileX = i % 100, TileY = i / 100 });
+            _cropPlanting.SeedInventory[(int)CropType.Wheat] = GameConfig.SeedInventoryMaxPerCrop - 2;
+            _gameState.Funds = 100000;
+
+            _service.TryPurchasePass();
+
+            Assert.AreEqual(GameConfig.SeedInventoryMaxPerCrop, _cropPlanting.SeedInventory[(int)CropType.Wheat],
+                "Seed count should stop exactly at the per-crop cap");
+            Assert.AreEqual(100000 - 2 * 25, _gameState.Funds,
+                "Only the 2 seeds of headroom should have been paid for");
+        }
+
+        [TestMethod]
         public void TryPurchasePass_AlreadyCoveredByExistingCrop_BuysNothing()
         {
             // Plan exists but the same-type crop is already growing → CountUnplantedPlans = 0

--- a/PitHero.Tests/AutoSeedPurchaseServiceTests.cs
+++ b/PitHero.Tests/AutoSeedPurchaseServiceTests.cs
@@ -1,0 +1,176 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Xna.Framework;
+using PitHero.Farming;
+using PitHero.Services;
+using PitHero.Util;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Tests for AutoSeedPurchaseService. All tests call TryPurchasePass() directly to bypass the
+    /// 1-second Time.DeltaTime throttle, which never elapses in a headless test context.
+    /// The Enabled=false path is verified via Update() (which returns before touching the timer).
+    /// Services are constructed directly (not via Core.Services) for headless safety.
+    /// </summary>
+    [TestClass]
+    public class AutoSeedPurchaseServiceTests
+    {
+        private CropPlantingService    _cropPlanting  = null!;
+        private CropGrowthService      _cropGrowth    = null!;
+        private GameStateService       _gameState     = null!;
+        private AutoSeedPurchaseService _service      = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _cropPlanting = new CropPlantingService();
+            _cropGrowth   = new CropGrowthService(_cropPlanting);
+            _gameState    = new GameStateService();
+
+            // coordinator is null — constructor accepts null for headless tests
+            _service = new AutoSeedPurchaseService(_cropPlanting, _cropGrowth, _gameState, coordinator: null);
+
+            // Initialise an empty seed inventory
+            _cropPlanting.SeedInventory = new int[CropTypeInfo.Count];
+        }
+
+        // ── Default state ────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void Service_DisabledByDefault()
+        {
+            Assert.IsFalse(_service.Enabled, "AutoSeedPurchaseService should be disabled by default");
+        }
+
+        [TestMethod]
+        public void Service_GoldBufferDefaultIs200()
+        {
+            Assert.AreEqual(200, _service.GoldBuffer, "GoldBuffer should default to 200");
+        }
+
+        // ── Update() when disabled ───────────────────────────────────────────
+
+        [TestMethod]
+        public void Update_WhenDisabled_BuysNothing()
+        {
+            // Place a plan and give the player enough gold
+            _cropPlanting.AddPlan(new PlacedCropPlan { Type = CropType.Wheat, TileX = 10, TileY = 5 });
+            _gameState.Funds = 10000;
+
+            // Enabled is false (default) — Update should exit immediately
+            _service.Update();
+
+            Assert.AreEqual(0, _cropPlanting.SeedInventory[(int)CropType.Wheat],
+                "No seeds should be purchased when Enabled=false");
+            Assert.AreEqual(10000, _gameState.Funds, "Funds should be unchanged when Enabled=false");
+        }
+
+        // ── TryPurchasePass() ────────────────────────────────────────────────
+
+        [TestMethod]
+        public void TryPurchasePass_BuysUntilCoverageMet()
+        {
+            // 2 Wheat plans, 0 seeds, plenty of gold
+            // Wheat price = 25; 2 seeds needed
+            _cropPlanting.AddPlan(new PlacedCropPlan { Type = CropType.Wheat, TileX = 10, TileY = 5 });
+            _cropPlanting.AddPlan(new PlacedCropPlan { Type = CropType.Wheat, TileX = 11, TileY = 5 });
+            _gameState.Funds = 10000;
+
+            _service.TryPurchasePass();
+
+            Assert.AreEqual(2, _cropPlanting.SeedInventory[(int)CropType.Wheat],
+                "Should buy exactly as many seeds as there are unplanted plans");
+            Assert.AreEqual(10000 - 2 * 25, _gameState.Funds, "Should deduct 2× seed price from funds");
+        }
+
+        [TestMethod]
+        public void TryPurchasePass_RespectsGoldBuffer_NoPurchaseWhenFundsTooLow()
+        {
+            // Wheat price=25; GoldBuffer=200 (default); Funds=220 → Funds-price=195 < 200 → no buy
+            _cropPlanting.AddPlan(new PlacedCropPlan { Type = CropType.Wheat, TileX = 10, TileY = 5 });
+            _gameState.Funds = 220;
+
+            _service.TryPurchasePass();
+
+            Assert.AreEqual(0, _cropPlanting.SeedInventory[(int)CropType.Wheat],
+                "Should not purchase when Funds - price < GoldBuffer");
+            Assert.AreEqual(220, _gameState.Funds, "Funds should be unchanged");
+        }
+
+        [TestMethod]
+        public void TryPurchasePass_RespectsGoldBuffer_PurchasesWhenFundsExceedBuffer()
+        {
+            // Wheat price=25; GoldBuffer=200; Funds=226 → Funds-price=201 >= 200 → buy 1
+            _cropPlanting.AddPlan(new PlacedCropPlan { Type = CropType.Wheat, TileX = 10, TileY = 5 });
+            _gameState.Funds = 226;
+
+            _service.TryPurchasePass();
+
+            Assert.AreEqual(1, _cropPlanting.SeedInventory[(int)CropType.Wheat],
+                "Should purchase when Funds - price >= GoldBuffer");
+            Assert.AreEqual(201, _gameState.Funds, "Funds should be reduced by the seed price");
+        }
+
+        [TestMethod]
+        public void TryPurchasePass_TerminatesWhenGoldRunsOutMidDeficit()
+        {
+            // 5 Wheat plans, only enough gold for 2 seeds (price=25 each, buffer=0)
+            _service.GoldBuffer = 0;
+            for (int i = 0; i < 5; i++)
+                _cropPlanting.AddPlan(new PlacedCropPlan { Type = CropType.Wheat, TileX = 10 + i, TileY = 5 });
+
+            _gameState.Funds = 50; // exactly 2 seeds worth
+
+            _service.TryPurchasePass();
+
+            Assert.AreEqual(2, _cropPlanting.SeedInventory[(int)CropType.Wheat],
+                "Should buy as many seeds as funds allow (not infinite loop)");
+            Assert.AreEqual(0, _gameState.Funds, "All available funds should be spent");
+        }
+
+        [TestMethod]
+        public void TryPurchasePass_WithNullCoordinator_DoesNotThrow()
+        {
+            // coordinator is null (set in Setup); verify no exception is thrown
+            _cropPlanting.AddPlan(new PlacedCropPlan { Type = CropType.Wheat, TileX = 10, TileY = 5 });
+            _gameState.Funds = 10000;
+            _service.GoldBuffer = 0;
+
+            // Should complete without throwing even though coordinator is null
+            _service.TryPurchasePass();
+
+            Assert.AreEqual(1, _cropPlanting.SeedInventory[(int)CropType.Wheat],
+                "Purchase should succeed even with a null coordinator");
+        }
+
+        [TestMethod]
+        public void TryPurchasePass_NoPlan_BuysNothing()
+        {
+            _gameState.Funds = 10000;
+
+            _service.TryPurchasePass();
+
+            // No plans → CountUnplantedPlans returns 0 for all crops → nothing bought
+            for (int i = 0; i < CropTypeInfo.Count; i++)
+                Assert.AreEqual(0, _cropPlanting.SeedInventory[i],
+                    $"No seeds should be bought when there are no plans (crop {i})");
+            Assert.AreEqual(10000, _gameState.Funds, "Funds should be unchanged with no plans");
+        }
+
+        [TestMethod]
+        public void TryPurchasePass_AlreadyCoveredByExistingCrop_BuysNothing()
+        {
+            // Plan exists but the same-type crop is already growing → CountUnplantedPlans = 0
+            var tile = new Point(10, 5);
+            _cropPlanting.AddPlan(new PlacedCropPlan { Type = CropType.Wheat, TileX = tile.X, TileY = tile.Y });
+            _cropGrowth.PlantCrop(tile, CropType.Wheat, null, null);
+            _gameState.Funds = 10000;
+            _service.GoldBuffer = 0;
+
+            _service.TryPurchasePass();
+
+            Assert.AreEqual(0, _cropPlanting.SeedInventory[(int)CropType.Wheat],
+                "Should not buy seeds when the plan's tile is already occupied by the same crop");
+        }
+    }
+}

--- a/PitHero.Tests/CropGrowthServiceTests.cs
+++ b/PitHero.Tests/CropGrowthServiceTests.cs
@@ -1,0 +1,138 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Xna.Framework;
+using PitHero.Farming;
+using PitHero.Services;
+using PitHero.Util;
+using System.Collections.Generic;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Tests for CropGrowthService.GetGrowthProgress.
+    /// RestoreAll is used with null scene/atlas for headless setup (no Nez Core required).
+    /// </summary>
+    [TestClass]
+    public class CropGrowthServiceTests
+    {
+        private CropPlantingService _cropPlanting = null!;
+        private CropGrowthService _growth = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _cropPlanting = new CropPlantingService();
+            _growth       = new CropGrowthService(_cropPlanting);
+        }
+
+        // ── Helper: Restore a crop into the service without a Scene or SpriteAtlas ──
+
+        private void RestoreCrop(Point tile, CropType type, float accumulatedHours,
+            int currentFrame, float regrowthMultiplier = 1f)
+        {
+            var states = new List<SavedCropGrowthState>
+            {
+                new SavedCropGrowthState
+                {
+                    TileX = tile.X,
+                    TileY = tile.Y,
+                    CropTypeId = (int)type,
+                    AccumulatedHours = accumulatedHours,
+                    CurrentFrame = currentFrame,
+                    RegrowthRateMultiplier = regrowthMultiplier,
+                }
+            };
+            _growth.RestoreAll(states, scene: null, atlas: null);
+        }
+
+        // ── GetGrowthProgress ────────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetGrowthProgress_NoCrop_ReturnsNegativeOne()
+        {
+            float progress = _growth.GetGrowthProgress(new Point(5, 5));
+
+            Assert.AreEqual(-1f, progress, "GetGrowthProgress should return -1 when no crop exists at the tile");
+        }
+
+        [TestMethod]
+        public void GetGrowthProgress_FreshlyPlanted_ReturnsZero()
+        {
+            // Wheat: maxFrame=5, hoursPerStage=2, totalHours=8
+            var tile = new Point(5, 5);
+            RestoreCrop(tile, CropType.Wheat, accumulatedHours: 0f, currentFrame: 1);
+
+            float progress = _growth.GetGrowthProgress(tile);
+
+            Assert.AreEqual(0f, progress, "Freshly planted crop (AccumulatedHours=0) should report 0 progress");
+        }
+
+        [TestMethod]
+        public void GetGrowthProgress_FullyGrown_ReturnsOne()
+        {
+            // Wheat: maxFrame=5, hoursPerStage=2, totalHours=(5-1)*2*1=8
+            var tile = new Point(5, 5);
+            int maxFrame = CropConfig.GetFrameCount(CropType.Wheat);
+            float hoursPerStage = CropConfig.GetHoursPerStage(CropType.Wheat);
+            float totalHours = (maxFrame - 1) * hoursPerStage;  // 8f
+            RestoreCrop(tile, CropType.Wheat, accumulatedHours: totalHours, currentFrame: maxFrame);
+
+            float progress = _growth.GetGrowthProgress(tile);
+
+            Assert.AreEqual(1f, progress, 0.001f, "Crop at full hours should report progress 1");
+        }
+
+        [TestMethod]
+        public void GetGrowthProgress_HalfGrown_ReturnsHalf()
+        {
+            // Wheat: totalHours=8, half=4
+            var tile = new Point(6, 5);
+            int maxFrame = CropConfig.GetFrameCount(CropType.Wheat);
+            float hoursPerStage = CropConfig.GetHoursPerStage(CropType.Wheat);
+            float totalHours = (maxFrame - 1) * hoursPerStage; // 8f
+            RestoreCrop(tile, CropType.Wheat, accumulatedHours: totalHours / 2f, currentFrame: 3);
+
+            float progress = _growth.GetGrowthProgress(tile);
+
+            Assert.AreEqual(0.5f, progress, 0.001f, "Crop at half the total hours should report 0.5 progress");
+        }
+
+        [TestMethod]
+        public void GetGrowthProgress_RespectsRegrowthRateMultiplier()
+        {
+            // Corn: maxFrame=10, hoursPerStage=3, multiplier=1.5
+            // totalHours = (10-1)*3*1.5 = 40.5
+            // At 20.25 hours → progress ≈ 0.5
+            var tile = new Point(7, 5);
+            int maxFrame = CropConfig.GetFrameCount(CropType.Corn);
+            float hoursPerStage = CropConfig.GetHoursPerStage(CropType.Corn);
+            float multiplier = 1.5f;
+            float totalHours = (maxFrame - 1) * hoursPerStage * multiplier; // 40.5
+
+            RestoreCrop(tile, CropType.Corn, accumulatedHours: totalHours / 2f, currentFrame: 1,
+                regrowthMultiplier: multiplier);
+
+            float progress = _growth.GetGrowthProgress(tile);
+
+            Assert.AreEqual(0.5f, progress, 0.001f,
+                "GetGrowthProgress should scale by RegrowthRateMultiplier (Corn at 1.5×)");
+        }
+
+        [TestMethod]
+        public void GetGrowthProgress_RegrowthMultiplierOne_MatchesBaseline()
+        {
+            // Lettuce: maxFrame=5, hoursPerStage=2, multiplier=1 (no regrowth override)
+            // totalHours = (5-1)*2*1 = 8; at 8h → progress=1
+            var tile = new Point(8, 5);
+            int maxFrame = CropConfig.GetFrameCount(CropType.Lettuce);
+            float hoursPerStage = CropConfig.GetHoursPerStage(CropType.Lettuce);
+            float totalHours = (maxFrame - 1) * hoursPerStage;
+
+            RestoreCrop(tile, CropType.Lettuce, accumulatedHours: totalHours, currentFrame: maxFrame,
+                regrowthMultiplier: 1f);
+
+            float progress = _growth.GetGrowthProgress(tile);
+
+            Assert.AreEqual(1f, progress, 0.001f, "Multiplier=1 should produce same result as no multiplier");
+        }
+    }
+}

--- a/PitHero.Tests/CropPlantingServiceTests.cs
+++ b/PitHero.Tests/CropPlantingServiceTests.cs
@@ -120,6 +120,31 @@ namespace PitHero.Tests
             Assert.IsFalse(_service.HasSeeds(CropType.Potato));
         }
 
+        // ── AddSeeds cap ─────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void AddSeeds_ClampsAtPerCropMax()
+        {
+            _service.SeedInventory = new int[CropTypeInfo.Count];
+            _service.SeedInventory[(int)CropType.Wheat] = GameConfig.SeedInventoryMaxPerCrop - 4;
+
+            _service.AddSeeds(CropType.Wheat, 10);
+
+            Assert.AreEqual(GameConfig.SeedInventoryMaxPerCrop, _service.SeedInventory[(int)CropType.Wheat],
+                "Seed count must clamp at the per-crop maximum");
+        }
+
+        [TestMethod]
+        public void AddSeeds_BelowCap_AddsNormally()
+        {
+            _service.SeedInventory = new int[CropTypeInfo.Count];
+            _service.SeedInventory[(int)CropType.Wheat] = 100;
+
+            _service.AddSeeds(CropType.Wheat, 10);
+
+            Assert.AreEqual(110, _service.SeedInventory[(int)CropType.Wheat]);
+        }
+
         // ── RemovePlan ───────────────────────────────────────────────────────
 
         [TestMethod]

--- a/PitHero.Tests/CropPlantingServiceTests.cs
+++ b/PitHero.Tests/CropPlantingServiceTests.cs
@@ -1,0 +1,157 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Xna.Framework;
+using PitHero.Farming;
+using PitHero.Services;
+
+namespace PitHero.Tests
+{
+    [TestClass]
+    public class CropPlantingServiceTests
+    {
+        private CropPlantingService _service = null!;
+        private CropGrowthService _growth = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _service = new CropPlantingService();
+            _growth  = new CropGrowthService(_service);
+        }
+
+        // ── CountUnplantedPlans ───────────────────────────────────────────────
+
+        /// <summary>A plan on a tile that has no crop at all counts as an unplanted plan.</summary>
+        [TestMethod]
+        public void CountUnplantedPlans_PlanWithNoCrop_Counts()
+        {
+            _service.AddPlan(new PlacedCropPlan { Type = CropType.Wheat, TileX = 10, TileY = 5 });
+
+            int count = _service.CountUnplantedPlans(CropType.Wheat, _growth);
+
+            Assert.AreEqual(1, count, "Plan on empty tile should count as unplanted");
+        }
+
+        /// <summary>A plan whose tile already has the same-type crop growing does not count.</summary>
+        [TestMethod]
+        public void CountUnplantedPlans_PlanWithSameTypeCrop_DoesNotCount()
+        {
+            var tile = new Point(10, 5);
+            _service.AddPlan(new PlacedCropPlan { Type = CropType.Wheat, TileX = tile.X, TileY = tile.Y });
+            // Plant the same crop type (null scene/atlas is fine for headless)
+            _growth.PlantCrop(tile, CropType.Wheat, null, null);
+
+            int count = _service.CountUnplantedPlans(CropType.Wheat, _growth);
+
+            Assert.AreEqual(0, count, "Plan whose tile already has the same-type crop should not count");
+        }
+
+        /// <summary>A plan whose tile has a DIFFERENT-type crop still counts (needs a seed for the swap).</summary>
+        [TestMethod]
+        public void CountUnplantedPlans_PlanWithDifferentTypeCrop_Counts()
+        {
+            var tile = new Point(10, 5);
+            _service.AddPlan(new PlacedCropPlan { Type = CropType.Corn, TileX = tile.X, TileY = tile.Y });
+            // Plant a different crop type at the same tile
+            _growth.PlantCrop(tile, CropType.Wheat, null, null);
+
+            int count = _service.CountUnplantedPlans(CropType.Corn, _growth);
+
+            Assert.AreEqual(1, count, "Plan whose tile has a different-type crop should still count");
+        }
+
+        // ── ConsumeSeed ───────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void ConsumeSeed_WithSufficientSeeds_DecrementsAndReturnsTrue()
+        {
+            _service.SeedInventory = new int[CropTypeInfo.Count];
+            _service.SeedInventory[(int)CropType.Wheat] = 3;
+
+            bool result = _service.ConsumeSeed(CropType.Wheat);
+
+            Assert.IsTrue(result, "ConsumeSeed should return true when seeds are available");
+            Assert.AreEqual(2, _service.SeedInventory[(int)CropType.Wheat], "Seed count should be decremented by 1");
+        }
+
+        [TestMethod]
+        public void ConsumeSeed_WithZeroSeeds_ReturnsFalseWithoutDecrementing()
+        {
+            _service.SeedInventory = new int[CropTypeInfo.Count];
+            _service.SeedInventory[(int)CropType.Corn] = 0;
+
+            bool result = _service.ConsumeSeed(CropType.Corn);
+
+            Assert.IsFalse(result, "ConsumeSeed should return false when count is 0");
+            Assert.AreEqual(0, _service.SeedInventory[(int)CropType.Corn], "Seed count must not go below 0");
+        }
+
+        [TestMethod]
+        public void ConsumeSeed_WithNullInventory_ReturnsFalse()
+        {
+            // SeedInventory is null by default
+            bool result = _service.ConsumeSeed(CropType.Wheat);
+
+            Assert.IsFalse(result, "ConsumeSeed should return false when SeedInventory is null");
+        }
+
+        // ── HasSeeds ─────────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void HasSeeds_WithSeedInInventory_ReturnsTrue()
+        {
+            _service.SeedInventory = new int[CropTypeInfo.Count];
+            _service.SeedInventory[(int)CropType.Potato] = 5;
+
+            Assert.IsTrue(_service.HasSeeds(CropType.Potato));
+        }
+
+        [TestMethod]
+        public void HasSeeds_WithZeroCount_ReturnsFalse()
+        {
+            _service.SeedInventory = new int[CropTypeInfo.Count];
+            _service.SeedInventory[(int)CropType.Potato] = 0;
+
+            Assert.IsFalse(_service.HasSeeds(CropType.Potato));
+        }
+
+        [TestMethod]
+        public void HasSeeds_WithNullInventory_ReturnsFalse()
+        {
+            Assert.IsFalse(_service.HasSeeds(CropType.Potato));
+        }
+
+        // ── RemovePlan ───────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void RemovePlan_ReturnsTheCropType()
+        {
+            _service.AddPlan(new PlacedCropPlan { Type = CropType.Tomato, TileX = 7, TileY = 3 });
+
+            CropType? removed = _service.RemovePlan(new Point(7, 3));
+
+            Assert.AreEqual(CropType.Tomato, removed, "RemovePlan should return the plan's crop type");
+        }
+
+        [TestMethod]
+        public void RemovePlan_DoesNotTouchSeedInventory()
+        {
+            _service.SeedInventory = new int[CropTypeInfo.Count];
+            _service.SeedInventory[(int)CropType.Tomato] = 4;
+            _service.AddPlan(new PlacedCropPlan { Type = CropType.Tomato, TileX = 7, TileY = 3 });
+
+            _service.RemovePlan(new Point(7, 3));
+
+            // Plans are permanent blueprints — removing one must not refund seeds
+            Assert.AreEqual(4, _service.SeedInventory[(int)CropType.Tomato],
+                "Removing a plan must not modify the seed inventory");
+        }
+
+        [TestMethod]
+        public void RemovePlan_NonExistentTile_ReturnsNull()
+        {
+            CropType? result = _service.RemovePlan(new Point(99, 99));
+
+            Assert.IsNull(result, "RemovePlan on a tile with no plan should return null");
+        }
+    }
+}

--- a/PitHero.Tests/PauseServiceTests.cs
+++ b/PitHero.Tests/PauseServiceTests.cs
@@ -149,5 +149,23 @@ namespace PitHero.Tests
             // The farm flag is untouched, so IsPaused is still true
             Assert.IsTrue(_pauseService.IsPaused, "IsPaused setter does not clear the farm-mode flag");
         }
+
+        [TestMethod]
+        public void IsManuallyPaused_ReflectsOnlyManualFlag_NotFarmGate()
+        {
+            // Farm pause alone: IsPaused true, but not manually paused (camera stays interactive)
+            _pauseService.SetFarmModePause(true);
+            Assert.IsTrue(_pauseService.IsPaused);
+            Assert.IsFalse(_pauseService.IsManuallyPaused, "Farm gate alone must not count as manual pause");
+
+            // Manual pause on top: both report true
+            _pauseService.IsPaused = true;
+            Assert.IsTrue(_pauseService.IsManuallyPaused, "Manual flag set → manually paused");
+
+            // Releasing the farm gate leaves the manual pause in effect
+            _pauseService.SetFarmModePause(false);
+            Assert.IsTrue(_pauseService.IsManuallyPaused);
+            Assert.IsTrue(_pauseService.IsPaused);
+        }
     }
 }

--- a/PitHero.Tests/PauseServiceTests.cs
+++ b/PitHero.Tests/PauseServiceTests.cs
@@ -65,15 +65,89 @@ namespace PitHero.Tests
         {
             // Act
             _pauseService.IsPaused = true;
-            
+
             // Assert
             Assert.IsTrue(_pauseService.IsPaused);
-            
+
             // Act
             _pauseService.IsPaused = false;
-            
+
             // Assert
             Assert.IsFalse(_pauseService.IsPaused);
+        }
+
+        // ── Farm-mode pause gate ─────────────────────────────────────────────
+
+        [TestMethod]
+        public void FarmModePause_SetTrue_MakesIsPausedTrue_IndependentOfManualFlag()
+        {
+            // Arrange: manual flag is false
+            Assert.IsFalse(_pauseService.IsPaused);
+
+            // Act
+            _pauseService.SetFarmModePause(true);
+
+            // Assert: farm flag alone is sufficient to make the service report paused
+            Assert.IsTrue(_pauseService.IsPaused);
+        }
+
+        [TestMethod]
+        public void FarmModePause_BothFlagsOrTogether_IsPausedTrue()
+        {
+            // Arrange: turn on both flags
+            _pauseService.IsPaused = true;
+            _pauseService.SetFarmModePause(true);
+
+            Assert.IsTrue(_pauseService.IsPaused, "Both flags set → IsPaused should be true");
+
+            // Clearing only the manual flag still keeps IsPaused true via the farm flag
+            _pauseService.IsPaused = false;
+            Assert.IsTrue(_pauseService.IsPaused, "Farm flag alone keeps IsPaused true");
+        }
+
+        [TestMethod]
+        public void FarmModePause_ToggleOnlyAffectsManualFlag_FarmGateStaysTrue()
+        {
+            // Arrange: farm pause on, manual flag off
+            _pauseService.SetFarmModePause(true);
+            Assert.IsTrue(_pauseService.IsPaused, "Precondition: paused via farm flag");
+
+            // Act: Toggle should flip the manual flag from false → true, but IsPaused stays true regardless
+            _pauseService.Toggle();
+
+            // The service is still paused (both flags are now true)
+            Assert.IsTrue(_pauseService.IsPaused, "After Toggle with farm flag on, IsPaused should still be true");
+
+            // Act: Toggle again (manual flag → false), farm flag still keeps IsPaused true
+            _pauseService.Toggle();
+            Assert.IsTrue(_pauseService.IsPaused, "After second Toggle, farm flag alone keeps IsPaused true");
+        }
+
+        [TestMethod]
+        public void FarmModePause_SetFalse_RestoresManualFlagControl()
+        {
+            // Arrange: farm pause on, manual flag off
+            _pauseService.SetFarmModePause(true);
+            Assert.IsTrue(_pauseService.IsPaused);
+
+            // Act: release farm pause
+            _pauseService.SetFarmModePause(false);
+
+            // Now only the manual flag controls IsPaused (which is still false)
+            Assert.IsFalse(_pauseService.IsPaused, "After farm flag cleared, manual flag (false) controls IsPaused");
+        }
+
+        [TestMethod]
+        public void FarmModePause_IsPausedSetterOnlyAffectsManualFlag()
+        {
+            // Arrange: farm pause on
+            _pauseService.SetFarmModePause(true);
+
+            // Act: try to "unpause" via the setter
+            _pauseService.IsPaused = false;
+
+            // The farm flag is untouched, so IsPaused is still true
+            Assert.IsTrue(_pauseService.IsPaused, "IsPaused setter does not clear the farm-mode flag");
         }
     }
 }

--- a/PitHero.Tests/SaveLoadTests.cs
+++ b/PitHero.Tests/SaveLoadTests.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using PitHero;
+using System.Text;
 
 namespace PitHero.Tests
 {
@@ -596,6 +597,85 @@ namespace PitHero.Tests
 
             Assert.AreEqual(1, migratedTier, "PitLevel 7 should map to tier 1");
             Assert.AreEqual(7, migratedLevel, "PitLevel 7 should remain 7 after migration");
+        }
+
+        /// <summary>
+        /// Verifies that AutomateSeedPurchases and AutoShopGoldBuffer round-trip correctly through
+        /// Persist/Recover in save version 15.
+        /// </summary>
+        [TestMethod]
+        public void SaveData_V15_AutoShopOptions_RoundTrip()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "pithero_v15_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var dataStore = new FileDataStore(tempDir);
+
+                var original = new SaveData();
+                original.AutomateSeedPurchases = true;
+                original.AutoShopGoldBuffer = 500;
+
+                dataStore.Save("v15_autoshop.bin", original);
+
+                var loaded = new SaveData();
+                dataStore.Load("v15_autoshop.bin", loaded);
+
+                Assert.AreEqual(true, loaded.AutomateSeedPurchases, "AutomateSeedPurchases should round-trip");
+                Assert.AreEqual(500, loaded.AutoShopGoldBuffer, "AutoShopGoldBuffer should round-trip");
+                Assert.AreEqual(15, loaded.LoadedFileVersion, "LoadedFileVersion should be 15");
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a save stream written without v15 fields yields the correct defaults
+        /// (AutomateSeedPurchases = false, AutoShopGoldBuffer = 200) when recovered.
+        /// The "older-version stream" is simulated by writing a v15 binary, patching the version
+        /// bytes to 14, and stripping the two v15 fields (bool + int = 5 bytes) from the tail.
+        /// </summary>
+        [TestMethod]
+        public void SaveData_OlderVersion_AutoShopOptions_DefaultValues()
+        {
+            // Write a full v15 SaveData to a MemoryStream
+            var ms = new MemoryStream();
+            using (var writer = new BinaryPersistableWriter(ms))
+            {
+                var original = new SaveData();
+                // Use non-default values so we can confirm they are NOT loaded
+                original.AutomateSeedPurchases = true;
+                original.AutoShopGoldBuffer = 999;
+                writer.Write(original);
+            }
+
+            byte[] bytes = ms.ToArray();
+
+            // Patch bytes [0-3] from version 15 to version 14 (little-endian int)
+            bytes[0] = 14;
+            bytes[1] = 0;
+            bytes[2] = 0;
+            bytes[3] = 0;
+
+            // Strip the last 5 bytes (section 30: bool AutomateSeedPurchases + int AutoShopGoldBuffer)
+            int trimmedLength = bytes.Length - 5;
+            var trimmed = new byte[trimmedLength];
+            Array.Copy(bytes, trimmed, trimmedLength);
+
+            // Recover from the modified stream (version 14, no v15 fields)
+            var loaded = new SaveData();
+            using (var rdr = new BinaryPersistableReader(new MemoryStream(trimmed)))
+            {
+                rdr.ReadPersistableInto(loaded);
+            }
+
+            Assert.AreEqual(14, loaded.LoadedFileVersion, "Should detect version 14");
+            Assert.AreEqual(false, loaded.AutomateSeedPurchases, "Default: AutomateSeedPurchases should be false for pre-v15 saves");
+            Assert.AreEqual(200, loaded.AutoShopGoldBuffer, "Default: AutoShopGoldBuffer should be 200 for pre-v15 saves");
         }
     }
 }

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -297,6 +297,11 @@ AddMonsterWindowTitle,Add Monsters
 AddMonsterRemainingSpace,Remaining Space: {0}
 AddMonsterDaytimeLabel,Daytime
 AddMonsterNocturnalLabel,Nocturnal
+TabAutoShop,Auto Shop
+SettingsAutomateSeedPurchases,Automate Seed Purchases
+SettingsAutoShopGoldBuffer,Gold Buffer: {0}
+SettingsAutomateSeedPurchasesTooltip,Buy seeds for planned crops as soon as gold is available
+SettingsAutoShopGoldBufferTooltip,No auto purchases will be made when gold is below this value
 AddMonsterConfirmPrompt,Add {0} for {1} Gold
 
 # Crop Storage options (issue #285)

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -255,6 +255,7 @@ SecondChanceBuyTotal,Total: {0} gold
 SecondChanceNoGold,Not enough gold!
 SecondChanceSellPrompt,Sell for {0} gold?
 SecondChanceOwnedCount,Owned: {0}
+SecondChanceNeedCount,Need: {0}
 
 # Event Console Messages
 ConsoleAttack,{0} attacks {1} for {2} damage!

--- a/PitHero/ECS/Components/CameraControllerComponent.cs
+++ b/PitHero/ECS/Components/CameraControllerComponent.cs
@@ -452,6 +452,21 @@ namespace PitHero.ECS.Components
         }
 
         /// <summary>
+        /// Resets camera zoom to the default while keeping the camera centered on the world
+        /// position it is currently looking at (clamped to the new zoom's bounds).
+        /// </summary>
+        public void ResetZoomToDefault()
+        {
+            if (_camera == null)
+                return;
+            var focus = _camera.Position;
+            _camera.RawZoom = GameConfig.CameraDefaultZoom;
+            _camera.Position = ConstrainCameraPosition(focus);
+            QuantizeCameraPosition();
+            Debug.Log($"[CameraController] ResetZoomToDefault zoom={_camera.RawZoom} positionX={_camera.Position.X} positionY={_camera.Position.Y}");
+        }
+
+        /// <summary>
         /// Configure zoom limits based on the map being loaded
         /// </summary>
         public void ConfigureZoomForMap(string mapPath)

--- a/PitHero/ECS/Components/CameraControllerComponent.cs
+++ b/PitHero/ECS/Components/CameraControllerComponent.cs
@@ -24,9 +24,10 @@ namespace PitHero.ECS.Components
         private Entity _heroEntity; // cached reference to hero entity
 
         /// <summary>
-        /// Gets whether this component should respect the global pause state.
+        /// Gets whether this component should respect the manual pause state.
         /// We shouldn't modify camera size or zoom while paused from menu.
-        /// We'll have separate menu controls that handle this.
+        /// The farm-mode pause gate is deliberately ignored so the player can pan/zoom the map
+        /// while planning crops over a wide area.
         /// </summary>
         public bool ShouldPause => true;
 
@@ -50,8 +51,10 @@ namespace PitHero.ECS.Components
             if (_camera == null)
                 return;
 
+            // Only the manual (menu) pause freezes the camera; the farm-mode pause keeps camera
+            // controls live so the player can right-mouse pan while planning crops.
             var pauseService = Core.Services.GetService<PauseService>();
-            if (pauseService?.IsPaused == true && ShouldPause)
+            if (pauseService?.IsManuallyPaused == true && ShouldPause)
                 return;
 
             // Cache hero entity reference if not already cached, or clear if hero is destroyed/dead

--- a/PitHero/ECS/Components/FarmingMonsterStateMachine.cs
+++ b/PitHero/ECS/Components/FarmingMonsterStateMachine.cs
@@ -442,7 +442,6 @@ namespace PitHero.ECS.Components
                         ? _cropGrowthService.GetGrowthProgress(tile)
                         : -1f;
                     bool stillValid = cropTypeAtTile.HasValue
-                        && Util.CropConfig.IsRepeatHarvest(cropTypeAtTile.Value)
                         && !planMatches
                         && arrivalProgress >= 0f
                         && arrivalProgress < GameConfig.CropSwapDestroyProgressThreshold;

--- a/PitHero/ECS/Components/FarmingMonsterStateMachine.cs
+++ b/PitHero/ECS/Components/FarmingMonsterStateMachine.cs
@@ -336,7 +336,12 @@ namespace PitHero.ECS.Components
                 }
                 else
                 {
-                    _coordinator.ReportBlocked(in _currentAction);
+                    // DestroyCrop tiles are released back to the queue (retried later) rather than
+                    // added to the building-change retry list which is only for till actions.
+                    if (_currentAction.Type == FarmActionType.DestroyCrop)
+                        _coordinator.ReleaseDestroyAction(in _currentAction);
+                    else
+                        _coordinator.ReportBlocked(in _currentAction);
                     _hasAction = false;
                 }
                 return;
@@ -424,6 +429,33 @@ namespace PitHero.ECS.Components
                     CurrentState = FarmingMonsterState.PerformHarvest;
                     break;
                 }
+                case FarmActionType.DestroyCrop:
+                {
+                    // Revalidate: crop still a swap candidate (plan may have been re-placed same-type,
+                    // or the crop may have grown past the threshold while walking).
+                    var cropPlanning = Core.Services.GetService<CropPlantingService>();
+                    var cropTypeAtTile = _cropGrowthService?.GetCropType(tile);
+                    bool planMatches = cropTypeAtTile.HasValue
+                        && cropPlanning != null
+                        && cropPlanning.GetPlanType(tile) == cropTypeAtTile.Value;
+                    float arrivalProgress = _cropGrowthService != null
+                        ? _cropGrowthService.GetGrowthProgress(tile)
+                        : -1f;
+                    bool stillValid = cropTypeAtTile.HasValue
+                        && Util.CropConfig.IsRepeatHarvest(cropTypeAtTile.Value)
+                        && !planMatches
+                        && arrivalProgress >= 0f
+                        && arrivalProgress < GameConfig.CropSwapDestroyProgressThreshold;
+                    if (!stillValid)
+                    {
+                        _coordinator.CompleteDestroyAction(in _currentAction);
+                        _hasAction = false;
+                        CurrentState = FarmingMonsterState.Idle;
+                        return;
+                    }
+                    CurrentState = FarmingMonsterState.PerformDestroyCrop;
+                    break;
+                }
                 default:
                     _coordinator.CompleteAction(in _currentAction);
                     _hasAction = false;
@@ -471,6 +503,65 @@ namespace PitHero.ECS.Components
             HoeAnimator?.SetEnabled(false);
         }
 
+        // ---------------------------------------------------------------- PerformDestroyCrop
+
+        private void PerformDestroyCrop_Enter()
+        {
+            _facing?.SetFacing(_standRight ? Direction.Left : Direction.Right);
+
+            float proficiencyScale = 1f - GameConfig.TillProficiencySpeedStep * (_monster.FarmingProficiency - 1);
+            _tillDuration = GameConfig.TillBaseDurationSeconds * proficiencyScale;
+
+            if (HoeAnimator != null)
+            {
+                float quadrant = GameConfig.TileSize / 4f;
+                HoeAnimator.SetLocalOffset(new Vector2(_standRight ? -quadrant : quadrant, quadrant));
+                HoeAnimator.FlipX = !_standRight;
+                if (BodyAnimator != null)
+                    HoeAnimator.SetLayerDepth(BodyAnimator.LayerDepth - 0.0001f);
+                HoeAnimator.SetEnabled(true);
+                HoeAnimator.Play("ForkedHoe", Nez.Sprites.SpriteAnimator.LoopMode.Loop);
+            }
+        }
+
+        private void PerformDestroyCrop_Tick()
+        {
+            if (elapsedTimeInState < _tillDuration)
+                return;
+
+            var tile = _currentAction.TargetTile;
+
+            // Re-check whether this tile still needs a destroy. If a same-type plan was placed
+            // while we were hoeing, leave the crop in place and just complete the action.
+            var cropPlanning = Core.Services.GetService<CropPlantingService>();
+            var cropTypeAtTile = _cropGrowthService?.GetCropType(tile);
+            bool planNowMatches = cropTypeAtTile.HasValue
+                && cropPlanning != null
+                && cropPlanning.GetPlanType(tile) == cropTypeAtTile.Value;
+
+            if (!planNowMatches && cropTypeAtTile.HasValue)
+            {
+                var tileState = Core.Services.GetService<TileStateService>();
+                _cropGrowthService?.RemoveCrop(tile);
+                tileState?.ClearFlag(tile, TileStateFlag.CropGrown);
+                tileState?.ClearFlag(tile, TileStateFlag.CropGrowing);
+                tileState?.ClearFlag(tile, TileStateFlag.Wet);
+                _wetTileService?.ClearWet(tile);
+            }
+
+            _coordinator.CompleteDestroyAction(in _currentAction);
+            _hasAction = false;
+            // Always notify: if crop was destroyed this schedules the waiting plan; if abort,
+            // HasCrop guard in NotifyPlanAddedOnTilledTile makes it a no-op.
+            _coordinator.NotifyPlanAddedOnTilledTile(tile);
+            CurrentState = FarmingMonsterState.Idle;
+        }
+
+        private void PerformDestroyCrop_Exit()
+        {
+            HoeAnimator?.SetEnabled(false);
+        }
+
         // ---------------------------------------------------------------- PerformPlant
 
         private void PerformPlant_Enter()
@@ -486,11 +577,29 @@ namespace PitHero.ECS.Components
 
             var tile = _currentAction.TargetTile;
             var cropPlanting = Core.Services.GetService<CropPlantingService>();
-            var cropType = cropPlanting?.GetPlanType(tile) ?? Farming.CropType.Wheat;
+            var planType = cropPlanting?.GetPlanType(tile);
 
-            // Load the crops atlas to get crop sprites
+            // Abort if the plan was removed while we were walking or waiting
+            if (!planType.HasValue)
+            {
+                _coordinator.CompletePlantAction(in _currentAction);
+                _hasAction = false;
+                CurrentState = FarmingMonsterState.Idle;
+                return;
+            }
+
+            // Abort if seeds ran out before we got here (another worker may have consumed them)
+            if (cropPlanting == null || !cropPlanting.ConsumeSeed(planType.Value))
+            {
+                _coordinator.CompletePlantAction(in _currentAction);
+                _hasAction = false;
+                CurrentState = FarmingMonsterState.Idle;
+                return;
+            }
+
+            // Load the crops atlas to get crop sprites; plan is kept after planting (permanent blueprint)
             var atlas = Core.Content.LoadSpriteAtlas("Content/Atlases/CropsProps.atlas");
-            _cropGrowthService?.PlantCrop(tile, cropType, Entity.Scene, atlas);
+            _cropGrowthService?.PlantCrop(tile, planType.Value, Entity.Scene, atlas);
 
             _coordinator.CompletePlantAction(in _currentAction);
             _hasAction = false;
@@ -818,24 +927,41 @@ namespace PitHero.ECS.Components
         {
             EnsureCropsAtlas();
             var tileState = Core.Services.GetService<TileStateService>();
+            var cropPlanting = Core.Services.GetService<CropPlantingService>();
 
             if (Util.CropConfig.IsRepeatHarvest(_harvestCropType))
             {
-                int revertFrame = Util.CropConfig.GetRevertFrame(_harvestCropType);
-                float mult = Util.CropConfig.GetRegrowthRateMultiplier(_harvestCropType);
-                _cropGrowthService?.RevertCropForRegrowth(tile, revertFrame, mult, _cropsAtlas);
-                tileState?.ClearFlag(tile, TileStateFlag.CropGrown);
-                tileState?.SetFlag(tile, TileStateFlag.CropGrowing);
-                // Soil dries out; the crop must be re-watered to regrow (re-enters the water queue)
-                tileState?.ClearFlag(tile, TileStateFlag.Wet);
-                _wetTileService?.ClearWet(tile);
+                // Only revert for regrowth when the plan still designates the same crop type.
+                // A different-type plan or no plan means the next cycle should be a swap/removal;
+                // taking the removal branch here ("after next harvest") is the cheapest path.
+                var planType = cropPlanting?.GetPlanType(tile);
+                if (planType.HasValue && planType.Value == _harvestCropType)
+                {
+                    int revertFrame = Util.CropConfig.GetRevertFrame(_harvestCropType);
+                    float mult = Util.CropConfig.GetRegrowthRateMultiplier(_harvestCropType);
+                    _cropGrowthService?.RevertCropForRegrowth(tile, revertFrame, mult, _cropsAtlas);
+                    tileState?.ClearFlag(tile, TileStateFlag.CropGrown);
+                    tileState?.SetFlag(tile, TileStateFlag.CropGrowing);
+                    // Soil dries out; the crop must be re-watered to regrow (re-enters the water queue)
+                    tileState?.ClearFlag(tile, TileStateFlag.Wet);
+                    _wetTileService?.ClearWet(tile);
+                }
+                else
+                {
+                    // Plan absent or changed — remove the repeat crop and schedule whatever comes next
+                    _cropGrowthService?.RemoveCrop(tile);
+                    tileState?.ClearFlag(tile, TileStateFlag.CropGrown);
+                    tileState?.ClearFlag(tile, TileStateFlag.CropGrowing);
+                    _coordinator.NotifyPlanAddedOnTilledTile(tile);
+                }
             }
             else
             {
-                // Regular crops are permanently removed — clean tilled slate for replanting
+                // One-shot crops are permanently removed — clean tilled slate for replanting
                 _cropGrowthService?.RemoveCrop(tile);
                 tileState?.ClearFlag(tile, TileStateFlag.CropGrown);
                 tileState?.ClearFlag(tile, TileStateFlag.CropGrowing);
+                _coordinator.NotifyPlanAddedOnTilledTile(tile);
             }
         }
 
@@ -1008,6 +1134,9 @@ namespace PitHero.ECS.Components
                     break;
                 case FarmActionType.Harvest:
                     _coordinator.ReleaseHarvestAction(in _currentAction);
+                    break;
+                case FarmActionType.DestroyCrop:
+                    _coordinator.ReleaseDestroyAction(in _currentAction);
                     break;
                 default:
                     _coordinator.ReleaseAction(in _currentAction);

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -2163,6 +2163,13 @@ namespace PitHero.ECS.Scenes
             {
                 if (inFarmMode)
                 {
+                    // Farm work is easier at full window size — temporarily restore full size
+                    // and default zoom while the farm UI is open; OnUIWindowClosing re-applies
+                    // the player's half-size preference on dismissal.
+                    bool wasHalfSize = WindowManager.IsHalfHeightMode();
+                    UIWindowManager.OnUIWindowOpening();
+                    if (wasHalfSize)
+                        _cameraController?.ResetZoomToDefault();
                     pauseService?.SetFarmModePause(true);
                     Core.Services.GetService<Services.CropGrowthService>()?.SetCropsVisible(false);
                     _savedFarmAutoScroll = UIWindowManager.AutoScrollToHeroEnabled;
@@ -2173,6 +2180,7 @@ namespace PitHero.ECS.Scenes
                 }
                 else
                 {
+                    UIWindowManager.OnUIWindowClosing();
                     pauseService?.SetFarmModePause(false);
                     Core.Services.GetService<Services.CropGrowthService>()?.SetCropsVisible(true);
                     Core.Services.GetService<Services.FarmTaskCoordinator>()?.RescanForPlanting();

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -256,6 +256,15 @@ namespace PitHero.ECS.Scenes
             farmTaskCoordinator.Initialize(this);
             Core.Services.AddService(farmTaskCoordinator);
 
+            // Auto seed purchase service buys seeds automatically to fulfil unplanted plans.
+            // Registered after the coordinator so its rescan hook is wired up.
+            var autoSeedPurchaseService = new Services.AutoSeedPurchaseService(
+                Core.Services.GetService<Services.CropPlantingService>(),
+                Core.Services.GetService<Services.CropGrowthService>(),
+                Core.Services.GetService<Services.GameStateService>(),
+                farmTaskCoordinator);
+            Core.Services.AddService(autoSeedPurchaseService);
+
             // Initialize hero promotion service (handles mercenary promotions and hero crystal ceremonies after death)
             _heroPromotionService = new Services.HeroPromotionService(this);
             Core.Services.AddService(_heroPromotionService);
@@ -396,6 +405,46 @@ namespace PitHero.ECS.Scenes
                     _seedModeOverlay.SpawnRestoredCropPlan((Farming.CropType)cp.CropTypeId, cp.TileX, cp.TileY);
                 }
             }
+
+            // v14 → v15 migration: old saves charged a seed at plan placement; new model pays at
+            // plant time, so refund each plan whose tile has no same-type growing crop, and infer
+            // plans for any growing crops that have no plan (so they aren't treated as pending-destroy).
+            if (pendingData.LoadedFileVersion < 15)
+            {
+                // (a) Refund +1 seed per plan whose tile lacks a same-type growing crop
+                if (pendingData.CropPlans != null && cropPlantingService != null && cropGrowthService != null)
+                {
+                    for (int i = 0; i < pendingData.CropPlans.Count; i++)
+                    {
+                        var cp       = pendingData.CropPlans[i];
+                        var planType = (Farming.CropType)cp.CropTypeId;
+                        var tile     = new Microsoft.Xna.Framework.Point(cp.TileX, cp.TileY);
+                        if (cropGrowthService.GetCropType(tile) != planType)
+                            cropPlantingService.AddSeeds(planType, 1);
+                    }
+                }
+
+                // (b) Infer plans for growing crops that have no plan (prevents pending-destroy treatment)
+                if (pendingData.CropGrowthStates != null && cropPlantingService != null && _seedModeOverlay != null)
+                {
+                    for (int i = 0; i < pendingData.CropGrowthStates.Count; i++)
+                    {
+                        var gs   = pendingData.CropGrowthStates[i];
+                        var tile = new Microsoft.Xna.Framework.Point(gs.TileX, gs.TileY);
+                        if (!cropPlantingService.HasPlan(tile))
+                            _seedModeOverlay.SpawnRestoredCropPlan((Farming.CropType)gs.CropTypeId, gs.TileX, gs.TileY);
+                    }
+                }
+            }
+
+            // Apply auto shop settings from save data and sync the settings UI controls
+            var autoSeedSvc = Core.Services.GetService<Services.AutoSeedPurchaseService>();
+            if (autoSeedSvc != null)
+            {
+                autoSeedSvc.Enabled    = pendingData.AutomateSeedPurchases;
+                autoSeedSvc.GoldBuffer = pendingData.AutoShopGoldBuffer;
+            }
+            _settingsUI?.SyncAutoShopControlsFromService();
 
             // Rebuild the plant queue now that both tile states and crop plans are restored
             Core.Services.GetService<Services.FarmTaskCoordinator>()?.RescanForPlanting();
@@ -2105,13 +2154,16 @@ namespace PitHero.ECS.Scenes
                 _wasInHarvestedCropsMode = inHarvestedCropsMode;
             }
 
-            // Show tilled-tile overlays and grayscale crop plans whenever the farm menu is open
-            // (sub-buttons visible or any sub-mode active). Also manages auto-scroll suppression.
+            // Show tilled-tile overlays and translucent crop plans whenever the farm menu is open
+            // (sub-buttons visible or any sub-mode active). Also manages pause gate, crop visibility,
+            // auto-scroll suppression, and post-close rescan for planting.
             bool inFarmMode = (_settingsUI?.IsFarmSubMenuOpen ?? false) || inTillMode || inBuildingMode || inSeedMode || inRemoveCropsMode || inHarvestedCropsMode;
             if (inFarmMode != _wasInFarmMode)
             {
                 if (inFarmMode)
                 {
+                    pauseService?.SetFarmModePause(true);
+                    Core.Services.GetService<Services.CropGrowthService>()?.SetCropsVisible(false);
                     _savedFarmAutoScroll = UIWindowManager.AutoScrollToHeroEnabled;
                     UIWindowManager.SetAutoScrollToHero(false);
                     if (!inTillMode)
@@ -2120,6 +2172,9 @@ namespace PitHero.ECS.Scenes
                 }
                 else
                 {
+                    pauseService?.SetFarmModePause(false);
+                    Core.Services.GetService<Services.CropGrowthService>()?.SetCropsVisible(true);
+                    Core.Services.GetService<Services.FarmTaskCoordinator>()?.RescanForPlanting();
                     UIWindowManager.SetAutoScrollToHero(_savedFarmAutoScroll);
                     if (!inTillMode)
                         _tillModeOverlay?.HideTilledOverlays();
@@ -2174,6 +2229,7 @@ namespace PitHero.ECS.Scenes
                 var cropsAtlas = Core.Content.LoadSpriteAtlas("Content/Atlases/CropsProps.atlas");
                 Core.Services.GetService<Services.CropGrowthService>()?.Update(
                     Core.Services.GetService<TileStateService>(), cropsAtlas);
+                Core.Services.GetService<Services.AutoSeedPurchaseService>()?.Update();
             }
 
             // Check if a living hero who respawned without a crystal has arrived at the statue

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -196,6 +196,7 @@ namespace PitHero.ECS.Scenes
             Core.Services.RemoveService(typeof(Services.TilledTileService));
             Core.Services.RemoveService(typeof(Services.WetTileService));
             Core.Services.RemoveService(typeof(Services.CropGrowthService));
+            Core.Services.RemoveService(typeof(Services.AutoSeedPurchaseService));
             Core.Services.GetService<Services.FarmTaskCoordinator>()?.Detach();
             Core.Services.RemoveService(typeof(Services.FarmTaskCoordinator));
             Core.Services.RemoveService(typeof(MercenaryManager));

--- a/PitHero/Farming/FarmAction.cs
+++ b/PitHero/Farming/FarmAction.cs
@@ -5,11 +5,13 @@ namespace PitHero.Farming
     /// <summary>Kinds of work a farming monster can perform.</summary>
     public enum FarmActionType
     {
-        Till       = 0,
-        Plant      = 1,
-        Water      = 2,
-        Harvest    = 3,
-        PickupDrop = 4,
+        Till        = 0,
+        Plant       = 1,
+        Water       = 2,
+        Harvest     = 3,
+        PickupDrop  = 4,
+        /// <summary>Destroy a repeat-harvest crop that is less than the swap threshold grown, to free the tile for a different-type plan.</summary>
+        DestroyCrop = 5,
     }
 
     /// <summary>A single unit of farm work, e.g. "till the tile at TargetTile".</summary>

--- a/PitHero/Farming/FarmingMonsterState.cs
+++ b/PitHero/Farming/FarmingMonsterState.cs
@@ -11,6 +11,7 @@ namespace PitHero.Farming
         PerformWater,
         FillWateringCan,
         PerformHarvest,
+        PerformDestroyCrop,
         MoveToDroppedCrop,
         CarryHarvestToStorage,
         DepositHarvest,

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -120,6 +120,12 @@ namespace PitHero
         public const float CropSwapDestroyProgressThreshold = 0.5f;
         /// <summary>Alpha value (0–255) for translucent plan-preview sprites shown in farm mode.</summary>
         public const int CropPlanPreviewAlpha = 153;
+        /// <summary>Maximum seed quantity purchasable in one Second Chance Shop transaction.</summary>
+        public const int SeedShopMaxPurchaseQuantity = 99;
+        /// <summary>Scale amplitude of the attention pulse on seed shop slots with unmet planned demand (0.1 = ±10%).</summary>
+        public const float SeedShopPulseAmplitude = 0.1f;
+        /// <summary>Angular speed (radians/sec) of the seed shop attention pulse.</summary>
+        public const float SeedShopPulseSpeed = 4f;
         public const int TillZerothGid = 122;            // GIDs 122-137 are the 16 tilled-tile bitmask variants
         public const int WetZeroTileIndex = 154;         // GIDs 154-169 are the 16 wet-tile bitmask variants
         public const float WaterBaseDurationSeconds = 3f;  // watering time at FarmingProficiency 1

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -116,8 +116,8 @@ namespace PitHero
         public const int TownBuildingHeight = 48;
 
         // Farming Configuration
-        /// <summary>Fraction of total growth at which a repeat-harvest crop is eligible for early destroy/swap (e.g. 0.2 = 20%).</summary>
-        public const float CropSwapDestroyProgressThreshold = 0.2f;
+        /// <summary>Fraction of total growth below which any crop is eligible for early destroy/swap (e.g. 0.5 = 50%).</summary>
+        public const float CropSwapDestroyProgressThreshold = 0.5f;
         /// <summary>Alpha value (0–255) for translucent plan-preview sprites shown in farm mode.</summary>
         public const int CropPlanPreviewAlpha = 153;
         public const int TillZerothGid = 122;            // GIDs 122-137 are the 16 tilled-tile bitmask variants

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -116,6 +116,10 @@ namespace PitHero
         public const int TownBuildingHeight = 48;
 
         // Farming Configuration
+        /// <summary>Fraction of total growth at which a repeat-harvest crop is eligible for early destroy/swap (e.g. 0.2 = 20%).</summary>
+        public const float CropSwapDestroyProgressThreshold = 0.2f;
+        /// <summary>Alpha value (0–255) for translucent plan-preview sprites shown in farm mode.</summary>
+        public const int CropPlanPreviewAlpha = 153;
         public const int TillZerothGid = 122;            // GIDs 122-137 are the 16 tilled-tile bitmask variants
         public const int WetZeroTileIndex = 154;         // GIDs 154-169 are the 16 wet-tile bitmask variants
         public const float WaterBaseDurationSeconds = 3f;  // watering time at FarmingProficiency 1

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -122,6 +122,8 @@ namespace PitHero
         public const int CropPlanPreviewAlpha = 153;
         /// <summary>Maximum seed quantity purchasable in one Second Chance Shop transaction.</summary>
         public const int SeedShopMaxPurchaseQuantity = 99;
+        /// <summary>Maximum seeds of a single crop type the player can hold.</summary>
+        public const int SeedInventoryMaxPerCrop = 999;
         /// <summary>Scale amplitude of the attention pulse on seed shop slots with unmet planned demand (0.1 = ±10%).</summary>
         public const float SeedShopPulseAmplitude = 0.1f;
         /// <summary>Angular speed (radians/sec) of the seed shop attention pulse.</summary>

--- a/PitHero/Services/AutoSeedPurchaseService.cs
+++ b/PitHero/Services/AutoSeedPurchaseService.cs
@@ -1,0 +1,95 @@
+using Nez;
+using PitHero.Farming;
+using PitHero.Util;
+
+namespace PitHero.Services
+{
+    /// <summary>
+    /// Automatically purchases seeds from the shop to fulfil outstanding crop planting plans.
+    /// Purchases are throttled to once per second and only fire while the game is unpaused.
+    /// </summary>
+    public class AutoSeedPurchaseService
+    {
+        private readonly CropPlantingService _cropPlanting;
+        private readonly CropGrowthService   _cropGrowth;
+        private readonly GameStateService    _gameState;
+        private readonly FarmTaskCoordinator _coordinator;
+        private float _throttleTimer;
+
+        /// <summary>Whether automatic seed purchasing is active.</summary>
+        public bool Enabled { get; set; } = false;
+
+        /// <summary>
+        /// Minimum gold the player must have above the seed price before a purchase is made.
+        /// No purchase fires when Funds - price &lt; GoldBuffer.
+        /// </summary>
+        public int GoldBuffer { get; set; } = 200;
+
+        /// <summary>
+        /// Initialises the service with the required dependencies.
+        /// <paramref name="coordinator"/> may be null in headless test contexts.
+        /// </summary>
+        public AutoSeedPurchaseService(
+            CropPlantingService cropPlanting,
+            CropGrowthService   cropGrowth,
+            GameStateService    gameState,
+            FarmTaskCoordinator coordinator)
+        {
+            _cropPlanting = cropPlanting;
+            _cropGrowth   = cropGrowth;
+            _gameState    = gameState;
+            _coordinator  = coordinator;
+        }
+
+        /// <summary>
+        /// Advances the purchase throttle and, when enabled, buys seeds for all under-stocked plans.
+        /// Called once per game frame while the game is unpaused.
+        /// </summary>
+        public void Update()
+        {
+            if (!Enabled) return;
+
+            _throttleTimer += Time.DeltaTime;
+            if (_throttleTimer < 1f) return;
+            _throttleTimer = 0f;
+
+            TryPurchasePass();
+        }
+
+        /// <summary>
+        /// Executes one purchase pass: buys seeds for any under-stocked plans while funds and the
+        /// gold-buffer constraint allow. Idempotent and safe to call directly from tests, bypassing
+        /// the 1-second throttle gate.
+        /// </summary>
+        public void TryPurchasePass()
+        {
+            if (_cropPlanting == null || _gameState == null) return;
+
+            bool boughtAnything = false;
+            for (int i = 0; i < CropTypeInfo.Count; i++)
+            {
+                var crop  = (CropType)i;
+                int price = CropConfig.GetSeedPrice(crop);
+                if (price <= 0) continue;
+
+                int needed = _cropPlanting.CountUnplantedPlans(crop, _cropGrowth);
+                if (needed <= 0) continue;
+
+                int owned = _cropPlanting.SeedInventory != null
+                    ? _cropPlanting.SeedInventory[(int)crop]
+                    : 0;
+
+                while (owned < needed && _gameState.Funds - price >= GoldBuffer)
+                {
+                    _gameState.Funds -= price;
+                    _cropPlanting.AddSeeds(crop, 1);
+                    owned++;
+                    boughtAnything = true;
+                }
+            }
+
+            if (boughtAnything)
+                _coordinator?.RescanForPlanting();
+        }
+    }
+}

--- a/PitHero/Services/AutoSeedPurchaseService.cs
+++ b/PitHero/Services/AutoSeedPurchaseService.cs
@@ -74,6 +74,10 @@ namespace PitHero.Services
 
                 int needed = _cropPlanting.CountUnplantedPlans(crop, _cropGrowth);
                 if (needed <= 0) continue;
+                // Never buy past the per-crop inventory cap — AddSeeds would clamp the
+                // overflow away and the gold would be wasted.
+                if (needed > GameConfig.SeedInventoryMaxPerCrop)
+                    needed = GameConfig.SeedInventoryMaxPerCrop;
 
                 int owned = _cropPlanting.SeedInventory != null
                     ? _cropPlanting.SeedInventory[(int)crop]

--- a/PitHero/Services/CropGrowthService.cs
+++ b/PitHero/Services/CropGrowthService.cs
@@ -28,6 +28,8 @@ namespace PitHero.Services
 
         private readonly Dictionary<Point, ActiveCropData> _crops = new Dictionary<Point, ActiveCropData>();
         private readonly CropPlantingService _cropPlantingService;
+        // When false, all crop world entities are hidden (farm UI is open)
+        private bool _cropsVisible = true;
 
         public CropGrowthService(CropPlantingService cropPlantingService)
         {
@@ -46,15 +48,14 @@ namespace PitHero.Services
         }
 
         /// <summary>
-        /// Plants a seed at the tile: removes the plan-preview entity, creates the frame-1 crop
-        /// entity, and registers the crop for growth tracking.
+        /// Plants a seed at the tile: creates the frame-1 crop entity and registers the crop for
+        /// growth tracking. The plan-preview entity is NOT removed here — plans are permanent
+        /// blueprints and their visuals are managed separately by the farm-mode gate.
         /// </summary>
         public void PlantCrop(Point tile, CropType type, Scene scene, SpriteAtlas atlas)
         {
             if (_crops.ContainsKey(tile))
                 return;
-
-            _cropPlantingService?.RemovePlan(tile);
 
             var sprite = atlas?.GetSprite(CropConfig.GetFrameSpriteName(type, 1));
             float sprH = sprite != null ? sprite.SourceRect.Height : GameConfig.TileSize;
@@ -68,6 +69,8 @@ namespace PitHero.Services
                 entity.SetPosition(wx, wy);
                 var renderer = entity.AddComponent(new SpriteRenderer(sprite));
                 renderer.SetRenderLayer(GameConfig.RenderLayerSingleTileObject - 1);
+                if (!_cropsVisible)
+                    entity.SetEnabled(false);
             }
 
             _crops[tile] = new ActiveCropData
@@ -194,6 +197,8 @@ namespace PitHero.Services
                     entity.SetPosition(wx, wy);
                     var renderer = entity.AddComponent(new SpriteRenderer(sprite));
                     renderer.SetRenderLayer(GameConfig.RenderLayerSingleTileObject - 1);
+                    if (!_cropsVisible)
+                        entity.SetEnabled(false);
                 }
 
                 _crops[tile] = new ActiveCropData
@@ -204,6 +209,44 @@ namespace PitHero.Services
                     WorldEntity = entity,
                     RegrowthRateMultiplier = s.RegrowthRateMultiplier <= 0f ? 1f : s.RegrowthRateMultiplier,
                 };
+            }
+        }
+
+        /// <summary>
+        /// Returns the growth progress of a crop at the given tile as a value in [0, 1], where
+        /// 0 is freshly planted and 1 is fully grown. Returns -1 when no crop exists at the tile.
+        /// Uses the crop's regrowth-rate multiplier so post-harvest regrowth progress is accurate.
+        /// </summary>
+        public float GetGrowthProgress(Point tile)
+        {
+            if (!_crops.TryGetValue(tile, out var data))
+                return -1f;
+
+            int maxFrame = CropConfig.GetFrameCount(data.Type);
+            float hoursPerStage = CropConfig.GetHoursPerStage(data.Type);
+            float multiplier = data.RegrowthRateMultiplier <= 0f ? 1f : data.RegrowthRateMultiplier;
+            float totalHours = (maxFrame - 1) * hoursPerStage * multiplier;
+            if (totalHours <= 0f)
+                return 1f;
+            float progress = data.AccumulatedHours / totalHours;
+            if (progress < 0f) progress = 0f;
+            if (progress > 1f) progress = 1f;
+            return progress;
+        }
+
+        /// <summary>
+        /// Shows or hides all crop world entities. Called when the Farm UI opens (false) or closes
+        /// (true) so real crops are not visible behind the translucent plan overlays. The state is
+        /// persisted and applied to entities created by PlantCrop and RestoreAll.
+        /// </summary>
+        public void SetCropsVisible(bool visible)
+        {
+            _cropsVisible = visible;
+            var keys = new List<Point>(_crops.Keys);
+            for (int i = 0; i < keys.Count; i++)
+            {
+                if (_crops.TryGetValue(keys[i], out var data))
+                    data.WorldEntity?.SetEnabled(visible);
             }
         }
 

--- a/PitHero/Services/CropPlantingService.cs
+++ b/PitHero/Services/CropPlantingService.cs
@@ -146,14 +146,18 @@ namespace PitHero.Services
         }
 
         /// <summary>
-        /// Adds the given number of seeds for the specified crop to the seed inventory.
-        /// Safe to call before the overlay assigns the array — allocates a fallback if needed.
+        /// Adds the given number of seeds for the specified crop to the seed inventory, clamped
+        /// at GameConfig.SeedInventoryMaxPerCrop. Safe to call before the overlay assigns the
+        /// array — allocates a fallback if needed.
         /// </summary>
         public void AddSeeds(CropType crop, int count)
         {
             if (SeedInventory == null)
                 SeedInventory = new int[CropTypeInfo.Count];
-            SeedInventory[(int)crop] += count;
+            int next = SeedInventory[(int)crop] + count;
+            if (next > GameConfig.SeedInventoryMaxPerCrop)
+                next = GameConfig.SeedInventoryMaxPerCrop;
+            SeedInventory[(int)crop] = next;
         }
 
         /// <summary>Destroys all world entities and clears the plan registry.</summary>

--- a/PitHero/Services/CropPlantingService.cs
+++ b/PitHero/Services/CropPlantingService.cs
@@ -101,6 +101,50 @@ namespace PitHero.Services
             return plan.Type;
         }
 
+        /// <summary>Returns true if at least one seed of the given type is in the inventory.</summary>
+        public bool HasSeeds(CropType crop)
+        {
+            if (SeedInventory == null)
+                return false;
+            return SeedInventory[(int)crop] > 0;
+        }
+
+        /// <summary>
+        /// Decrements the seed inventory by one and returns true. Returns false without
+        /// modifying the inventory when there are no seeds or the array is not yet assigned.
+        /// </summary>
+        public bool ConsumeSeed(CropType crop)
+        {
+            if (SeedInventory == null)
+                return false;
+            int idx = (int)crop;
+            if (SeedInventory[idx] <= 0)
+                return false;
+            SeedInventory[idx]--;
+            return true;
+        }
+
+        /// <summary>
+        /// Counts plans of the given type whose tile does NOT have a same-type growing crop
+        /// (i.e. plans that still require a seed to be planted). A different-type crop on the
+        /// same tile is excluded: it counts as needing a future seed for the swap.
+        /// </summary>
+        public int CountUnplantedPlans(CropType crop, CropGrowthService growth)
+        {
+            int count = 0;
+            for (int i = 0; i < _plans.Count; i++)
+            {
+                if (_plans[i].Type != crop)
+                    continue;
+                var tile = new Microsoft.Xna.Framework.Point(_plans[i].TileX, _plans[i].TileY);
+                // Skip tiles that already have the same-type crop growing
+                if (growth != null && growth.GetCropType(tile) == crop)
+                    continue;
+                count++;
+            }
+            return count;
+        }
+
         /// <summary>
         /// Adds the given number of seeds for the specified crop to the seed inventory.
         /// Safe to call before the overlay assigns the array — allocates a fallback if needed.

--- a/PitHero/Services/FarmTaskCoordinator.cs
+++ b/PitHero/Services/FarmTaskCoordinator.cs
@@ -44,6 +44,10 @@ namespace PitHero.Services
         private readonly Deque<FarmAction> _harvestQueue = new Deque<FarmAction>(64);
         private readonly HashSet<Point> _harvestTracked = new HashSet<Point>();
 
+        // Destroy queue — repeat-harvest crops that are <20% grown with a missing/different plan
+        private readonly Deque<FarmAction> _destroyQueue = new Deque<FarmAction>(64);
+        private readonly HashSet<Point> _destroyTracked = new HashSet<Point>();
+
         // Pickup queue — crops dropped on the ground awaiting recovery to storage
         private readonly Deque<FarmAction> _pickupQueue = new Deque<FarmAction>(16);
         private readonly HashSet<Point> _pickupTracked = new HashSet<Point>();
@@ -287,12 +291,12 @@ namespace PitHero.Services
             enumerator.Dispose();
         }
 
-        /// <summary>Claims the next valid action from the queues (priority: Till > Plant > Water).</summary>
+        /// <summary>Claims the next valid action from the queues (priority: Pickup > Till > Destroy > Plant > Harvest > Water).</summary>
         public bool TryClaimAction(out FarmAction action) => TryClaimAction(0f, out action);
 
         /// <summary>
         /// Pops the next valid action near the given normalized queue position (0 = front,
-        /// 1 = back), with priority: Till first, then Plant, then Water.
+        /// 1 = back), with priority: Pickup > Till > Destroy > Plant > Harvest > Water.
         /// Workers are given different positions so they spread across the field instead of clustering.
         /// A returned action is considered claimed until Complete/Release/ReportBlocked.
         /// Returns false when all queues are empty.
@@ -306,15 +310,20 @@ namespace PitHero.Services
             // Priority 1: Till
             if (TryClaimFromQueue(_queue, _tracked, queuePick, ValidateTill, out action))
                 return true;
-            // Priority 2: Plant
+            // Priority 2: Destroy — remove repeat crops whose plan changed (frees tile for swap-plant)
+            PopulateDestroyQueue();
+            if (TryClaimFromQueue(_destroyQueue, _destroyTracked, queuePick, ValidateDestroy, out action))
+                return true;
+            // Priority 3: Plant
             if (TryClaimFromQueue(_plantQueue, _plantTracked, queuePick, ValidatePlant, out action))
                 return true;
-            // Priority 3: Harvest — collect fully-grown crops before watering still-growing ones
+            // Priority 4: Harvest — collect fully-grown crops before watering still-growing ones
             PopulateHarvestQueue();
             if (TryClaimFromQueue(_harvestQueue, _harvestTracked, queuePick, ValidateHarvest, out action))
                 return true;
-            // Priority 4: Water — only when no plant work remains (queued or in-progress)
-            if (_plantTracked.Count == 0)
+            // Priority 5: Water — only when no plant or destroy work remains (queued or in-progress);
+            // guards against watering a crop that is about to be destroyed for a swap.
+            if (_plantTracked.Count == 0 && _destroyTracked.Count == 0)
             {
                 PopulateWaterQueue();
                 if (TryClaimFromQueue(_waterQueue, _waterTracked, queuePick, ValidateWater, out action))
@@ -357,8 +366,46 @@ namespace PitHero.Services
         {
             var cropPlanting = GetService<CropPlantingService>();
             var cropGrowth = GetService<CropGrowthService>();
-            return cropPlanting != null && cropPlanting.HasPlan(tile)
-                && (cropGrowth == null || !cropGrowth.HasCrop(tile));
+            if (cropPlanting == null || !cropPlanting.HasPlan(tile))
+                return false;
+            if (cropGrowth != null && cropGrowth.HasCrop(tile))
+                return false;
+            var planType = cropPlanting.GetPlanType(tile);
+            return planType.HasValue && cropPlanting.HasSeeds(planType.Value);
+        }
+
+        /// <summary>
+        /// Returns true when a repeat-harvest crop at the tile is a candidate for early removal:
+        /// the plan is absent or designates a different crop type, and the crop is less than the
+        /// swap-destroy threshold grown (so destroying and replanting is cheaper than waiting to
+        /// harvest). Null-safe for headless tests.
+        /// </summary>
+        private bool ValidateDestroy(Point tile)
+        {
+            var cropGrowth = GetService<CropGrowthService>();
+            if (cropGrowth == null)
+                return false;
+
+            var cropType = cropGrowth.GetCropType(tile);
+            if (!cropType.HasValue)
+                return false;
+
+            // Only early-destroy repeat-harvest crops; one-shot crops are never destroyed early
+            if (!CropConfig.IsRepeatHarvest(cropType.Value))
+                return false;
+
+            // No-op when the plan matches the growing crop (no swap pending)
+            var cropPlanting = GetService<CropPlantingService>();
+            var planType = cropPlanting?.GetPlanType(tile);
+            if (planType.HasValue && planType.Value == cropType.Value)
+                return false;
+
+            // Only eligible while the crop is less than the threshold fraction grown
+            float progress = cropGrowth.GetGrowthProgress(tile);
+            if (progress < 0f || progress >= GameConfig.CropSwapDestroyProgressThreshold)
+                return false;
+
+            return true;
         }
 
         private bool ValidateWater(Point tile)
@@ -456,6 +503,12 @@ namespace PitHero.Services
         /// <summary>Returns a claimed harvest action to the front of the queue.</summary>
         public void ReleaseHarvestAction(in FarmAction action) => _harvestQueue.AddFront(action);
 
+        /// <summary>Marks a claimed destroy-crop action finished.</summary>
+        public void CompleteDestroyAction(in FarmAction action) => _destroyTracked.Remove(action.TargetTile);
+
+        /// <summary>Returns a claimed destroy-crop action to the front of the queue.</summary>
+        public void ReleaseDestroyAction(in FarmAction action) => _destroyQueue.AddFront(action);
+
         /// <summary>Marks a claimed pickup action finished (the drop was recovered or removed).</summary>
         public void CompletePickupAction(in FarmAction action) => _pickupTracked.Remove(action.TargetTile);
 
@@ -471,13 +524,17 @@ namespace PitHero.Services
         }
 
         /// <summary>
-        /// Called when a crop plan is placed on a tile that is already Tilled.
-        /// In that case HandleTileTilled won't fire again, so we enqueue the Plant action here.
+        /// Called when a crop plan is placed on a tile that is already Tilled, or after a destroy/
+        /// harvest completes to schedule the waiting plan. Guards against duplicate enqueues and
+        /// no-op calls (no plan, crop still present). Safe to call unconditionally.
         /// </summary>
         public void NotifyPlanAddedOnTilledTile(Point tile)
         {
             var cropGrowth = GetService<CropGrowthService>();
             if (cropGrowth != null && cropGrowth.HasCrop(tile))
+                return;
+            var cropPlanting = GetService<CropPlantingService>();
+            if (cropPlanting == null || !cropPlanting.HasPlan(tile))
                 return;
             if (_plantTracked.Add(tile))
                 _plantQueue.AddBack(new FarmAction { Type = FarmActionType.Plant, TargetTile = tile });
@@ -530,6 +587,26 @@ namespace PitHero.Services
                     continue;
                 if (_waterTracked.Add(tile))
                     _waterQueue.AddBack(new FarmAction { Type = FarmActionType.Water, TargetTile = tile });
+            }
+        }
+
+        /// <summary>
+        /// Enqueues DestroyCrop actions for repeat-harvest crops that are less than
+        /// <see cref="GameConfig.CropSwapDestroyProgressThreshold"/> grown and whose plan is absent
+        /// or designates a different crop type. Called from TryClaimAction (cheap scan).
+        /// </summary>
+        public void PopulateDestroyQueue()
+        {
+            var cropGrowth = GetService<CropGrowthService>();
+            if (cropGrowth == null)
+                return;
+
+            foreach (var tile in cropGrowth.GetAllCropTiles())
+            {
+                if (!ValidateDestroy(tile))
+                    continue;
+                if (_destroyTracked.Add(tile))
+                    _destroyQueue.AddBack(new FarmAction { Type = FarmActionType.DestroyCrop, TargetTile = tile });
             }
         }
 

--- a/PitHero/Services/FarmTaskCoordinator.cs
+++ b/PitHero/Services/FarmTaskCoordinator.cs
@@ -375,10 +375,10 @@ namespace PitHero.Services
         }
 
         /// <summary>
-        /// Returns true when a repeat-harvest crop at the tile is a candidate for early removal:
-        /// the plan is absent or designates a different crop type, and the crop is less than the
-        /// swap-destroy threshold grown (so destroying and replanting is cheaper than waiting to
-        /// harvest). Null-safe for headless tests.
+        /// Returns true when a crop at the tile is a candidate for early removal: the plan is
+        /// absent or designates a different crop type, and the crop is less than the swap-destroy
+        /// threshold grown (so destroying and replanting is cheaper than waiting to harvest).
+        /// Crops past the threshold are left to be harvested first. Null-safe for headless tests.
         /// </summary>
         private bool ValidateDestroy(Point tile)
         {
@@ -388,10 +388,6 @@ namespace PitHero.Services
 
             var cropType = cropGrowth.GetCropType(tile);
             if (!cropType.HasValue)
-                return false;
-
-            // Only early-destroy repeat-harvest crops; one-shot crops are never destroyed early
-            if (!CropConfig.IsRepeatHarvest(cropType.Value))
                 return false;
 
             // No-op when the plan matches the growing crop (no swap pending)
@@ -591,7 +587,7 @@ namespace PitHero.Services
         }
 
         /// <summary>
-        /// Enqueues DestroyCrop actions for repeat-harvest crops that are less than
+        /// Enqueues DestroyCrop actions for crops that are less than
         /// <see cref="GameConfig.CropSwapDestroyProgressThreshold"/> grown and whose plan is absent
         /// or designates a different crop type. Called from TryClaimAction (cheap scan).
         /// </summary>

--- a/PitHero/Services/PauseService.cs
+++ b/PitHero/Services/PauseService.cs
@@ -31,6 +31,13 @@ namespace PitHero.Services
         }
 
         /// <summary>
+        /// True only when the manual pause flag is set (settings menu, dialogs). Excludes the
+        /// farm-mode gate, so components like the camera controller can stay interactive while
+        /// the player is planning crops.
+        /// </summary>
+        public bool IsManuallyPaused => _isPaused;
+
+        /// <summary>
         /// Activates or deactivates the farm-mode pause gate. While true, IsPaused returns
         /// true regardless of the manual pause flag, stopping workers and crop growth.
         /// </summary>

--- a/PitHero/Services/PauseService.cs
+++ b/PitHero/Services/PauseService.cs
@@ -8,13 +8,18 @@ namespace PitHero.Services
     public class PauseService
     {
         private bool _isPaused = false;
+        // Independent flag set while the Farm UI is open; OR'd into IsPaused so existing
+        // writers (SettingsUI, Escape key, etc.) continue to operate on _isPaused only.
+        private bool _farmModePause = false;
 
         /// <summary>
-        /// Gets or sets whether the game is currently paused
+        /// Gets or sets whether the game is currently paused. The getter returns true when either
+        /// the manual pause flag or the farm-mode gate is active; the setter and helpers only
+        /// mutate the manual flag.
         /// </summary>
         public bool IsPaused
         {
-            get => _isPaused;
+            get => _isPaused || _farmModePause;
             set
             {
                 if (_isPaused != value)
@@ -23,6 +28,15 @@ namespace PitHero.Services
                     Debug.Log($"[PauseService] Game pause state changed to: {_isPaused}");
                 }
             }
+        }
+
+        /// <summary>
+        /// Activates or deactivates the farm-mode pause gate. While true, IsPaused returns
+        /// true regardless of the manual pause flag, stopping workers and crop growth.
+        /// </summary>
+        public void SetFarmModePause(bool active)
+        {
+            _farmModePause = active;
         }
 
         /// <summary>
@@ -42,11 +56,11 @@ namespace PitHero.Services
         }
 
         /// <summary>
-        /// Toggles the pause state
+        /// Toggles the manual pause flag (does not touch the farm-mode gate).
         /// </summary>
         public void Toggle()
         {
-            IsPaused = !IsPaused;
+            IsPaused = !_isPaused;
         }
     }
 }

--- a/PitHero/Services/SaveData.cs
+++ b/PitHero/Services/SaveData.cs
@@ -246,7 +246,7 @@ namespace PitHero.Services
     public class SaveData : IPersistable
     {
         /// <summary>Current save file version.</summary>
-        public const int CurrentVersion = 14;
+        public const int CurrentVersion = 15;
 
         // Total Time
         /// <summary>Total time played in seconds.</summary>
@@ -457,6 +457,16 @@ namespace PitHero.Services
         // Defeated Monsters
         /// <summary>Bare enum names of monster types the player has defeated in battle (version 11+).</summary>
         public List<string> DefeatedMonsterTypes;
+
+        // Auto Shop Options (version 15+)
+        /// <summary>Whether automatic seed purchasing is enabled (version 15+).</summary>
+        public bool AutomateSeedPurchases = false;
+
+        /// <summary>Gold buffer threshold: no purchase fires when Funds - price &lt; this value (version 15+).</summary>
+        public int AutoShopGoldBuffer = 200;
+
+        /// <summary>The save file version number read during Recover; 0 for a brand-new in-memory instance.</summary>
+        public int LoadedFileVersion;
 
         /// <summary>Initializes a new SaveData with default empty collections.</summary>
         public SaveData()
@@ -814,6 +824,10 @@ namespace PitHero.Services
             // 29. Pit tier (version 13+)
             writer.Write(PitTier);
             writer.Write(TierBaseLevel);
+
+            // 30. Auto shop options (v15+)
+            writer.Write(AutomateSeedPurchases);
+            writer.Write(AutoShopGoldBuffer);
         }
 
         /// <summary>Reads all game state from the persistence reader.</summary>
@@ -821,6 +835,7 @@ namespace PitHero.Services
         {
             // 1. File Version
             int fileVersion = reader.ReadInt();
+            LoadedFileVersion = fileVersion;
 
             // 2. Total Time Played
             TotalTimePlayed = reader.ReadFloat();
@@ -1260,6 +1275,14 @@ namespace PitHero.Services
                 // Normalise PitLevel to biome-local range so the rest of the game sees [1..MaxBiomeLevel].
                 PitLevel = BiomeProgressionConfig.GetDisplayedLevelForDepth(PitLevel);
             }
+
+            // 30. Auto shop options (version 15+)
+            if (fileVersion >= 15)
+            {
+                AutomateSeedPurchases = reader.ReadBool();
+                AutoShopGoldBuffer    = reader.ReadInt();
+            }
+            // else keep defaults: AutomateSeedPurchases = false, AutoShopGoldBuffer = 200
         }
 
         /// <summary>Writes a Color as four individual int components (R, G, B, A).</summary>

--- a/PitHero/Services/SaveLoadService.cs
+++ b/PitHero/Services/SaveLoadService.cs
@@ -735,6 +735,14 @@ namespace PitHero.Services
                 }
             }
 
+            // Auto shop options (v15+)
+            var autoSeedPurchaseService = Core.Services.GetService<AutoSeedPurchaseService>();
+            if (autoSeedPurchaseService != null)
+            {
+                data.AutomateSeedPurchases = autoSeedPurchaseService.Enabled;
+                data.AutoShopGoldBuffer    = autoSeedPurchaseService.GoldBuffer;
+            }
+
             return data;
         }
 

--- a/PitHero/UI/HoverableCheckBox.cs
+++ b/PitHero/UI/HoverableCheckBox.cs
@@ -1,13 +1,18 @@
+using Microsoft.Xna.Framework;
 using Nez;
 using Nez.UI;
 
 namespace PitHero.UI
 {
-    /// <summary>A CheckBox that shows a hover-text tooltip at the mouse cursor when hovered.</summary>
+    /// <summary>A CheckBox that shows a windowed tooltip at the mouse cursor when hovered,
+    /// matching the HoverableTextButton / HoverableLabel tooltip styling.</summary>
     public class HoverableCheckBox : CheckBox
     {
+        private static readonly Color BrownFontColor = new Color(71, 36, 7);
+
         private readonly string _tooltipText;
         private readonly Stage _stage;
+        private Window _tooltipWindow;
         private bool _wasMouseOver;
 
         public HoverableCheckBox(string text, Skin skin, string tooltipText, Stage stage)
@@ -15,22 +20,37 @@ namespace PitHero.UI
         {
             _tooltipText = tooltipText;
             _stage = stage;
+
+            if (_stage != null && !string.IsNullOrEmpty(_tooltipText))
+                BuildTooltipWindow(skin);
+        }
+
+        private void BuildTooltipWindow(Skin skin)
+        {
+            _tooltipWindow = new Window("", skin);
+            _tooltipWindow.SetMovable(false);
+            _tooltipWindow.SetResizable(false);
+            _tooltipWindow.SetKeepWithinStage(false);
+            _tooltipWindow.SetColor(GameConfig.TransparentMenu);
+
+            var label = new Label(_tooltipText, new LabelStyle { Font = Nez.Graphics.Instance.BitmapFont, FontColor = BrownFontColor });
+            _tooltipWindow.Add(label).Pad(6f);
+            _tooltipWindow.Pack();
+            _tooltipWindow.SetVisible(false);
+            _stage.AddElement(_tooltipWindow);
         }
 
         public override void Draw(Batcher batcher, float parentAlpha)
         {
             base.Draw(batcher, parentAlpha);
 
-            if (string.IsNullOrEmpty(_tooltipText) || _stage == null)
-                return;
+            if (_tooltipWindow == null) return;
 
+            // Hide whenever the checkbox's own hierarchy is invisible
             if (!IsVisible())
             {
-                if (_wasMouseOver)
-                {
-                    HoverTextManager.HideHoverText();
-                    _wasMouseOver = false;
-                }
+                _tooltipWindow.SetVisible(false);
+                _wasMouseOver = false;
                 return;
             }
 
@@ -38,15 +58,32 @@ namespace PitHero.UI
 
             if (!isOver && _wasMouseOver)
             {
-                HoverTextManager.HideHoverText();
+                _tooltipWindow.SetVisible(false);
             }
-            else if (isOver && !_wasMouseOver)
+            else if (isOver)
             {
-                var mp = _stage.GetMousePosition();
-                HoverTextManager.ShowHoverText(_tooltipText, mp.X + 12f, mp.Y + 12f);
+                PositionTooltip(_stage.GetMousePosition());
+                _tooltipWindow.SetVisible(true);
+                _tooltipWindow.ToFront();
             }
 
             _wasMouseOver = isOver;
+        }
+
+        private void PositionTooltip(Vector2 mousePos)
+        {
+            float w = _tooltipWindow.GetWidth();
+            float h = _tooltipWindow.GetHeight();
+            float sw = _stage.GetWidth();
+            float sh = _stage.GetHeight();
+
+            float x = mousePos.X + 12f;
+            float y = mousePos.Y + 12f;
+
+            if (x + w > sw) x = mousePos.X - w - 4f;
+            if (y + h > sh) y = mousePos.Y - h - 4f;
+
+            _tooltipWindow.SetPosition(x, y);
         }
     }
 }

--- a/PitHero/UI/HoverableCheckBox.cs
+++ b/PitHero/UI/HoverableCheckBox.cs
@@ -1,0 +1,52 @@
+using Nez;
+using Nez.UI;
+
+namespace PitHero.UI
+{
+    /// <summary>A CheckBox that shows a hover-text tooltip at the mouse cursor when hovered.</summary>
+    public class HoverableCheckBox : CheckBox
+    {
+        private readonly string _tooltipText;
+        private readonly Stage _stage;
+        private bool _wasMouseOver;
+
+        public HoverableCheckBox(string text, Skin skin, string tooltipText, Stage stage)
+            : base(text, skin, "ph-default")
+        {
+            _tooltipText = tooltipText;
+            _stage = stage;
+        }
+
+        public override void Draw(Batcher batcher, float parentAlpha)
+        {
+            base.Draw(batcher, parentAlpha);
+
+            if (string.IsNullOrEmpty(_tooltipText) || _stage == null)
+                return;
+
+            if (!IsVisible())
+            {
+                if (_wasMouseOver)
+                {
+                    HoverTextManager.HideHoverText();
+                    _wasMouseOver = false;
+                }
+                return;
+            }
+
+            bool isOver = _mouseOver;
+
+            if (!isOver && _wasMouseOver)
+            {
+                HoverTextManager.HideHoverText();
+            }
+            else if (isOver && !_wasMouseOver)
+            {
+                var mp = _stage.GetMousePosition();
+                HoverTextManager.ShowHoverText(_tooltipText, mp.X + 12f, mp.Y + 12f);
+            }
+
+            _wasMouseOver = isOver;
+        }
+    }
+}

--- a/PitHero/UI/HoverableLabel.cs
+++ b/PitHero/UI/HoverableLabel.cs
@@ -12,6 +12,7 @@ namespace PitHero.UI
         private readonly string _tooltipText;
         private readonly Stage _stage;
         private Window _tooltipWindow;
+        private bool _hovered;
 
         public HoverableLabel(string text, Skin skin, string styleName, string tooltipText, Stage stage)
             : base(text, skin, styleName)
@@ -41,6 +42,7 @@ namespace PitHero.UI
 
         void IInputListener.OnMouseEnter()
         {
+            _hovered = true;
             if (_tooltipWindow == null) return;
             PositionTooltip(_stage.GetMousePosition());
             _tooltipWindow.SetVisible(true);
@@ -49,13 +51,33 @@ namespace PitHero.UI
 
         void IInputListener.OnMouseMoved(Vector2 mousePos)
         {
-            if (_tooltipWindow == null || !_tooltipWindow.IsVisible()) return;
-            PositionTooltip(_stage.GetMousePosition());
+            // Nez only dispatches this while a mouse button is held (drag tracking), so the
+            // per-frame follow happens in Draw instead.
         }
 
         void IInputListener.OnMouseExit()
         {
+            _hovered = false;
             _tooltipWindow?.SetVisible(false);
+        }
+
+        public override void Draw(Batcher batcher, float parentAlpha)
+        {
+            base.Draw(batcher, parentAlpha);
+
+            if (_tooltipWindow == null) return;
+
+            // Hide whenever the label's own hierarchy is invisible (e.g. settings window closed)
+            if (!IsVisible())
+            {
+                _tooltipWindow.SetVisible(false);
+                _hovered = false;
+                return;
+            }
+
+            // Follow the cursor each frame while hovered
+            if (_hovered && _tooltipWindow.IsVisible())
+                PositionTooltip(_stage.GetMousePosition());
         }
 
         private void PositionTooltip(Vector2 mousePos)

--- a/PitHero/UI/SecondChanceShopUI.cs
+++ b/PitHero/UI/SecondChanceShopUI.cs
@@ -289,8 +289,9 @@ namespace PitHero.UI
         /// <summary>Populates the Seeds tab with a 4-per-row grid of purchasable crop seed slots.</summary>
         private void PopulateSeedsTab(Tab tab, Skin skin)
         {
-            var cropsAtlas       = Core.Content?.LoadSpriteAtlas("Content/Atlases/CropsProps.atlas");
+            var cropsAtlas          = Core.Content?.LoadSpriteAtlas("Content/Atlases/CropsProps.atlas");
             var cropPlantingService = Core.Services?.GetService<CropPlantingService>();
+            var cropGrowthService   = Core.Services?.GetService<CropGrowthService>();
 
             var grid = new Table();
             grid.Top().Left().Pad(4f);
@@ -306,7 +307,7 @@ namespace PitHero.UI
                 int price       = CropConfig.GetSeedPrice(crop);
                 string tooltip  = cropName + " - " + price + "G";
 
-                var slot = new SeedShopSlot(sprite, crop, cropPlantingService, tooltip);
+                var slot = new SeedShopSlot(sprite, crop, cropPlantingService, cropGrowthService, tooltip);
                 slot.OnBuyClicked += HandleSeedBuyClicked;
 
                 grid.Add(slot).Size(40f, 40f).Pad(2f);
@@ -358,6 +359,7 @@ namespace PitHero.UI
                     if (gameState.Funds < totalPrice) return;
                     gameState.Funds -= totalPrice;
                     cropPlantingService.AddSeeds(crop, qty);
+                    Core.Services?.GetService<FarmTaskCoordinator>()?.RescanForPlanting();
                 },
                 onCancel: null,
                 ownedCount: ownedCount,
@@ -1208,15 +1210,20 @@ namespace PitHero.UI
         /// A single slot in the Seeds shop grid.  Draws the crop's fully-grown sprite, overlays
         /// a live owned-count badge (read each frame so it updates immediately after a purchase),
         /// shows a hover tooltip with crop name and price, and fires OnBuyClicked on left-mouse-up.
+        /// When the player has fewer seeds than unplanted plans, the slot background is tinted green.
         /// </summary>
         private class SeedShopSlot : Element, IInputListener
         {
             // Inventory-slot background drawn at the same translucency as the inventory UI.
-            private static readonly Color SlotBgColor = new Color(255, 255, 255, 100);
-            private readonly Sprite          _sprite;
-            private readonly CropType        _crop;
+            private static readonly Color SlotBgColor       = new Color(255, 255, 255, 100);
+            // Green tint used when seeds are needed to fulfil outstanding plans.
+            private static readonly Color GreenHighlightColor = new Color(0, 255, 0, 128);
+
+            private readonly Sprite              _sprite;
+            private readonly CropType            _crop;
             private readonly CropPlantingService _cropService;
-            private readonly SpriteDrawable  _draw;
+            private readonly CropGrowthService   _cropGrowth;
+            private readonly SpriteDrawable      _draw;
             private SpriteDrawable _background;
             private Sprite _selectBox;
             private bool   _hovered;
@@ -1225,11 +1232,12 @@ namespace PitHero.UI
             /// <summary>Fired when the player left-clicks this slot.</summary>
             public event System.Action<CropType> OnBuyClicked;
 
-            public SeedShopSlot(Sprite sprite, CropType crop, CropPlantingService cropService, string tooltipText)
+            public SeedShopSlot(Sprite sprite, CropType crop, CropPlantingService cropService, CropGrowthService cropGrowth, string tooltipText)
             {
                 _sprite      = sprite;
                 _crop        = crop;
                 _cropService = cropService;
+                _cropGrowth  = cropGrowth;
                 _tooltipText = tooltipText;
                 _draw        = sprite != null ? new SpriteDrawable(sprite) : null;
                 SetTouchable(Touchable.Enabled);
@@ -1249,7 +1257,18 @@ namespace PitHero.UI
 
             public override void Draw(Batcher batcher, float parentAlpha)
             {
-                _background?.Draw(batcher, GetX(), GetY(), GetWidth(), GetHeight(), SlotBgColor);
+                // Resolve live seed count up front so it can drive both the background tint and badge.
+                int count = _cropService?.SeedInventory != null
+                    ? _cropService.SeedInventory[(int)_crop]
+                    : 0;
+
+                // Green highlight when there are more unplanted plans than owned seeds.
+                int needed = (_cropService != null && _cropGrowth != null)
+                    ? _cropService.CountUnplantedPlans(_crop, _cropGrowth)
+                    : 0;
+                Color bgColor = needed > count ? GreenHighlightColor : SlotBgColor;
+
+                _background?.Draw(batcher, GetX(), GetY(), GetWidth(), GetHeight(), bgColor);
 
                 _draw?.Draw(batcher, GetX(), GetY(), GetWidth(), GetHeight(), Color.White);
 
@@ -1257,10 +1276,7 @@ namespace PitHero.UI
                     new SpriteDrawable(_selectBox).Draw(
                         batcher, GetX(), GetY(), GetWidth(), GetHeight(), Color.White);
 
-                // Live count from seed inventory (read each frame — auto-updates after purchase)
-                int count = _cropService?.SeedInventory != null
-                    ? _cropService.SeedInventory[(int)_crop]
-                    : 0;
+                // Live count badge (read each frame — auto-updates after purchase)
                 var font = Nez.Graphics.Instance?.BitmapFont;
                 if (font != null)
                 {

--- a/PitHero/UI/SecondChanceShopUI.cs
+++ b/PitHero/UI/SecondChanceShopUI.cs
@@ -355,11 +355,19 @@ namespace PitHero.UI
                 : 0;
             if (plannedDeficit < 0) plannedDeficit = 0;
 
+            // Cap the transaction at both the per-purchase limit and the remaining headroom
+            // below the per-crop inventory cap; at cap there is nothing to buy.
+            int headroom = GameConfig.SeedInventoryMaxPerCrop - ownedCount;
+            int maxQty = GameConfig.SeedShopMaxPurchaseQuantity < headroom
+                ? GameConfig.SeedShopMaxPurchaseQuantity
+                : headroom;
+            if (maxQty <= 0) return;
+
             var qtyDialog = new VaultBuyQuantityDialog(
                 shopTitle,
                 cropName,
                 unitPrice,
-                GameConfig.SeedShopMaxPurchaseQuantity,
+                maxQty,
                 _skin,
                 onConfirm: (qty) =>
                 {

--- a/PitHero/UI/SecondChanceShopUI.cs
+++ b/PitHero/UI/SecondChanceShopUI.cs
@@ -347,11 +347,19 @@ namespace PitHero.UI
             string shopTitle = GetText(TextType.UI, UITextKey.WindowSecondChanceShop);
             string cropName  = GetText(TextType.UI, CropConfig.GetDisplayNameKey(crop));
 
+            // Outstanding planned demand not yet covered by owned seeds — drives the
+            // "Need: N" row in the quantity dialog (omitted when zero).
+            var cropGrowthService = Core.Services?.GetService<CropGrowthService>();
+            int plannedDeficit = cropGrowthService != null
+                ? cropPlantingService.CountUnplantedPlans(crop, cropGrowthService) - ownedCount
+                : 0;
+            if (plannedDeficit < 0) plannedDeficit = 0;
+
             var qtyDialog = new VaultBuyQuantityDialog(
                 shopTitle,
                 cropName,
                 unitPrice,
-                9,
+                GameConfig.SeedShopMaxPurchaseQuantity,
                 _skin,
                 onConfirm: (qty) =>
                 {
@@ -363,7 +371,8 @@ namespace PitHero.UI
                 },
                 onCancel: null,
                 ownedCount: ownedCount,
-                availableFunds: gameState.Funds);
+                availableFunds: gameState.Funds,
+                plannedCount: plannedDeficit);
             qtyDialog.Show(_stage);
         }
 
@@ -1210,19 +1219,20 @@ namespace PitHero.UI
         /// A single slot in the Seeds shop grid.  Draws the crop's fully-grown sprite, overlays
         /// a live owned-count badge (read each frame so it updates immediately after a purchase),
         /// shows a hover tooltip with crop name and price, and fires OnBuyClicked on left-mouse-up.
-        /// When the player has fewer seeds than unplanted plans, the slot background is tinted green.
+        /// When the player has fewer seeds than unplanted plans, the crop sprite gently pulses
+        /// in size to draw attention to the purchase.
         /// </summary>
         private class SeedShopSlot : Element, IInputListener
         {
             // Inventory-slot background drawn at the same translucency as the inventory UI.
             private static readonly Color SlotBgColor       = new Color(255, 255, 255, 100);
-            // Green tint used when seeds are needed to fulfil outstanding plans.
-            private static readonly Color GreenHighlightColor = new Color(0, 255, 0, 128);
 
-            private readonly Sprite              _sprite;
-            private readonly CropType            _crop;
-            private readonly CropPlantingService _cropService;
-            private readonly CropGrowthService   _cropGrowth;
+            private readonly Sprite   _sprite;
+            private readonly CropType _crop;
+            // Not readonly: the slot is built during Scene.Initialize(), before LoadMap registers
+            // CropGrowthService, so null services are re-resolved lazily on draw.
+            private CropPlantingService _cropService;
+            private CropGrowthService   _cropGrowth;
             private readonly SpriteDrawable      _draw;
             private SpriteDrawable _background;
             private Sprite _selectBox;
@@ -1257,20 +1267,37 @@ namespace PitHero.UI
 
             public override void Draw(Batcher batcher, float parentAlpha)
             {
-                // Resolve live seed count up front so it can drive both the background tint and badge.
+                // Services may not have existed at construction time — resolve lazily.
+                if (_cropService == null)
+                    _cropService = Core.Services?.GetService<CropPlantingService>();
+                if (_cropGrowth == null)
+                    _cropGrowth = Core.Services?.GetService<CropGrowthService>();
+
+                // Resolve live seed count up front so it can drive both the attention pulse and badge.
                 int count = _cropService?.SeedInventory != null
                     ? _cropService.SeedInventory[(int)_crop]
                     : 0;
 
-                // Green highlight when there are more unplanted plans than owned seeds.
+                // Attention pulse when there are more unplanted plans than owned seeds: the crop
+                // sprite gently scales up and down around the slot center.
                 int needed = (_cropService != null && _cropGrowth != null)
                     ? _cropService.CountUnplantedPlans(_crop, _cropGrowth)
                     : 0;
-                Color bgColor = needed > count ? GreenHighlightColor : SlotBgColor;
 
-                _background?.Draw(batcher, GetX(), GetY(), GetWidth(), GetHeight(), bgColor);
+                _background?.Draw(batcher, GetX(), GetY(), GetWidth(), GetHeight(), SlotBgColor);
 
-                _draw?.Draw(batcher, GetX(), GetY(), GetWidth(), GetHeight(), Color.White);
+                float spriteX = GetX(), spriteY = GetY(), spriteW = GetWidth(), spriteH = GetHeight();
+                if (needed > count)
+                {
+                    float pulse = 1f + GameConfig.SeedShopPulseAmplitude * Mathf.Sin(Time.TotalTime * GameConfig.SeedShopPulseSpeed);
+                    float pw = spriteW * pulse;
+                    float ph = spriteH * pulse;
+                    spriteX += (spriteW - pw) * 0.5f;
+                    spriteY += (spriteH - ph) * 0.5f;
+                    spriteW = pw;
+                    spriteH = ph;
+                }
+                _draw?.Draw(batcher, spriteX, spriteY, spriteW, spriteH, Color.White);
 
                 if (_hovered && _selectBox != null)
                     new SpriteDrawable(_selectBox).Draw(

--- a/PitHero/UI/SeedPlantingModeOverlay.cs
+++ b/PitHero/UI/SeedPlantingModeOverlay.cs
@@ -48,10 +48,6 @@ namespace PitHero.UI
         private static readonly Point NoTile = new Point(int.MinValue, int.MinValue);
         private Point _lastDragTile = NoTile;
 
-        // ── Growing-crop overlays (shown in all farm sub-modes, separate from plans) ──
-        private readonly System.Collections.Generic.List<Entity> _growingCropOverlays =
-            new System.Collections.Generic.List<Entity>();
-
         // ── Constants ─────────────────────────────────────────────────────────────
         private const float SlotSize   = 40f;
         private const float WinPad     = 16f;
@@ -117,18 +113,16 @@ namespace PitHero.UI
             _lastDragTile = NoTile;
         }
 
-        /// <summary>Creates grayscale world entities for all plans and planted crops. Called when any farm sub-mode is entered.</summary>
+        /// <summary>Creates translucent world entities for all plans. Called when any farm sub-mode is entered.</summary>
         public void ShowPlanVisuals()
         {
             RestorePlanVisuals();
-            RestoreGrowingCropOverlays();
         }
 
-        /// <summary>Destroys grayscale world entities for all plans and planted-crop overlays. Called when all farm sub-modes are exited.</summary>
+        /// <summary>Destroys translucent plan world entities. Called when all farm sub-modes are exited.</summary>
         public void HidePlanVisuals()
         {
             Core.Services.GetService<CropPlantingService>()?.DestroyPlanVisuals();
-            DestroyGrowingCropOverlays();
         }
 
         /// <summary>Called when the player enters remove-crops mode; creates the tile indicator.</summary>
@@ -200,17 +194,37 @@ namespace PitHero.UI
                     _stackCountLabel.SetVisible(true);
                 }
 
-                // Place crop on valid click / drag
-                var tile = new Point(tileX, tileY);
-                if (Input.LeftMouseButtonDown && tile != _lastDragTile)
+                // Shift-click: delete the plan on a tile without refunding seeds
+                bool shiftHeld = Input.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.LeftShift)
+                              || Input.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.RightShift);
+                if (shiftHeld)
                 {
-                    _lastDragTile = tile;
-                    if (IsValidPlacement(tileX, tileY))
-                        PlaceCrop(tileX, tileY);
+                    var shiftTile = new Point(tileX, tileY);
+                    // Mark the hovered tile as already-dragged so releasing shift with the button
+                    // still held doesn't immediately place a plan on it.
+                    _lastDragTile = shiftTile;
+                    var shiftCropService = Core.Services.GetService<CropPlantingService>();
+                    if (Input.LeftMouseButtonPressed
+                        && shiftCropService != null
+                        && shiftCropService.HasPlan(shiftTile))
+                    {
+                        shiftCropService.RemovePlan(shiftTile); // destroys entity inside RemovePlan; no refund
+                    }
                 }
-                else if (!Input.LeftMouseButtonDown)
+                else
                 {
-                    _lastDragTile = NoTile;
+                    // Place crop on valid click / drag
+                    var tile = new Point(tileX, tileY);
+                    if (Input.LeftMouseButtonDown && tile != _lastDragTile)
+                    {
+                        _lastDragTile = tile;
+                        if (IsValidPlacement(tileX, tileY))
+                            PlaceCrop(tileX, tileY);
+                    }
+                    else if (!Input.LeftMouseButtonDown)
+                    {
+                        _lastDragTile = NoTile;
+                    }
                 }
             }
             else // Removing
@@ -231,13 +245,9 @@ namespace PitHero.UI
                             : new Color(255, 0, 0, 128);
                 }
 
-                // Single click to remove (no drag)
+                // Single click to remove (no drag, no seed refund — plans are now free to place)
                 if (Input.LeftMouseButtonPressed && hasPlan)
-                {
-                    var removed = cropService.RemovePlan(tile);
-                    if (removed.HasValue)
-                        _seedInventory[(int)removed.Value]++;
-                }
+                    cropService.RemovePlan(tile);
             }
         }
 
@@ -282,8 +292,8 @@ namespace PitHero.UI
         // ── Plan visual helpers ───────────────────────────────────────────────────
 
         /// <summary>
-        /// Recreates world-space grayscale entities for any plans whose entity was destroyed
-        /// on the previous OnExitSeedMode call.  Does not re-register plans with the service.
+        /// Recreates world-space translucent entities for any plans whose entity was destroyed
+        /// on the previous farm-mode exit. Does not re-register plans with the service.
         /// </summary>
         private void RestorePlanVisuals()
         {
@@ -307,49 +317,10 @@ namespace PitHero.UI
                 entity.SetPosition(wx, wy);
                 var renderer = entity.AddComponent(new SpriteRenderer(sprite));
                 renderer.SetRenderLayer(GameConfig.RenderLayerSingleTileObject - 1);
-                renderer.SetMaterial(new Material(new GrayscaleEffect()));
+                renderer.Color = new Color(255, 255, 255, GameConfig.CropPlanPreviewAlpha);
 
                 service.SetPlanEntity(new Microsoft.Xna.Framework.Point(plan.TileX, plan.TileY), entity);
             }
-        }
-
-        /// <summary>
-        /// Spawns grayscale overlays for all actively planted crops so players can identify crop
-        /// types while in any farm planning sub-mode. Destroyed on HidePlanVisuals.
-        /// </summary>
-        private void RestoreGrowingCropOverlays()
-        {
-            DestroyGrowingCropOverlays();
-
-            var cropGrowthService = Core.Services.GetService<CropGrowthService>();
-            if (cropGrowthService == null)
-                return;
-
-            foreach (var kvp in cropGrowthService.GetAllData())
-            {
-                var tile = kvp.Key;
-                var cropType = kvp.Value.Type;
-
-                var sprite = _cropsAtlas.GetSprite(CropConfig.GetFullyGrownSpriteName(cropType));
-                float sprH = sprite != null ? sprite.SourceRect.Height : GameConfig.TileSize;
-                float wx = tile.X * GameConfig.TileSize + GameConfig.TileSize / 2f;
-                float wy = tile.Y * GameConfig.TileSize + GameConfig.TileSize - sprH / 2f;
-
-                var entity = _scene.CreateEntity("growing-crop-overlay-" + tile.X + "-" + tile.Y);
-                entity.SetPosition(wx, wy);
-                var renderer = entity.AddComponent(new SpriteRenderer(sprite));
-                renderer.SetRenderLayer(GameConfig.RenderLayerSingleTileObject - 1);
-                renderer.SetMaterial(new Material(new GrayscaleEffect()));
-
-                _growingCropOverlays.Add(entity);
-            }
-        }
-
-        private void DestroyGrowingCropOverlays()
-        {
-            for (int i = 0; i < _growingCropOverlays.Count; i++)
-                _growingCropOverlays[i]?.Destroy();
-            _growingCropOverlays.Clear();
         }
 
         // ── Inventory window ──────────────────────────────────────────────────────
@@ -388,12 +359,12 @@ namespace PitHero.UI
 
         private void ShowInventoryWindow()
         {
-            // Rebuild slot table every time: skip zero-count crops and show live counts.
+            // Rebuild slot table every time: show all crops with live counts (plans are now free
+            // to place, so zero-seed crops are still selectable for blueprint placement).
             _slotTable.Clear();
             int col = 0;
             for (int i = 0; i < CropTypeInfo.Count; i++)
             {
-                if (_seedInventory[i] <= 0) continue;
                 var cropType = (CropType)i;
                 var sprite   = _cropsAtlas.GetSprite(CropConfig.GetFullyGrownSpriteName(cropType));
                 var slot     = new CropSlotButton(sprite, GetText(CropConfig.GetDisplayNameKey(cropType)), _seedInventory, i);
@@ -441,14 +412,12 @@ namespace PitHero.UI
             if (!readyOrTilled)
                 return false;
 
-            // Reject if a plan already exists or a crop is already planted/growing/grown
-            if (cropService != null && cropService.HasPlan(tile))
-                return false;
+            // Invalid only when the effective type at the tile already matches the selection:
+            // same plan type is a no-op; a same-type crop with no plan is re-placeable (cancels
+            // any pending destroy). A different plan or different crop is always replaceable.
             var cropGrowthService = Core.Services.GetService<CropGrowthService>();
-            if (cropGrowthService != null && cropGrowthService.HasCrop(tile))
-                return false;
-
-            if (_seedInventory[(int)_selectedCrop] <= 0)
+            var effective = cropService?.GetPlanType(tile) ?? cropGrowthService?.GetCropType(tile);
+            if (effective.HasValue && effective.Value == _selectedCrop)
                 return false;
 
             // Reject if any of the 8 neighboring tiles has a different crop type (planned or planted)
@@ -469,7 +438,13 @@ namespace PitHero.UI
 
         private void PlaceCrop(int tileX, int tileY)
         {
-            _seedInventory[(int)_selectedCrop]--;
+            var tile = new Point(tileX, tileY);
+            var cropService = Core.Services.GetService<CropPlantingService>();
+
+            // If a different-type plan already exists, remove it first before placing the new one
+            // (validation guarantees the existing plan, if any, is of a different type).
+            if (cropService != null && cropService.HasPlan(tile))
+                cropService.RemovePlan(tile);
 
             var sprite = _cropsAtlas.GetSprite(CropConfig.GetFullyGrownSpriteName(_selectedCrop));
             float spriteH = sprite != null ? sprite.SourceRect.Height : GameConfig.TileSize;
@@ -482,10 +457,9 @@ namespace PitHero.UI
 
             var renderer = entity.AddComponent(new SpriteRenderer(sprite));
             renderer.SetRenderLayer(GameConfig.RenderLayerSingleTileObject - 1);
-            renderer.SetMaterial(new Material(new GrayscaleEffect()));
+            renderer.Color = new Color(255, 255, 255, GameConfig.CropPlanPreviewAlpha);
 
-            var tile = new Point(tileX, tileY);
-            Core.Services.GetService<CropPlantingService>()?.AddPlan(new PlacedCropPlan
+            cropService?.AddPlan(new PlacedCropPlan
             {
                 Type        = _selectedCrop,
                 TileX       = tileX,
@@ -497,16 +471,6 @@ namespace PitHero.UI
             var tileStateService = Core.Services.GetService<TileStateService>();
             if (tileStateService != null && tileStateService.HasFlag(tile, TileStateFlag.Tilled))
                 Core.Services.GetService<FarmTaskCoordinator>()?.NotifyPlanAddedOnTilledTile(tile);
-
-            // If seeds are exhausted, return to the inventory window
-            if (_seedInventory[(int)_selectedCrop] <= 0)
-            {
-                DestroyGhost();
-                DestroyTileIndicator();
-                HideStackCountLabel();
-                ShowInventoryWindow();
-                _state = PlacementState.Choosing;
-            }
         }
 
         // ── Ghost management ──────────────────────────────────────────────────────
@@ -518,8 +482,7 @@ namespace PitHero.UI
             _ghostEntity   = _scene.CreateEntity("seed-ghost");
             _ghostRenderer = _ghostEntity.AddComponent(new SpriteRenderer(sprite));
             _ghostRenderer.SetRenderLayer(GameConfig.RenderLayerTop);
-            _ghostRenderer.Color = Color.White;
-            _ghostRenderer.SetMaterial(new Material(new GrayscaleEffect()));
+            _ghostRenderer.Color = new Color(255, 255, 255, GameConfig.CropPlanPreviewAlpha);
         }
 
         private void DestroyGhost()

--- a/PitHero/UI/SeedPlantingModeOverlay.cs
+++ b/PitHero/UI/SeedPlantingModeOverlay.cs
@@ -412,22 +412,25 @@ namespace PitHero.UI
             if (!readyOrTilled)
                 return false;
 
-            // Invalid only when the effective type at the tile already matches the selection:
-            // same plan type is a no-op; a same-type crop with no plan is re-placeable (cancels
-            // any pending destroy). A different plan or different crop is always replaceable.
-            var cropGrowthService = Core.Services.GetService<CropGrowthService>();
-            var effective = cropService?.GetPlanType(tile) ?? cropGrowthService?.GetCropType(tile);
-            if (effective.HasValue && effective.Value == _selectedCrop)
+            // Validation looks ONLY at the crop plan, never at real growing crops: plans govern
+            // the future state of the field, and any underlying crop will be destroyed/harvested
+            // before the plan is carried out. Invalid only when the same plan type already exists
+            // here (a no-op); a plan-less tile is fair game even while a crop grows on it, and a
+            // same-type placement over a plan-less crop re-plans it (cancels a pending destroy).
+            var planType = cropService?.GetPlanType(tile);
+            if (planType.HasValue && planType.Value == _selectedCrop)
                 return false;
 
-            // Reject if any of the 8 neighboring tiles has a different crop type (planned or planted)
+            // Reject if any of the 8 neighboring tiles has a PLANNED crop of a different type.
+            // Real growing crops are ignored: a plan-less crop is pending destroy/no-replant, so
+            // it doesn't constrain the planned layout.
             for (int dy = -1; dy <= 1; dy++)
             {
                 for (int dx = -1; dx <= 1; dx++)
                 {
                     if (dx == 0 && dy == 0) continue;
                     var neighbor = new Microsoft.Xna.Framework.Point(tx + dx, ty + dy);
-                    var neighborType = cropService?.GetPlanType(neighbor) ?? cropGrowthService?.GetCropType(neighbor);
+                    var neighborType = cropService?.GetPlanType(neighbor);
                     if (neighborType.HasValue && neighborType.Value != _selectedCrop)
                         return false;
                 }

--- a/PitHero/UI/SeedPlantingModeOverlay.cs
+++ b/PitHero/UI/SeedPlantingModeOverlay.cs
@@ -129,6 +129,7 @@ namespace PitHero.UI
         public void OnEnterRemoveCropsMode()
         {
             _state = PlacementState.Removing;
+            _lastDragTile = NoTile;
             CreateTileIndicator();
         }
 
@@ -245,9 +246,25 @@ namespace PitHero.UI
                             : new Color(255, 0, 0, 128);
                 }
 
-                // Single click to remove (no drag, no seed refund — plans are now free to place)
-                if (Input.LeftMouseButtonPressed && hasPlan)
-                    cropService.RemovePlan(tile);
+                // Shift + held click: drag-remove plans continuously across tiles.
+                // Plain click: remove a single plan per press. No seed refund either way.
+                bool shiftHeld = Input.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.LeftShift)
+                              || Input.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.RightShift);
+                if (shiftHeld && Input.LeftMouseButtonDown)
+                {
+                    if (tile != _lastDragTile)
+                    {
+                        _lastDragTile = tile;
+                        if (hasPlan)
+                            cropService.RemovePlan(tile);
+                    }
+                }
+                else
+                {
+                    _lastDragTile = NoTile;
+                    if (Input.LeftMouseButtonPressed && hasPlan)
+                        cropService.RemovePlan(tile);
+                }
             }
         }
 

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -25,6 +25,7 @@ namespace PitHero.UI
         private Tab _windowTab;
         private Tab _sessionTab;
         private Tab _buttonsTab;
+        private Tab _autoShopTab;
 
         // Window positioning controls
         private EnhancedSlider _yOffsetSlider;
@@ -57,6 +58,11 @@ namespace PitHero.UI
         private EnhancedSlider _replenishMPSlider;
         private Label _replenishHPThresholdLabel;
         private Label _replenishMPThresholdLabel;
+
+        // Auto Shop tab controls
+        private HoverableCheckBox _automateSeedsCheckBox;
+        private EnhancedSlider _goldBufferSlider;
+        private HoverableLabel _goldBufferLabel;
 
         // Confirmation dialogs
         private Window _exitConfirmationDialog;
@@ -474,11 +480,14 @@ namespace PitHero.UI
             PopulateWindowTab(_windowTab, skin);
             PopulateSessionTab(_sessionTab, skin);
             PopulateButtonsTab(_buttonsTab, skin);
+            _autoShopTab = new Tab(GetText(TextType.UI, UITextKey.TabAutoShop), tabStyle);
+            PopulateAutoShopTab(_autoShopTab, skin);
 
             // Add tabs to TabPane
             _tabPane.AddTab(_windowTab);
             _tabPane.AddTab(_sessionTab);
             _tabPane.AddTab(_buttonsTab);
+            _tabPane.AddTab(_autoShopTab);
 
             // Add TabPane to settings window
             _settingsWindow.Add(_tabPane).Expand().Fill().Pad(0); // No cell padding - tabs flush with window edges
@@ -826,6 +835,69 @@ namespace PitHero.UI
             buttonsTable.Add(_hideEventConsoleCheckBox).Left();
 
             buttonsTab.Add(buttonsTable).Expand().Top().Left();
+        }
+
+        /// <summary>Populates the Auto Shop tab with seed-purchase automation controls.</summary>
+        private void PopulateAutoShopTab(Tab autoShopTab, Skin skin)
+        {
+            var autoShopTable = new Table();
+            autoShopTable.Pad(20);
+
+            string checkboxTooltip = GetText(TextType.UI, UITextKey.SettingsAutomateSeedPurchasesTooltip);
+            _automateSeedsCheckBox = new HoverableCheckBox(
+                GetText(TextType.UI, UITextKey.SettingsAutomateSeedPurchases),
+                skin,
+                checkboxTooltip,
+                _stage);
+            _automateSeedsCheckBox.IsChecked = false;
+            _automateSeedsCheckBox.OnChanged += (isChecked) =>
+            {
+                var svc = Core.Services?.GetService<AutoSeedPurchaseService>();
+                if (svc != null) svc.Enabled = isChecked;
+            };
+            autoShopTable.Add(_automateSeedsCheckBox).Left().SetPadBottom(15f);
+            autoShopTable.Row();
+
+            string bufferTooltip = GetText(TextType.UI, UITextKey.SettingsAutoShopGoldBufferTooltip);
+            _goldBufferLabel = new HoverableLabel(
+                string.Format(GetText(TextType.UI, UITextKey.SettingsAutoShopGoldBuffer), 200),
+                skin, "ph-default", bufferTooltip, _stage);
+            autoShopTable.Add(_goldBufferLabel).Left().SetPadBottom(8f);
+            autoShopTable.Row();
+
+            _goldBufferSlider = new EnhancedSlider(0, 100000, 200, false, skin, null, false);
+            _goldBufferSlider.SetValueAndCommit(200);
+            _goldBufferSlider.OnChanged += (value) =>
+            {
+                _goldBufferLabel.SetText(string.Format(GetText(TextType.UI, UITextKey.SettingsAutoShopGoldBuffer), (int)value));
+            };
+            _goldBufferSlider.OnValueCommitted += (value) =>
+            {
+                var svc = Core.Services?.GetService<AutoSeedPurchaseService>();
+                if (svc != null) svc.GoldBuffer = (int)value;
+            };
+            autoShopTable.Add(_goldBufferSlider).Width(240).Left().SetPadBottom(15f);
+
+            autoShopTab.Add(autoShopTable).Expand().Top().Left();
+        }
+
+        /// <summary>
+        /// Reads AutoSeedPurchaseService state and syncs the Auto Shop tab controls.
+        /// Called after load to reflect persisted settings.
+        /// </summary>
+        public void SyncAutoShopControlsFromService()
+        {
+            var svc = Core.Services?.GetService<AutoSeedPurchaseService>();
+            if (svc == null) return;
+
+            if (_automateSeedsCheckBox != null)
+                _automateSeedsCheckBox.IsChecked = svc.Enabled;
+
+            if (_goldBufferSlider != null)
+                _goldBufferSlider.SetValueAndCommit(svc.GoldBuffer);
+
+            if (_goldBufferLabel != null)
+                _goldBufferLabel.SetText(string.Format(GetText(TextType.UI, UITextKey.SettingsAutoShopGoldBuffer), svc.GoldBuffer));
         }
 
         /// <summary>

--- a/PitHero/UI/VaultBuyQuantityDialog.cs
+++ b/PitHero/UI/VaultBuyQuantityDialog.cs
@@ -23,8 +23,10 @@ namespace PitHero.UI
         private readonly int _unitPrice;
         private readonly int _maxQty;
         private readonly bool _canAffordAny;
+        private readonly int _plannedCount;
         private Label _quantityLabel;
         private Label _totalCostLabel;
+        private Label _plannedLabel;
         private TextButton _decreaseBtn;
         private TextButton _increaseBtn;
         private readonly System.Action<int> _onConfirm;
@@ -45,6 +47,12 @@ namespace PitHero.UI
         /// Yes button is disabled when the player cannot afford even one unit. Pass -1 (default)
         /// to skip the affordability cap.
         /// </param>
+        /// <param name="plannedCount">
+        /// When &gt; 0, a "Need: N" label is rendered to the right of the Owned row showing
+        /// how many planned crops remain uncovered after buying the current quantity
+        /// (max(0, plannedCount - quantity)); the label hides once the quantity covers them all.
+        /// Pass 0 (default) to omit it; existing call sites are unaffected.
+        /// </param>
         public VaultBuyQuantityDialog(
             string title,
             string itemName,
@@ -54,11 +62,13 @@ namespace PitHero.UI
             System.Action<int> onConfirm,
             System.Action onCancel = null,
             int ownedCount = -1,
-            int availableFunds = -1)
+            int availableFunds = -1,
+            int plannedCount = 0)
             : base(title, skin)
         {
             _unitPrice = unitPrice;
             _onConfirm = onConfirm;
+            _plannedCount = plannedCount > 0 ? plannedCount : 0;
 
             int affordableMax = (availableFunds >= 0 && unitPrice > 0)
                 ? availableFunds / unitPrice
@@ -102,7 +112,25 @@ namespace PitHero.UI
                     textService.DisplayText(TextType.UI, UITextKey.SecondChanceOwnedCount),
                     ownedCount);
                 var ownedLabel = new Label(ownedText, skin);
-                dialogTable.Add(ownedLabel).Width(330f).SetPadBottom(8);
+
+                var ownedRow = new Table();
+                ownedRow.Left();
+                ownedRow.Add(ownedLabel);
+
+                // Planned demand label (seeds with outstanding plan coverage only).
+                if (_plannedCount > 0)
+                {
+                    int remaining = _plannedCount - _quantity;
+                    if (remaining < 0) remaining = 0;
+                    string plannedText = string.Format(
+                        textService.DisplayText(TextType.UI, UITextKey.SecondChanceNeedCount),
+                        remaining);
+                    _plannedLabel = new Label(plannedText, skin);
+                    _plannedLabel.SetVisible(remaining > 0);
+                    ownedRow.Add(_plannedLabel).SetPadLeft(24f);
+                }
+
+                dialogTable.Add(ownedRow).Width(330f).SetPadBottom(8);
                 dialogTable.Row();
             }
 
@@ -203,6 +231,18 @@ namespace PitHero.UI
                     textService.DisplayText(TextType.UI, UITextKey.SecondChanceBuyTotal),
                     _unitPrice * _quantity);
                 _totalCostLabel.SetText(totalText);
+            }
+
+            if (_plannedLabel != null)
+            {
+                int remaining = _plannedCount - _quantity;
+                if (remaining < 0) remaining = 0;
+                var textService = Core.Services.GetService<TextService>();
+                string plannedText = string.Format(
+                    textService.DisplayText(TextType.UI, UITextKey.SecondChanceNeedCount),
+                    remaining);
+                _plannedLabel.SetText(plannedText);
+                _plannedLabel.SetVisible(remaining > 0);
             }
         }
 

--- a/PitHero/UI/VaultBuyQuantityDialog.cs
+++ b/PitHero/UI/VaultBuyQuantityDialog.cs
@@ -8,7 +8,8 @@ namespace PitHero.UI
     /// <summary>
     /// A confirmation dialog for vault item purchases that includes a < qty > selector
     /// when the vault stack contains more than one item.  The player can raise or lower
-    /// the quantity (1 … maxQty) before confirming; the total gold cost updates live.
+    /// the quantity (1 … maxQty; lowering below 1 wraps around to the purchasable max)
+    /// before confirming; the total gold cost updates live.
     /// When availableFunds is provided, the selectable quantity is additionally capped at
     /// what the player can afford, and the arrow buttons grey out at the limits.
     /// When maxQty == 1 the selector row is hidden and the dialog behaves like a plain
@@ -216,7 +217,9 @@ namespace PitHero.UI
         private void ChangeQuantity(int delta)
         {
             int next = _quantity + delta;
-            if (next < 1) next = 1;
+            // "<" below 1 wraps around to the purchasable max (stock cap and affordable
+            // funds already folded into _maxQty); ">" clamps at the max as before.
+            if (next < 1) next = _maxQty;
             if (next > _maxQty) next = _maxQty;
             if (next == _quantity) return;
 
@@ -246,10 +249,11 @@ namespace PitHero.UI
             }
         }
 
-        /// <summary>Greys out an arrow when the quantity can move no further in its direction.</summary>
+        /// <summary>Greys out an arrow when it can have no effect. The decrease arrow stays
+        /// enabled at quantity 1 so it can wrap around to the purchasable max.</summary>
         private void UpdateArrowStates()
         {
-            _decreaseBtn?.SetDisabled(_quantity <= 1);
+            _decreaseBtn?.SetDisabled(_maxQty <= 1);
             _increaseBtn?.SetDisabled(_quantity >= _maxQty || !_canAffordAny);
         }
     }

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -308,5 +308,10 @@ namespace PitHero
         public const string AddMonsterConfirmPrompt = "AddMonsterConfirmPrompt";
         public const string ConsoleTrapTriggered = "ConsoleTrapTriggered";
         public const string ConsoleTrapDisarmed = "ConsoleTrapDisarmed";
+        public const string TabAutoShop = "TabAutoShop";
+        public const string SettingsAutomateSeedPurchases = "SettingsAutomateSeedPurchases";
+        public const string SettingsAutoShopGoldBuffer = "SettingsAutoShopGoldBuffer";
+        public const string SettingsAutomateSeedPurchasesTooltip = "SettingsAutomateSeedPurchasesTooltip";
+        public const string SettingsAutoShopGoldBufferTooltip = "SettingsAutoShopGoldBufferTooltip";
     }
 }

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -300,6 +300,7 @@ namespace PitHero
         public const string ConsoleWelcomePhrase3 = "ConsoleWelcomePhrase3";
         public const string TabSeeds = "TabSeeds";
         public const string SecondChanceOwnedCount = "SecondChanceOwnedCount";
+        public const string SecondChanceNeedCount = "SecondChanceNeedCount";
         public const string ConsoleSeedsFound = "ConsoleSeedsFound";
         public const string AddMonsterWindowTitle = "AddMonsterWindowTitle";
         public const string AddMonsterRemainingSpace = "AddMonsterRemainingSpace";


### PR DESCRIPTION
Closes #305.

## What changed

Crop plans become **permanent blueprints**: placing a plan is free (no seed cost, no inventory requirement) and plans survive planting and harvest, driving continuous replanting until the player changes them.

### Crop plan mechanics
- **Seeds consumed at plant time, not placement.** The worker's `PerformPlant` consumes a seed via `CropPlantingService.ConsumeSeed`; `ValidatePlant` gates plant tasks on seed availability, and every seed-acquisition site (shop buy, auto-purchase, farm-mode exit) calls `RescanForPlanting()`.
- **Seed menu shows all crops** regardless of inventory; all are clickable at 0 seeds.
- **Plan replacement:** clicking a different seed type over an existing plan/growing crop replaces the plan (same type = no-op). **Shift-click deletes a plan.** The Remove Crops sub-mode keeps working, minus its now-obsolete seed refund.
- **Derived swap/destroy (never persisted):** crop type ≠ plan type → swap; crop with no plan → destroy. Any crop (repeat-harvest or single-harvest) under **50% grown** (`CropGrowthService.GetGrowthProgress` vs `GameConfig.CropSwapDestroyProgressThreshold`) is removed early by a new `PerformDestroyCrop` worker state with the ForkedHoe (tilling) animation; at ≥50% the crop is harvested first and the removal folds into `ApplyHarvestResult`'s removal branch, matching "wait until after next harvest".
- New coordinator destroy queue with priority Pickup > Till > **Destroy** > Plant > Harvest > Water; watering is suppressed while destroy work is pending.

### Farm UI presentation
- Opening the Farm UI **pauses gameplay** (new farm-mode flag OR'd into `PauseService.IsPaused`; existing writers untouched).
- Plan previews render **60% translucent in normal color** (grayscale material removed); **real growing crops are hidden** while the Farm UI is open and restored on dismiss, when workers carry out the planned work.

### Auto Shop Options (Settings UI)
- New **"Auto Shop" tab**: "Automate Seed Purchases" toggle (default off, tooltip "Buy seeds for planned crops as soon as gold is available") and "Gold Buffer" slider 0–100,000 step 200 default 200 (tooltip "No auto purchases will be made when gold is below this value").
- New `AutoSeedPurchaseService` buys seeds for planned-but-unplanted crops while `Funds − price ≥ GoldBuffer`, throttled to once per second, paused-gated.

### Second Chance Shop
- Seed slots show a **green highlight background** while planned demand exceeds owned seeds, using the shared `CropPlantingService.CountUnplantedPlans` coverage formula; clears once coverage is adequate.

### Persistence
- Save version **14 → 15**: persists the two auto-shop settings (section 30).
- **v<15 migration** in `ApplyPendingLoadData`: refunds +1 seed per restored plan whose tile lacks a same-type crop (old model charged the seed at placement; new model charges at plant time) and infers plans for growing crops without one (so they aren't treated as pending-destroy).

## Testing
- 35 new tests: `CropPlantingServiceTests` (coverage formula, ConsumeSeed/HasSeeds, no-refund removal), `CropGrowthServiceTests` (growth progress incl. regrowth multiplier), `AutoSeedPurchaseServiceTests` (buffer, termination, coverage), plus PauseService composition and SaveData v15 round-trip/defaults.
- Full suite: **1439 passed / 11 failed / 6 skipped** — the 11 failures are the same pre-existing baseline failures (unchanged from master).

Known gap (out of scope): the Virtual Game Layer has no farming coverage, so these mechanics have no headless simulation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)