### PR TITLE
UI improvements: half-window zoom default, middle-mouse pan, farm UI zoom restore

### DIFF
--- a/PitHero/ECS/Components/CameraControllerComponent.cs
+++ b/PitHero/ECS/Components/CameraControllerComponent.cs
@@ -92,6 +92,7 @@ namespace PitHero.ECS.Components
 
             HandleZoomInput();
             HandlePanInput();
+            HandleKeyboardPanInput();
             HandleHeroFollowing();
         }
 
@@ -306,6 +307,40 @@ namespace PitHero.ECS.Components
                 // Reset manual control timer on active panning
                 _manualControlTimer = 0f;
             }
+        }
+
+        /// <summary>
+        /// Smoothly scrolls the camera while arrow keys or WASD are held — an alternative panning
+        /// method to the middle-mouse drag. Skipped while SHIFT/CTRL are held so modifier-based
+        /// shortcuts (e.g. SHIFT+S) and zoom controls don't also pan the camera.
+        /// </summary>
+        private void HandleKeyboardPanInput()
+        {
+            if (Input.IsKeyDown(Keys.LeftShift) || Input.IsKeyDown(Keys.RightShift) ||
+                Input.IsKeyDown(Keys.LeftControl) || Input.IsKeyDown(Keys.RightControl))
+                return;
+
+            var direction = Vector2.Zero;
+            if (Input.IsKeyDown(Keys.Left) || Input.IsKeyDown(Keys.A))
+                direction.X -= 1f;
+            if (Input.IsKeyDown(Keys.Right) || Input.IsKeyDown(Keys.D))
+                direction.X += 1f;
+            if (Input.IsKeyDown(Keys.Up) || Input.IsKeyDown(Keys.W))
+                direction.Y -= 1f;
+            if (Input.IsKeyDown(Keys.Down) || Input.IsKeyDown(Keys.S))
+                direction.Y += 1f;
+
+            if (direction == Vector2.Zero)
+                return;
+
+            direction.Normalize();
+            SwitchToManualControl();
+
+            // Divide by zoom so on-screen scroll speed stays consistent at every zoom level
+            var panDelta = direction * GameConfig.CameraKeyboardPanSpeed * Time.DeltaTime / _camera.RawZoom;
+            _camera.Position = ConstrainCameraPosition(_camera.Position + panDelta);
+            QuantizeCameraPosition();
+            _manualControlTimer = 0f;
         }
 
         /// <summary>

--- a/PitHero/ECS/Components/CameraControllerComponent.cs
+++ b/PitHero/ECS/Components/CameraControllerComponent.cs
@@ -22,6 +22,7 @@ namespace PitHero.ECS.Components
         private bool _isFollowingHero = true; // camera auto-follows hero by default
         private float _manualControlTimer = 0f; // tracks time since last manual control input
         private float _keyboardPanHeldTime = 0f; // continuous seconds arrow/WASD pan keys have been held
+        private Vector2 _keyboardPanRemainder; // banked sub-pixel movement released in whole-pixel steps
         private Entity _heroEntity; // cached reference to hero entity
 
         /// <summary>
@@ -322,6 +323,7 @@ namespace PitHero.ECS.Components
                 Input.IsKeyDown(Keys.LeftControl) || Input.IsKeyDown(Keys.RightControl))
             {
                 _keyboardPanHeldTime = 0f;
+                _keyboardPanRemainder = Vector2.Zero;
                 return;
             }
 
@@ -338,6 +340,7 @@ namespace PitHero.ECS.Components
             if (direction == Vector2.Zero)
             {
                 _keyboardPanHeldTime = 0f;
+                _keyboardPanRemainder = Vector2.Zero;
                 return;
             }
 
@@ -349,11 +352,23 @@ namespace PitHero.ECS.Components
             var ramp = MathHelper.Clamp(_keyboardPanHeldTime / GameConfig.CameraKeyboardPanAccelSeconds, 0f, 1f);
             var speed = MathHelper.Lerp(GameConfig.CameraKeyboardPanSpeed, GameConfig.CameraKeyboardPanMaxSpeed, ramp);
 
