### PR TITLE
Add farming analytics events (#312)

### DIFF
--- a/PitHero.Tests/AnalyticsServiceTests.cs
+++ b/PitHero.Tests/AnalyticsServiceTests.cs
@@ -195,6 +195,137 @@ namespace PitHero.Tests
             gameState.AddFunds(25, "battle");
             Assert.AreEqual(35, gameState.Funds);
         }
+
+        [TestMethod]
+        public void LogFarmingLifecycleEvents_WriteExpectedTypesAndFields()
+        {
+            AnalyticsService.Initialize(_tempDir);
+            AnalyticsService.LogCropPlanted("Turnip", 3, 4, "Slime A", "Slime");
+            AnalyticsService.LogCropGrown("Turnip", 3, 4);
+            AnalyticsService.LogCropWatered("Turnip", 3, 4, "Slime A", "Slime", 7);
+            AnalyticsService.LogCropHarvested("Turnip", 3, 4, 5, "Slime A", "Slime");
+            AnalyticsService.LogCropStored("Turnip", 5, "Slime A", "Slime");
+            AnalyticsService.LogCropDropped("Turnip", 2, 6, 9);
+            AnalyticsService.LogCropDestroyed("Turnip", 3, 4, "Slime A", "Slime");
+
+            var lines = ReadAllEventLines();
+            Assert.AreEqual(7, lines.Length);
+
+            var expectedTypes = new[] { "crop_planted", "crop_grown", "crop_watered", "crop_harvested",
+                "crop_stored", "crop_dropped", "crop_destroyed" };
+            for (int i = 0; i < lines.Length; i++)
+            {
+                using var lineDoc = JsonDocument.Parse(lines[i]);
+                Assert.AreEqual(expectedTypes[i], lineDoc.RootElement.GetProperty("e").GetString());
+                Assert.AreEqual("Turnip", lineDoc.RootElement.GetProperty("crop").GetString());
+            }
+
+            using var planted = JsonDocument.Parse(lines[0]);
+            Assert.AreEqual(3, planted.RootElement.GetProperty("x").GetInt32());
+            Assert.AreEqual(4, planted.RootElement.GetProperty("y").GetInt32());
+            Assert.AreEqual("Slime A", planted.RootElement.GetProperty("monster").GetString());
+            Assert.AreEqual("Slime", planted.RootElement.GetProperty("monsterType").GetString());
+
+            using var watered = JsonDocument.Parse(lines[2]);
+            Assert.AreEqual(7, watered.RootElement.GetProperty("waterLeft").GetInt32());
+
+            using var harvested = JsonDocument.Parse(lines[3]);
+            Assert.AreEqual(5, harvested.RootElement.GetProperty("qty").GetInt32());
+
+            using var stored = JsonDocument.Parse(lines[4]);
+            Assert.AreEqual(5, stored.RootElement.GetProperty("qty").GetInt32());
+
+            using var dropped = JsonDocument.Parse(lines[5]);
+            Assert.AreEqual(2, dropped.RootElement.GetProperty("qty").GetInt32());
+            Assert.AreEqual(6, dropped.RootElement.GetProperty("x").GetInt32());
+            Assert.AreEqual(9, dropped.RootElement.GetProperty("y").GetInt32());
+        }
+
+        [TestMethod]
+        public void LogCropWatered_NullCrop_WritesNullCropField()
+        {
+            AnalyticsService.Initialize(_tempDir);
+            AnalyticsService.LogCropWatered(null, 1, 2, "Slime A", "Slime", 3);
+
+            var lines = ReadAllEventLines();
+            using var doc = JsonDocument.Parse(lines[0]);
+            Assert.AreEqual("crop_watered", doc.RootElement.GetProperty("e").GetString());
+            Assert.AreEqual(JsonValueKind.Null, doc.RootElement.GetProperty("crop").ValueKind);
+        }
+
+        [TestMethod]
+        public void LogSeedPurchasedAndCropSold_WriteSourceAndGoldFields()
+        {
+            AnalyticsService.Initialize(_tempDir);
+            AnalyticsService.LogSeedPurchased("Turnip", 4, 80, "manual", 920);
+            AnalyticsService.LogSeedPurchased("Wheat", 2, 30, "auto", 890);
+            AnalyticsService.LogCropSold("Turnip", 10, 250, "manual");
+            AnalyticsService.LogCropSold("Wheat", 8, 120, "auto");
+
+            var lines = ReadAllEventLines();
+            Assert.AreEqual(4, lines.Length);
+
+            using var manualBuy = JsonDocument.Parse(lines[0]);
+            Assert.AreEqual("seed_purchased", manualBuy.RootElement.GetProperty("e").GetString());
+            Assert.AreEqual("Turnip", manualBuy.RootElement.GetProperty("crop").GetString());
+            Assert.AreEqual(4, manualBuy.RootElement.GetProperty("qty").GetInt32());
+            Assert.AreEqual(80, manualBuy.RootElement.GetProperty("goldSpent").GetInt32());
+            Assert.AreEqual("manual", manualBuy.RootElement.GetProperty("source").GetString());
+            Assert.AreEqual(920, manualBuy.RootElement.GetProperty("currentGold").GetInt32());
+
+            using var autoBuy = JsonDocument.Parse(lines[1]);
+            Assert.AreEqual("auto", autoBuy.RootElement.GetProperty("source").GetString());
+
+            using var manualSell = JsonDocument.Parse(lines[2]);
+            Assert.AreEqual("crop_sold", manualSell.RootElement.GetProperty("e").GetString());
+            Assert.AreEqual(10, manualSell.RootElement.GetProperty("qty").GetInt32());
+            Assert.AreEqual(250, manualSell.RootElement.GetProperty("gold").GetInt32());
+            Assert.AreEqual("manual", manualSell.RootElement.GetProperty("source").GetString());
+
+            using var autoSell = JsonDocument.Parse(lines[3]);
+            Assert.AreEqual("auto", autoSell.RootElement.GetProperty("source").GetString());
+        }
+
+        [TestMethod]
+        public void LogBuildingEvents_WriteCoordinatesAndType()
+        {
+            AnalyticsService.Initialize(_tempDir);
+            AnalyticsService.LogBuildingCreated("CropStorage", 10, 5, 500);
+            AnalyticsService.LogBuildingMoved("MonsterHouse", 3, 4, 8, 9);
+
+            var lines = ReadAllEventLines();
+            Assert.AreEqual(2, lines.Length);
+
+            using var created = JsonDocument.Parse(lines[0]);
+            Assert.AreEqual("building_created", created.RootElement.GetProperty("e").GetString());
+            Assert.AreEqual("CropStorage", created.RootElement.GetProperty("buildingType").GetString());
+            Assert.AreEqual(10, created.RootElement.GetProperty("x").GetInt32());
+            Assert.AreEqual(5, created.RootElement.GetProperty("y").GetInt32());
+            Assert.AreEqual(500, created.RootElement.GetProperty("cost").GetInt32());
+
+            using var moved = JsonDocument.Parse(lines[1]);
+            Assert.AreEqual("building_moved", moved.RootElement.GetProperty("e").GetString());
+            Assert.AreEqual("MonsterHouse", moved.RootElement.GetProperty("buildingType").GetString());
+            Assert.AreEqual(3, moved.RootElement.GetProperty("fromX").GetInt32());
+            Assert.AreEqual(4, moved.RootElement.GetProperty("fromY").GetInt32());
+            Assert.AreEqual(8, moved.RootElement.GetProperty("toX").GetInt32());
+            Assert.AreEqual(9, moved.RootElement.GetProperty("toY").GetInt32());
+        }
+
+        [TestMethod]
+        public void LogWateringCanFilled_WritesMonsterAndLocation()
+        {
+            AnalyticsService.Initialize(_tempDir);
+            AnalyticsService.LogWateringCanFilled("Slime A", "Slime", 118, 5);
+
+            var lines = ReadAllEventLines();
+            using var doc = JsonDocument.Parse(lines[0]);
+            Assert.AreEqual("watering_can_filled", doc.RootElement.GetProperty("e").GetString());
+            Assert.AreEqual("Slime A", doc.RootElement.GetProperty("monster").GetString());
+            Assert.AreEqual("Slime", doc.RootElement.GetProperty("monsterType").GetString());
+            Assert.AreEqual(118, doc.RootElement.GetProperty("x").GetInt32());
+            Assert.AreEqual(5, doc.RootElement.GetProperty("y").GetInt32());
+        }
     }
 }
 #endif

