### PR TITLE
Unify save format to single version 17, fix all broken tests, and fix two UI/AI bugs

### DIFF
--- a/PitHero.Tests/PitGeneratorTests.cs
+++ b/PitHero.Tests/PitGeneratorTests.cs
@@ -104,8 +104,8 @@ namespace PitHero.Tests
         {
             var generator = new PitGenerator((Nez.Scene)null!);
             int[] bossFloors = { 5, 10, 15, 20, 25 };
-            string[] expectedBosses = { "StoneGuardian", "PitLord", "EarthElemental", "MoltenTitan", "AncientWyrm" };
-            int[] expectedLevels = { 10, 10, 28, 38, 46 };
+            string[] expectedBosses = { "StoneGuardian", "EarthElemental", "AncientWyrm", "PitLord", "MoltenTitan" };
+            int[] expectedLevels = { 10, 18, 28, 38, 46 };
 
             for (int index = 0; index < bossFloors.Length; index++)
             {

--- a/PitHero.Tests/PotionItemsTests.cs
+++ b/PitHero.Tests/PotionItemsTests.cs
@@ -35,19 +35,19 @@ namespace PitHero.Tests
         {
             var midHpPotion = PotionItems.MidHPPotion();
             Assert.AreEqual(InventoryTextKey.Inv_MidHPPotion_Name, midHpPotion.Name);
-            Assert.AreEqual(ItemRarity.Rare, midHpPotion.Rarity);
+            Assert.AreEqual(ItemRarity.Normal, midHpPotion.Rarity);
             Assert.AreEqual(500, midHpPotion.HPRestoreAmount);
             Assert.AreEqual(0, midHpPotion.MPRestoreAmount);
 
             var midApPotion = PotionItems.MidMPPotion();
             Assert.AreEqual(InventoryTextKey.Inv_MidMPPotion_Name, midApPotion.Name);
-            Assert.AreEqual(ItemRarity.Rare, midApPotion.Rarity);
+            Assert.AreEqual(ItemRarity.Normal, midApPotion.Rarity);
             Assert.AreEqual(0, midApPotion.HPRestoreAmount);
             Assert.AreEqual(500, midApPotion.MPRestoreAmount);
 
             var midMixPotion = PotionItems.MidMixPotion();
             Assert.AreEqual(InventoryTextKey.Inv_MidMixPotion_Name, midMixPotion.Name);
-            Assert.AreEqual(ItemRarity.Rare, midMixPotion.Rarity);
+            Assert.AreEqual(ItemRarity.Normal, midMixPotion.Rarity);
             Assert.AreEqual(500, midMixPotion.HPRestoreAmount);
             Assert.AreEqual(500, midMixPotion.MPRestoreAmount);
         }
@@ -57,19 +57,19 @@ namespace PitHero.Tests
         {
             var fullHpPotion = PotionItems.FullHPPotion();
             Assert.AreEqual(InventoryTextKey.Inv_FullHPPotion_Name, fullHpPotion.Name);
-            Assert.AreEqual(ItemRarity.Epic, fullHpPotion.Rarity);
+            Assert.AreEqual(ItemRarity.Normal, fullHpPotion.Rarity);
             Assert.AreEqual(-1, fullHpPotion.HPRestoreAmount); // -1 indicates full restore
             Assert.AreEqual(0, fullHpPotion.MPRestoreAmount);
 
             var fullApPotion = PotionItems.FullMPPotion();
             Assert.AreEqual(InventoryTextKey.Inv_FullMPPotion_Name, fullApPotion.Name);
-            Assert.AreEqual(ItemRarity.Epic, fullApPotion.Rarity);
+            Assert.AreEqual(ItemRarity.Normal, fullApPotion.Rarity);
             Assert.AreEqual(0, fullApPotion.HPRestoreAmount);
             Assert.AreEqual(-1, fullApPotion.MPRestoreAmount); // -1 indicates full restore
 
             var fullMixPotion = PotionItems.FullMixPotion();
             Assert.AreEqual(InventoryTextKey.Inv_FullMixPotion_Name, fullMixPotion.Name);
-            Assert.AreEqual(ItemRarity.Epic, fullMixPotion.Rarity);
+            Assert.AreEqual(ItemRarity.Normal, fullMixPotion.Rarity);
             Assert.AreEqual(-1, fullMixPotion.HPRestoreAmount); // -1 indicates full restore
             Assert.AreEqual(-1, fullMixPotion.MPRestoreAmount); // -1 indicates full restore
         }

--- a/PitHero.Tests/PotionSystemIntegrationTests.cs
+++ b/PitHero.Tests/PotionSystemIntegrationTests.cs
@@ -36,7 +36,7 @@ namespace PitHero.Tests
                         break;
                         
                     case 3: // Mid potions
-                        Assert.AreEqual(ItemRarity.Rare, item.Rarity);
+                        Assert.AreEqual(ItemRarity.Normal, item.Rarity);
                         Assert.IsTrue(item is Consumable);
                         var midPotion = (Consumable)item;
                         bool isMidPotion = midPotion.Name == InventoryTextKey.Inv_MidHPPotion_Name
@@ -46,7 +46,7 @@ namespace PitHero.Tests
                         break;
                         
                     case 4: // Full potions
-                        Assert.AreEqual(ItemRarity.Epic, item.Rarity);
+                        Assert.AreEqual(ItemRarity.Normal, item.Rarity);
                         Assert.IsTrue(item is Consumable);
                         var fullPotion = (Consumable)item;
                         bool isFullPotion = fullPotion.Name == InventoryTextKey.Inv_FullHPPotion_Name
@@ -56,7 +56,7 @@ namespace PitHero.Tests
                         break;
                         
                     case 5: // No Legendary consumables exist, falls back to Full potions
-                        Assert.AreEqual(ItemRarity.Epic, item.Rarity);
+                        Assert.AreEqual(ItemRarity.Normal, item.Rarity);
                         Assert.IsTrue(item is Consumable);
                         break;
                 }
@@ -122,13 +122,13 @@ namespace PitHero.Tests
             var retrievedMidMPPotion = (Consumable)bag.Items[1];
             Assert.AreEqual(InventoryTextKey.Inv_MidMPPotion_Name, retrievedMidMPPotion.Name);
             Assert.AreEqual(500, retrievedMidMPPotion.MPRestoreAmount);
-            Assert.AreEqual(ItemRarity.Rare, retrievedMidMPPotion.Rarity);
+            Assert.AreEqual(ItemRarity.Normal, retrievedMidMPPotion.Rarity);
 
             var retrievedFullMixPotion = (Consumable)bag.Items[2];
             Assert.AreEqual(InventoryTextKey.Inv_FullMixPotion_Name, retrievedFullMixPotion.Name);
             Assert.AreEqual(-1, retrievedFullMixPotion.HPRestoreAmount);
             Assert.AreEqual(-1, retrievedFullMixPotion.MPRestoreAmount);
-            Assert.AreEqual(ItemRarity.Epic, retrievedFullMixPotion.Rarity);
+            Assert.AreEqual(ItemRarity.Normal, retrievedFullMixPotion.Rarity);
         }
 
         [TestMethod]

--- a/PitHero.Tests/SaveLoadTests.cs
+++ b/PitHero.Tests/SaveLoadTests.cs
@@ -460,17 +460,15 @@ namespace PitHero.Tests
             }
         }
 
-        /// <summary>Verifies version 1 save files load without shortcut data (backward compatibility).</summary>
+        /// <summary>Verifies a save with an empty shortcut bar round-trips correctly.</summary>
         [TestMethod]
