### PR TITLE
Fix half-window preference lost when switching from farm UI to another UI

### DIFF
--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -2176,8 +2176,11 @@ namespace PitHero.ECS.Scenes
                 {
                     UIWindowManager.OnUIWindowClosing();
                     // Restore the half-window default zoom that was reset when the farm UI opened
-                    // (skip if the persistent size changed to Normal while the farm UI was open)
-                    if (_farmModeRestoreHalfZoom && WindowManager.IsHalfHeightMode())
+                    // (skip if the persistent size changed to Normal while the farm UI was open).
+                    // Check the persistent preference, not the live window state: when another UI
+                    // (e.g. Settings) is still open the window is temporarily Normal here, but it
+                    // returns to Half once that UI closes and the zoom must be ready for it.
+                    if (_farmModeRestoreHalfZoom && UIWindowManager.PersistentWindowSize == UIWindowManager.WindowSizeMode.Half)
                         _cameraController?.ApplyHalfWindowZoom();
                     _farmModeRestoreHalfZoom = false;
                     pauseService?.SetFarmModePause(false);

--- a/PitHero/UI/UIWindowManager.cs
+++ b/PitHero/UI/UIWindowManager.cs
@@ -140,10 +140,19 @@ namespace PitHero.UI
             _openUIWindowCount++;
             Debug.Log($"[UIWindowManager] UI window opening (count: {_openUIWindowCount})");
 
-            // Always store the current window state as persistent BEFORE any changes
-            var currentActualSize = GetCurrentWindowSize();
-            _persistentWindowSize = currentActualSize;
-            Debug.Log($"[UIWindowManager] Stored persistent size: {_persistentWindowSize}");
+            // Store the current window state as persistent only when this is the first UI
+            // window opening. When another UI window is already open (e.g. Settings pressed
+            // while the farm UI is up), the window is already at the temporary Normal size —
+            // capturing it here would clobber the player's real Half preference.
+            if (_openUIWindowCount == 1)
+            {
+                _persistentWindowSize = GetCurrentWindowSize();
+                Debug.Log($"[UIWindowManager] Stored persistent size: {_persistentWindowSize}");
+            }
+            else
+            {
+                Debug.Log($"[UIWindowManager] Another UI window already open, keeping persistent size: {_persistentWindowSize}");
+            }
 
             // Temporarily restore to normal size for UI viewing
             if (WindowManager.IsHalfHeightMode())
@@ -194,10 +203,18 @@ namespace PitHero.UI
             // Decrement open window counter
             _openUIWindowCount = Math.Max(0, _openUIWindowCount - 1);
             Debug.Log($"[UIWindowManager] UI window closing (count: {_openUIWindowCount})");
-            Debug.Log($"[UIWindowManager] Applying persistent size: {_persistentWindowSize}");
 
-            // Apply persistent window size when closing UI
-            ApplyPersistentWindowSize();
+            // Only re-apply the persistent size once the last UI window closes; while other
+            // UI windows remain open the window must stay at the temporary Normal size.
+            if (_openUIWindowCount == 0)
+            {
+                Debug.Log($"[UIWindowManager] Applying persistent size: {_persistentWindowSize}");
+                ApplyPersistentWindowSize();
+            }
+            else
+            {
+                Debug.Log("[UIWindowManager] Other UI windows still open, deferring persistent size restore");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Bug

In half-window mode, opening the farm UI temporarily restores the window to normal size (expected). But pressing another button like Settings while the farm UI is open, then dismissing it, left the window at normal size instead of restoring the player's half-size preference. Other windows (e.g. Party → Settings) were unaffected.

## Root cause

`UIWindowManager.OnUIWindowOpening()` unconditionally stored the *current* window size as the persistent preference. Regular windows are force-closed synchronously by the single-window policy **before** the next window's `OnUIWindowOpening()`, so the close restores Half first and the subsequent capture is correct. The farm UI, however, is dismissed via mutual exclusion in `SettingsUI.Update()` and its close is detected by polling in `MainGameScene.Update()` — **one frame after** Settings has already opened. Settings therefore captured the temporary Normal size, clobbering the Half preference.

## Fix

- `UIWindowManager.OnUIWindowOpening()`: capture the persistent size only when the **first** UI window opens (`_openUIWindowCount == 1`). When another window is already open, the window is already at the temporary Normal size and the stored preference is the truth.
- `UIWindowManager.OnUIWindowClosing()`: apply the persistent size only when the **last** UI window closes. While other windows remain open the window stays at the temporary Normal size.
- `MainGameScene` farm-close branch: restore the half-window zoom based on `UIWindowManager.PersistentWindowSize` instead of the live `IsHalfHeightMode()` state — when another UI is still open the window is temporarily Normal at that moment, but returns to Half once that UI closes and the zoom must be ready for it.

This also fixes the same latent clobbering in the nested MonsterUI → AddMonsterDialog flow.

## Testing

- `dotnet build -c Debug` clean; full suite: 1475 passed, 0 failed.
- Manual repro to verify: half-window mode → farm button (window goes normal) → Settings (farm dismissed) → close Settings → window returns to half size with half-window zoom. Party → Settings → dismiss continues to behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)