--- a/PitHero/ECS/Components/FarmingMonsterStateMachine.cs
+++ b/PitHero/ECS/Components/FarmingMonsterStateMachine.cs
@@ -3,6 +3,7 @@ using Nez;
 using Nez.AI.FSM;
 using PitHero.Farming;
 using PitHero.Services;
+using PitHero.Services.Analytics;
 using RolePlayingFramework.AlliedMonsters;
 
 namespace PitHero.ECS.Components
@@ -546,6 +547,7 @@ namespace PitHero.ECS.Components
                 tileState?.ClearFlag(tile, TileStateFlag.CropGrowing);
                 tileState?.ClearFlag(tile, TileStateFlag.Wet);
                 _wetTileService?.ClearWet(tile);
+                AnalyticsService.LogCropDestroyed(cropTypeAtTile.Value.ToString(), tile.X, tile.Y, _monster.Name, _monster.MonsterTypeName);
             }
 
             _coordinator.CompleteDestroyAction(in _currentAction);
@@ -599,6 +601,7 @@ namespace PitHero.ECS.Components
             // Load the crops atlas to get crop sprites; plan is kept after planting (permanent blueprint)
             var atlas = Core.Content.LoadSpriteAtlas("Content/Atlases/CropsProps.atlas");
             _cropGrowthService?.PlantCrop(tile, planType.Value, Entity.Scene, atlas);