-        public void SaveData_Version1_LoadsWithoutShortcutSlots()
+        public void SaveData_EmptyShortcutSlots_RoundTrip()
         {
             var tempDir = Path.Combine(Path.GetTempPath(), "pithero_v1_test_" + Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(tempDir);
 
             try
             {
-                // Create a version 1 save file manually by saving with the old format
-                // We simulate this by creating data with empty shortcuts and checking the loaded result
                 var saveData = new SaveData();
                 saveData.HeroName = "V1Hero";
                 saveData.JobName = JobTextKey.Job_Knight_Name;
@@ -560,48 +558,8 @@ namespace PitHero.Tests
         }
 
         /// <summary>
-        /// Migration test: saves created before v13 (where PitLevel was cumulative depth) are
-        /// decoded into the correct tier + displayed level.  We simulate a v12-era save whose
-        /// PitLevel field holds cumulative depth 119 (tier 5, displayed level 19).
-        /// </summary>
-        [TestMethod]
-        public void SaveData_Migration_PitLevel119_DecodesAsTier5_Level19()
-        {
-            // SaveData.Recover normalises PitLevel from cumulative depth to biome-local when
-            // fileVersion < 13.  We can't write a true v12 binary from a unit test without
-            // down-grading CurrentVersion, so we validate the helper logic directly.
-            var data = new SaveData();
-            data.PitLevel = 119;
-            data.Level = 40; // hero level used for TierBaseLevel migration
-
-            // Apply the same migration formula as Recover does for fileVersion < 13:
-            int rawPitLevel = data.PitLevel;
-            int migratedTier = PitHero.Config.BiomeProgressionConfig.GetTierForDepth(rawPitLevel);
-            int migratedBaseLevel = migratedTier >= 2 ? (data.Level > 0 ? data.Level : 1) : 1;
-            int migratedLevel = PitHero.Config.BiomeProgressionConfig.GetDisplayedLevelForDepth(rawPitLevel);
-
-            Assert.AreEqual(5, migratedTier, "Depth 119 should decode to tier 5");
-            Assert.AreEqual(19, migratedLevel, "Depth 119 should decode to level 19");
-            Assert.AreEqual(40, migratedBaseLevel, "TierBaseLevel should equal saved hero level when tier >= 2");
-        }
-
-        /// <summary>
-        /// Migration: a v12 save with PitLevel ≤ 25 (already a normal level) should decode to tier 1.
-        /// </summary>
-        [TestMethod]
-        public void SaveData_Migration_PitLevel7_DecodesAsTier1()
-        {
-            int rawPitLevel = 7;
-            int migratedTier = PitHero.Config.BiomeProgressionConfig.GetTierForDepth(rawPitLevel);
-            int migratedLevel = PitHero.Config.BiomeProgressionConfig.GetDisplayedLevelForDepth(rawPitLevel);
-
-            Assert.AreEqual(1, migratedTier, "PitLevel 7 should map to tier 1");
-            Assert.AreEqual(7, migratedLevel, "PitLevel 7 should remain 7 after migration");
-        }
-
-        /// <summary>
         /// Verifies that AutomateSeedPurchases and AutoShopGoldBuffer round-trip correctly through
-        /// Persist/Recover in save version 15.
+        /// Persist/Recover.
         /// </summary>
         [TestMethod]
         public void SaveData_V15_AutoShopOptions_RoundTrip()
@@ -624,7 +582,6 @@ namespace PitHero.Tests
 
                 Assert.AreEqual(true, loaded.AutomateSeedPurchases, "AutomateSeedPurchases should round-trip");
                 Assert.AreEqual(500, loaded.AutoShopGoldBuffer, "AutoShopGoldBuffer should round-trip");
-                Assert.AreEqual(SaveData.CurrentVersion, loaded.LoadedFileVersion, "LoadedFileVersion should be the current version");
             }
             finally
             {
@@ -634,53 +591,8 @@ namespace PitHero.Tests
         }
 
         /// <summary>
-        /// Verifies that a save stream written without v15 fields yields the correct defaults
-        /// (AutomateSeedPurchases = false, AutoShopGoldBuffer = 200) when recovered.
-        /// The "older-version stream" is simulated by writing a v15 binary, patching the version
-        /// bytes to 14, and stripping the two v15 fields (bool + int = 5 bytes) from the tail.
-        /// </summary>
-        [TestMethod]
-        public void SaveData_OlderVersion_AutoShopOptions_DefaultValues()
-        {
-            // Write a full v15 SaveData to a MemoryStream
-            var ms = new MemoryStream();
-            using (var writer = new BinaryPersistableWriter(ms))
-            {
-                var original = new SaveData();
-                // Use non-default values so we can confirm they are NOT loaded
-                original.AutomateSeedPurchases = true;
-                original.AutoShopGoldBuffer = 999;
-                writer.Write(original);
-            }
-
-            byte[] bytes = ms.ToArray();
-
-            // Patch bytes [0-3] from version 15 to version 14 (little-endian int)
-            bytes[0] = 14;
-            bytes[1] = 0;
-            bytes[2] = 0;
-            bytes[3] = 0;
-
-            // Strip the last 5 bytes (section 30: bool AutomateSeedPurchases + int AutoShopGoldBuffer)
-            int trimmedLength = bytes.Length - 5;
-            var trimmed = new byte[trimmedLength];
-            Array.Copy(bytes, trimmed, trimmedLength);
-
-            // Recover from the modified stream (version 14, no v15 fields)
-            var loaded = new SaveData();
-            using (var rdr = new BinaryPersistableReader(new MemoryStream(trimmed)))
-            {
-                rdr.ReadPersistableInto(loaded);
-            }
-
-            Assert.AreEqual(14, loaded.LoadedFileVersion, "Should detect version 14");
-            Assert.AreEqual(false, loaded.AutomateSeedPurchases, "Default: AutomateSeedPurchases should be false for pre-v15 saves");
-            Assert.AreEqual(200, loaded.AutoShopGoldBuffer, "Default: AutoShopGoldBuffer should be 200 for pre-v15 saves");
-        }
-
-        /// <summary>
         /// Verifies that AutoSellCrops and AutoSellCropDesignations round-trip correctly through
-        /// Persist/Recover in save version 16.
+        /// Persist/Recover.
         /// </summary>
         [TestMethod]
         public void SaveData_V16_AutoSellCrops_RoundTrip()
@@ -709,7 +621,6 @@ namespace PitHero.Tests
                 Assert.AreEqual(false, loaded.AutoSellCropDesignations[0], "Designation[0]=false should round-trip");
                 for (int i = 1; i < PitHero.Farming.CropTypeInfo.Count; i++)
                     Assert.AreEqual(true, loaded.AutoSellCropDesignations[i], $"Designation[{i}]=true should round-trip");
-                Assert.AreEqual(SaveData.CurrentVersion, loaded.LoadedFileVersion, "LoadedFileVersion should be the current version");
             }
             finally
             {
@@ -719,59 +630,7 @@ namespace PitHero.Tests
         }
 
         /// <summary>
-        /// Verifies that a save stream written without v16+ fields yields the correct defaults
-        /// (AutoSellCrops = false, all designations true, KeepStacks = 0) when recovered.
-        /// The "older-version stream" is simulated by writing a current-version binary, patching
-        /// the version bytes to 15, and stripping the v16 fields (bool + int count + 13 bools = 18
-        /// bytes) plus the v17 field (int KeepStacks = 4 bytes) from the tail.
-        /// </summary>
-        [TestMethod]
-        public void SaveData_OlderVersion_AutoSellCrops_DefaultValues()
-        {
-            // Write a full current-version SaveData to a MemoryStream
-            var ms = new MemoryStream();
-            using (var writer = new BinaryPersistableWriter(ms))
-            {
-                var original = new SaveData();
-                // Use non-default values so we can confirm they are NOT loaded
-                original.AutoSellCrops = true;
-                original.AutoSellCropDesignations = new bool[PitHero.Farming.CropTypeInfo.Count]; // all false
-                original.AutoSellKeepStacks = 7;
-                writer.Write(original);
-            }
-
-            byte[] bytes = ms.ToArray();
-
-            // Patch bytes [0-3] from the current version to version 15 (little-endian int)
-            bytes[0] = 15;
-            bytes[1] = 0;
-            bytes[2] = 0;
-            bytes[3] = 0;
-
-            // Strip sections 31+32 from the tail:
-            // bool AutoSellCrops (1) + int count (4) + 13 bools (13) + int KeepStacks (4)
-            int trimmedLength = bytes.Length - (1 + 4 + PitHero.Farming.CropTypeInfo.Count + 4);
-            var trimmed = new byte[trimmedLength];
-            Array.Copy(bytes, trimmed, trimmedLength);
-
-            // Recover from the modified stream (version 15, no v16+ fields)
-            var loaded = new SaveData();
-            using (var rdr = new BinaryPersistableReader(new MemoryStream(trimmed)))
-            {
-                rdr.ReadPersistableInto(loaded);
-            }
-
-            Assert.AreEqual(15, loaded.LoadedFileVersion, "Should detect version 15");
-            Assert.AreEqual(false, loaded.AutoSellCrops, "Default: AutoSellCrops should be false for pre-v16 saves");
-            Assert.IsNotNull(loaded.AutoSellCropDesignations, "Designations should be normalized for pre-v16 saves");
-            for (int i = 0; i < PitHero.Farming.CropTypeInfo.Count; i++)
-                Assert.AreEqual(true, loaded.AutoSellCropDesignations[i],
-                    $"Default: designation {i} should be true for pre-v16 saves");
-            Assert.AreEqual(0, loaded.AutoSellKeepStacks, "Default: AutoSellKeepStacks should be 0 for pre-v17 saves");
-        }
-
-        /// <summary>
-        /// Verifies that AutoSellKeepStacks round-trips through Persist/Recover in save version 17.
+        /// Verifies that AutoSellKeepStacks round-trips through Persist/Recover.
         /// </summary>
         [TestMethod]
         public void SaveData_V17_KeepStacks_RoundTrip()
@@ -792,7 +651,6 @@ namespace PitHero.Tests
                 dataStore.Load("v17_keepstacks.bin", loaded);
 
                 Assert.AreEqual(3, loaded.AutoSellKeepStacks, "AutoSellKeepStacks should round-trip");
