### PR TITLE
Auto-sell crop stacks in Auto Shop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,3 +16,5 @@ Claude Code-specific notes for PitHero. **All project development rules live in 
 - Skills follow progressive disclosure — thin `SKILL.md` + `references/*.md` loaded on demand. Don't list skills in agent files; let description-matching discover them.
 - `.github/agents/` and `.github/skills/` are symlinks to `.claude/`. `.claude/` is the source of truth.
 - Plan mode replaces the previous `planner` and `feature-builder` agents — use it for multi-step work.
+- Do not write "Co-authored by Claude..." in commit messages
+

--- a/PitHero.Tests/AutoCropSellServiceTests.cs
+++ b/PitHero.Tests/AutoCropSellServiceTests.cs
@@ -163,5 +163,95 @@ namespace PitHero.Tests
 
             Assert.AreEqual(50, _gameState.Funds, "Funds should be unchanged with no stored crops");
         }
+
+        // ── KeepStacks ───────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void KeepStacks_ZeroByDefault()
+        {
+            Assert.AreEqual(0, _service.KeepStacks, "KeepStacks should default to 0 (sell every full stack)");
+        }
+
+        [TestMethod]
+        public void KeepStacks_ClampsToValidRange()
+        {
+            _service.KeepStacks = -3;
+            Assert.AreEqual(0, _service.KeepStacks, "KeepStacks should clamp below at 0");
+
+            _service.KeepStacks = 99;
+            Assert.AreEqual(AutoCropSellService.MaxKeepStacks, _service.KeepStacks,
+                "KeepStacks should clamp above at MaxKeepStacks");
+        }
+
+        [TestMethod]
+        public void TrySellPass_KeepStacks_SellsOnlyStacksBeyondKeepCount()
+        {
+            int max = CropConfig.GetMaxHarvestStack(CropType.Wheat);
+            // Three full Wheat stacks in one building
+            _storage.DepositReturningStored(BuildingA, CropType.Wheat, max * 3);
+            _service.KeepStacks = 2;
+            _gameState.Funds = 0;
+
+            _service.TrySellPass();
+
+            Assert.AreEqual(CropConfig.GetHarvestStackSellPrice(CropType.Wheat, max), _gameState.Funds,
+                "Only the third full stack should be sold when KeepStacks=2");
+            var slots = _storage.GetSlots(BuildingA);
+            int fullStacksRemaining = 0;
+            for (int s = 0; s < slots.Count; s++)
+                if (!slots[s].IsEmpty && slots[s].Type == CropType.Wheat && slots[s].Count == max)
+                    fullStacksRemaining++;
+            Assert.AreEqual(2, fullStacksRemaining, "Two full Wheat stacks should be kept");
+        }
+
+        [TestMethod]
+        public void TrySellPass_KeepStacks_AtOrBelowKeepCount_SellsNothing()
+        {
+            int max = CropConfig.GetMaxHarvestStack(CropType.Wheat);
+            // Two full Wheat stacks, keep 2 — nothing to sell yet
+            _storage.DepositReturningStored(BuildingA, CropType.Wheat, max * 2);
+            _service.KeepStacks = 2;
+            _gameState.Funds = 0;
+
+            _service.TrySellPass();
+
+            Assert.AreEqual(0, _gameState.Funds, "No stacks should be sold at or below the keep count");
+        }
+
+        [TestMethod]
+        public void TrySellPass_KeepStacks_CountsPerCropAcrossBuildings()
+        {
+            int wheatMax  = CropConfig.GetMaxHarvestStack(CropType.Wheat);
+            int turnipMax = CropConfig.GetMaxHarvestStack(CropType.Turnip);
+            // Two full Wheat stacks split across buildings, one full Turnip stack
+            _storage.DepositReturningStored(BuildingA, CropType.Wheat, wheatMax);
+            _storage.DepositReturningStored(BuildingB, CropType.Wheat, wheatMax);
+            _storage.DepositReturningStored(BuildingB, CropType.Turnip, turnipMax);
+            _service.KeepStacks = 1;
+            _gameState.Funds = 0;
+
+            _service.TrySellPass();
+
+            Assert.AreEqual(CropConfig.GetHarvestStackSellPrice(CropType.Wheat, wheatMax), _gameState.Funds,
+                "One Wheat stack (the second, counted across buildings) should be sold; the Turnip stack is its crop's first and is kept");
+            Assert.AreEqual(turnipMax, _storage.GetSlots(BuildingB)[1].Count,
+                "The single full Turnip stack should be kept when KeepStacks=1");
+        }
+
+        [TestMethod]
+        public void TrySellPass_KeepStacks_KeepCountResetsBetweenPasses()
+        {
+            int max = CropConfig.GetMaxHarvestStack(CropType.Wheat);
+            _storage.DepositReturningStored(BuildingA, CropType.Wheat, max);
+            _service.KeepStacks = 1;
+            _gameState.Funds = 0;
+
+            // Two passes: the single kept stack must not be sold by the second pass's counter state
+            _service.TrySellPass();
+            _service.TrySellPass();
+
+            Assert.AreEqual(0, _gameState.Funds, "The kept stack should survive repeated passes");
+            Assert.AreEqual(max, _storage.GetSlots(BuildingA)[0].Count, "Kept stack should remain untouched");
+        }
     }
 }