+            AnalyticsService.LogCropPlanted(planType.Value.ToString(), tile.X, tile.Y, _monster.Name, _monster.MonsterTypeName);
 
             _coordinator.CompletePlantAction(in _currentAction);
             _hasAction = false;
@@ -644,6 +647,9 @@ namespace PitHero.ECS.Components
 
             _wetTileService?.SetWet(_currentAction.TargetTile);
             _wateringCanCharges--;
+            AnalyticsService.LogCropWatered(_cropGrowthService?.GetCropType(_currentAction.TargetTile)?.ToString(),
+                _currentAction.TargetTile.X, _currentAction.TargetTile.Y,
+                _monster.Name, _monster.MonsterTypeName, _wateringCanCharges);
             _coordinator.CompleteWaterAction(in _currentAction);
             _hasAction = false;
             CurrentState = FarmingMonsterState.Idle;
@@ -699,6 +705,8 @@ namespace PitHero.ECS.Components
                 return;
 
             _wateringCanCharges = GameConfig.WateringCanMaxCharges;
+            AnalyticsService.LogWateringCanFilled(_monster.Name, _monster.MonsterTypeName,
+                _mover.CurrentTile.X, _mover.CurrentTile.Y);
 
             if (TryPathToStandTile())
             {
@@ -917,6 +925,7 @@ namespace PitHero.ECS.Components
             _harvestDoorTile = door;
             _harvestCarryCount = Util.CropConfig.GetHarvestYield(_harvestCropType);
             ApplyHarvestResult(tile);
+            AnalyticsService.LogCropHarvested(_harvestCropType.ToString(), tile.X, tile.Y, _harvestCarryCount, _monster.Name, _monster.MonsterTypeName);
             ShowCarrySprite();
             _harvestPickedUp = true;
             return true;
@@ -970,6 +979,8 @@ namespace PitHero.ECS.Components
             int carried = _harvestCarryCount;
             int stored = storage != null ? storage.DepositReturningStored(_harvestBuildingId, _harvestCropType, carried) : 0;
             int remaining = carried - stored;
+            if (stored > 0)
+                AnalyticsService.LogCropStored(_harvestCropType.ToString(), stored, _monster.Name, _monster.MonsterTypeName);
 
             if (remaining > 0 && storage != null)
             {
@@ -984,6 +995,8 @@ namespace PitHero.ECS.Components
                         return; // keep carrying the remainder to the new destination
                     stored = storage.DepositReturningStored(_harvestBuildingId, _harvestCropType, remaining); // adjacent fallback
                     remaining -= stored;
+                    if (stored > 0)
+                        AnalyticsService.LogCropStored(_harvestCropType.ToString(), stored, _monster.Name, _monster.MonsterTypeName);
                 }
 
                 // Still holding crops with nowhere to go — drop them on the ground for later pickup.

--- a/PitHero/Services/Analytics/AnalyticsService.cs
+++ b/PitHero/Services/Analytics/AnalyticsService.cs
@@ -574,6 +574,217 @@ namespace PitHero.Services.Analytics
 #endif
         }
 