-                Assert.AreEqual(SaveData.CurrentVersion, loaded.LoadedFileVersion, "LoadedFileVersion should be the current version");
             }
             finally
             {
@@ -801,48 +659,76 @@ namespace PitHero.Tests
         }
 
         /// <summary>
-        /// Verifies that a v16 stream (which lacks the KeepStacks field) recovers with the default
-        /// KeepStacks = 0 while still reading the v16 auto-sell fields. Simulated by writing a
-        /// current-version binary, patching the version bytes to 16, and stripping the 4-byte
-        /// KeepStacks int from the tail.
+        /// Verifies that a save stream with an older version header is rejected with
+        /// InvalidDataException. Simulated by writing a current-version binary and patching the
+        /// version bytes down by one.
         /// </summary>
         [TestMethod]
-        public void SaveData_V16Stream_KeepStacks_DefaultValue()
+        public void SaveData_OlderVersionHeader_ThrowsInvalidData()
         {
             var ms = new MemoryStream();
             using (var writer = new BinaryPersistableWriter(ms))
             {
                 var original = new SaveData();
-                original.AutoSellCrops = true;
-                original.AutoSellCropDesignations = new bool[PitHero.Farming.CropTypeInfo.Count];
-                for (int i = 0; i < original.AutoSellCropDesignations.Length; i++)
-                    original.AutoSellCropDesignations[i] = true;
-                original.AutoSellKeepStacks = 9; // must NOT survive the v16 downgrade
+                original.HeroName = "OldHero";
                 writer.Write(original);
             }
 
             byte[] bytes = ms.ToArray();
 
-            // Patch bytes [0-3] from the current version to version 16 (little-endian int)
-            bytes[0] = 16;
+            // Patch bytes [0-3] to one version below current (little-endian int)
+            bytes[0] = (byte)(SaveData.CurrentVersion - 1);
             bytes[1] = 0;
             bytes[2] = 0;
             bytes[3] = 0;
 
-            // Strip section 32 from the tail: int KeepStacks (4 bytes)
-            int trimmedLength = bytes.Length - 4;
-            var trimmed = new byte[trimmedLength];
-            Array.Copy(bytes, trimmed, trimmedLength);
-
             var loaded = new SaveData();
-            using (var rdr = new BinaryPersistableReader(new MemoryStream(trimmed)))
+            using (var rdr = new BinaryPersistableReader(new MemoryStream(bytes)))
             {
-                rdr.ReadPersistableInto(loaded);
+                Assert.ThrowsException<InvalidDataException>(() => rdr.ReadPersistableInto(loaded),
+                    "Loading a save with an older version header should throw InvalidDataException");
             }
+        }
 
-            Assert.AreEqual(16, loaded.LoadedFileVersion, "Should detect version 16");
-            Assert.AreEqual(true, loaded.AutoSellCrops, "v16 AutoSellCrops field should still load");
-            Assert.AreEqual(0, loaded.AutoSellKeepStacks, "Default: AutoSellKeepStacks should be 0 for v16 saves");
+        /// <summary>
+        /// Verifies that SaveLoadService treats a slot holding an incompatible-version file as
+        /// empty instead of crashing (previews built in the constructor and explicit loads).
+        /// </summary>
+        [TestMethod]
+        public void SaveLoadService_IncompatibleSlotFile_TreatedAsEmpty()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "pithero_oldslot_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                // Write a valid current-version save, then downgrade its version header
+                var ms = new MemoryStream();
+                using (var writer = new BinaryPersistableWriter(ms))
+                {
+                    var original = new SaveData();
+                    original.HeroName = "OldHero";
+                    writer.Write(original);
+                }
+
+                byte[] bytes = ms.ToArray();
+                bytes[0] = (byte)(SaveData.CurrentVersion - 1);
+                bytes[1] = 0;
+                bytes[2] = 0;
+                bytes[3] = 0;
+                File.WriteAllBytes(Path.Combine(tempDir, "save_slot_0.bin"), bytes);
+
+                // Constructor refreshes slot previews — must not throw on the incompatible file
+                var service = new SaveLoadService(new FileDataStore(tempDir));
+
+                Assert.IsFalse(service.SlotHasData(0), "Incompatible slot should be treated as empty");
+                Assert.IsNull(service.LoadFromSlot(0), "Loading an incompatible slot should return null");
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
+            }
         }
     }
 }

--- a/PitHero.Tests/TilledTileServiceTests.cs
+++ b/PitHero.Tests/TilledTileServiceTests.cs
@@ -12,7 +12,7 @@ namespace PitHero.Tests
     public class TilledTileServiceTests
     {
         private TmxMap _map;
-        private TmxLayer _detailLayer;
+        private TmxLayer _baseLayer;
         private TileStateService _tileState;
         private TilledTileService _service;
 
@@ -33,22 +33,22 @@ namespace PitHero.Tests
                 FirstGid = 1,
                 Tiles = new Dictionary<int, TmxTilesetTile>()
             });
-            _detailLayer = new TmxLayer
+            _baseLayer = new TmxLayer
             {
-                Name = "Detail",
+                Name = "Base",
                 Map = _map,
                 Width = W,
                 Height = H,
                 Grid = new uint[W * H],
                 Tiles = new Dictionary<uint, TmxLayerTile>()
             };
-            _map.Layers.Add(_detailLayer);
+            _map.Layers.Add(_baseLayer);
 
             _tileState = new TileStateService();
             _service = new TilledTileService(_map, _tileState);
         }
 
-        private int GidAt(int x, int y) => (int)_detailLayer.Grid[x + y * W];
+        private int GidAt(int x, int y) => (int)_baseLayer.Grid[x + y * W];
 
         [TestMethod]
         public void TillTile_SetsTilledFlag_AndClearsReadyToTill()

--- a/PitHero.Tests/TreasureComponentTests.cs
+++ b/PitHero.Tests/TreasureComponentTests.cs
@@ -211,21 +211,21 @@ namespace PitHero.Tests
             Assert.IsTrue(level2IsNormalPotion, $"Level 2 item should be a normal potion, but got {level2Item.Name}");
 
             var level3Item = TreasureComponent.GenerateItemForTreasureLevel(3);
-            Assert.AreEqual(ItemRarity.Rare, level3Item.Rarity);
+            Assert.AreEqual(ItemRarity.Normal, level3Item.Rarity);
             bool level3IsMidPotion = level3Item.Name == InventoryTextKey.Inv_MidHPPotion_Name
                 || level3Item.Name == InventoryTextKey.Inv_MidMPPotion_Name
                 || level3Item.Name == InventoryTextKey.Inv_MidMixPotion_Name;
             Assert.IsTrue(level3IsMidPotion, $"Level 3 item should be a Mid potion, but got {level3Item.Name}");
 
             var level4Item = TreasureComponent.GenerateItemForTreasureLevel(4);
-            Assert.AreEqual(ItemRarity.Epic, level4Item.Rarity);
+            Assert.AreEqual(ItemRarity.Normal, level4Item.Rarity);
             bool level4IsFullPotion = level4Item.Name == InventoryTextKey.Inv_FullHPPotion_Name
                 || level4Item.Name == InventoryTextKey.Inv_FullMPPotion_Name
                 || level4Item.Name == InventoryTextKey.Inv_FullMixPotion_Name;
             Assert.IsTrue(level4IsFullPotion, $"Level 4 item should be a Full potion, but got {level4Item.Name}");
 
             var level5Item = TreasureComponent.GenerateItemForTreasureLevel(5);
-            Assert.AreEqual(ItemRarity.Epic, level5Item.Rarity);
+            Assert.AreEqual(ItemRarity.Normal, level5Item.Rarity);
             bool level5IsFullPotion = level5Item.Name == InventoryTextKey.Inv_FullHPPotion_Name
                 || level5Item.Name == InventoryTextKey.Inv_FullMPPotion_Name
                 || level5Item.Name == InventoryTextKey.Inv_FullMixPotion_Name;

--- a/PitHero/AI/JumpIntoPitAction.cs
+++ b/PitHero/AI/JumpIntoPitAction.cs
@@ -27,6 +27,14 @@ namespace PitHero.AI
             SetPostcondition(GoapConstants.InsidePit, true);
         }
 