--- a/PitHero.Tests/AutoCropSellServiceTests.cs
+++ b/PitHero.Tests/AutoCropSellServiceTests.cs
@@ -1,0 +1,167 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Farming;
+using PitHero.Services;
+using PitHero.Util;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Tests for AutoCropSellService. All tests call TrySellPass() directly to bypass the
+    /// 1-second Time.DeltaTime throttle, which never elapses in a headless test context.
+    /// The Enabled=false path is verified via Update() (which returns before touching the timer).
+    /// Services are constructed directly (not via Core.Services) for headless safety.
+    /// </summary>
+    [TestClass]
+    public class AutoCropSellServiceTests
+    {
+        private const int BuildingA = 1;
+        private const int BuildingB = 2;
+
+        private CropStorageInventoryService _storage   = null!;
+        private GameStateService            _gameState = null!;
+        private AutoCropSellService         _service   = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _storage   = new CropStorageInventoryService(buildingService: null);
+            _gameState = new GameStateService();
+            _service   = new AutoCropSellService(_storage, _gameState);
+        }
+
+        // ── Default state ────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void Service_DisabledByDefault()
+        {
+            Assert.IsFalse(_service.Enabled, "AutoCropSellService should be disabled by default");
+        }
+
+        [TestMethod]
+        public void Designations_AllTrueByDefault()
+        {
+            for (int i = 0; i < CropTypeInfo.Count; i++)
+                Assert.IsTrue(_service.Designations[i],
+                    $"All crop types should be designated for auto-sell by default (crop {i})");
+        }
+
+        // ── Update() when disabled ───────────────────────────────────────────
+
+        [TestMethod]
+        public void Update_WhenDisabled_SellsNothing()
+        {
+            int max = CropConfig.GetMaxHarvestStack(CropType.Wheat);
+            _storage.DepositReturningStored(BuildingA, CropType.Wheat, max);
+            _gameState.Funds = 100;
+
+            // Enabled is false (default) — Update should exit immediately
+            _service.Update();
+
+            Assert.AreEqual(100, _gameState.Funds, "Funds should be unchanged when Enabled=false");
+            Assert.AreEqual(max, _storage.GetSlots(BuildingA)[0].Count,
+                "Full stack should remain when Enabled=false");
+        }
+
+        // ── TrySellPass() ────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void TrySellPass_SellsStackAtMaxSize()
+        {
+            int max = CropConfig.GetMaxHarvestStack(CropType.Wheat);
+            _storage.DepositReturningStored(BuildingA, CropType.Wheat, max);
+            _gameState.Funds = 0;
+
+            _service.TrySellPass();
+
+            Assert.AreEqual(CropConfig.GetHarvestStackSellPrice(CropType.Wheat, max), _gameState.Funds,
+                "Funds should increase by the stack sell price");
+            Assert.IsTrue(_storage.GetSlots(BuildingA)[0].IsEmpty, "Sold slot should be cleared");
+        }
+
+        [TestMethod]
+        public void TrySellPass_IgnoresStackBelowMaxSize()
+        {
+            int max = CropConfig.GetMaxHarvestStack(CropType.Wheat);
+            _storage.DepositReturningStored(BuildingA, CropType.Wheat, max - 1);
+            _gameState.Funds = 0;
+
+            _service.TrySellPass();
+
+            Assert.AreEqual(0, _gameState.Funds, "Nothing should be sold below max stack size");
+            Assert.AreEqual(max - 1, _storage.GetSlots(BuildingA)[0].Count,
+                "Partial stack should remain untouched");
+        }
+
+        [TestMethod]
+        public void TrySellPass_RespectsDesignationOff()
+        {
+            int max = CropConfig.GetMaxHarvestStack(CropType.Wheat);
+            _storage.DepositReturningStored(BuildingA, CropType.Wheat, max);
+            _service.Designations[(int)CropType.Wheat] = false;
+            _gameState.Funds = 0;
+
+            _service.TrySellPass();
+
+            Assert.AreEqual(0, _gameState.Funds, "Undesignated crops should not be sold");
+            Assert.AreEqual(max, _storage.GetSlots(BuildingA)[0].Count,
+                "Undesignated full stack should remain untouched");
+        }
+
+        [TestMethod]
+        public void TrySellPass_SellsMultipleFullStacksAcrossBuildingsInOnePass()
+        {
+            int wheatMax  = CropConfig.GetMaxHarvestStack(CropType.Wheat);
+            int turnipMax = CropConfig.GetMaxHarvestStack(CropType.Turnip);
+            int tomatoMax = CropConfig.GetMaxHarvestStack(CropType.Tomato);
+            _storage.DepositReturningStored(BuildingA, CropType.Wheat, wheatMax);
+            _storage.DepositReturningStored(BuildingB, CropType.Turnip, turnipMax);
+            // Full but designated off — must survive the pass
+            _storage.DepositReturningStored(BuildingB, CropType.Tomato, tomatoMax);
+            _service.Designations[(int)CropType.Tomato] = false;
+            _gameState.Funds = 0;
+
+            _service.TrySellPass();
+
+            int expected = CropConfig.GetHarvestStackSellPrice(CropType.Wheat, wheatMax)
+                         + CropConfig.GetHarvestStackSellPrice(CropType.Turnip, turnipMax);
+            Assert.AreEqual(expected, _gameState.Funds,
+                "Both designated full stacks should be sold in one pass");
+            Assert.IsTrue(_storage.GetSlots(BuildingA)[0].IsEmpty, "Building A stack should be sold");
+            Assert.IsTrue(_storage.GetSlots(BuildingB)[0].IsEmpty, "Building B Turnip stack should be sold");
+            Assert.AreEqual(tomatoMax, _storage.GetSlots(BuildingB)[1].Count,
+                "Designated-off Tomato stack should remain");
+        }
+
+        [TestMethod]
+        public void TrySellPass_MixedSlots_OnlyFullDesignatedSold()
+        {
+            int wheatMax  = CropConfig.GetMaxHarvestStack(CropType.Wheat);
+            int turnipMax = CropConfig.GetMaxHarvestStack(CropType.Turnip);
+            int tomatoMax = CropConfig.GetMaxHarvestStack(CropType.Tomato);
+            _storage.DepositReturningStored(BuildingA, CropType.Wheat, wheatMax);       // full, designated
+            _storage.DepositReturningStored(BuildingA, CropType.Turnip, turnipMax - 5); // partial, designated
+            _storage.DepositReturningStored(BuildingA, CropType.Tomato, tomatoMax);     // full, undesignated
+            _service.Designations[(int)CropType.Tomato] = false;
+            _gameState.Funds = 0;
+
+            _service.TrySellPass();
+
+            Assert.AreEqual(CropConfig.GetHarvestStackSellPrice(CropType.Wheat, wheatMax), _gameState.Funds,
+                "Only the full designated stack should be sold");
+            var slots = _storage.GetSlots(BuildingA);
+            Assert.IsTrue(slots[0].IsEmpty, "Full designated Wheat stack should be sold");
+            Assert.AreEqual(turnipMax - 5, slots[1].Count, "Partial Turnip stack should remain");
+            Assert.AreEqual(tomatoMax, slots[2].Count, "Undesignated Tomato stack should remain");
+        }
+
+        [TestMethod]
+        public void TrySellPass_EmptyStorage_DoesNothing()
+        {
+            _gameState.Funds = 50;
+
+            _service.TrySellPass();
+
+            Assert.AreEqual(50, _gameState.Funds, "Funds should be unchanged with no stored crops");
+        }
+    }
+}

--- a/PitHero.Tests/SaveLoadTests.cs
+++ b/PitHero.Tests/SaveLoadTests.cs
@@ -719,16 +719,16 @@ namespace PitHero.Tests
         }
 
         /// <summary>