+        /// <summary>Logs a crop being planted at a tile by a farming monster.</summary>
+        [Conditional("DEBUG")]
+        public static void LogCropPlanted(string crop, int x, int y, string monster, string monsterType)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("crop_planted"))
+                return;
+            _json.Field("crop", crop);
+            _json.Field("x", x);
+            _json.Field("y", y);
+            _json.Field("monster", monster);
+            _json.Field("monsterType", monsterType);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs a crop reaching full size and becoming ready to harvest (re-fires on each regrowth cycle).</summary>
+        [Conditional("DEBUG")]
+        public static void LogCropGrown(string crop, int x, int y)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("crop_grown"))
+                return;
+            _json.Field("crop", crop);
+            _json.Field("x", x);
+            _json.Field("y", y);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs a crop being harvested by a farming monster, with the yield taken.</summary>
+        [Conditional("DEBUG")]
+        public static void LogCropHarvested(string crop, int x, int y, int qty, string monster, string monsterType)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("crop_harvested"))
+                return;
+            _json.Field("crop", crop);
+            _json.Field("x", x);
+            _json.Field("y", y);
+            _json.Field("qty", qty);
+            _json.Field("monster", monster);
+            _json.Field("monsterType", monsterType);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs harvested crops accepted into a Crop Storage building (may fire twice for a split deposit).</summary>
+        [Conditional("DEBUG")]
+        public static void LogCropStored(string crop, int qty, string monster, string monsterType)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("crop_stored"))
+                return;
+            _json.Field("crop", crop);
+            _json.Field("qty", qty);
+            _json.Field("monster", monster);
+            _json.Field("monsterType", monsterType);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs harvested crops dropped on the ground because no storage had room; x/y is the final placement tile.</summary>
+        [Conditional("DEBUG")]
+        public static void LogCropDropped(string crop, int qty, int x, int y)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("crop_dropped"))
+                return;
+            _json.Field("crop", crop);
+            _json.Field("qty", qty);
+            _json.Field("x", x);
+            _json.Field("y", y);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs a crop destroyed by a farming monster because its plan was swapped or removed.</summary>
+        [Conditional("DEBUG")]
+        public static void LogCropDestroyed(string crop, int x, int y, string monster, string monsterType)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("crop_destroyed"))
+                return;
+            _json.Field("crop", crop);
+            _json.Field("x", x);
+            _json.Field("y", y);
+            _json.Field("monster", monster);
+            _json.Field("monsterType", monsterType);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs a tile being watered by a farming monster; waterLeft is charges remaining after the pour.</summary>
+        [Conditional("DEBUG")]
+        public static void LogCropWatered(string crop, int x, int y, string monster, string monsterType, int waterLeft)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("crop_watered"))
+                return;
+            _json.Field("crop", crop);
+            _json.Field("x", x);
+            _json.Field("y", y);
+            _json.Field("monster", monster);
+            _json.Field("monsterType", monsterType);
+            _json.Field("waterLeft", waterLeft);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs a seed purchase (manual shop buy or auto-purchase pass); currentGold is funds after the spend.</summary>
+        [Conditional("DEBUG")]
+        public static void LogSeedPurchased(string crop, int qty, int goldSpent, string source, int currentGold)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("seed_purchased"))
+                return;
+            _json.Field("crop", crop);
+            _json.Field("qty", qty);
+            _json.Field("goldSpent", goldSpent);
+            _json.Field("source", source);
+            _json.Field("currentGold", currentGold);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs a harvested crop stack being sold (manual or auto); the matching gold_gained is emitted separately.</summary>
+        [Conditional("DEBUG")]
+        public static void LogCropSold(string crop, int qty, int gold, string source)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("crop_sold"))
+                return;
+            _json.Field("crop", crop);
+            _json.Field("qty", qty);
+            _json.Field("gold", gold);
+            _json.Field("source", source);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs a farming monster refilling its watering can at a pond tile.</summary>
+        [Conditional("DEBUG")]
+        public static void LogWateringCanFilled(string monster, string monsterType, int x, int y)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("watering_can_filled"))
+                return;
+            _json.Field("monster", monster);
+            _json.Field("monsterType", monsterType);
+            _json.Field("x", x);
+            _json.Field("y", y);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs a building placed by the player (never fired on save restore).</summary>
+        [Conditional("DEBUG")]
+        public static void LogBuildingCreated(string buildingType, int x, int y, int cost)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("building_created"))
+                return;
+            _json.Field("buildingType", buildingType);
+            _json.Field("x", x);
+            _json.Field("y", y);
+            _json.Field("cost", cost);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs a building moved by the player to a new tile.</summary>
+        [Conditional("DEBUG")]
+        public static void LogBuildingMoved(string buildingType, int fromX, int fromY, int toX, int toY)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("building_moved"))
+                return;
+            _json.Field("buildingType", buildingType);
+            _json.Field("fromX", fromX);
+            _json.Field("fromY", fromY);
+            _json.Field("toX", toX);
+            _json.Field("toY", toY);
+            EndEvent();
+#endif
+        }
+
 #if DEBUG
         /// <summary>Opens a new event object with timestamp, in-game time and event type. Returns false if output is unavailable.</summary>
         private static bool BeginEvent(string eventType)