+        /// <summary>A jump is a short atomic animation — never interrupt it mid-air (the movement
+        /// coroutine cannot be cancelled and would fight any replanned movement). Only applies
+        /// while airborne; a jump that has not started yet remains interruptible.</summary>
+        public override bool ShouldNotOverride()
+        {
+            return _isJumping;
+        }
+
         public override bool Execute(HeroComponent hero)
         {
             // If already jumping, wait for the coroutine to finish
@@ -43,7 +51,12 @@ namespace PitHero.AI
 
                 if (currentTile.X != _plannedTargetTile.X || currentTile.Y != _plannedTargetTile.Y)
                 {
-                    Debug.Warn($"[JumpIntoPit] Jump finished flag set but hero at {currentTile.X},{currentTile.Y} not at planned target {_plannedTargetTile.X},{_plannedTargetTile.Y}. Waiting one more frame.");
+                    // Stale state from a jump that was interrupted mid-air (the coroutine finished
+                    // but the hero has since been moved elsewhere). Waiting cannot resolve this —
+                    // reset so the next Execute starts a fresh jump from the actual position.
+                    Debug.Warn($"[JumpIntoPit] Jump finished flag set but hero at {currentTile.X},{currentTile.Y} not at planned target {_plannedTargetTile.X},{_plannedTargetTile.Y}. Restarting jump from current tile.");
+                    _isJumping = false;
+                    _jumpFinished = false;
                     return false;
                 }
 

--- a/PitHero/AI/JumpOutOfPitForInnAction.cs
+++ b/PitHero/AI/JumpOutOfPitForInnAction.cs
@@ -32,6 +32,14 @@ namespace PitHero.AI
             SetPostcondition(GoapConstants.OutsidePit, true);
         }
 
+        /// <summary>A jump is a short atomic animation — never interrupt it mid-air (the movement
+        /// coroutine cannot be cancelled and would fight any replanned movement). Only applies
+        /// while airborne; a jump that has not started yet remains interruptible.</summary>
+        public override bool ShouldNotOverride()
+        {
+            return _isJumping;
+        }
+
         public override bool Validate()
         {
             HeroComponent heroComponent;
@@ -122,7 +130,12 @@ namespace PitHero.AI
 
                 if (currentTile.X != _plannedTargetTile.X || currentTile.Y != _plannedTargetTile.Y)
                 {
-                    Debug.Warn($"[JumpOutOfPit] Jump finished flag set but hero at {currentTile.X},{currentTile.Y} not at planned target {_plannedTargetTile.X},{_plannedTargetTile.Y}. Waiting one more frame.");
+                    // Stale state from a jump that was interrupted mid-air (the coroutine finished
+                    // but the hero has since been moved elsewhere). Waiting cannot resolve this —
+                    // reset so the next Execute starts a fresh jump from the actual position.
+                    Debug.Warn($"[JumpOutOfPit] Jump finished flag set but hero at {currentTile.X},{currentTile.Y} not at planned target {_plannedTargetTile.X},{_plannedTargetTile.Y}. Restarting jump from current tile.");
+                    _isJumping = false;
+                    _jumpFinished = false;
                     return false;
                 }
 

--- a/PitHero/AI/JumpOutOfPitForStopAction.cs
+++ b/PitHero/AI/JumpOutOfPitForStopAction.cs
@@ -26,6 +26,14 @@ namespace PitHero.AI
             SetPostcondition(GoapConstants.OutsidePit, true);
         }
 
+        /// <summary>A jump is a short atomic animation — never interrupt it mid-air (the movement
+        /// coroutine cannot be cancelled and would fight any replanned movement). Only applies
+        /// while airborne; a jump that has not started yet remains interruptible.</summary>
+        public override bool ShouldNotOverride()
+        {
+            return _isJumping;
+        }
+
         /// <summary>
         /// Execute action - jump hero out of the pit
         /// </summary>
@@ -47,7 +55,12 @@ namespace PitHero.AI
 
                 if (currentTile.X != _plannedTargetTile.X || currentTile.Y != _plannedTargetTile.Y)
                 {
-                    Debug.Warn($"[JumpOutOfPitForStop] Jump finished flag set but hero at {currentTile.X},{currentTile.Y} not at planned target {_plannedTargetTile.X},{_plannedTargetTile.Y}. Waiting one more frame.");
+                    // Stale state from a jump that was interrupted mid-air (the coroutine finished
+                    // but the hero has since been moved elsewhere). Waiting cannot resolve this —
+                    // reset so the next Execute starts a fresh jump from the actual position.
+                    Debug.Warn($"[JumpOutOfPitForStop] Jump finished flag set but hero at {currentTile.X},{currentTile.Y} not at planned target {_plannedTargetTile.X},{_plannedTargetTile.Y}. Restarting jump from current tile.");
+                    _isJumping = false;
+                    _jumpFinished = false;
                     return false;
                 }
 

--- a/PitHero/AI/MercenaryActionBase.cs
+++ b/PitHero/AI/MercenaryActionBase.cs
@@ -14,6 +14,14 @@ namespace PitHero.AI
         }
 
         /// <summary>
+        /// When true, the state machine will not interrupt this action mid-execution to replan.
+        /// </summary>
+        public virtual bool ShouldNotOverride()
+        {
+            return false;
+        }
+
+        /// <summary>
         /// Execute the action for the given mercenary
         /// </summary>
         /// <returns>True if action is complete, false if still in progress</returns>

--- a/PitHero/AI/MercenaryJumpIntoPitAction.cs
+++ b/PitHero/AI/MercenaryJumpIntoPitAction.cs
@@ -29,6 +29,14 @@ namespace PitHero.AI
             SetPostcondition(GoapConstants.MercenaryFollowingTarget, true);
         }
 
+        /// <summary>A jump is a short atomic animation — never interrupt it mid-air (the movement
+        /// coroutine cannot be cancelled and would fight any replanned movement). Only applies
+        /// while airborne; a jump that has not started yet remains interruptible.</summary>
+        public override bool ShouldNotOverride()
+        {
+            return _isJumping;
+        }
+
         public override bool Execute(MercenaryComponent mercenary)
         {
             if (_isJumping)
@@ -43,7 +51,12 @@ namespace PitHero.AI
 
                 if (currentTile.X != _plannedTargetTile.X || currentTile.Y != _plannedTargetTile.Y)
                 {
-                    Debug.Warn($"[MercenaryJumpIntoPit] Jump finished flag set but mercenary at {currentTile.X},{currentTile.Y} not at planned target {_plannedTargetTile.X},{_plannedTargetTile.Y}. Waiting one more frame.");
+                    // Stale state from a jump that was interrupted mid-air (the coroutine finished
+                    // but the mercenary has since been moved elsewhere). Waiting cannot resolve this —
+                    // reset so the next Execute starts a fresh jump from the actual position.
+                    Debug.Warn($"[MercenaryJumpIntoPit] Jump finished flag set but mercenary at {currentTile.X},{currentTile.Y} not at planned target {_plannedTargetTile.X},{_plannedTargetTile.Y}. Restarting jump from current tile.");
+                    _isJumping = false;
+                    _jumpFinished = false;
                     return false;
                 }
 

--- a/PitHero/AI/MercenaryJumpOutOfPitAction.cs
+++ b/PitHero/AI/MercenaryJumpOutOfPitAction.cs
@@ -30,6 +30,14 @@ namespace PitHero.AI
             SetPostcondition(GoapConstants.MercenaryFollowingTarget, true);
         }
 
+        /// <summary>A jump is a short atomic animation — never interrupt it mid-air (the movement
+        /// coroutine cannot be cancelled and would fight any replanned movement). Only applies
+        /// while airborne; the walk to the jump position remains interruptible.</summary>
+        public override bool ShouldNotOverride()
+        {
+            return _isJumping;
+        }
+
         public override bool Execute(MercenaryComponent mercenary)
         {
             if (_isJumping)
@@ -44,7 +52,14 @@ namespace PitHero.AI
 
                 if (currentTile.X != _plannedTargetTile.X || currentTile.Y != _plannedTargetTile.Y)
                 {
-                    Debug.Warn($"[MercenaryJumpOutOfPit] Jump finished flag set but mercenary at {currentTile.X},{currentTile.Y} not at planned target {_plannedTargetTile.X},{_plannedTargetTile.Y}. Waiting one more frame.");
+                    // Stale state from a jump that was interrupted mid-air (the coroutine finished
+                    // but the mercenary has since been moved elsewhere). Waiting cannot resolve this —
+                    // reset so the next Execute starts a fresh jump from the actual position.
+                    Debug.Warn($"[MercenaryJumpOutOfPit] Jump finished flag set but mercenary at {currentTile.X},{currentTile.Y} not at planned target {_plannedTargetTile.X},{_plannedTargetTile.Y}. Restarting jump from current tile.");
+                    _isJumping = false;
+                    _jumpFinished = false;
+                    _pathToJumpPosition = null;
+                    _pathIndex = 0;
                     return false;
                 }
 

--- a/PitHero/AI/MercenaryStateMachine.cs
+++ b/PitHero/AI/MercenaryStateMachine.cs
@@ -138,7 +138,7 @@ namespace PitHero.AI
 
             // Check if world state has changed significantly (e.g., target jumped into/out of pit)
             // This allows us to interrupt continuous actions like FollowTargetAction
-            if (ShouldReplan())
+            if (ShouldReplan() && !_currentAction.ShouldNotOverride())
             {
                 Debug.Log($"[MercenaryStateMachine] {Entity.Name} world state changed, interrupting {_currentAction.Name} and replanning");
                 _currentAction = null;

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -417,37 +417,6 @@ namespace PitHero.ECS.Scenes
                 }
             }
 