-        /// Verifies that a save stream written without v16 fields yields the correct defaults
-        /// (AutoSellCrops = false, all designations true) when recovered.
-        /// The "older-version stream" is simulated by writing a v16 binary, patching the version
-        /// bytes to 15, and stripping the v16 fields (bool + int count + 13 bools = 18 bytes)
-        /// from the tail.
+        /// Verifies that a save stream written without v16+ fields yields the correct defaults
+        /// (AutoSellCrops = false, all designations true, KeepStacks = 0) when recovered.
+        /// The "older-version stream" is simulated by writing a current-version binary, patching
+        /// the version bytes to 15, and stripping the v16 fields (bool + int count + 13 bools = 18
+        /// bytes) plus the v17 field (int KeepStacks = 4 bytes) from the tail.
         /// </summary>
         [TestMethod]
         public void SaveData_OlderVersion_AutoSellCrops_DefaultValues()
         {
-            // Write a full v16 SaveData to a MemoryStream
+            // Write a full current-version SaveData to a MemoryStream
             var ms = new MemoryStream();
             using (var writer = new BinaryPersistableWriter(ms))
             {
@@ -736,23 +736,25 @@ namespace PitHero.Tests
                 // Use non-default values so we can confirm they are NOT loaded
                 original.AutoSellCrops = true;
                 original.AutoSellCropDesignations = new bool[PitHero.Farming.CropTypeInfo.Count]; // all false
+                original.AutoSellKeepStacks = 7;
                 writer.Write(original);
             }
 
             byte[] bytes = ms.ToArray();
 
-            // Patch bytes [0-3] from version 16 to version 15 (little-endian int)
+            // Patch bytes [0-3] from the current version to version 15 (little-endian int)
             bytes[0] = 15;
             bytes[1] = 0;
             bytes[2] = 0;
             bytes[3] = 0;
 
-            // Strip section 31 from the tail: bool AutoSellCrops (1) + int count (4) + 13 bools (13)
-            int trimmedLength = bytes.Length - (1 + 4 + PitHero.Farming.CropTypeInfo.Count);
+            // Strip sections 31+32 from the tail:
+            // bool AutoSellCrops (1) + int count (4) + 13 bools (13) + int KeepStacks (4)
+            int trimmedLength = bytes.Length - (1 + 4 + PitHero.Farming.CropTypeInfo.Count + 4);
             var trimmed = new byte[trimmedLength];
             Array.Copy(bytes, trimmed, trimmedLength);
 
-            // Recover from the modified stream (version 15, no v16 fields)
+            // Recover from the modified stream (version 15, no v16+ fields)
             var loaded = new SaveData();
             using (var rdr = new BinaryPersistableReader(new MemoryStream(trimmed)))
             {
@@ -765,6 +767,82 @@ namespace PitHero.Tests
             for (int i = 0; i < PitHero.Farming.CropTypeInfo.Count; i++)
                 Assert.AreEqual(true, loaded.AutoSellCropDesignations[i],
                     $"Default: designation {i} should be true for pre-v16 saves");
+            Assert.AreEqual(0, loaded.AutoSellKeepStacks, "Default: AutoSellKeepStacks should be 0 for pre-v17 saves");
+        }
+
+        /// <summary>
+        /// Verifies that AutoSellKeepStacks round-trips through Persist/Recover in save version 17.
+        /// </summary>
+        [TestMethod]
+        public void SaveData_V17_KeepStacks_RoundTrip()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "pithero_v17_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var dataStore = new FileDataStore(tempDir);
+
+                var original = new SaveData();
+                original.AutoSellKeepStacks = 3;
+
+                dataStore.Save("v17_keepstacks.bin", original);
+
+                var loaded = new SaveData();
+                dataStore.Load("v17_keepstacks.bin", loaded);
+
+                Assert.AreEqual(3, loaded.AutoSellKeepStacks, "AutoSellKeepStacks should round-trip");
+                Assert.AreEqual(SaveData.CurrentVersion, loaded.LoadedFileVersion, "LoadedFileVersion should be the current version");
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a v16 stream (which lacks the KeepStacks field) recovers with the default
+        /// KeepStacks = 0 while still reading the v16 auto-sell fields. Simulated by writing a
+        /// current-version binary, patching the version bytes to 16, and stripping the 4-byte
+        /// KeepStacks int from the tail.
+        /// </summary>
+        [TestMethod]
+        public void SaveData_V16Stream_KeepStacks_DefaultValue()
+        {
+            var ms = new MemoryStream();
+            using (var writer = new BinaryPersistableWriter(ms))
+            {
+                var original = new SaveData();
+                original.AutoSellCrops = true;
+                original.AutoSellCropDesignations = new bool[PitHero.Farming.CropTypeInfo.Count];
+                for (int i = 0; i < original.AutoSellCropDesignations.Length; i++)
+                    original.AutoSellCropDesignations[i] = true;
+                original.AutoSellKeepStacks = 9; // must NOT survive the v16 downgrade
+                writer.Write(original);
+            }
+
+            byte[] bytes = ms.ToArray();
+
+            // Patch bytes [0-3] from the current version to version 16 (little-endian int)
+            bytes[0] = 16;
+            bytes[1] = 0;
+            bytes[2] = 0;
+            bytes[3] = 0;
+
+            // Strip section 32 from the tail: int KeepStacks (4 bytes)
+            int trimmedLength = bytes.Length - 4;
+            var trimmed = new byte[trimmedLength];
+            Array.Copy(bytes, trimmed, trimmedLength);
+
+            var loaded = new SaveData();
+            using (var rdr = new BinaryPersistableReader(new MemoryStream(trimmed)))
+            {
+                rdr.ReadPersistableInto(loaded);
+            }
+
+            Assert.AreEqual(16, loaded.LoadedFileVersion, "Should detect version 16");
+            Assert.AreEqual(true, loaded.AutoSellCrops, "v16 AutoSellCrops field should still load");
+            Assert.AreEqual(0, loaded.AutoSellKeepStacks, "Default: AutoSellKeepStacks should be 0 for v16 saves");
         }
     }
 }

--- a/PitHero.Tests/SaveLoadTests.cs
+++ b/PitHero.Tests/SaveLoadTests.cs
@@ -624,7 +624,7 @@ namespace PitHero.Tests
 
                 Assert.AreEqual(true, loaded.AutomateSeedPurchases, "AutomateSeedPurchases should round-trip");
                 Assert.AreEqual(500, loaded.AutoShopGoldBuffer, "AutoShopGoldBuffer should round-trip");
-                Assert.AreEqual(15, loaded.LoadedFileVersion, "LoadedFileVersion should be 15");
+                Assert.AreEqual(SaveData.CurrentVersion, loaded.LoadedFileVersion, "LoadedFileVersion should be the current version");
             }
             finally
             {
@@ -676,6 +676,95 @@ namespace PitHero.Tests
             Assert.AreEqual(14, loaded.LoadedFileVersion, "Should detect version 14");
             Assert.AreEqual(false, loaded.AutomateSeedPurchases, "Default: AutomateSeedPurchases should be false for pre-v15 saves");
             Assert.AreEqual(200, loaded.AutoShopGoldBuffer, "Default: AutoShopGoldBuffer should be 200 for pre-v15 saves");
+        }
+
+        /// <summary>
+        /// Verifies that AutoSellCrops and AutoSellCropDesignations round-trip correctly through
+        /// Persist/Recover in save version 16.
+        /// </summary>
+        [TestMethod]
+        public void SaveData_V16_AutoSellCrops_RoundTrip()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "pithero_v16_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var dataStore = new FileDataStore(tempDir);
+
+                var original = new SaveData();
+                original.AutoSellCrops = true;
+                original.AutoSellCropDesignations = new bool[PitHero.Farming.CropTypeInfo.Count];
+                for (int i = 0; i < original.AutoSellCropDesignations.Length; i++)
+                    original.AutoSellCropDesignations[i] = true;
+                original.AutoSellCropDesignations[0] = false; // mixed values to prove real round-trip
+
+                dataStore.Save("v16_autosell.bin", original);
+
+                var loaded = new SaveData();
+                dataStore.Load("v16_autosell.bin", loaded);
+
+                Assert.AreEqual(true, loaded.AutoSellCrops, "AutoSellCrops should round-trip");
+                Assert.IsNotNull(loaded.AutoSellCropDesignations, "Designations should be recovered");
+                Assert.AreEqual(false, loaded.AutoSellCropDesignations[0], "Designation[0]=false should round-trip");
+                for (int i = 1; i < PitHero.Farming.CropTypeInfo.Count; i++)
+                    Assert.AreEqual(true, loaded.AutoSellCropDesignations[i], $"Designation[{i}]=true should round-trip");
+                Assert.AreEqual(SaveData.CurrentVersion, loaded.LoadedFileVersion, "LoadedFileVersion should be the current version");
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a save stream written without v16 fields yields the correct defaults
+        /// (AutoSellCrops = false, all designations true) when recovered.
+        /// The "older-version stream" is simulated by writing a v16 binary, patching the version
+        /// bytes to 15, and stripping the v16 fields (bool + int count + 13 bools = 18 bytes)
+        /// from the tail.
+        /// </summary>
+        [TestMethod]
+        public void SaveData_OlderVersion_AutoSellCrops_DefaultValues()
+        {
+            // Write a full v16 SaveData to a MemoryStream
+            var ms = new MemoryStream();
+            using (var writer = new BinaryPersistableWriter(ms))
+            {
+                var original = new SaveData();
+                // Use non-default values so we can confirm they are NOT loaded
+                original.AutoSellCrops = true;
+                original.AutoSellCropDesignations = new bool[PitHero.Farming.CropTypeInfo.Count]; // all false
+                writer.Write(original);
+            }
+
+            byte[] bytes = ms.ToArray();
+
+            // Patch bytes [0-3] from version 16 to version 15 (little-endian int)
+            bytes[0] = 15;
+            bytes[1] = 0;
+            bytes[2] = 0;
+            bytes[3] = 0;
+
+            // Strip section 31 from the tail: bool AutoSellCrops (1) + int count (4) + 13 bools (13)
+            int trimmedLength = bytes.Length - (1 + 4 + PitHero.Farming.CropTypeInfo.Count);
+            var trimmed = new byte[trimmedLength];
+            Array.Copy(bytes, trimmed, trimmedLength);
+
+            // Recover from the modified stream (version 15, no v16 fields)
+            var loaded = new SaveData();
+            using (var rdr = new BinaryPersistableReader(new MemoryStream(trimmed)))
+            {
+                rdr.ReadPersistableInto(loaded);
+            }
+
+            Assert.AreEqual(15, loaded.LoadedFileVersion, "Should detect version 15");
+            Assert.AreEqual(false, loaded.AutoSellCrops, "Default: AutoSellCrops should be false for pre-v16 saves");
+            Assert.IsNotNull(loaded.AutoSellCropDesignations, "Designations should be normalized for pre-v16 saves");
+            for (int i = 0; i < PitHero.Farming.CropTypeInfo.Count; i++)
+                Assert.AreEqual(true, loaded.AutoSellCropDesignations[i],
+                    $"Default: designation {i} should be true for pre-v16 saves");
         }
     }
 }

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -307,6 +307,8 @@ SettingsAutoSellCrops,Auto-Sell Crops
 SettingsAutoSellCropsTooltip,When a crop reaches max stack quantity, sell it automatically
 ButtonDesignateCrops,Designate Crops
 WindowAutoSellCropTypes,Auto-Sell Crop Types