--- a/PitHero/Services/AutoCropSellService.cs
+++ b/PitHero/Services/AutoCropSellService.cs
@@ -96,6 +96,7 @@ namespace PitHero.Services
 
                     int gold = CropConfig.GetHarvestStackSellPrice(crop, slots[s].Count);
                     _gameState.AddFunds(gold, SellSource);
+                    Analytics.AnalyticsService.LogCropSold(crop.ToString(), slots[s].Count, gold, "auto");
                     _storage.ClearSlot(buildingId, s);
                 }
             }

--- a/PitHero/Services/AutoSeedPurchaseService.cs
+++ b/PitHero/Services/AutoSeedPurchaseService.cs
@@ -1,5 +1,6 @@
 using Nez;
 using PitHero.Farming;
+using PitHero.Services.Analytics;
 using PitHero.Util;
 
 namespace PitHero.Services
@@ -83,6 +84,7 @@ namespace PitHero.Services
                     ? _cropPlanting.SeedInventory[(int)crop]
                     : 0;
 
+                int ownedBefore = owned;
                 while (owned < needed && _gameState.Funds - price >= GoldBuffer)
                 {
                     _gameState.Funds -= price;
@@ -90,6 +92,9 @@ namespace PitHero.Services
                     owned++;
                     boughtAnything = true;
                 }
+                if (owned > ownedBefore)
+                    AnalyticsService.LogSeedPurchased(crop.ToString(), owned - ownedBefore,
+                        (owned - ownedBefore) * price, "auto", _gameState.Funds);
             }
 
             if (boughtAnything)

--- a/PitHero/Services/CropGrowthService.cs
+++ b/PitHero/Services/CropGrowthService.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework;
 using Nez;
 using Nez.Sprites;
 using PitHero.Farming;
+using PitHero.Services.Analytics;
 using PitHero.Util;
 
 namespace PitHero.Services
@@ -156,6 +157,7 @@ namespace PitHero.Services
                 {
                     tileState.SetFlag(tile, TileStateFlag.CropGrown);
                     tileState.ClearFlag(tile, TileStateFlag.CropGrowing);
+                    AnalyticsService.LogCropGrown(data.Type.ToString(), tile.X, tile.Y);
                 }
 
                 _crops[tile] = data;

--- a/PitHero/Services/DroppedCropService.cs
+++ b/PitHero/Services/DroppedCropService.cs
@@ -4,6 +4,7 @@ using Nez;
 using Nez.Sprites;
 using Nez.Textures;
 using PitHero.Farming;
+using PitHero.Services.Analytics;
 using PitHero.Util;
 
 namespace PitHero.Services
@@ -55,6 +56,7 @@ namespace PitHero.Services
             if (existing != null && existing.Type == crop)
             {
                 existing.Count += count;
+                AnalyticsService.LogCropDropped(crop.ToString(), count, tile.X, tile.Y);
                 return;
             }
             if (existing != null)
@@ -63,6 +65,7 @@ namespace PitHero.Services
             var drop = new DroppedCrop { Type = crop, Count = count, Tile = tile };
             SpawnEntity(drop);
             _drops.Add(drop);
+            AnalyticsService.LogCropDropped(crop.ToString(), count, drop.Tile.X, drop.Tile.Y);
         }
 
         /// <summary>Returns the drop at a tile, or null.</summary>

--- a/PitHero/UI/BuildingModeOverlay.cs
+++ b/PitHero/UI/BuildingModeOverlay.cs
@@ -6,6 +6,7 @@ using Nez.UI;
 using PitHero.ECS.Components;
 using PitHero.Farming;
 using PitHero.Services;
+using PitHero.Services.Analytics;
 using PitHero.Util;
 
 namespace PitHero.UI
@@ -201,6 +202,7 @@ namespace PitHero.UI
             var moved = _movingBuilding;
             if (moved != null)
             {
+                AnalyticsService.LogBuildingMoved(moved.Type.ToString(), moved.TileX, moved.TileY, tileX, tileY);
                 moved.TileX = tileX;
                 moved.TileY = tileY;
                 if (moved.WorldEntity != null)
@@ -522,6 +524,7 @@ namespace PitHero.UI
                 UniqueId    = newId,
                 WorldEntity = entity
             });