-            // v14 → v15 migration: old saves charged a seed at plan placement; new model pays at
-            // plant time, so refund each plan whose tile has no same-type growing crop, and infer
-            // plans for any growing crops that have no plan (so they aren't treated as pending-destroy).
-            if (pendingData.LoadedFileVersion < 15)
-            {
-                // (a) Refund +1 seed per plan whose tile lacks a same-type growing crop
-                if (pendingData.CropPlans != null && cropPlantingService != null && cropGrowthService != null)
-                {
-                    for (int i = 0; i < pendingData.CropPlans.Count; i++)
-                    {
-                        var cp       = pendingData.CropPlans[i];
-                        var planType = (Farming.CropType)cp.CropTypeId;
-                        var tile     = new Microsoft.Xna.Framework.Point(cp.TileX, cp.TileY);
-                        if (cropGrowthService.GetCropType(tile) != planType)
-                            cropPlantingService.AddSeeds(planType, 1);
-                    }
-                }
-
-                // (b) Infer plans for growing crops that have no plan (prevents pending-destroy treatment)
-                if (pendingData.CropGrowthStates != null && cropPlantingService != null && _seedModeOverlay != null)
-                {
-                    for (int i = 0; i < pendingData.CropGrowthStates.Count; i++)
-                    {
-                        var gs   = pendingData.CropGrowthStates[i];
-                        var tile = new Microsoft.Xna.Framework.Point(gs.TileX, gs.TileY);
-                        if (!cropPlantingService.HasPlan(tile))
-                            _seedModeOverlay.SpawnRestoredCropPlan((Farming.CropType)gs.CropTypeId, gs.TileX, gs.TileY);
-                    }
-                }
-            }
-
             // Apply auto shop settings from save data and sync the settings UI controls
             var autoSeedSvc = Core.Services.GetService<Services.AutoSeedPurchaseService>();
             if (autoSeedSvc != null)

--- a/PitHero/Services/SaveData.cs
+++ b/PitHero/Services/SaveData.cs
@@ -1,6 +1,5 @@
 using Microsoft.Xna.Framework;
 using Nez.Persistence.Binary;
-using PitHero.Config;
 using RolePlayingFramework.Heroes;
 using RolePlayingFramework.Jobs;
 using RolePlayingFramework.Stats;
@@ -34,7 +33,7 @@ namespace PitHero.Services
         public int ItemBagIndex;
         /// <summary>Skill ID string (only valid when SlotType == 2).</summary>
         public string SkillId;
-        /// <summary>Index into HiredMercenaries of the skill's owner, or -1 for the hero (SlotType == 2, version 14+).</summary>
+        /// <summary>Index into HiredMercenaries of the skill's owner, or -1 for the hero (SlotType == 2).</summary>
         public int OwnerMercIndex;
     }
 
@@ -182,7 +181,7 @@ namespace PitHero.Services
         public int CropTypeId;
         public float AccumulatedHours;
         public int CurrentFrame;
-        /// <summary>Per-stage time multiplier (1 normally, &gt;1 while a repeat crop regrows). Save version 10+.</summary>
+        /// <summary>Per-stage time multiplier (1 normally, &gt;1 while a repeat crop regrows).</summary>
         public float RegrowthRateMultiplier;
     }
 
@@ -194,14 +193,14 @@ namespace PitHero.Services
         public int Count;
     }
 
-    /// <summary>Harvested-crop inventory for one Crop Storage building (save version 10+).</summary>
+    /// <summary>Harvested-crop inventory for one Crop Storage building.</summary>
     public struct SavedCropStorageInventory
     {
         public int BuildingUniqueId;
         public List<SavedHarvestSlot> Slots;
     }
 
-    /// <summary>A harvested-crop stack dropped on the ground awaiting pickup (save version 12+).</summary>
+    /// <summary>A harvested-crop stack dropped on the ground awaiting pickup.</summary>
     public struct SavedDroppedCrop
     {
         public int CropTypeId;
@@ -358,10 +357,10 @@ namespace PitHero.Services
         /// <summary>Current pit level (biome-local, 1–MaxBiomeLevel).</summary>
         public int PitLevel;
 
-        /// <summary>Current pit tier (1–99, permanent, never decreases). Version 13+.</summary>
+        /// <summary>Current pit tier (1–99, permanent, never decreases).</summary>
         public int PitTier = 1;
 
-        /// <summary>Hero level at which the tier first incremented; respawned heroes start here. Version 13+.</summary>
+        /// <summary>Hero level at which the tier first incremented; respawned heroes start here.</summary>
         public int TierBaseLevel = 1;
 
         // Priorities (stored as ints, cast from HeroPitPriority / HeroHealPriority)
@@ -451,31 +450,28 @@ namespace PitHero.Services
         /// <summary>Harvested-crop inventories, one per Crop Storage building.</summary>
         public List<SavedCropStorageInventory> CropStorageInventories;
 
-        /// <summary>Harvested crops dropped on the ground awaiting pickup (version 12+).</summary>
+        /// <summary>Harvested crops dropped on the ground awaiting pickup.</summary>
         public List<SavedDroppedCrop> DroppedCrops;
 
         // Defeated Monsters
-        /// <summary>Bare enum names of monster types the player has defeated in battle (version 11+).</summary>
+        /// <summary>Bare enum names of monster types the player has defeated in battle.</summary>
         public List<string> DefeatedMonsterTypes;
 
-        // Auto Shop Options (version 15+)
-        /// <summary>Whether automatic seed purchasing is enabled (version 15+).</summary>
+        // Auto Shop Options
+        /// <summary>Whether automatic seed purchasing is enabled.</summary>
         public bool AutomateSeedPurchases = false;
 
-        /// <summary>Gold buffer threshold: no purchase fires when Funds - price &lt; this value (version 15+).</summary>
+        /// <summary>Gold buffer threshold: no purchase fires when Funds - price &lt; this value.</summary>
         public int AutoShopGoldBuffer = 200;
 
-        /// <summary>Whether automatic crop selling at max stack size is enabled (version 16+).</summary>
+        /// <summary>Whether automatic crop selling at max stack size is enabled.</summary>
         public bool AutoSellCrops = false;
 
-        /// <summary>Per-crop auto-sell designations indexed by CropType (version 16+). Null until Recover normalizes it.</summary>
+        /// <summary>Per-crop auto-sell designations indexed by CropType. Null until Recover normalizes it.</summary>
         public bool[] AutoSellCropDesignations;
 
-        /// <summary>Number of full stacks of each crop to keep before auto-selling (version 17+).</summary>
+        /// <summary>Number of full stacks of each crop to keep before auto-selling.</summary>
         public int AutoSellKeepStacks = 0;
-
-        /// <summary>The save file version number read during Recover; 0 for a brand-new in-memory instance.</summary>
-        public int LoadedFileVersion;
 
         /// <summary>Initializes a new SaveData with default empty collections.</summary>
         public SaveData()
@@ -658,7 +654,7 @@ namespace PitHero.Services
                 else if (slot.SlotType == 2) // Skill
                 {
                     writer.Write(slot.SkillId ?? string.Empty);
-                    writer.Write(slot.OwnerMercIndex); // version 14+: -1 = hero
+                    writer.Write(slot.OwnerMercIndex); // -1 = hero
                 }
             }
 
@@ -753,7 +749,7 @@ namespace PitHero.Services
                 writer.Write(TileStates[i].Flags);
             }
 
-            // 21. Placed Buildings (version 5+)
+            // 21. Placed Buildings
             int buildingCount = PlacedBuildings != null ? PlacedBuildings.Count : 0;
             writer.Write(buildingCount);
             for (int i = 0; i < buildingCount; i++)
@@ -764,13 +760,13 @@ namespace PitHero.Services
                 writer.Write(PlacedBuildings[i].UniqueId);
             }
 
-            // 22. Seed Inventory (version 6+)
+            // 22. Seed Inventory
             int seedCount = SeedInventory != null ? SeedInventory.Length : 0;
             writer.Write(seedCount);
             for (int i = 0; i < seedCount; i++)
                 writer.Write(SeedInventory[i]);
 
-            // 23. Crop Plans (version 6+)
+            // 23. Crop Plans
             int cropPlanCount = CropPlans != null ? CropPlans.Count : 0;
             writer.Write(cropPlanCount);
             for (int i = 0; i < cropPlanCount; i++)
@@ -780,10 +776,10 @@ namespace PitHero.Services
                 writer.Write(CropPlans[i].TileY);
             }
 
-            // 24. Next Building ID (version 8+)
+            // 24. Next Building ID
             writer.Write(NextBuildingId);
 
-            // 25. Crop Growth States (version 9+; RegrowthRateMultiplier added in version 10)
+            // 25. Crop Growth States
             int cropGrowthCount = CropGrowthStates != null ? CropGrowthStates.Count : 0;
             writer.Write(cropGrowthCount);
             for (int i = 0; i < cropGrowthCount; i++)