+ButtonSelectAll,Select All
+ButtonDeselectAll,Deselect All
 AddMonsterConfirmPrompt,Add {0} for {1} Gold
 
 # Crop Storage options (issue #285)

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -299,7 +299,7 @@ AddMonsterRemainingSpace,Remaining Space: {0}
 AddMonsterDaytimeLabel,Daytime
 AddMonsterNocturnalLabel,Nocturnal
 TabAutoShop,Auto Shop
-SettingsAutomateSeedPurchases,Automate Seed Purchases
+SettingsAutomateSeedPurchases,Auto-Purchase Seeds
 SettingsAutoShopGoldBuffer,Gold Buffer: {0}
 SettingsAutomateSeedPurchasesTooltip,Buy seeds for planned crops as soon as gold is available
 SettingsAutoShopGoldBufferTooltip,No auto purchases will be made when gold is below this value
@@ -309,6 +309,8 @@ ButtonDesignateCrops,Designate Crops
 WindowAutoSellCropTypes,Auto-Sell Crop Types
 ButtonSelectAll,Select All
 ButtonDeselectAll,Deselect All
+SettingsAutoSellKeepStacks,Keep Stacks: {0}
+SettingsAutoSellKeepStacksTooltip,Keep this many stacks of a crop before selling.
 AddMonsterConfirmPrompt,Add {0} for {1} Gold
 
 # Crop Storage options (issue #285)

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -303,6 +303,10 @@ SettingsAutomateSeedPurchases,Automate Seed Purchases
 SettingsAutoShopGoldBuffer,Gold Buffer: {0}
 SettingsAutomateSeedPurchasesTooltip,Buy seeds for planned crops as soon as gold is available
 SettingsAutoShopGoldBufferTooltip,No auto purchases will be made when gold is below this value
+SettingsAutoSellCrops,Auto-Sell Crops
+SettingsAutoSellCropsTooltip,When a crop reaches max stack quantity, sell it automatically
+ButtonDesignateCrops,Designate Crops
+WindowAutoSellCropTypes,Auto-Sell Crop Types
 AddMonsterConfirmPrompt,Add {0} for {1} Gold
 
 # Crop Storage options (issue #285)

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -459,6 +459,7 @@ namespace PitHero.ECS.Scenes
             if (autoCropSellSvc != null)
             {
                 autoCropSellSvc.Enabled = pendingData.AutoSellCrops;
+                autoCropSellSvc.KeepStacks = pendingData.AutoSellKeepStacks;
                 if (pendingData.AutoSellCropDesignations != null)
                 {
                     int count = pendingData.AutoSellCropDesignations.Length < Farming.CropTypeInfo.Count

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -200,6 +200,7 @@ namespace PitHero.ECS.Scenes
             Core.Services.RemoveService(typeof(Services.WetTileService));
             Core.Services.RemoveService(typeof(Services.CropGrowthService));
             Core.Services.RemoveService(typeof(Services.AutoSeedPurchaseService));
+            Core.Services.RemoveService(typeof(Services.AutoCropSellService));
             Core.Services.GetService<Services.FarmTaskCoordinator>()?.Detach();
             Core.Services.RemoveService(typeof(Services.FarmTaskCoordinator));
             Core.Services.RemoveService(typeof(MercenaryManager));
@@ -268,6 +269,12 @@ namespace PitHero.ECS.Scenes
                 Core.Services.GetService<Services.GameStateService>(),
                 farmTaskCoordinator);
             Core.Services.AddService(autoSeedPurchaseService);
+
+            // Auto crop sell service sells designated crop stacks once they reach max stack size.
+            var autoCropSellService = new Services.AutoCropSellService(
+                Core.Services.GetService<Services.CropStorageInventoryService>(),
+                Core.Services.GetService<Services.GameStateService>());
+            Core.Services.AddService(autoCropSellService);
 
             // Initialize hero promotion service (handles mercenary promotions and hero crystal ceremonies after death)
             _heroPromotionService = new Services.HeroPromotionService(this);
@@ -447,6 +454,19 @@ namespace PitHero.ECS.Scenes
             {
                 autoSeedSvc.Enabled    = pendingData.AutomateSeedPurchases;
                 autoSeedSvc.GoldBuffer = pendingData.AutoShopGoldBuffer;
+            }
+            var autoCropSellSvc = Core.Services.GetService<Services.AutoCropSellService>();
+            if (autoCropSellSvc != null)
+            {
+                autoCropSellSvc.Enabled = pendingData.AutoSellCrops;
+                if (pendingData.AutoSellCropDesignations != null)
+                {
+                    int count = pendingData.AutoSellCropDesignations.Length < Farming.CropTypeInfo.Count
+                        ? pendingData.AutoSellCropDesignations.Length
+                        : Farming.CropTypeInfo.Count;
+                    for (int i = 0; i < count; i++)
+                        autoCropSellSvc.Designations[i] = pendingData.AutoSellCropDesignations[i];
+                }
             }
             _settingsUI?.SyncAutoShopControlsFromService();
 
@@ -2248,6 +2268,7 @@ namespace PitHero.ECS.Scenes
                 Core.Services.GetService<Services.CropGrowthService>()?.Update(
                     Core.Services.GetService<TileStateService>(), cropsAtlas);
                 Core.Services.GetService<Services.AutoSeedPurchaseService>()?.Update();
+                Core.Services.GetService<Services.AutoCropSellService>()?.Update();
             }
 
             // Check if a living hero who respawned without a crystal has arrived at the statue