+            AnalyticsService.LogBuildingCreated(type.ToString(), tileX, tileY, _pendingCost);
 
             // Return to Choosing so the player can place more
             ShowInventoryWindow();

--- a/PitHero/UI/HarvestedCropsModeOverlay.cs
+++ b/PitHero/UI/HarvestedCropsModeOverlay.cs
@@ -5,6 +5,7 @@ using Nez.Textures;
 using Nez.UI;
 using PitHero.Farming;
 using PitHero.Services;
+using PitHero.Services.Analytics;
 using PitHero.Util;
 
 namespace PitHero.UI
@@ -164,6 +165,15 @@ namespace PitHero.UI
                 {
                     var gameState = Core.Services.GetService<GameStateService>();
                     gameState?.AddFunds(totalGold, "sell_crops");
+#if DEBUG
+                    // Per-stack detail lines for the analytics log; re-read live slots because
+                    // auto-sell may have emptied some while the dialog was open.
+                    var liveSlots = storage.GetSlots(buildingId);
+                    for (int s = 0; s < liveSlots.Count; s++)
+                        if (!liveSlots[s].IsEmpty)
+                            AnalyticsService.LogCropSold(liveSlots[s].Type.ToString(), liveSlots[s].Count,
+                                CropConfig.GetHarvestStackSellPrice(liveSlots[s].Type, liveSlots[s].Count), "manual");
+#endif
                     storage.ClearBuilding(buildingId);
                     _descWindow?.SetVisible(false);
                     LayoutButtonRow();
@@ -201,6 +211,20 @@ namespace PitHero.UI
                 {
                     var gameState = Core.Services.GetService<GameStateService>();
                     gameState?.AddFunds(totalGold, "sell_crops");
+#if DEBUG
+                    // Per-stack detail lines for the analytics log; re-read live slots because
+                    // auto-sell may have emptied some while the dialog was open.
+                    for (int b = 0; b < all.Count; b++)
+                    {
+                        if (all[b].Type != BuildingType.CropStorage)
+                            continue;
+                        var liveSlots = storage.GetSlots(all[b].UniqueId);
+                        for (int s = 0; s < liveSlots.Count; s++)
+                            if (!liveSlots[s].IsEmpty)
+                                AnalyticsService.LogCropSold(liveSlots[s].Type.ToString(), liveSlots[s].Count,
+                                    CropConfig.GetHarvestStackSellPrice(liveSlots[s].Type, liveSlots[s].Count), "manual");
+                    }
+#endif
                     for (int b = 0; b < all.Count; b++)
                         if (all[b].Type == BuildingType.CropStorage)
                             storage.ClearBuilding(all[b].UniqueId);
@@ -406,6 +430,7 @@ namespace PitHero.UI
                     {
                         int liveGold = CropConfig.GetHarvestStackSellPrice(liveSlot.Type, liveSlot.Count);
                         gameState?.AddFunds(liveGold, "sell_crops");
+                        AnalyticsService.LogCropSold(liveSlot.Type.ToString(), liveSlot.Count, liveGold, "manual");
                         storage?.ClearSlot(buildingId, slotIndex);
                     }
                     _descWindow.SetVisible(false);

--- a/PitHero/UI/SecondChanceShopUI.cs
+++ b/PitHero/UI/SecondChanceShopUI.cs
@@ -5,6 +5,7 @@ using Nez.UI;
 using PitHero.ECS.Components;
 using PitHero.Farming;
 using PitHero.Services;
+using PitHero.Services.Analytics;
 using PitHero.Util;
 using RolePlayingFramework.Equipment;
 using RolePlayingFramework.Heroes;
@@ -375,6 +376,7 @@ namespace PitHero.UI
                     if (gameState.Funds < totalPrice) return;
                     gameState.Funds -= totalPrice;
                     cropPlantingService.AddSeeds(crop, qty);
+                    AnalyticsService.LogSeedPurchased(crop.ToString(), qty, totalPrice, "manual", gameState.Funds);
                     Core.Services?.GetService<FarmTaskCoordinator>()?.RescanForPlanting();
                 },
                 onCancel: null,

--- a/PitHero/docs/AnalyticsSchema.md
+++ b/PitHero/docs/AnalyticsSchema.md
@@ -66,7 +66,7 @@ interpretation caveats that are not obvious from the raw data.
 |---|---|---|
 | `item_acquired` | `item`, `kind`, `rarity`, `pitLevel`, `chestLevel` | Item actually collected from a chest. Pair with `chest_spawned` (availability) — they answer different questions. |
 | `gear_equipped` | `character`, `charType`, `slot`, `item`, `rarity`, `str/agi/vit/mag`, `maxHP`, `maxMP` | Stats are the character's **resulting totals after** the equip. Save-restore re-equips are deliberately not logged. |
-| `gold_gained` | `amount`, `source`, `sessionTotal`, `currentGold` | `source`: `"battle"`, `"sell_item"`, `"sell_building"`, `"sell_crops"`, `"refund"`. `sessionTotal` resets each `session_start`. Spends are not logged; infer from `currentGold` deltas (e.g. `inn_sleep.goldAfter`). |
+| `gold_gained` | `amount`, `source`, `sessionTotal`, `currentGold` | `source`: `"battle"`, `"sell_item"`, `"sell_building"`, `"sell_crops"`, `"refund"`. `sessionTotal` resets each `session_start`. Spends are mostly not logged; infer from `currentGold` deltas (e.g. `inn_sleep.goldAfter`). Exceptions: `seed_purchased` and `building_created` (below) record their own spends. `source:"sell_crops"` lines pair with per-stack `crop_sold` detail lines. |
 
 ### Battle
 | `e` | Fields | Notes |
@@ -76,6 +76,27 @@ interpretation caveats that are not obvious from the raw data.
 | `buff` | `actor`, `source` (skill id), `target`, `buffType`, `magnitude`, `durationTurns` | One row per granted buff actually applied (a multi-buff skill like `synergy.fade` logs one row per buff). Buffs skipped by the MaxStacks at-cap guard are not logged. `durationTurns: -1` = until battle end. `buffType` is the `BuffType` enum name (`DefenseUp`, `EvasionUp`, `MPRegen`, `Untargetable`). |
 | `monster_defeated` | `name`, `enemyId`, `level`, `isBoss`, `pitLevel`, `pitTier`, `xp`, `jp`, `gold` | One per kill regardless of killer; the matching `gold_gained` (`source:"battle"`) follows. |
 | `char_killed` | full victim snapshot (same shape as a `party_snapshot` member) + `killer{name, enemyId, level, str/agi/vit/mag, maxHP}` | Hero or mercenary killed by a monster. |
+
+### Farming (issue #312)
+
+All farming work is performed by allied monsters; `monster` is the worker's display name and
+`monsterType` its species name. `crop` is always the `CropType` enum name (`AppleTree`,
+`Turnip`, …), **not** the localized display name. `x`/`y` are tile coordinates.
+
+| `e` | Fields | Notes |
+|---|---|---|
+| `crop_planted` | `crop`, `x`, `y`, `monster`, `monsterType` | Seed consumed and crop entity spawned on a planned tile. |
+| `crop_grown` | `crop`, `x`, `y` | Crop reached full size (CropGrown set) and is ready to harvest. No monster — growth is time/water driven. Re-fires on every regrowth cycle of repeat-harvest crops; not replayed on save load. |
+| `crop_harvested` | `crop`, `x`, `y`, `qty`, `monster`, `monsterType` | `qty` is the harvest yield picked up. Fires when the worker commits to carrying (storage with room was found). Picking a dropped stack back up is **not** a harvest. |
+| `crop_stored` | `crop`, `qty`, `monster`, `monsterType` | `qty` is the units actually accepted by the Crop Storage. Can appear **twice for one harvest** when a deposit is split across two storages (destination filled mid-walk). |
+| `crop_dropped` | `crop`, `qty`, `x`, `y` | Carried crops dropped on the ground because no storage had room (or the target storage was sold mid-carry). `x`/`y` is the **final placement tile**, which may be relocated to the nearest drop-free tile if another drop occupied the intended one. Save-restore of existing drops is not logged. |
+| `crop_destroyed` | `crop`, `x`, `y`, `monster`, `monsterType` | Worker removed a crop whose plan was swapped/removed (issue #305 destroy flow). |
+| `crop_watered` | `crop`, `x`, `y`, `monster`, `monsterType`, `waterLeft` | `waterLeft` is the watering-can charges remaining **after** this pour. `crop` is `null` when the crop vanished before the pour landed. |
+| `watering_can_filled` | `monster`, `monsterType`, `x`, `y` | Worker refilled its can to `GameConfig.WateringCanMaxCharges` at a pond tile. |
+| `seed_purchased` | `crop`, `qty`, `goldSpent`, `source`, `currentGold` | `source`: `"manual"` (shop dialog) or `"auto"` (AutoSeedPurchaseService; one aggregate line per crop per pass). `currentGold` is funds **after** the spend. First instrumented gold spend. |
+| `crop_sold` | `crop`, `qty`, `gold`, `source` | One line **per stack sold**; `source`: `"manual"` or `"auto"`. The gold itself arrives via the paired `gold_gained (source:"sell_crops")`. In bulk manual sells the per-stack `gold` sum can deviate from the paired `gold_gained.amount` if auto-sell emptied slots while the confirm dialog was open (pre-existing quirk; the detail lines reflect what was actually cleared). |
+| `building_created` | `buildingType`, `x`, `y`, `cost` | `buildingType`: `"MonsterHouse"` or `"CropStorage"`. Player placements only — never fired on save restore. `cost` is the gold spent. |
+| `building_moved` | `buildingType`, `fromX`, `fromY`, `toX`, `toY` | Player moved an existing building. |
 
 ## Interpretation caveats
 
@@ -92,9 +113,9 @@ interpretation caveats that are not obvious from the raw data.
 - **Load-time replay:** on `mode:"load"`, the pit is regenerated, so the first
   `pit_generated`/`chest_spawned`/`monster_spawned` burst right after `session_start`
   reflects the restored pit, and one `merc_arrived` fires for the initial tavern spawn.
-- **Not instrumented:** gold spends (except via `goldAfter`/`currentGold`), out-of-battle
-  healing GOAP actions, the virtual game layer (`PitHero.VirtualGame` has no
-  combat simulation).
+- **Not instrumented:** gold spends other than `seed_purchased` and `building_created`
+  (infer the rest via `goldAfter`/`currentGold`), out-of-battle healing GOAP actions,
+  the virtual game layer (`PitHero.VirtualGame` has no combat simulation or farming).
 
 ## Typical analysis joins
 


### PR DESCRIPTION
Closes #312.

Logs all important farming events to the debug analytics JSONL in the standard format (envelope `t`/`gt`/`e`, snake_case event names, separate int `x`/`y`, enum names for crops/buildings).

## New events

| Event | Fields |
|---|---|
| `crop_planted` | crop, x, y, monster, monsterType |
| `crop_grown` | crop, x, y |
| `crop_harvested` | crop, x, y, qty, monster, monsterType |
| `crop_stored` | crop, qty, monster, monsterType |
| `crop_dropped` | crop, qty, x, y (final placement tile) |
| `crop_destroyed` | crop, x, y, monster, monsterType |
| `crop_watered` | crop, x, y, monster, monsterType, waterLeft |
| `seed_purchased` | crop, qty, goldSpent, source (manual/auto), currentGold |
| `crop_sold` | crop, qty, gold, source (manual/auto) |
| `watering_can_filled` | monster, monsterType, x, y |
| `building_created` | buildingType, x, y, cost |
| `building_moved` | buildingType, fromX, fromY, toX, toY |

## Notes

- The issue wording says "Seed sold", but the codebase only sells harvested crop stacks (`AutoCropSellService` + manual overlay), so sells are logged as `crop_sold` — one line per stack, pairing with the existing `gold_gained (source:"sell_crops")`.
- Building create/move events fire only on player actions in `BuildingModeOverlay`; save-restore spawns stay silent (matches the `gear_equipped` restore convention).
- `crop_dropped` is logged at the single `DroppedCropService.Drop` choke point so the recorded tile is the final placement tile (drops can be relocated when the target tile is occupied).
- `crop_stored` can fire twice for one harvest when a deposit is split across two storages.
- All new `Log*` methods are `[Conditional("DEBUG")]` with primitive/string parameters only; every call-site argument is a pure read, and the log-only loops in the bulk-sell handlers are `#if DEBUG`-wrapped, so Release builds are unchanged.
- Schema documented in `PitHero/docs/AnalyticsSchema.md` (new Farming section).

## Testing

- `dotnet build -c Debug` and `-c Release` both clean (Release proves no DEBUG leakage).
- `dotnet test`: 1475 passed, 0 failed (baseline 0), including 5 new end-to-end analytics tests covering the farming lifecycle, null-crop watering, purchase/sell sources, building events, and watering-can fills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)