@@ -796,7 +792,7 @@ namespace PitHero.Services
                 writer.Write(CropGrowthStates[i].RegrowthRateMultiplier);
             }
 
-            // 26. Crop Storage harvested-crop inventories (version 10+)
+            // 26. Crop Storage harvested-crop inventories
             int storageInvCount = CropStorageInventories != null ? CropStorageInventories.Count : 0;
             writer.Write(storageInvCount);
             for (int i = 0; i < storageInvCount; i++)
@@ -813,13 +809,13 @@ namespace PitHero.Services
                 }
             }
 
-            // 27. Defeated Monster Types (version 11+)
+            // 27. Defeated Monster Types
             int defeatedCount = DefeatedMonsterTypes != null ? DefeatedMonsterTypes.Count : 0;
             writer.Write(defeatedCount);
             for (int i = 0; i < defeatedCount; i++)
                 writer.Write(DefeatedMonsterTypes[i] ?? string.Empty);
 
-            // 28. Dropped crops awaiting pickup (version 12+)
+            // 28. Dropped crops awaiting pickup
             int droppedCount = DroppedCrops != null ? DroppedCrops.Count : 0;
             writer.Write(droppedCount);
             for (int i = 0; i < droppedCount; i++)
@@ -830,22 +826,22 @@ namespace PitHero.Services
                 writer.Write(DroppedCrops[i].TileY);
             }
 
-            // 29. Pit tier (version 13+)
+            // 29. Pit tier
             writer.Write(PitTier);
             writer.Write(TierBaseLevel);
 
-            // 30. Auto shop options (v15+)
+            // 30. Auto shop options
             writer.Write(AutomateSeedPurchases);
             writer.Write(AutoShopGoldBuffer);
 
-            // 31. Auto-sell crops (v16+)
+            // 31. Auto-sell crops
             writer.Write(AutoSellCrops);
             int designationCount = AutoSellCropDesignations != null ? AutoSellCropDesignations.Length : 0;
             writer.Write(designationCount);
             for (int i = 0; i < designationCount; i++)
                 writer.Write(AutoSellCropDesignations[i]);
 
-            // 32. Auto-sell keep stacks (v17+)
+            // 32. Auto-sell keep stacks
             writer.Write(AutoSellKeepStacks);
         }
 
@@ -854,12 +850,12 @@ namespace PitHero.Services
         {
             // 1. File Version
             int fileVersion = reader.ReadInt();
-            LoadedFileVersion = fileVersion;
+            if (fileVersion != CurrentVersion)
+                throw new System.IO.InvalidDataException($"Unsupported save file version {fileVersion} (expected {CurrentVersion})");
 
             // 2. Total Time Played
             TotalTimePlayed = reader.ReadFloat();
-            if (fileVersion >= 3)
-                InGameTimeAccumulatedSeconds = reader.ReadFloat();
+            InGameTimeAccumulatedSeconds = reader.ReadFloat();
 
             // 3. Hero Design
             HeroName = reader.ReadString();
@@ -982,23 +978,8 @@ namespace PitHero.Services
                 monster.FishingProficiency = reader.ReadInt();
                 monster.CookingProficiency = reader.ReadInt();
                 monster.FarmingProficiency = reader.ReadInt();
-                if (fileVersion >= 8)
-                {
-                    monster.MonsterJobId = reader.ReadInt();
-                    monster.MonsterHouseId = reader.ReadInt();
-                }
-                else if (fileVersion >= 7)
-                {
-                    monster.MonsterJobId = reader.ReadInt();
-                    reader.ReadInt(); // discard old MonsterHouseTileX
-                    reader.ReadInt(); // discard old MonsterHouseTileY
-                    monster.MonsterHouseId = -1;
-                }
-                else
-                {
-                    monster.MonsterHouseId = 0;
-                    monster.MonsterJobId = 0;
-                }
+                monster.MonsterJobId = reader.ReadInt();
+                monster.MonsterHouseId = reader.ReadInt();
                 AlliedMonsters.Add(monster);
             }
 
@@ -1019,8 +1000,7 @@ namespace PitHero.Services
                 else if (slot.SlotType == 2) // Skill
                 {
                     slot.SkillId = reader.ReadString();
-                    if (fileVersion >= 14)
-                        slot.OwnerMercIndex = reader.ReadInt(); // pre-14 saves default to hero (-1)
+                    slot.OwnerMercIndex = reader.ReadInt();
                 }
                 ShortcutSlots.Add(slot);
             }
@@ -1092,241 +1072,144 @@ namespace PitHero.Services
             bool hasForgeB = reader.ReadBool();
             ForgeSlotB = hasForgeB ? ReadCrystal(reader) : (SavedHeroCrystal?)null;
 
-            // 19. Second Chance Vault Items (version 2+)
-            if (fileVersion >= 2)
+            // 19. Second Chance Vault Items
+            int vaultItemCount = reader.ReadInt();
+            SecondChanceVaultItems = new List<SavedVaultItem>(vaultItemCount);
+            for (int i = 0; i < vaultItemCount; i++)
             {
-                int vaultItemCount = reader.ReadInt();
-                SecondChanceVaultItems = new List<SavedVaultItem>(vaultItemCount);
-                for (int i = 0; i < vaultItemCount; i++)
+                SavedVaultItem vi;
+                vi.Name = reader.ReadString();
+                vi.IsConsumable = reader.ReadBool();
+                vi.Quantity = reader.ReadInt();
+                SecondChanceVaultItems.Add(vi);
+            }
+
+            // 20. Tile States
+            int tileStateCount = reader.ReadInt();
+            TileStates = new List<SavedTileState>(tileStateCount);
+            for (int i = 0; i < tileStateCount; i++)
+            {
+                SavedTileState ts;
+                ts.X = reader.ReadInt();
+                ts.Y = reader.ReadInt();
+                ts.Flags = reader.ReadInt();
+                TileStates.Add(ts);
+            }
+
+            // 21. Placed Buildings
+            int buildingCount = reader.ReadInt();
+            PlacedBuildings = new List<SavedBuilding>(buildingCount);
+            for (int i = 0; i < buildingCount; i++)
+            {
+                SavedBuilding b;
+                b.BuildingTypeId = reader.ReadInt();
+                b.TileX          = reader.ReadInt();
+                b.TileY          = reader.ReadInt();
+                b.UniqueId       = reader.ReadInt();
+                PlacedBuildings.Add(b);
+            }
+
+            // 22. Seed Inventory. Crop types added after the save was written default to 16 seeds.
+            int seedCount = reader.ReadInt();
+            SeedInventory = new int[Farming.CropTypeInfo.Count];
+            for (int i = 0; i < seedCount && i < Farming.CropTypeInfo.Count; i++)
+                SeedInventory[i] = reader.ReadInt();
+            for (int i = seedCount; i < Farming.CropTypeInfo.Count; i++)
+                SeedInventory[i] = 16;
+
+            // 23. Crop Plans
+            int cropPlanCount = reader.ReadInt();
+            CropPlans = new List<SavedCropPlan>(cropPlanCount);
+            for (int i = 0; i < cropPlanCount; i++)
+            {
+                SavedCropPlan cp;
+                cp.CropTypeId = reader.ReadInt();
+                cp.TileX      = reader.ReadInt();
+                cp.TileY      = reader.ReadInt();
+                CropPlans.Add(cp);
+            }
+
+            // 24. Next Building ID
+            NextBuildingId = reader.ReadInt();
+
+            // 25. Crop Growth States
+            int cropGrowthCount = reader.ReadInt();
+            CropGrowthStates = new List<SavedCropGrowthState>(cropGrowthCount);
+            for (int i = 0; i < cropGrowthCount; i++)
+            {
+                SavedCropGrowthState cgs;
+                cgs.TileX            = reader.ReadInt();
+                cgs.TileY            = reader.ReadInt();
+                cgs.CropTypeId       = reader.ReadInt();
+                cgs.AccumulatedHours = reader.ReadFloat();
+                cgs.CurrentFrame     = reader.ReadInt();
+                cgs.RegrowthRateMultiplier = reader.ReadFloat();
+                CropGrowthStates.Add(cgs);
+            }
+
+            // 26. Crop Storage harvested-crop inventories
+            int storageInvCount = reader.ReadInt();
+            CropStorageInventories = new List<SavedCropStorageInventory>(storageInvCount);
+            for (int i = 0; i < storageInvCount; i++)
+            {
+                SavedCropStorageInventory inv;
+                inv.BuildingUniqueId = reader.ReadInt();
+                int slotCount = reader.ReadInt();
+                inv.Slots = new List<SavedHarvestSlot>(slotCount);
+                for (int s = 0; s < slotCount; s++)
                 {
-                    SavedVaultItem vi;
-                    vi.Name = reader.ReadString();
-                    vi.IsConsumable = reader.ReadBool();
-                    vi.Quantity = reader.ReadInt();
-                    SecondChanceVaultItems.Add(vi);
+                    SavedHarvestSlot slot;
+                    slot.SlotIndex  = reader.ReadInt();
+                    slot.CropTypeId = reader.ReadInt();
+                    slot.Count      = reader.ReadInt();
+                    inv.Slots.Add(slot);
                 }
-            }
-            else
-            {
-                SecondChanceVaultItems = new List<SavedVaultItem>();
+                CropStorageInventories.Add(inv);
             }
 