--- a/PitHero/Services/AutoCropSellService.cs
+++ b/PitHero/Services/AutoCropSellService.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using Nez;
+using PitHero.Farming;
+using PitHero.Util;
+
+namespace PitHero.Services
+{
+    /// <summary>
+    /// Automatically sells harvested crop stacks that have reached their max stack size, for crop
+    /// types the player has designated. Sell passes are throttled to once per second and only fire
+    /// while the game is unpaused.
+    /// </summary>
+    public class AutoCropSellService
+    {
+        private const string SellSource = "sell_crops";
+
+        private readonly CropStorageInventoryService _storage;
+        private readonly GameStateService _gameState;
+        private readonly List<int> _idScratch = new List<int>(16);
+        private float _throttleTimer;
+
+        /// <summary>Whether automatic crop selling is active.</summary>
+        public bool Enabled { get; set; } = false;
+
+        /// <summary>
+        /// Per-crop auto-sell designations indexed by CropType. All true by default so that the
+        /// first time auto-sell is enabled every crop type participates.
+        /// </summary>
+        public bool[] Designations { get; } = new bool[CropTypeInfo.Count];
+
+        /// <summary>Initialises the service with the required dependencies.</summary>
+        public AutoCropSellService(CropStorageInventoryService storage, GameStateService gameState)
+        {
+            _storage = storage;
+            _gameState = gameState;
+            for (int i = 0; i < Designations.Length; i++)
+                Designations[i] = true;
+        }
+
+        /// <summary>
+        /// Advances the sell throttle and, when enabled, sells all full designated crop stacks.
+        /// Called once per game frame while the game is unpaused.
+        /// </summary>
+        public void Update()
+        {
+            if (!Enabled) return;
+
+            _throttleTimer += Time.DeltaTime;
+            if (_throttleTimer < 1f) return;
+            _throttleTimer = 0f;
+
+            TrySellPass();
+        }
+
+        /// <summary>
+        /// Executes one sell pass: sells every designated crop stack at max stack size across all
+        /// Crop Storage buildings. Idempotent and safe to call directly from tests, bypassing the
+        /// 1-second throttle gate.
+        /// </summary>
+        public void TrySellPass()
+        {
+            if (_storage == null || _gameState == null) return;
+
+            _storage.CopyBuildingIds(_idScratch);
+            for (int b = 0; b < _idScratch.Count; b++)
+            {
+                int buildingId = _idScratch[b];
+                var slots = _storage.GetSlots(buildingId);
+                for (int s = 0; s < slots.Count; s++)
+                {
+                    if (slots[s].IsEmpty) continue;
+                    var crop = slots[s].Type;
+                    if (!Designations[(int)crop]) continue;
+                    if (slots[s].Count < CropConfig.GetMaxHarvestStack(crop)) continue;
+
+                    int gold = CropConfig.GetHarvestStackSellPrice(crop, slots[s].Count);
+                    _gameState.AddFunds(gold, SellSource);
+                    _storage.ClearSlot(buildingId, s);
+                }
+            }
+        }
+    }
+}

--- a/PitHero/Services/AutoCropSellService.cs
+++ b/PitHero/Services/AutoCropSellService.cs
@@ -14,13 +14,28 @@ namespace PitHero.Services
     {
         private const string SellSource = "sell_crops";
 
+        /// <summary>Upper bound of the Keep Stacks setting (matches the dialog slider range).</summary>
+        public const int MaxKeepStacks = 10;
+
         private readonly CropStorageInventoryService _storage;
         private readonly GameStateService _gameState;
         private readonly List<int> _idScratch = new List<int>(16);
+        private readonly int[] _fullSeenScratch = new int[CropTypeInfo.Count];
         private float _throttleTimer;
+        private int _keepStacks;
 
         /// <summary>Whether automatic crop selling is active.</summary>
         public bool Enabled { get; set; } = false;
+
+        /// <summary>
+        /// Number of full stacks of each crop to keep before selling; only full stacks beyond this
+        /// count are auto-sold. 0 (default) sells every full designated stack. Clamped to 0..10.
+        /// </summary>
+        public int KeepStacks
+        {
+            get => _keepStacks;
+            set => _keepStacks = value < 0 ? 0 : (value > MaxKeepStacks ? MaxKeepStacks : value);
+        }
 
         /// <summary>
         /// Per-crop auto-sell designations indexed by CropType. All true by default so that the
@@ -54,12 +69,15 @@ namespace PitHero.Services
 
         /// <summary>
         /// Executes one sell pass: sells every designated crop stack at max stack size across all
-        /// Crop Storage buildings. Idempotent and safe to call directly from tests, bypassing the
-        /// 1-second throttle gate.
+        /// Crop Storage buildings, keeping the first <see cref="KeepStacks"/> full stacks of each
+        /// crop. Idempotent and safe to call directly from tests, bypassing the 1-second throttle gate.
         /// </summary>
         public void TrySellPass()
         {
             if (_storage == null || _gameState == null) return;
+
+            for (int i = 0; i < _fullSeenScratch.Length; i++)
+                _fullSeenScratch[i] = 0;
 
             _storage.CopyBuildingIds(_idScratch);
             for (int b = 0; b < _idScratch.Count; b++)
@@ -72,6 +90,9 @@ namespace PitHero.Services
                     var crop = slots[s].Type;
                     if (!Designations[(int)crop]) continue;
                     if (slots[s].Count < CropConfig.GetMaxHarvestStack(crop)) continue;
+
+                    _fullSeenScratch[(int)crop]++;
+                    if (_fullSeenScratch[(int)crop] <= _keepStacks) continue;
 
                     int gold = CropConfig.GetHarvestStackSellPrice(crop, slots[s].Count);
                     _gameState.AddFunds(gold, SellSource);

--- a/PitHero/Services/CropStorageInventoryService.cs
+++ b/PitHero/Services/CropStorageInventoryService.cs
@@ -186,6 +186,14 @@ namespace PitHero.Services
         /// <summary>Enumerates all building inventories for serialization.</summary>
         public IEnumerable<KeyValuePair<int, HarvestSlot[]>> GetAllInventories() => _byBuilding;
 
+        /// <summary>Copies all building ids that have an inventory into <paramref name="dest"/> (cleared first).</summary>
+        public void CopyBuildingIds(List<int> dest)
+        {
+            dest.Clear();
+            foreach (var kvp in _byBuilding)
+                dest.Add(kvp.Key);
+        }
+
         /// <summary>Replaces a building's inventory from saved data.</summary>
         public void RestoreInventory(int buildingId, HarvestSlot[] slots)
         {

--- a/PitHero/Services/SaveData.cs
+++ b/PitHero/Services/SaveData.cs
@@ -246,7 +246,7 @@ namespace PitHero.Services
     public class SaveData : IPersistable
     {
         /// <summary>Current save file version.</summary>
-        public const int CurrentVersion = 15;
+        public const int CurrentVersion = 16;
 
         // Total Time
         /// <summary>Total time played in seconds.</summary>
@@ -464,6 +464,12 @@ namespace PitHero.Services
 
         /// <summary>Gold buffer threshold: no purchase fires when Funds - price &lt; this value (version 15+).</summary>
         public int AutoShopGoldBuffer = 200;
+
+        /// <summary>Whether automatic crop selling at max stack size is enabled (version 16+).</summary>
+        public bool AutoSellCrops = false;
+
+        /// <summary>Per-crop auto-sell designations indexed by CropType (version 16+). Null until Recover normalizes it.</summary>
+        public bool[] AutoSellCropDesignations;
 
         /// <summary>The save file version number read during Recover; 0 for a brand-new in-memory instance.</summary>
         public int LoadedFileVersion;
@@ -828,6 +834,13 @@ namespace PitHero.Services
             // 30. Auto shop options (v15+)
             writer.Write(AutomateSeedPurchases);
             writer.Write(AutoShopGoldBuffer);
+
+            // 31. Auto-sell crops (v16+)
+            writer.Write(AutoSellCrops);
+            int designationCount = AutoSellCropDesignations != null ? AutoSellCropDesignations.Length : 0;
+            writer.Write(designationCount);
+            for (int i = 0; i < designationCount; i++)
+                writer.Write(AutoSellCropDesignations[i]);
         }
 
         /// <summary>Reads all game state from the persistence reader.</summary>
@@ -1283,6 +1296,24 @@ namespace PitHero.Services
                 AutoShopGoldBuffer    = reader.ReadInt();
             }
             // else keep defaults: AutomateSeedPurchases = false, AutoShopGoldBuffer = 200
+
+            // 31. Auto-sell crops (version 16+). Designations default to all-true so pre-v16 saves
+            // (and crop types added after the save was written) behave like a fresh enable.
+            AutoSellCropDesignations = new bool[Farming.CropTypeInfo.Count];
+            for (int i = 0; i < AutoSellCropDesignations.Length; i++)
+                AutoSellCropDesignations[i] = true;
+            if (fileVersion >= 16)
+            {
+                AutoSellCrops = reader.ReadBool();
+                int designationCount = reader.ReadInt();
+                for (int i = 0; i < designationCount; i++)
+                {
+                    bool designated = reader.ReadBool();
+                    if (i < AutoSellCropDesignations.Length)
+                        AutoSellCropDesignations[i] = designated;
+                }
+            }
+            // else keep defaults: AutoSellCrops = false, all designations true
         }
 
         /// <summary>Writes a Color as four individual int components (R, G, B, A).</summary>

--- a/PitHero/Services/SaveData.cs
+++ b/PitHero/Services/SaveData.cs
@@ -246,7 +246,7 @@ namespace PitHero.Services
     public class SaveData : IPersistable
     {
         /// <summary>Current save file version.</summary>
-        public const int CurrentVersion = 16;
+        public const int CurrentVersion = 17;
 
         // Total Time
         /// <summary>Total time played in seconds.</summary>
@@ -470,6 +470,9 @@ namespace PitHero.Services
 
         /// <summary>Per-crop auto-sell designations indexed by CropType (version 16+). Null until Recover normalizes it.</summary>
         public bool[] AutoSellCropDesignations;
+
+        /// <summary>Number of full stacks of each crop to keep before auto-selling (version 17+).</summary>
+        public int AutoSellKeepStacks = 0;
 
         /// <summary>The save file version number read during Recover; 0 for a brand-new in-memory instance.</summary>
         public int LoadedFileVersion;
@@ -841,6 +844,9 @@ namespace PitHero.Services
             writer.Write(designationCount);
             for (int i = 0; i < designationCount; i++)
                 writer.Write(AutoSellCropDesignations[i]);
+
+            // 32. Auto-sell keep stacks (v17+)
+            writer.Write(AutoSellKeepStacks);
         }
 
         /// <summary>Reads all game state from the persistence reader.</summary>
@@ -1314,6 +1320,13 @@ namespace PitHero.Services
                 }
             }
             // else keep defaults: AutoSellCrops = false, all designations true