-            // Divide by zoom so on-screen scroll speed stays consistent at every zoom level
-            var panDelta = direction * speed * Time.DeltaTime / _camera.RawZoom;
-            _camera.Position = ConstrainCameraPosition(_camera.Position + panDelta);
-            QuantizeCameraPosition();
+            // Divide by zoom so on-screen scroll speed stays consistent at every zoom level.
+            // Movement is released only in whole screen-pixel steps (banking the fractional part
+            // in a remainder) so the camera never lands on sub-pixel positions mid-scroll, which
+            // reads as blur/shimmer. At 1x zoom this is exactly integer world-position snapping.
+            float pixelStep = 1f / _camera.RawZoom; // world units per screen pixel
+            var desired = direction * speed * Time.DeltaTime / _camera.RawZoom + _keyboardPanRemainder;
+            var applied = new Vector2(
+                (float)System.Math.Truncate(desired.X / pixelStep) * pixelStep,
+                (float)System.Math.Truncate(desired.Y / pixelStep) * pixelStep);
+            _keyboardPanRemainder = desired - applied;
             _manualControlTimer = 0f;
+
+            if (applied == Vector2.Zero)
+                return;
+
+            _camera.Position = ConstrainCameraPosition(_camera.Position + applied);
+            QuantizeCameraPosition();
         }
 
         /// <summary>

--- a/PitHero/ECS/Components/CameraControllerComponent.cs
+++ b/PitHero/ECS/Components/CameraControllerComponent.cs
@@ -21,6 +21,7 @@ namespace PitHero.ECS.Components
 
         private bool _isFollowingHero = true; // camera auto-follows hero by default
         private float _manualControlTimer = 0f; // tracks time since last manual control input
+        private float _keyboardPanHeldTime = 0f; // continuous seconds arrow/WASD pan keys have been held
         private Entity _heroEntity; // cached reference to hero entity
 
         /// <summary>
@@ -311,14 +312,18 @@ namespace PitHero.ECS.Components
 
         /// <summary>
         /// Smoothly scrolls the camera while arrow keys or WASD are held — an alternative panning