-            // 20. Tile States (version 4+)
-            if (fileVersion >= 4)
+            // 27. Defeated Monster Types
+            int defeatedCount = reader.ReadInt();
+            DefeatedMonsterTypes = new List<string>(defeatedCount);
+            for (int i = 0; i < defeatedCount; i++)
+                DefeatedMonsterTypes.Add(reader.ReadString());
+
+            // 28. Dropped crops awaiting pickup
+            int droppedCount = reader.ReadInt();
+            DroppedCrops = new List<SavedDroppedCrop>(droppedCount);
+            for (int i = 0; i < droppedCount; i++)
             {
-                int tileStateCount = reader.ReadInt();
-                TileStates = new List<SavedTileState>(tileStateCount);
-                for (int i = 0; i < tileStateCount; i++)
-                {
-                    SavedTileState ts;
-                    ts.X = reader.ReadInt();
-                    ts.Y = reader.ReadInt();
-                    ts.Flags = reader.ReadInt();
-                    TileStates.Add(ts);
-                }
-            }
-            else
-            {
-                TileStates = new List<SavedTileState>();
+                SavedDroppedCrop drop;
+                drop.CropTypeId = reader.ReadInt();
+                drop.Count      = reader.ReadInt();
+                drop.TileX      = reader.ReadInt();
+                drop.TileY      = reader.ReadInt();
+                DroppedCrops.Add(drop);
             }
 
-            // 21. Placed Buildings (version 5+)
-            if (fileVersion >= 5)
-            {
-                int buildingCount = reader.ReadInt();
-                PlacedBuildings = new List<SavedBuilding>(buildingCount);
-                for (int i = 0; i < buildingCount; i++)
-                {
-                    SavedBuilding b;
-                    b.BuildingTypeId = reader.ReadInt();
-                    b.TileX          = reader.ReadInt();
-                    b.TileY          = reader.ReadInt();
-                    if (fileVersion >= 8)
-                        b.UniqueId = reader.ReadInt();
-                    else
-                        b.UniqueId = i + 1; // assign sequential IDs for old saves
-                    PlacedBuildings.Add(b);
-                }
-                if (fileVersion < 8)
-                    NextBuildingId = PlacedBuildings.Count + 1;
-            }
-            else
-            {
-                PlacedBuildings = new List<SavedBuilding>();
-            }
+            // 29. Pit tier
+            PitTier = reader.ReadInt();
+            TierBaseLevel = reader.ReadInt();
 
-            // 22. Seed Inventory (version 6+)
-            if (fileVersion >= 6)
-            {
-                int seedCount = reader.ReadInt();
-                SeedInventory = new int[Farming.CropTypeInfo.Count];
-                for (int i = 0; i < seedCount && i < Farming.CropTypeInfo.Count; i++)
-                    SeedInventory[i] = reader.ReadInt();
-                for (int i = seedCount; i < Farming.CropTypeInfo.Count; i++)
-                    SeedInventory[i] = 16;
-            }
-            else
-            {
-                SeedInventory = new int[Farming.CropTypeInfo.Count];
-                for (int i = 0; i < Farming.CropTypeInfo.Count; i++)
-                    SeedInventory[i] = 16;
-            }
+            // 30. Auto shop options
+            AutomateSeedPurchases = reader.ReadBool();
+            AutoShopGoldBuffer    = reader.ReadInt();
 
-            // 23. Crop Plans (version 6+)
-            if (fileVersion >= 6)
-            {
-                int cropPlanCount = reader.ReadInt();
-                CropPlans = new List<SavedCropPlan>(cropPlanCount);
-                for (int i = 0; i < cropPlanCount; i++)
-                {
-                    SavedCropPlan cp;
-                    cp.CropTypeId = reader.ReadInt();
-                    cp.TileX      = reader.ReadInt();
-                    cp.TileY      = reader.ReadInt();
-                    CropPlans.Add(cp);
-                }
-            }
-            else
-            {
-                CropPlans = new List<SavedCropPlan>();
-            }
-
-            // 24. Next Building ID (version 8+)
-            if (fileVersion >= 8)
-                NextBuildingId = reader.ReadInt();
-
-            // 25. Crop Growth States (version 9+; RegrowthRateMultiplier added in version 10)
-            if (fileVersion >= 9)
-            {
-                int cropGrowthCount = reader.ReadInt();
-                CropGrowthStates = new List<SavedCropGrowthState>(cropGrowthCount);
-                for (int i = 0; i < cropGrowthCount; i++)
-                {
-                    SavedCropGrowthState cgs;
-                    cgs.TileX            = reader.ReadInt();
-                    cgs.TileY            = reader.ReadInt();
-                    cgs.CropTypeId       = reader.ReadInt();
-                    cgs.AccumulatedHours = reader.ReadFloat();
-                    cgs.CurrentFrame     = reader.ReadInt();
-                    cgs.RegrowthRateMultiplier = fileVersion >= 10 ? reader.ReadFloat() : 1f;
-                    CropGrowthStates.Add(cgs);
-                }
-            }
-            else
-            {
-                CropGrowthStates = new List<SavedCropGrowthState>();
-            }
-
-            // 26. Crop Storage harvested-crop inventories (version 10+)
-            if (fileVersion >= 10)
-            {
-                int storageInvCount = reader.ReadInt();
-                CropStorageInventories = new List<SavedCropStorageInventory>(storageInvCount);
-                for (int i = 0; i < storageInvCount; i++)
-                {
-                    SavedCropStorageInventory inv;
-                    inv.BuildingUniqueId = reader.ReadInt();
-                    int slotCount = reader.ReadInt();
-                    inv.Slots = new List<SavedHarvestSlot>(slotCount);
-                    for (int s = 0; s < slotCount; s++)
-                    {
-                        SavedHarvestSlot slot;
-                        slot.SlotIndex  = reader.ReadInt();
-                        slot.CropTypeId = reader.ReadInt();
-                        slot.Count      = reader.ReadInt();
-                        inv.Slots.Add(slot);
-                    }
-                    CropStorageInventories.Add(inv);
-                }
-            }
-            else
-            {
-                CropStorageInventories = new List<SavedCropStorageInventory>();
-            }
-
-            // 27. Defeated Monster Types (version 11+)
-            if (fileVersion >= 11)
-            {
-                int defeatedCount = reader.ReadInt();
-                DefeatedMonsterTypes = new List<string>(defeatedCount);
-                for (int i = 0; i < defeatedCount; i++)
-                    DefeatedMonsterTypes.Add(reader.ReadString());
-            }
-            else
-            {
-                DefeatedMonsterTypes = new List<string>();
-            }
-
-            // 28. Dropped crops awaiting pickup (version 12+)
-            if (fileVersion >= 12)
-            {
-                int droppedCount = reader.ReadInt();
-                DroppedCrops = new List<SavedDroppedCrop>(droppedCount);
-                for (int i = 0; i < droppedCount; i++)
-                {
-                    SavedDroppedCrop drop;
-                    drop.CropTypeId = reader.ReadInt();
-                    drop.Count      = reader.ReadInt();
-                    drop.TileX      = reader.ReadInt();
-                    drop.TileY      = reader.ReadInt();
-                    DroppedCrops.Add(drop);
-                }
-            }
-            else
-            {
-                DroppedCrops = new List<SavedDroppedCrop>();
-            }
-
-            // 29. Pit tier (version 13+)
-            // Migration: old saves whose PitLevel exceeded MaxBiomeLevel (e.g. pit 119) are
-            // decoded into the correct tier and displayed level so the game never sees a raw
-            // depth value in PitLevel. Level (hero level) is read earlier in section 4.
-            if (fileVersion >= 13)
-            {
-                PitTier = reader.ReadInt();
-                TierBaseLevel = reader.ReadInt();
-            }
-            else
-            {
-                // Infer tier from the raw pit level (which may be cumulative depth on old saves).
-                PitTier = BiomeProgressionConfig.GetTierForDepth(PitLevel);
-                TierBaseLevel = PitTier >= 2 ? (Level > 0 ? Level : 1) : 1;
-                // Normalise PitLevel to biome-local range so the rest of the game sees [1..MaxBiomeLevel].
-                PitLevel = BiomeProgressionConfig.GetDisplayedLevelForDepth(PitLevel);
-            }
-
-            // 30. Auto shop options (version 15+)
-            if (fileVersion >= 15)
-            {
-                AutomateSeedPurchases = reader.ReadBool();
-                AutoShopGoldBuffer    = reader.ReadInt();
-            }
-            // else keep defaults: AutomateSeedPurchases = false, AutoShopGoldBuffer = 200
-
-            // 31. Auto-sell crops (version 16+). Designations default to all-true so pre-v16 saves
-            // (and crop types added after the save was written) behave like a fresh enable.
+            // 31. Auto-sell crops. Designations default to all-true so crop types added after
+            // the save was written behave like a fresh enable.
             AutoSellCropDesignations = new bool[Farming.CropTypeInfo.Count];
             for (int i = 0; i < AutoSellCropDesignations.Length; i++)
                 AutoSellCropDesignations[i] = true;