+
+            // 32. Auto-sell keep stacks (version 17+)
+            if (fileVersion >= 17)
+            {
+                AutoSellKeepStacks = reader.ReadInt();
+            }
+            // else keep default: AutoSellKeepStacks = 0
         }
 
         /// <summary>Writes a Color as four individual int components (R, G, B, A).</summary>

--- a/PitHero/Services/SaveLoadService.cs
+++ b/PitHero/Services/SaveLoadService.cs
@@ -751,6 +751,7 @@ namespace PitHero.Services
                 data.AutoSellCropDesignations = new bool[Farming.CropTypeInfo.Count];
                 for (int i = 0; i < data.AutoSellCropDesignations.Length; i++)
                     data.AutoSellCropDesignations[i] = autoCropSellService.Designations[i];
+                data.AutoSellKeepStacks = autoCropSellService.KeepStacks;
             }
 
             return data;

--- a/PitHero/Services/SaveLoadService.cs
+++ b/PitHero/Services/SaveLoadService.cs
@@ -743,6 +743,16 @@ namespace PitHero.Services
                 data.AutoShopGoldBuffer    = autoSeedPurchaseService.GoldBuffer;
             }
 
+            // Auto-sell crops (v16+)
+            var autoCropSellService = Core.Services.GetService<AutoCropSellService>();
+            if (autoCropSellService != null)
+            {
+                data.AutoSellCrops = autoCropSellService.Enabled;
+                data.AutoSellCropDesignations = new bool[Farming.CropTypeInfo.Count];
+                for (int i = 0; i < data.AutoSellCropDesignations.Length; i++)
+                    data.AutoSellCropDesignations[i] = autoCropSellService.Designations[i];
+            }
+
             return data;
         }
 

--- a/PitHero/UI/AutoSellCropTypesDialog.cs
+++ b/PitHero/UI/AutoSellCropTypesDialog.cs
@@ -81,9 +81,20 @@ namespace PitHero.UI
             content.Add(grid);
             content.Row();
 
+            var buttonRow = new Table();
+            var selectAllButton = new TextButton(GetText(UITextKey.ButtonSelectAll), skin, "ph-default");
+            selectAllButton.OnClicked += (_) => SetAllDesignations(true);
+            buttonRow.Add(selectAllButton).Width(110f).SetPadRight(8f);
+
+            var deselectAllButton = new TextButton(GetText(UITextKey.ButtonDeselectAll), skin, "ph-default");
+            deselectAllButton.OnClicked += (_) => SetAllDesignations(false);
+            buttonRow.Add(deselectAllButton).Width(110f).SetPadRight(8f);
+
             var closeButton = new TextButton(GetText(UITextKey.ButtonClose), skin, "ph-default");
             closeButton.OnClicked += (_) => Hide();
-            content.Add(closeButton).Width(100f).SetPadTop(12f);
+            buttonRow.Add(closeButton).Width(100f);
+
+            content.Add(buttonRow).SetPadTop(12f);
 
             _window.Add(content).Expand().Fill();
             _window.SetVisible(false);
@@ -106,6 +117,22 @@ namespace PitHero.UI
         public void Hide()
         {
             _window?.SetVisible(false);
+        }
+
+        /// <summary>
+        /// Sets every crop's designation and checkbox state. Commits to the service directly:
+        /// programmatic IsChecked assignment does not fire OnChanged (ProgrammaticChangeEvents is off).
+        /// </summary>
+        private void SetAllDesignations(bool designated)
+        {
+            var svc = Core.Services?.GetService<AutoCropSellService>();
+            for (int i = 0; i < _cropChecks.Length; i++)
+            {
+                if (svc != null)
+                    svc.Designations[i] = designated;
+                if (_cropChecks[i] != null)
+                    _cropChecks[i].IsChecked = designated;
+            }
         }
 
         /// <summary>Copies the service's current designations into the checkbox states.</summary>