-        /// method to the middle-mouse drag. Skipped while SHIFT/CTRL are held so modifier-based
-        /// shortcuts (e.g. SHIFT+S) and zoom controls don't also pan the camera.
+        /// method to the middle-mouse drag. Speed ramps from the starting to the top pan speed the
+        /// longer keys are held continuously, so long trips get faster. Skipped while SHIFT/CTRL are
+        /// held so modifier-based shortcuts (e.g. SHIFT+S) and zoom controls don't also pan the camera.
         /// </summary>
         private void HandleKeyboardPanInput()
         {
             if (Input.IsKeyDown(Keys.LeftShift) || Input.IsKeyDown(Keys.RightShift) ||
                 Input.IsKeyDown(Keys.LeftControl) || Input.IsKeyDown(Keys.RightControl))
+            {
+                _keyboardPanHeldTime = 0f;
                 return;
+            }
 
             var direction = Vector2.Zero;
             if (Input.IsKeyDown(Keys.Left) || Input.IsKeyDown(Keys.A))
@@ -331,13 +336,21 @@ namespace PitHero.ECS.Components
                 direction.Y += 1f;
 
             if (direction == Vector2.Zero)
+            {
+                _keyboardPanHeldTime = 0f;
                 return;
+            }
 
             direction.Normalize();
             SwitchToManualControl();
 
+            // Accelerate from starting to top speed over the ramp duration while keys stay held
+            _keyboardPanHeldTime += Time.DeltaTime;
+            var ramp = MathHelper.Clamp(_keyboardPanHeldTime / GameConfig.CameraKeyboardPanAccelSeconds, 0f, 1f);
+            var speed = MathHelper.Lerp(GameConfig.CameraKeyboardPanSpeed, GameConfig.CameraKeyboardPanMaxSpeed, ramp);
+
             // Divide by zoom so on-screen scroll speed stays consistent at every zoom level
-            var panDelta = direction * GameConfig.CameraKeyboardPanSpeed * Time.DeltaTime / _camera.RawZoom;
+            var panDelta = direction * speed * Time.DeltaTime / _camera.RawZoom;
             _camera.Position = ConstrainCameraPosition(_camera.Position + panDelta);
             QuantizeCameraPosition();
             _manualControlTimer = 0f;

--- a/PitHero/ECS/Components/CameraControllerComponent.cs
+++ b/PitHero/ECS/Components/CameraControllerComponent.cs
@@ -267,9 +267,9 @@ namespace PitHero.ECS.Components
             var currentMousePosition = Input.ScaledMousePosition;
             bool shiftDown = Input.IsKeyDown(Keys.LeftShift) || Input.IsKeyDown(Keys.RightShift);
 
-            if (Input.RightMouseButtonPressed && IsMouseInsideWindow())
+            if (Input.MiddleMouseButtonPressed && IsMouseInsideWindow())
             {
-                // Do not start panning if this press is used for SHIFT+Right-Click reset
+                // Do not start panning if this press is used for SHIFT+Middle-Click reset
                 if (shiftDown)
                 {
                     _isPanning = false;
@@ -278,16 +278,16 @@ namespace PitHero.ECS.Components
 
                 _isPanning = true;
                 _lastMousePosition = currentMousePosition;
-                
+
                 // Switch to manual control mode
                 SwitchToManualControl();
             }
-            else if (Input.RightMouseButtonReleased)
+            else if (Input.MiddleMouseButtonReleased)
             {
                 _isPanning = false;
             }
 
-            if (_isPanning && Input.RightMouseButtonDown)
+            if (_isPanning && Input.MiddleMouseButtonDown)
             {
                 var mouseDelta = currentMousePosition - _lastMousePosition;
                 var panDelta = -mouseDelta * GameConfig.CameraPanSpeed / _camera.RawZoom;
@@ -306,7 +306,7 @@ namespace PitHero.ECS.Components
 
         /// <summary>
         /// Returns true when the window has OS focus and the raw cursor is within the client area.
-        /// Used to gate the start of right-mouse panning so scrolling doesn't begin while the
+        /// Used to gate the start of middle-mouse panning so scrolling doesn't begin while the
         /// cursor is outside the game window.
         /// </summary>
         private static bool IsMouseInsideWindow()
@@ -457,13 +457,27 @@ namespace PitHero.ECS.Components
         /// </summary>
         public void ResetZoomToDefault()
         {
+            SetZoomPreservingFocus(GameConfig.CameraDefaultZoom, "ResetZoomToDefault");
+        }
+
+        /// <summary>
+        /// Applies the half-window default zoom while keeping the camera centered on the world
+        /// position it is currently looking at (clamped to the new zoom's bounds).
+        /// </summary>
+        public void ApplyHalfWindowZoom()
+        {
+            SetZoomPreservingFocus(GameConfig.CameraHalfSizeWindowZoom, "ApplyHalfWindowZoom");
+        }
+
+        private void SetZoomPreservingFocus(float zoom, string logContext)
+        {
             if (_camera == null)
                 return;
             var focus = _camera.Position;
-            _camera.RawZoom = GameConfig.CameraDefaultZoom;
+            _camera.RawZoom = zoom;
             _camera.Position = ConstrainCameraPosition(focus);
             QuantizeCameraPosition();
-            Debug.Log($"[CameraController] ResetZoomToDefault zoom={_camera.RawZoom} positionX={_camera.Position.X} positionY={_camera.Position.Y}");
+            Debug.Log($"[CameraController] {logContext} zoom={_camera.RawZoom} positionX={_camera.Position.X} positionY={_camera.Position.Y}");
         }
 
         /// <summary>

--- a/PitHero/ECS/Components/CameraControllerComponent.cs
+++ b/PitHero/ECS/Components/CameraControllerComponent.cs
@@ -24,6 +24,12 @@ namespace PitHero.ECS.Components
         private Entity _heroEntity; // cached reference to hero entity
 
         /// <summary>
+        /// Optional hook set by the scene; returns true when the pointer is over a UI element.
+        /// Gates the modifier-less wheel zoom so scrolling a UI list doesn't also zoom the camera.
+        /// </summary>
+        public System.Func<bool> IsPointerOverUI;
+
+        /// <summary>
         /// Gets whether this component should respect the manual pause state.
         /// We shouldn't modify camera size or zoom while paused from menu.
         /// The farm-mode pause gate is deliberately ignored so the player can pan/zoom the map
@@ -107,13 +113,10 @@ namespace PitHero.ECS.Components
                 return;
             }
 
-            // SHIFT + Middle-Click: Reset zoom (preserve current window size)
+            // SHIFT + Middle-Click: Reset zoom (preserve current window size and camera location)
             if (shiftDown && Input.MiddleMouseButtonPressed)
             {
-                _camera.RawZoom = GameConfig.CameraDefaultZoom;
-                _camera.Position = ConstrainCameraPosition(_defaultCameraPosition);
-                QuantizeCameraPosition();
-                Debug.Log($"[CameraController] SHIFT+MiddleClick reset zoom={_camera.RawZoom} positionX={_camera.Position.X} positionY={_camera.Position.Y}");
+                SetZoomPreservingFocus(GameConfig.CameraDefaultZoom, "SHIFT+MiddleClick reset");
                 return;
             }
 
@@ -121,15 +124,16 @@ namespace PitHero.ECS.Components
             if (wheelDelta == 0)
                 return;
 
-            // SHIFT + scroll: camera zoom only
-            if (shiftDown)
-            {
-                HandleCameraOnlyZoom(wheelDelta);
-            }
             // CTRL + scroll: window resize
-            else if (ctrlDown)
+            if (ctrlDown)
             {
                 HandleWindowResizeZoom(wheelDelta);
+            }
+            // Plain or SHIFT + scroll: camera zoom. The modifier-less path is skipped while the
+            // pointer is over UI so scrolling a UI list doesn't also zoom the camera underneath.
+            else if (shiftDown || IsPointerOverUI?.Invoke() != true)
+            {
+                HandleCameraOnlyZoom(wheelDelta);
             }
         }
 

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -135,6 +135,8 @@ namespace PitHero.ECS.Scenes
             var cameraEntity = CreateEntity("camera-controller");
             cameraEntity.AddComponent(Camera);
             _cameraController = cameraEntity.AddComponent(new CameraControllerComponent());
+            // Delegate reads _uiStage at call time, so it is safe to wire before the stage exists
+            _cameraController.IsPointerOverUI = () => _uiStage != null && _uiStage.Hit(_uiStage.GetMousePosition()) != null;
 
             // Load HUD fonts (normal, 2x, 4x for shrink levels)
             _hudFontNormal = Content.LoadBitmapFont(GameConfig.FontPathHud);

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -56,6 +56,7 @@ namespace PitHero.ECS.Scenes
         private bool _wasInBuildingMode;
         private bool _wasInFarmMode;
         private bool _savedFarmAutoScroll;
+        private bool _farmModeRestoreHalfZoom;
         private SeedPlantingModeOverlay _seedModeOverlay;
         private bool _wasInSeedMode;
         private bool _wasInRemoveCropsMode;
@@ -2167,6 +2168,7 @@ namespace PitHero.ECS.Scenes
                     // and default zoom while the farm UI is open; OnUIWindowClosing re-applies
                     // the player's half-size preference on dismissal.
                     bool wasHalfSize = WindowManager.IsHalfHeightMode();
+                    _farmModeRestoreHalfZoom = wasHalfSize;
                     UIWindowManager.OnUIWindowOpening();
                     if (wasHalfSize)
                         _cameraController?.ResetZoomToDefault();
@@ -2181,6 +2183,11 @@ namespace PitHero.ECS.Scenes
                 else
                 {
                     UIWindowManager.OnUIWindowClosing();
+                    // Restore the half-window default zoom that was reset when the farm UI opened
+                    // (skip if the persistent size changed to Normal while the farm UI was open)
+                    if (_farmModeRestoreHalfZoom && WindowManager.IsHalfHeightMode())
+                        _cameraController?.ApplyHalfWindowZoom();
+                    _farmModeRestoreHalfZoom = false;
                     pauseService?.SetFarmModePause(false);
                     Core.Services.GetService<Services.CropGrowthService>()?.SetCropsVisible(true);
                     Core.Services.GetService<Services.FarmTaskCoordinator>()?.RescanForPlanting();

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -155,6 +155,7 @@ namespace PitHero
         public const float CameraMinimumZoomLargeMap = 0.25f; // can zoom out to 0.5x for large maps (clean divisor)
         public const float CameraZoomSpeed = 0.001f; // zoom sensitivity per mouse wheel notch
         public const float CameraPanSpeed = 1f; // pan speed multiplier
+        public const float CameraKeyboardPanSpeed = 300f; // screen pixels per second scrolled while an arrow/WASD key is held
         public const float CameraFollowLerpSpeed = 5f; // speed at which camera lerps to hero position
         public const float CameraManualControlTimeout = 7f; // seconds of inactivity before auto-following resumes (paused when player interacts with selectables)
         public const bool CameraAutoScrollToHeroDefault = true; // default value for auto-scroll to hero setting

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -151,7 +151,7 @@ namespace PitHero
         public const float CameraDefaultZoom = 1f; // default zoom level
         public const float CameraMinimumZoom = 0.5f; // can't zoom out past default for normal maps
         public const float CameraMaximumZoom = 3f; // can zoom in really close
-        public const float CameraHalfSizeWindowZoom = 1.5f; // default zoom applied automatically when switching to Half Size window (4 zoom-slider levels in from 1x)
+        public const float CameraHalfSizeWindowZoom = 1.25f; // default zoom applied automatically when switching to Half Size window (2 zoom-slider levels in from 1x)
         public const float CameraMinimumZoomLargeMap = 0.25f; // can zoom out to 0.5x for large maps (clean divisor)
         public const float CameraZoomSpeed = 0.001f; // zoom sensitivity per mouse wheel notch
         public const float CameraPanSpeed = 1f; // pan speed multiplier

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -155,7 +155,9 @@ namespace PitHero
         public const float CameraMinimumZoomLargeMap = 0.25f; // can zoom out to 0.5x for large maps (clean divisor)
         public const float CameraZoomSpeed = 0.001f; // zoom sensitivity per mouse wheel notch
         public const float CameraPanSpeed = 1f; // pan speed multiplier
-        public const float CameraKeyboardPanSpeed = 300f; // screen pixels per second scrolled while an arrow/WASD key is held
+        public const float CameraKeyboardPanSpeed = 300f; // starting screen pixels per second scrolled when an arrow/WASD key is first held
+        public const float CameraKeyboardPanMaxSpeed = 1200f; // top screen pixels per second reached after holding pan keys continuously
+        public const float CameraKeyboardPanAccelSeconds = 1.5f; // seconds of continuous key-hold to ramp pan speed from starting to top
         public const float CameraFollowLerpSpeed = 5f; // speed at which camera lerps to hero position
         public const float CameraManualControlTimeout = 7f; // seconds of inactivity before auto-following resumes (paused when player interacts with selectables)
         public const bool CameraAutoScrollToHeroDefault = true; // default value for auto-scroll to hero setting

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -1300,6 +1300,7 @@ namespace PitHero.UI
 
         /// <summary>
         /// Processes keyboard shortcut presses and dispatches to the appropriate UI actions.
+        /// Letter shortcuts require SHIFT; bare letters are reserved for WASD camera panning.
         /// </summary>
         private void HandleKeyboardShortcuts()
         {
@@ -1314,31 +1315,37 @@ namespace PitHero.UI
             bool JustPressed(Microsoft.Xna.Framework.Input.Keys key)
                 => currentKeyState.IsKeyDown(key) && !_prevKeyboardState.IsKeyDown(key);
 
-            if (JustPressed(Microsoft.Xna.Framework.Input.Keys.R))
+            // Letter shortcuts require SHIFT so bare WASD keys stay free for camera panning
+            bool shiftDown = currentKeyState.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.LeftShift)
+                          || currentKeyState.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.RightShift);
+            bool ShortcutPressed(Microsoft.Xna.Framework.Input.Keys key)
+                => shiftDown && JustPressed(key);
+
+            if (ShortcutPressed(Microsoft.Xna.Framework.Input.Keys.R))
                 _replenishUI?.TriggerReplenish();
 
-            if (JustPressed(Microsoft.Xna.Framework.Input.Keys.S))
+            if (ShortcutPressed(Microsoft.Xna.Framework.Input.Keys.S))
                 _stopAdventuringUI?.TriggerToggle();
 
-            if (JustPressed(Microsoft.Xna.Framework.Input.Keys.F))
+            if (ShortcutPressed(Microsoft.Xna.Framework.Input.Keys.F))
                 _fastFUI?.TriggerToggle();
 
-            if (JustPressed(Microsoft.Xna.Framework.Input.Keys.E))
+            if (ShortcutPressed(Microsoft.Xna.Framework.Input.Keys.E))
                 ToggleSettingsVisibility();
 
-            if (JustPressed(Microsoft.Xna.Framework.Input.Keys.H))
+            if (ShortcutPressed(Microsoft.Xna.Framework.Input.Keys.H))
                 _heroUI?.TriggerToggle();
 
-            if (JustPressed(Microsoft.Xna.Framework.Input.Keys.I))
+            if (ShortcutPressed(Microsoft.Xna.Framework.Input.Keys.I))
                 _heroUI?.OpenToInventoryTab();
 
-            if (JustPressed(Microsoft.Xna.Framework.Input.Keys.N))
+            if (ShortcutPressed(Microsoft.Xna.Framework.Input.Keys.N))
                 _heroUI?.OpenToHeroInfoTab();
 
-            if (JustPressed(Microsoft.Xna.Framework.Input.Keys.B))
+            if (ShortcutPressed(Microsoft.Xna.Framework.Input.Keys.B))
                 _heroUI?.OpenToBehaviorTab();
 
-            if (JustPressed(Microsoft.Xna.Framework.Input.Keys.M))
+            if (ShortcutPressed(Microsoft.Xna.Framework.Input.Keys.M))
                 _monsterUI?.TriggerToggle();
 
             if (JustPressed(Microsoft.Xna.Framework.Input.Keys.Tab))


### PR DESCRIPTION
Closes #307

## Changes

* **Half window size default zoom → 2 units in (1.25x)** — `GameConfig.CameraHalfSizeWindowZoom` changed from `1.5f` (4 zoom-slider steps) to `1.25f` (2 steps). All appliers reference the constant.
* **Middle-mouse pan** — scene drag/pan in `CameraControllerComponent.HandlePanInput()` now uses the middle mouse button instead of right. The cursor-inside-window gate is unchanged, and the SHIFT guard now protects the SHIFT+Middle-Click zoom reset from starting a pan. SHIFT+Right-Click (window+zoom reset) shortcut is untouched.
* **Farm UI zoom restore fix** — opening the Farm UI from half window size temporarily restores Normal size + default zoom; dismissing it previously restored the half-size *window* but left the camera at 1x. `MainGameScene` now remembers that the zoom was reset (`_farmModeRestoreHalfZoom`) and re-applies the half-window default zoom via the new `CameraControllerComponent.ApplyHalfWindowZoom()` after `OnUIWindowClosing()` shrinks the window back. Skipped if the persistent size changed to Normal while the farm UI was open.
* **Modifier-less wheel zoom** — rolling the mouse wheel with no modifier now zooms the camera with the same fixed-step behavior as SHIFT+wheel. Skipped while the pointer is over a UI element (via a scene-provided `IsPointerOverUI` hook using `_uiStage.Hit`) so scrolling a UI list doesn't also zoom the camera underneath; SHIFT+wheel still zooms unconditionally, CTRL+wheel still resizes the window.
* **Location-preserving SHIFT+Middle zoom reset** — SHIFT+Middle-Click still resets to default zoom but now keeps the camera centered on its current location (clamped to the new zoom's bounds) instead of jumping back to the default far-left position.
* **Keyboard panning (arrows + WASD) with hold acceleration** — holding arrow keys or WASD smoothly scrolls the camera as an alternative to middle-mouse drag. Speed ramps linearly from `CameraKeyboardPanSpeed` (300 screen px/s) to `CameraKeyboardPanMaxSpeed` (1200 px/s) over `CameraKeyboardPanAccelSeconds` (1.5s) of continuous hold, resetting on release. Zoom-compensated so on-screen speed is constant, diagonals normalized, switches to manual control like mouse panning. Skipped while SHIFT/CTRL are held.
* **UI letter shortcuts now require SHIFT** — the SettingsUI shortcuts (R/S/F/E/H/I/N/B/M) fire on SHIFT+letter so bare WASD keys stay free for panning. Tab and shortcut-bar number keys are unchanged.

## Verification

* `dotnet build PitHero.sln` — 0 errors
* `dotnet test PitHero.Tests/PitHero.Tests.csproj` — 11 failed / 1443 passed, matching the pre-existing 11-failure baseline (no new failures)
* Manual in-game check recommended: middle-drag pans only when cursor is in the window; Half size applies 1.25x; farm UI open/close round-trip returns to Half + 1.25x; plain wheel zooms (but not while hovering UI); SHIFT+Middle reset stays put; arrows/WASD scroll smoothly and speed up over ~1.5s of holding; SHIFT+S toggles Stop Adventuring without panning

🤖 Generated with [Claude Code](https://claude.com/claude-code)