-            if (fileVersion >= 16)
+            AutoSellCrops = reader.ReadBool();
+            int designationCount = reader.ReadInt();
+            for (int i = 0; i < designationCount; i++)
             {
-                AutoSellCrops = reader.ReadBool();
-                int designationCount = reader.ReadInt();
-                for (int i = 0; i < designationCount; i++)
-                {
-                    bool designated = reader.ReadBool();
-                    if (i < AutoSellCropDesignations.Length)
-                        AutoSellCropDesignations[i] = designated;
-                }
+                bool designated = reader.ReadBool();
+                if (i < AutoSellCropDesignations.Length)
+                    AutoSellCropDesignations[i] = designated;
             }
-            // else keep defaults: AutoSellCrops = false, all designations true
 
-            // 32. Auto-sell keep stacks (version 17+)
-            if (fileVersion >= 17)
-            {
-                AutoSellKeepStacks = reader.ReadInt();
-            }
-            // else keep default: AutoSellKeepStacks = 0
+            // 32. Auto-sell keep stacks
+            AutoSellKeepStacks = reader.ReadInt();
         }
 
         /// <summary>Writes a Color as four individual int components (R, G, B, A).</summary>

--- a/PitHero/Services/SaveLoadService.cs
+++ b/PitHero/Services/SaveLoadService.cs
@@ -101,14 +101,23 @@ namespace PitHero.Services
         {
             for (int i = 0; i < MaxSlots; i++)
             {
-                var data = new SaveData();
-                _fileDataStore.Load(GetFilename(i), data);
+                try
+                {
+                    var data = new SaveData();
+                    _fileDataStore.Load(GetFilename(i), data);
 
-                // If HeroName was populated by Load, the file existed and had valid data
-                if (data.HeroName != null)
-                    _slotPreviews[i] = data;
-                else
+                    // If HeroName was populated by Load, the file existed and had valid data
+                    if (data.HeroName != null)
+                        _slotPreviews[i] = data;
+                    else
+                        _slotPreviews[i] = null;
+                }
+                catch (System.Exception ex)
+                {
+                    // Incompatible version or corrupt file — treat the slot as empty
+                    Debug.Log("SaveLoadService: Slot " + i + " unreadable (" + ex.Message + ")");
                     _slotPreviews[i] = null;
+                }
             }
         }
 
@@ -136,8 +145,18 @@ namespace PitHero.Services
                 return null;
             }
 
-            var data = new SaveData();
-            _fileDataStore.Load(GetFilename(slotIndex), data);
+            SaveData data;
+            try
+            {
+                data = new SaveData();
+                _fileDataStore.Load(GetFilename(slotIndex), data);
+            }
+            catch (System.Exception ex)
+            {
+                // Incompatible version or corrupt file — treat the slot as empty
+                Debug.Log("SaveLoadService: Slot " + slotIndex + " unreadable (" + ex.Message + ")");
+                return null;
+            }
 
             if (data.HeroName == null)
             {

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -2033,12 +2033,24 @@ namespace PitHero.UI
             // Marker is only shown once the panel has fully slid off-screen, and never during farm modes.
             _consoleMarker?.SetVisible(_consoleHidden && !_consoleAnimating && !ecFarmActive);
 
-            if (!_consoleAnimating) return;
-
             float stageH = _stage.GetHeight();
             float consolePanelBaseY = _eventConsolePanel.BaseY;
             // Push the panel far enough below the bottom edge to fully clear it.
             float hideOffset = (stageH - consolePanelBaseY) + 4f;
+
+            if (!_consoleAnimating)
+            {
+                // Keep a hidden console pinned at the correct off-screen offset. A window-mode
+                // switch repositions the panel (BaseY and visual height change), which would
+                // otherwise leave a stale hide offset half-revealing the panel.
+                if (_consoleHidden && _consoleSlideY != hideOffset)
+                {
+                    _consoleSlideY = hideOffset;
+                    _eventConsolePanel.SetSlideOffsetY(_consoleSlideY);
+                }
+                return;
+            }
+
             float targetOffsetY = _consoleHidden ? hideOffset : 0f;
             float delta = targetOffsetY - _consoleSlideY;
             float step = GameConfig.UIBarSlideSpeed * Time.UnscaledDeltaTime;


### PR DESCRIPTION
Closes #311

## Save format unification

- `SaveData.Recover` now reads only the v17 layout — all per-version conditional load branches (v2–v17) are removed. `Persist` and `CurrentVersion` are untouched, so existing v17 saves load byte-identically.
- Loading a save whose header version isn't 17 throws `InvalidDataException`. `SaveLoadService` catches unreadable/corrupt slot files in both `RefreshSlotPreviews` and `LoadFromSlot`, treating the slot as empty (previously an old save on disk would have crashed the game at startup while building slot previews). Older saves are left on disk untouched.
- Deleted the v14→v15 crop-economy migration in `MainGameScene` and the now-unused `SaveData.LoadedFileVersion` field.
- Kept two pieces of forward-compat logic that only look like version shims: the seed-inventory pad-to-16 loop and the auto-sell designation all-true pre-fill both handle crop types added after a save was written.
- Removed stale per-version annotations from save-field comments.

## Test fixes (11 failures → 0)

- **Potion rarity (5 tests):** expectations updated from Rare/Epic to `Normal` to match the flattened potion rarities (`PotionItemsTests`, `PotionSystemIntegrationTests`, `TreasureComponentTests`).
- **Tilled tiles (5 tests):** the fixture built a layer named `"Detail"` but `TilledTileService` binds `"Base"`, so GID writes silently no-op'd; the fixture layer is renamed to `"Base"` (`TilledTileServiceTests`).
- **Cave boss floors (1 test):** expected boss order and levels updated to the current `PitGenerator` mapping (5→StoneGuardian L10, 10→EarthElemental L18, 15→AncientWyrm L28, 20→PitLord L38, 25→MoltenTitan L46).
- **Removed** 5 tests whose tested behavior no longer exists: 3 legacy-version load tests (byte-patched version headers + truncated tails) and 2 pre-v13 depth→tier migration tests.
- **Added** 2 tests: `SaveData_OlderVersionHeader_ThrowsInvalidData` and `SaveLoadService_IncompatibleSlotFile_TreatedAsEmpty` (locks in the no-crash startup path end to end).

## Bug fix: party stuck at pit edge after Replenish mid-jump

The five GOAP jump actions are planner singletons that keep `_isJumping`/`_jumpFinished`/`_plannedTargetTile` across plans. Interrupting a plan mid-jump (e.g. pressing Replenish) never reset that state and never cancelled the in-flight movement coroutine, so the next run of the same action resumed the stale verification branch and warned "Waiting one more frame" forever — hero and mercenaries deadlocked at the pit edge.

- Jump actions now report `ShouldNotOverride()` while airborne, so Replenish / heal-priority / replan interrupts defer until landing (a queued jump that hasn't started stays interruptible). `MercenaryActionBase` gains the hook and `MercenaryStateMachine` honors it.
- The tile-mismatch verification branch self-heals: it resets jump state and restarts from the actual tile instead of waiting for a frame that never comes.

## Bug fix: hidden event console half-reveals after window-mode switch

The console's hide offset (`(stageHeight − BaseY) + 4`) differs between normal and half-window mode because the panel's base position and 2× visual height change. Switching modes while hidden re-applied the stale offset from the old mode, leaving the panel poking into view with no animation running to correct it. While hidden and not animating, the auto-hide update now re-pins the slide offset to the freshly computed hide offset whenever it drifts, so the console stays fully off-screen after any reposition in either switch direction.

## Verification

- `dotnet build PitHero.sln` — 0 errors
- `dotnet test PitHero.Tests` — **1470 passed, 0 failed, 6 skipped (1476 total)**; previously 11 failures
- Byte-compat: the full `SaveData_PersistAndRecover_RoundTrip` plus the tier/auto-shop/auto-sell/keep-stacks round-trip tests all pass unchanged, proving v17 files still load identically
- Save/test changes verified in-game by the user; the jump-deadlock and event-console fixes are covered by build + suite and await in-game confirmation (repro: press Replenish mid-jump; hide console then toggle full ↔ half window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)