--- a/PitHero/UI/AutoSellCropTypesDialog.cs
+++ b/PitHero/UI/AutoSellCropTypesDialog.cs
@@ -1,0 +1,121 @@
+using Nez;
+using Nez.Sprites;
+using Nez.Textures;
+using Nez.UI;
+using PitHero.Farming;
+using PitHero.Services;
+using PitHero.Util;
+
+namespace PitHero.UI
+{
+    /// <summary>
+    /// The "Auto-Sell Crop Types" designation window opened from the Auto Shop tab's
+    /// "Designate Crops" button. Shows a grid of every crop type with its harvested-product sprite
+    /// and a checkbox; checked crops are auto-sold when their stack reaches max size. Checkbox
+    /// changes commit immediately to <see cref="AutoCropSellService.Designations"/>.
+    /// </summary>
+    public class AutoSellCropTypesDialog
+    {
+        private const int Columns = 4;
+        private const float SpriteSize = 32f;
+        private const float WinPad = 16f;
+
+        private readonly Stage _stage;
+        private readonly SpriteAtlas _cropsAtlas;
+        private readonly CheckBox[] _cropChecks = new CheckBox[CropTypeInfo.Count];
+
+        private Window _window;
+        private TextService _textService;
+
+        public AutoSellCropTypesDialog(Stage stage)
+        {
+            _stage = stage;
+            _cropsAtlas = Core.Content.LoadSpriteAtlas("Content/Atlases/CropsProps.atlas");
+            CreateWindow();
+        }
+
+        /// <summary>Resolves a localized UI string, falling back to the key if the service is unavailable.</summary>
+        private string GetText(string key)
+        {
+            if (_textService == null)
+                _textService = Core.Services?.GetService<TextService>();
+            return _textService?.DisplayText(TextType.UI, key) ?? key;
+        }
+
+        private void CreateWindow()
+        {
+            var skin = PitHeroSkin.CreateSkin();
+            _window = new Window(GetText(UITextKey.WindowAutoSellCropTypes), skin, "ph-default");
+            _window.SetMovable(false);
+            _window.SetResizable(false);
+
+            var content = new Table();
+            content.Pad(WinPad);
+
+            var grid = new Table();
+            int col = 0;
+            for (int i = 0; i < CropTypeInfo.Count; i++)
+            {
+                var crop = (CropType)i;
+                var cell = new Table();
+
+                var sprite = _cropsAtlas.GetSprite(CropConfig.GetHarvestSpriteName(crop));
+                cell.Add(new Image(new SpriteDrawable(sprite))).Size(SpriteSize, SpriteSize).SetPadRight(4f);
+
+                var check = new CheckBox(GetText(CropConfig.GetHarvestDisplayNameKey(crop)), skin, "ph-default");
+                check.IsChecked = true;
+                int captured = i;
+                check.OnChanged += (isChecked) =>
+                {
+                    var svc = Core.Services?.GetService<AutoCropSellService>();
+                    if (svc != null) svc.Designations[captured] = isChecked;
+                };
+                _cropChecks[i] = check;
+                cell.Add(check).Left();
+
+                grid.Add(cell).Left().Pad(4f);
+                col++;
+                if (col % Columns == 0)
+                    grid.Row();
+            }
+            content.Add(grid);
+            content.Row();
+
+            var closeButton = new TextButton(GetText(UITextKey.ButtonClose), skin, "ph-default");
+            closeButton.OnClicked += (_) => Hide();
+            content.Add(closeButton).Width(100f).SetPadTop(12f);
+
+            _window.Add(content).Expand().Fill();
+            _window.SetVisible(false);
+            _stage.AddElement(_window);
+        }
+
+        /// <summary>Syncs the checkboxes from the service, then shows the window centered on the stage.</summary>
+        public void Show()
+        {
+            SyncFromService();
+            _window.Pack();
+            _window.SetPosition(
+                (_stage.GetWidth() - _window.GetWidth()) / 2f,
+                (_stage.GetHeight() - _window.GetHeight()) / 2f);
+            _window.SetVisible(true);
+            _window.ToFront();
+        }
+
+        /// <summary>Hides the window.</summary>
+        public void Hide()
+        {
+            _window?.SetVisible(false);
+        }
+
+        /// <summary>Copies the service's current designations into the checkbox states.</summary>
+        public void SyncFromService()
+        {
+            var svc = Core.Services?.GetService<AutoCropSellService>();
+            if (svc == null) return;
+            for (int i = 0; i < _cropChecks.Length; i++)
+                if (_cropChecks[i] != null)
+                    _cropChecks[i].IsChecked = svc.Designations[i];
+        }
+    }
+}

--- a/PitHero/UI/AutoSellCropTypesDialog.cs
+++ b/PitHero/UI/AutoSellCropTypesDialog.cs
@@ -25,6 +25,8 @@ namespace PitHero.UI
         private readonly CheckBox[] _cropChecks = new CheckBox[CropTypeInfo.Count];
 
         private Window _window;
+        private HoverableLabel _keepStacksLabel;
+        private EnhancedSlider _keepStacksSlider;
         private TextService _textService;
 
         public AutoSellCropTypesDialog(Stage stage)
@@ -81,6 +83,28 @@ namespace PitHero.UI
             content.Add(grid);
             content.Row();
 
+            var keepStacksRow = new Table();
+            _keepStacksLabel = new HoverableLabel(
+                string.Format(GetText(UITextKey.SettingsAutoSellKeepStacks), 0),
+                skin, "ph-default", GetText(UITextKey.SettingsAutoSellKeepStacksTooltip), _stage);
+            keepStacksRow.Add(_keepStacksLabel).Left().SetPadRight(12f);
+
+            _keepStacksSlider = new EnhancedSlider(0, AutoCropSellService.MaxKeepStacks, 1, false, skin, null, false);
+            _keepStacksSlider.SetValueAndCommit(0);
+            _keepStacksSlider.OnChanged += (value) =>
+            {
+                _keepStacksLabel.SetText(string.Format(GetText(UITextKey.SettingsAutoSellKeepStacks), (int)value));
+            };
+            _keepStacksSlider.OnValueCommitted += (value) =>
+            {
+                var svc = Core.Services?.GetService<AutoCropSellService>();
+                if (svc != null) svc.KeepStacks = (int)value;
+            };
+            keepStacksRow.Add(_keepStacksSlider).Width(200f).Left();
+
+            content.Add(keepStacksRow).Left().SetPadTop(12f);
+            content.Row();
+
             var buttonRow = new Table();
             var selectAllButton = new TextButton(GetText(UITextKey.ButtonSelectAll), skin, "ph-default");
             selectAllButton.OnClicked += (_) => SetAllDesignations(true);
@@ -135,7 +159,7 @@ namespace PitHero.UI
             }
         }
 
-        /// <summary>Copies the service's current designations into the checkbox states.</summary>
+        /// <summary>Copies the service's current designations and keep-stacks value into the controls.</summary>
         public void SyncFromService()
         {
             var svc = Core.Services?.GetService<AutoCropSellService>();
@@ -143,6 +167,8 @@ namespace PitHero.UI
             for (int i = 0; i < _cropChecks.Length; i++)
                 if (_cropChecks[i] != null)
                     _cropChecks[i].IsChecked = svc.Designations[i];
+            _keepStacksSlider?.SetValueAndCommit(svc.KeepStacks);
+            _keepStacksLabel?.SetText(string.Format(GetText(UITextKey.SettingsAutoSellKeepStacks), svc.KeepStacks));
         }
     }
 }

--- a/PitHero/UI/HarvestedCropsModeOverlay.cs
+++ b/PitHero/UI/HarvestedCropsModeOverlay.cs
@@ -400,8 +400,14 @@ namespace PitHero.UI
                 {
                     var storage = Core.Services.GetService<CropStorageInventoryService>();
                     var gameState = Core.Services.GetService<GameStateService>();
-                    gameState?.AddFunds(gold, "sell_crops");
-                    storage?.ClearSlot(buildingId, slotIndex);
+                    // Re-read the slot: auto-sell may have emptied it while the dialog was open.
+                    var liveSlot = storage != null ? storage.GetSlots(buildingId)[slotIndex] : default;
+                    if (!liveSlot.IsEmpty && liveSlot.Type == _descCropType)
+                    {
+                        int liveGold = CropConfig.GetHarvestStackSellPrice(liveSlot.Type, liveSlot.Count);
+                        gameState?.AddFunds(liveGold, "sell_crops");
+                        storage?.ClearSlot(buildingId, slotIndex);
+                    }
                     _descWindow.SetVisible(false);
                     LayoutButtonRow();
                     RebuildSlots();

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -63,6 +63,9 @@ namespace PitHero.UI
         private HoverableCheckBox _automateSeedsCheckBox;
         private EnhancedSlider _goldBufferSlider;
         private HoverableLabel _goldBufferLabel;
+        private HoverableCheckBox _autoSellCropsCheckBox;
+        private TextButton _designateCropsButton;
+        private AutoSellCropTypesDialog _autoSellCropTypesDialog;
 
         // Confirmation dialogs
         private Window _exitConfirmationDialog;
@@ -877,6 +880,35 @@ namespace PitHero.UI
                 if (svc != null) svc.GoldBuffer = (int)value;
             };
             autoShopTable.Add(_goldBufferSlider).Width(240).Left().SetPadBottom(15f);
+            autoShopTable.Row();
+
+            string autoSellTooltip = GetText(TextType.UI, UITextKey.SettingsAutoSellCropsTooltip);
+            _autoSellCropsCheckBox = new HoverableCheckBox(
+                GetText(TextType.UI, UITextKey.SettingsAutoSellCrops),
+                skin,
+                autoSellTooltip,
+                _stage);
+            _autoSellCropsCheckBox.IsChecked = false;
+            _autoSellCropsCheckBox.OnChanged += (isChecked) =>
+            {
+                var svc = Core.Services?.GetService<AutoCropSellService>();
+                if (svc != null) svc.Enabled = isChecked;
+                _designateCropsButton?.SetVisible(isChecked);
+                if (!isChecked)
+                    _autoSellCropTypesDialog?.Hide();
+            };
+            autoShopTable.Add(_autoSellCropsCheckBox).Left().SetPadBottom(8f);
+            autoShopTable.Row();
+
+            _designateCropsButton = new TextButton(GetText(TextType.UI, UITextKey.ButtonDesignateCrops), skin, "ph-default");
+            _designateCropsButton.OnClicked += (_) =>
+            {
+                if (_autoSellCropTypesDialog == null)
+                    _autoSellCropTypesDialog = new AutoSellCropTypesDialog(_stage);
+                _autoSellCropTypesDialog.Show();
+            };
+            _designateCropsButton.SetVisible(false);
+            autoShopTable.Add(_designateCropsButton).Left().Width(140f);
 
             autoShopTab.Add(autoShopTable).Expand().Top().Left();
         }
@@ -898,6 +930,15 @@ namespace PitHero.UI
 
             if (_goldBufferLabel != null)
                 _goldBufferLabel.SetText(string.Format(GetText(TextType.UI, UITextKey.SettingsAutoShopGoldBuffer), svc.GoldBuffer));
+
+            var cropSellSvc = Core.Services?.GetService<AutoCropSellService>();
+            if (cropSellSvc != null)
+            {
+                if (_autoSellCropsCheckBox != null)
+                    _autoSellCropsCheckBox.IsChecked = cropSellSvc.Enabled;
+                _designateCropsButton?.SetVisible(cropSellSvc.Enabled);
+                _autoSellCropTypesDialog?.SyncFromService();
+            }
         }
 
         /// <summary>

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -320,5 +320,7 @@ namespace PitHero
         public const string WindowAutoSellCropTypes = "WindowAutoSellCropTypes";
         public const string ButtonSelectAll = "ButtonSelectAll";
         public const string ButtonDeselectAll = "ButtonDeselectAll";
+        public const string SettingsAutoSellKeepStacks = "SettingsAutoSellKeepStacks";
+        public const string SettingsAutoSellKeepStacksTooltip = "SettingsAutoSellKeepStacksTooltip";
     }
 }

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -314,5 +314,9 @@ namespace PitHero
         public const string SettingsAutoShopGoldBuffer = "SettingsAutoShopGoldBuffer";
         public const string SettingsAutomateSeedPurchasesTooltip = "SettingsAutomateSeedPurchasesTooltip";
         public const string SettingsAutoShopGoldBufferTooltip = "SettingsAutoShopGoldBufferTooltip";
+        public const string SettingsAutoSellCrops = "SettingsAutoSellCrops";
+        public const string SettingsAutoSellCropsTooltip = "SettingsAutoSellCropsTooltip";
+        public const string ButtonDesignateCrops = "ButtonDesignateCrops";
+        public const string WindowAutoSellCropTypes = "WindowAutoSellCropTypes";
     }
 }

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -318,5 +318,7 @@ namespace PitHero
         public const string SettingsAutoSellCropsTooltip = "SettingsAutoSellCropsTooltip";
         public const string ButtonDesignateCrops = "ButtonDesignateCrops";
         public const string WindowAutoSellCropTypes = "WindowAutoSellCropTypes";
+        public const string ButtonSelectAll = "ButtonSelectAll";
+        public const string ButtonDeselectAll = "ButtonDeselectAll";
     }
 }


### PR DESCRIPTION
Closes #309

## What

Adds an **Auto-Sell Crops** option to the Auto Shop tab of the Settings UI, with a per-crop designation dialog and a backing service that automatically sells designated crop stacks once they reach max stack size.

- **Auto Shop tab**: new "Auto-Sell Crops" checkbox (off by default) with tooltip *"When a crop reaches max stack quantity, sell it automatically"*. Checking it reveals a **Designate Crops** button.
- **Auto-Sell Crop Types dialog** (`AutoSellCropTypesDialog`): 4-column grid of all 13 crop types, each with its harvested-product sprite and a checkbox. Designations default to all-enabled (satisfying "first checked → all enabled") and commit immediately to the service.
- **`AutoCropSellService`** (mirrors `AutoSeedPurchaseService` from #305): 1-second-throttled `Update()` pass over all Crop Storage buildings; any designated stack at `CropConfig.GetMaxHarvestStack` is sold via the existing `GetHarvestStackSellPrice` + `AddFunds(gold, "sell_crops")` + `ClearSlot` path.
- **Save version 15 → 16**: persists the enabled flag and a length-prefixed designation array. Pre-v16 saves load with the feature off and all crops designated.
- **Hardening**: `HarvestedCropsModeOverlay`'s manual Sell now re-reads the slot on confirm, so a stack auto-sold while the confirmation dialog was open can't grant gold twice.

## Design notes

- Polling (matching the #305 precedent) rather than a hook in `DepositReturningStored` — this also sells stacks that were already full when the option is enabled, or filled via "Move all crops". Intentionally slightly broader than "on harvest" for better UX.
- Designations are never reset by the checkbox handler, so per-crop choices survive toggling the feature off and on.

## Testing

- New `AutoCropSellServiceTests` (9 cases): defaults, disabled path, sell-at-max, below-max ignored, designation-off respected, multiple buildings in one pass, mixed slots, empty storage.
- New `SaveLoadTests` cases: v16 round-trip with mixed designations; older-version stream yields defaults (off, all designated).
- Full suite: 1454 passed, 11 failed — the pre-existing baseline, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)