### PR TITLE
Add new-game starting content (#316)

### DIFF
--- a/PitHero.Tests/FarmTaskCoordinatorTests.cs
+++ b/PitHero.Tests/FarmTaskCoordinatorTests.cs
@@ -212,15 +212,16 @@ namespace PitHero.Tests
         }
 
         [TestMethod]
-        public void GetRightmostFarmObjectTileX_NoFarmObjects_ReturnsMinusOne()
+        public void RightmostFarmObject_NoFarmObjects_IsMinusOne()
         {
-            Assert.AreEqual(-1, _coordinator.GetRightmostFarmObjectTileX());
+            Assert.AreEqual(-1, _coordinator.RightmostFarmObjectTileX);
         }
 
         [TestMethod]
-        public void GetRightmostFarmObjectTileX_UsesBuildingFootprintEastEdge()
+        public void RightmostFarmObject_BuildingPlacement_UpdatesCacheToFootprintEastEdge()
         {
-            // MonsterHouse footprint spans anchor.X-2 .. anchor.X+2
+            // MonsterHouse footprint spans anchor.X-2 .. anchor.X+2; AddBuilding fires
+            // BuildingsChanged, which refreshes the cache — no explicit recalc needed
             _buildingService.AddBuilding(new PlacedBuilding
             {
                 Type = BuildingType.MonsterHouse,
@@ -229,11 +230,33 @@ namespace PitHero.Tests
                 UniqueId = _buildingService.AllocateId()
             });
 
-            Assert.AreEqual(125, _coordinator.GetRightmostFarmObjectTileX());
+            Assert.AreEqual(125, _coordinator.RightmostFarmObjectTileX);
         }
 
         [TestMethod]
-        public void GetRightmostFarmObjectTileX_TakesMaxAcrossBuildingsAndTilledTiles()
+        public void RightmostFarmObject_ReadyToTillDesignation_UpdatesCacheIncrementally()
+        {
+            _tileState.SetFlag(new Point(132, 6), TileStateFlag.ReadyToTill);
+            Assert.AreEqual(132, _coordinator.RightmostFarmObjectTileX);
+
+            // A designation further west must not lower the bound
+            _tileState.SetFlag(new Point(125, 6), TileStateFlag.ReadyToTill);
+            Assert.AreEqual(132, _coordinator.RightmostFarmObjectTileX);
+        }
+
+        [TestMethod]
+        public void RightmostFarmObject_ClearingRightmostDesignation_ShrinksCache()
+        {
+            _tileState.SetFlag(new Point(125, 6), TileStateFlag.ReadyToTill);
+            _tileState.SetFlag(new Point(132, 6), TileStateFlag.ReadyToTill);
+
+            _tileState.ClearFlag(new Point(132, 6), TileStateFlag.ReadyToTill);
+
+            Assert.AreEqual(125, _coordinator.RightmostFarmObjectTileX);
+        }
+
+        [TestMethod]
+        public void RecalculateRightmostFarmObject_TakesMaxAcrossBuildingsAndTilledTiles()
         {
             // CropStorage footprint spans anchor.X-1 .. anchor.X+1 → east edge 128
             _buildingService.AddBuilding(new PlacedBuilding
@@ -243,10 +266,13 @@ namespace PitHero.Tests
                 TileY = 2,
                 UniqueId = _buildingService.AllocateId()
             });
+            // Directly-set Tilled flags raise no event (the load-restore case) — the explicit
+            // recalc the load path performs must pick them up
             _tileState.SetFlag(new Point(135, 5), TileStateFlag.Tilled);
-            _tileState.SetFlag(new Point(132, 6), TileStateFlag.ReadyToTill);
 
-            Assert.AreEqual(135, _coordinator.GetRightmostFarmObjectTileX());
+            _coordinator.RecalculateRightmostFarmObject();
+
+            Assert.AreEqual(135, _coordinator.RightmostFarmObjectTileX);
         }
 
         [TestMethod]

--- a/PitHero.Tests/FarmTaskCoordinatorTests.cs
+++ b/PitHero.Tests/FarmTaskCoordinatorTests.cs
@@ -212,6 +212,44 @@ namespace PitHero.Tests
         }
 
         [TestMethod]
+        public void GetRightmostFarmObjectTileX_NoFarmObjects_ReturnsMinusOne()
+        {
+            Assert.AreEqual(-1, _coordinator.GetRightmostFarmObjectTileX());
+        }
+
+        [TestMethod]
+        public void GetRightmostFarmObjectTileX_UsesBuildingFootprintEastEdge()
+        {
+            // MonsterHouse footprint spans anchor.X-2 .. anchor.X+2
+            _buildingService.AddBuilding(new PlacedBuilding
+            {
+                Type = BuildingType.MonsterHouse,
+                TileX = 123,
+                TileY = 2,
+                UniqueId = _buildingService.AllocateId()
+            });
+
+            Assert.AreEqual(125, _coordinator.GetRightmostFarmObjectTileX());
+        }
+
+        [TestMethod]
+        public void GetRightmostFarmObjectTileX_TakesMaxAcrossBuildingsAndTilledTiles()
+        {
+            // CropStorage footprint spans anchor.X-1 .. anchor.X+1 → east edge 128
+            _buildingService.AddBuilding(new PlacedBuilding
+            {
+                Type = BuildingType.CropStorage,
+                TileX = 127,
+                TileY = 2,
+                UniqueId = _buildingService.AllocateId()
+            });
+            _tileState.SetFlag(new Point(135, 5), TileStateFlag.Tilled);
+            _tileState.SetFlag(new Point(132, 6), TileStateFlag.ReadyToTill);
+
+            Assert.AreEqual(135, _coordinator.GetRightmostFarmObjectTileX());
+        }
+
+        [TestMethod]
         public void TryGetNearestFieldTile_FalseWhenNoFieldExists()
         {
             Assert.IsFalse(_coordinator.TryGetNearestFieldTile(new Point(130, 5), out _));

--- a/PitHero.Tests/JobStartingWeaponsTests.cs
+++ b/PitHero.Tests/JobStartingWeaponsTests.cs
@@ -1,0 +1,95 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RolePlayingFramework.Equipment;
+using RolePlayingFramework.Jobs;
+using RolePlayingFramework.Stats;
+using PitHero;
+
+namespace PitHero.Tests
+{
+    [TestClass]
+    public class JobStartingWeaponsTests
+    {
+        [TestMethod]
+        public void Knight_StartsWithRustyBlade()
+        {
+            var weapon = JobStartingWeapons.CreateStartingWeapon(JobType.Knight);
+
+            Assert.IsNotNull(weapon);
+            Assert.AreEqual(InventoryTextKey.Inv_RustyBlade_Name, weapon.Name);
+            Assert.AreEqual(ItemKind.WeaponSword, weapon.Kind);
+        }
+
+        [TestMethod]
+        public void Thief_StartsWithRustyDagger()
+        {
+            var weapon = JobStartingWeapons.CreateStartingWeapon(JobType.Thief);
+
+            Assert.IsNotNull(weapon);
+            Assert.AreEqual(InventoryTextKey.Inv_RustyDagger_Name, weapon.Name);
+            Assert.AreEqual(ItemKind.WeaponKnife, weapon.Kind);
+        }
+
+        [TestMethod]
+        public void Mage_StartsWithRustyDagger()
+        {
+            var weapon = JobStartingWeapons.CreateStartingWeapon(JobType.Mage);
+
+            Assert.IsNotNull(weapon);
+            Assert.AreEqual(InventoryTextKey.Inv_RustyDagger_Name, weapon.Name);
+            Assert.AreEqual(ItemKind.WeaponKnife, weapon.Kind);
+        }
+
+        [TestMethod]
+        public void Priest_StartsWithMallet()
+        {
+            var weapon = JobStartingWeapons.CreateStartingWeapon(JobType.Priest);
+
+            Assert.IsNotNull(weapon);
+            Assert.AreEqual(InventoryTextKey.Inv_Mallet_Name, weapon.Name);
+            Assert.AreEqual(ItemKind.WeaponHammer, weapon.Kind);
+        }
+
+        [TestMethod]
+        public void MonkAndArcher_HaveNoStartingWeaponYet()
+        {
+            // TODO(issue #317): remove once WeaponKnuckle/WeaponBow items exist
+            Assert.IsNull(JobStartingWeapons.CreateStartingWeapon(JobType.Monk));
+            Assert.IsNull(JobStartingWeapons.CreateStartingWeapon(JobType.Archer));
+        }
+
+        [TestMethod]
+        public void None_ReturnsNull()
+        {
+            Assert.IsNull(JobStartingWeapons.CreateStartingWeapon(JobType.None));
+        }
+
+        [TestMethod]
+        public void StartingWeapons_AreEquippableByTheirJob()
+        {
+            var jobFlags = new[] { JobType.Knight, JobType.Thief, JobType.Mage, JobType.Priest };
+            for (int i = 0; i < jobFlags.Length; i++)
+            {
+                var weapon = JobStartingWeapons.CreateStartingWeapon(jobFlags[i]);
+                Assert.IsNotNull(weapon);
+                Assert.IsTrue((weapon.AllowedJobs & jobFlags[i]) != 0,
+                    $"{jobFlags[i]} cannot equip its own starting weapon");
+            }
+        }
+
+        [TestMethod]
+        public void Hero_TryEquip_StartingWeapon_Succeeds()
+        {
+            var jobNames = new[] { "Knight", "Thief", "Mage", "Priest" };
+            for (int i = 0; i < jobNames.Length; i++)
+            {
+                var job = JobFactory.CreateJob(jobNames[i]);
+                var hero = new RolePlayingFramework.Heroes.Hero("Test", job, 1, new StatBlock(4, 3, 5, 1));
+                var weapon = JobStartingWeapons.CreateStartingWeapon(job.JobFlag);
+
+                Assert.IsNotNull(weapon);
+                Assert.IsTrue(hero.TryEquip(weapon), $"{jobNames[i]} failed to equip starting weapon");
+                Assert.AreSame(weapon, hero.WeaponShield1);
+            }
+        }
+    }
+}

--- a/PitHero/ECS/Components/FarmingMonsterStateMachine.cs
+++ b/PitHero/ECS/Components/FarmingMonsterStateMachine.cs
@@ -1206,6 +1206,17 @@ namespace PitHero.ECS.Components
         {
             var pathfinder = _coordinator.Pathfinder;
 
+            // Idle wander is bounded east by the rightmost farm object (building or tilled tile)
+            // plus a small margin, so monsters don't roam far past the developed farm.
+            int maxWanderX = pathfinder.Width - 1;
+            var rightmostFarmObjectX = _coordinator.GetRightmostFarmObjectTileX();
+            if (rightmostFarmObjectX >= 0)
+            {
+                maxWanderX = rightmostFarmObjectX + GameConfig.FarmWanderMaxEastOffsetTiles;
+                if (maxWanderX < GameConfig.FarmMinWanderTileX) maxWanderX = GameConfig.FarmMinWanderTileX;
+                else if (maxWanderX > pathfinder.Width - 1) maxWanderX = pathfinder.Width - 1;
+            }
+
             // Idle monsters hang around the field rather than roaming the whole farm
             if (_coordinator.TryGetNearestFieldTile(_mover.CurrentTile, out var fieldTile))
             {
@@ -1215,7 +1226,7 @@ namespace PitHero.ECS.Components
                     int x = fieldTile.X + Nez.Random.Range(-r, r + 1);
                     int y = fieldTile.Y + Nez.Random.Range(-r, r + 1);
                     if (x < GameConfig.FarmMinWanderTileX) x = GameConfig.FarmMinWanderTileX;
-                    else if (x >= pathfinder.Width) x = pathfinder.Width - 1;
+                    else if (x > maxWanderX) x = maxWanderX;
                     if (y < 1) y = 1;
                     else if (y > pathfinder.Height - 2) y = pathfinder.Height - 2;
                     var goal = new Point(x, y);
@@ -1229,7 +1240,7 @@ namespace PitHero.ECS.Components
             // No field yet (or all nearby spots unreachable) — wander anywhere on the farm
             for (int attempt = 0; attempt < 8; attempt++)
             {
-                int x = Nez.Random.Range(GameConfig.FarmMinWanderTileX, pathfinder.Width);
+                int x = Nez.Random.Range(GameConfig.FarmMinWanderTileX, maxWanderX + 1);
                 int y = Nez.Random.Range(1, pathfinder.Height - 1);
                 var goal = new Point(x, y);
                 if (goal == _mover.CurrentTile)

--- a/PitHero/ECS/Components/FarmingMonsterStateMachine.cs
+++ b/PitHero/ECS/Components/FarmingMonsterStateMachine.cs
@@ -1209,7 +1209,7 @@ namespace PitHero.ECS.Components
             // Idle wander is bounded east by the rightmost farm object (building or tilled tile)
             // plus a small margin, so monsters don't roam far past the developed farm.
             int maxWanderX = pathfinder.Width - 1;
-            var rightmostFarmObjectX = _coordinator.GetRightmostFarmObjectTileX();
+            var rightmostFarmObjectX = _coordinator.RightmostFarmObjectTileX;
             if (rightmostFarmObjectX >= 0)
             {
                 maxWanderX = rightmostFarmObjectX + GameConfig.FarmWanderMaxEastOffsetTiles;

--- a/PitHero/ECS/Components/HeroComponent.cs
+++ b/PitHero/ECS/Components/HeroComponent.cs
@@ -635,6 +635,17 @@ namespace PitHero.ECS.Components
             {
                 for (int i = 0; i < GameConfig.NewGameStartingHPPotions; i++)
                     TryAddItem(PotionItems.HPPotion());
+                for (int i = 0; i < GameConfig.NewGameStartingMPPotions; i++)
+                    TryAddItem(PotionItems.MPPotion());
+
+                // Pre-equip the job's weakest weapon (issue #316); fall back to the bag if equip fails
+                if (LinkedHero != null)
+                {
+                    var startingWeapon = JobStartingWeapons.CreateStartingWeapon(LinkedHero.Job.JobFlag);
+                    if (startingWeapon != null && !LinkedHero.TryEquip(startingWeapon))
+                        TryAddItem(startingWeapon);
+                }
+
                 GrantNewGameStartingItems = false;
             }
 

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -387,6 +387,10 @@ namespace PitHero.ECS.Scenes
             if (buildingService != null)
                 buildingService.NextId = pendingData.NextBuildingId;
 
+            // Tile flags restored from a save don't raise per-tile events, so re-derive the idle
+            // wander bound now that both buildings and tile states are in place
+            Core.Services.GetService<Services.FarmTaskCoordinator>()?.RecalculateRightmostFarmObject();
+
             // Restore harvested-crop storage inventories (keyed by building UniqueId, so after buildings)
             var cropStorageService = Core.Services.GetService<Services.CropStorageInventoryService>();
             if (cropStorageService != null)

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -293,6 +293,37 @@ namespace PitHero.ECS.Scenes
             _isInitializationComplete = true;
         }
 
+        /// <summary>Spawns the scripted new-game farm content: Monster House + Crop Storage + starter farming Slime (issue #316).</summary>
+        private void SetupNewGameFarmContent()
+        {
+            var buildingService = Core.Services.GetService<Services.BuildingService>();
+            if (buildingService == null || _buildingModeOverlay == null)
+                return;
+
+            var houseId = buildingService.AllocateId();
+            _buildingModeOverlay.SpawnRestoredBuilding(Util.BuildingType.MonsterHouse,
+                GameConfig.NewGameMonsterHouseAnchorTileX, GameConfig.NewGameMonsterHouseAnchorTileY, houseId);
+
+            var storageId = buildingService.AllocateId();
+            _buildingModeOverlay.SpawnRestoredBuilding(Util.BuildingType.CropStorage,
+                GameConfig.NewGameCropStorageAnchorTileX, GameConfig.NewGameCropStorageAnchorTileY, storageId);
+
+            var alliedManager = Core.Services.GetService<AlliedMonsterManager>();
+            if (alliedManager != null)
+            {
+                var starter = new AlliedMonster(NameGenerator.GenerateFirstName(), MonsterTextKey.Monster_Slime,
+                    GameConfig.NewGameStarterSlimeFishingProficiency,
+                    GameConfig.NewGameStarterSlimeCookingProficiency,
+                    GameConfig.NewGameStarterSlimeFarmingProficiency,
+                    houseId);
+                // Scripted pre-assignment unique to this starter monster; recruits/purchases stay Job=None
+                starter.Job = MonsterJob.Farming;
+                alliedManager.AddAlliedMonster(starter);
+                // A housed monster implies its type was defeated (issue #283 invariant)
+                Core.Services.GetService<DefeatedMonsterService>()?.MarkDefeatedByTypeName(MonsterTextKey.Monster_Slime);
+            }
+        }
+
         /// <summary>Applies pending save data to restore game state after scene initialization.</summary>
         private void ApplyPendingLoadData()
         {
@@ -300,6 +331,7 @@ namespace PitHero.ECS.Scenes
             if (pendingData == null)
             {
                 Core.Services.GetService<SaveLoadService>()?.ResetForNewGame();
+                SetupNewGameFarmContent();
                 return;
             }
 

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -141,6 +141,7 @@ namespace PitHero
         public const float TillProficiencySpeedStep = 0.06f;   // till duration reduced 6% per proficiency point above 1
         public const float FarmMonsterIdlePollInterval = 0.25f; // seconds between queue checks while idle
         public const int FarmWanderRadiusTiles = 4;             // idle wander stays within this radius of the nearest field tile
+        public const int FarmWanderMaxEastOffsetTiles = 5;      // idle wander goes at most this many tiles east of the rightmost farm object (building or tilled tile)
         public const float HarvestWaitSeconds = 5f;             // worker waits this long on the crop tile before harvesting
         public const float AppleHarvestWaitSeconds = 2f;        // worker waits this long under an apple tree before jumping
         public const float AppleHarvestJumpDurationSeconds = 0.6f; // duration of the apple-picking jump arc

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -230,6 +230,22 @@ namespace PitHero
         // New-game starting resources
         public const int NewGameStartingGold = 200; // Gold the player starts with in a new game
         public const int NewGameStartingHPPotions = 5; // HPPotions in the hero's bag at new game start
+        public const int NewGameStartingMPPotions = 5; // MPPotions in the hero's bag at new game start
+        public const int NewGameStartingWheatSeeds = 12; // Wheat seeds in the seed inventory at new game start
+        public const int NewGameStartingTomatoSeeds = 6; // Tomato seeds in the seed inventory at new game start
+        public const int NewGameStartingAppleTreeSeeds = 2; // Apple tree seeds in the seed inventory at new game start
+
+        // New-game starting farm buildings (issue #316). Anchor tiles; footprints span
+        // MonsterHouse tiles 121-125 x 0-4 and CropStorage tiles 126-128 x 0-3.
+        public const int NewGameMonsterHouseAnchorTileX = 123;
+        public const int NewGameMonsterHouseAnchorTileY = 2;
+        public const int NewGameCropStorageAnchorTileX = 127;
+        public const int NewGameCropStorageAnchorTileY = 2;
+
+        // Starter farming Slime housed in the new-game Monster House (proficiencies 1-9)
+        public const int NewGameStarterSlimeFarmingProficiency = 7;
+        public const int NewGameStarterSlimeFishingProficiency = 3;
+        public const int NewGameStarterSlimeCookingProficiency = 3;
 
         // Render Layers (the lower the number, the higher the layer)
 

--- a/PitHero/RolePlayingFramework/Equipment/JobStartingWeapons.cs
+++ b/PitHero/RolePlayingFramework/Equipment/JobStartingWeapons.cs
@@ -1,0 +1,30 @@
+using RolePlayingFramework.Equipment.Daggers;
+using RolePlayingFramework.Equipment.Hammers;
+using RolePlayingFramework.Equipment.Swords;
+using RolePlayingFramework.Jobs;
+
+namespace RolePlayingFramework.Equipment
+{
+    /// <summary>Maps each primary job to the weakest weapon it can equip, granted pre-equipped at new game start (issue #316).</summary>
+    public static class JobStartingWeapons
+    {
+        /// <summary>Returns a new instance of the job's starting weapon, or null if the job has no equippable weapon.</summary>
+        public static Gear CreateStartingWeapon(JobType jobFlag)
+        {
+            switch (jobFlag)
+            {
+                case JobType.Knight:
+                    return RustyBlade.Create();
+                case JobType.Thief:
+                case JobType.Mage:
+                    return RustyDagger.Create();
+                case JobType.Priest:
+                    return Mallet.Create();
+                // TODO(issue #317): Monk (WeaponKnuckle) and Archer (WeaponBow) have no
+                // equippable weapon items yet — map their weakest weapon here once one exists.
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/PitHero/Services/FarmTaskCoordinator.cs
+++ b/PitHero/Services/FarmTaskCoordinator.cs
@@ -713,6 +713,38 @@ namespace PitHero.Services
             return best != long.MaxValue;
         }
 
+        /// <summary>
+        /// Rightmost tile X occupied by any farm object — a placed building (using its footprint's
+        /// east edge) or a tilled/ready-to-till tile. Governs how far east idle monsters may wander.
+        /// Returns -1 when no farm objects exist.
+        /// </summary>
+        public int GetRightmostFarmObjectTileX()
+        {
+            int max = -1;
+
+            var buildings = _buildingService.GetAll();
+            for (int i = 0; i < buildings.Count; i++)
+            {
+                var b = buildings[i];
+                var bounds = Util.BuildingConfig.GetFootprintBounds(b.Type);
+                int right = b.TileX + bounds.dxMax;
+                if (right > max)
+                    max = right;
+            }
+
+            var enumerator = _tileState.GetAllStates().GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                if ((enumerator.Current.Value & (TileStateFlag.Tilled | TileStateFlag.ReadyToTill)) == 0)
+                    continue;
+                if (enumerator.Current.Key.X > max)
+                    max = enumerator.Current.Key.X;
+            }
+            enumerator.Dispose();
+
+            return max;
+        }
+
         private void HandleReadyToTillSet(Point tile)
         {
             if (_tracked.Add(tile))

--- a/PitHero/Services/FarmTaskCoordinator.cs
+++ b/PitHero/Services/FarmTaskCoordinator.cs
@@ -92,6 +92,7 @@ namespace PitHero.Services
                 _tilledTileService.OnTileTilled += HandleTileTilled;
 
             RescanReadyToTill();
+            RecalculateRightmostFarmObject();
         }
 
         /// <summary>Unsubscribes from service events. Call when the scene is torn down.</summary>
@@ -716,9 +717,19 @@ namespace PitHero.Services
         /// <summary>
         /// Rightmost tile X occupied by any farm object — a placed building (using its footprint's
         /// east edge) or a tilled/ready-to-till tile. Governs how far east idle monsters may wander.
-        /// Returns -1 when no farm objects exist.
+        /// -1 when no farm objects exist. Maintained incrementally from building/tile events so the
+        /// wander logic can read it every tick without scanning.
         /// </summary>
-        public int GetRightmostFarmObjectTileX()
+        public int RightmostFarmObjectTileX => _rightmostFarmObjectTileX;
+
+        private int _rightmostFarmObjectTileX = -1;
+
+        /// <summary>
+        /// Full rescan of buildings and tilled/ready-to-till tiles. Called from the constructor,
+        /// on shrink events (building changes, rightmost designation cleared), and after a save is
+        /// loaded (tile flags restored from a save don't raise per-tile events).
+        /// </summary>
+        public void RecalculateRightmostFarmObject()
         {
             int max = -1;
 
@@ -742,11 +753,13 @@ namespace PitHero.Services
             }
             enumerator.Dispose();
 
-            return max;
+            _rightmostFarmObjectTileX = max;
         }
 
         private void HandleReadyToTillSet(Point tile)
         {
+            if (tile.X > _rightmostFarmObjectTileX)
+                _rightmostFarmObjectTileX = tile.X;
             if (_tracked.Add(tile))
                 _queue.AddBack(new FarmAction { Type = FarmActionType.Till, TargetTile = tile });
         }
@@ -758,10 +771,18 @@ namespace PitHero.Services
             bool claimed = _tracked.Contains(tile) && !IsQueued(tile);
             if (!claimed)
                 _tracked.Remove(tile);
+
+            // Only a clear at the cached east edge can shrink the wander bound; anything left of
+            // it can't change the max. (Till completion clears here then re-raises via OnTileTilled.)
+            if (tile.X >= _rightmostFarmObjectTileX)
+                RecalculateRightmostFarmObject();
         }
 
         private void HandleTileTilled(Point tile)
         {
+            if (tile.X > _rightmostFarmObjectTileX)
+                _rightmostFarmObjectTileX = tile.X;
+
             var cropPlanting = GetService<CropPlantingService>();
             if (cropPlanting == null || !cropPlanting.HasPlan(tile))
                 return;
@@ -772,6 +793,9 @@ namespace PitHero.Services
         private void HandleBuildingsChanged()
         {
             Pathfinder.RebuildWalls(_buildingService);
+
+            // Building placement/removal is rare, so a full rescan of the wander bound is fine here
+            RecalculateRightmostFarmObject();
 
             // Retry tiles that were unreachable — a new building can't help, but this also covers
             // future building moves/removals; tiles still ReadyToTill simply re-enter the queue.

--- a/PitHero/Services/SaveData.cs
+++ b/PitHero/Services/SaveData.cs
@@ -496,7 +496,9 @@ namespace PitHero.Services
             TileStates = new List<SavedTileState>();
             PlacedBuildings = new List<SavedBuilding>();
             SeedInventory = new int[Farming.CropTypeInfo.Count];
-            SeedInventory[(int)Farming.CropType.Wheat] = 5;
+            SeedInventory[(int)Farming.CropType.Wheat]     = GameConfig.NewGameStartingWheatSeeds;
+            SeedInventory[(int)Farming.CropType.Tomato]    = GameConfig.NewGameStartingTomatoSeeds;
+            SeedInventory[(int)Farming.CropType.AppleTree] = GameConfig.NewGameStartingAppleTreeSeeds;
             CropPlans = new List<SavedCropPlan>();
             NextBuildingId = 1;
             CropGrowthStates = new List<SavedCropGrowthState>();

--- a/PitHero/UI/SeedPlantingModeOverlay.cs
+++ b/PitHero/UI/SeedPlantingModeOverlay.cs
@@ -83,7 +83,9 @@ namespace PitHero.UI
             _cropsAtlas = Core.Content.LoadSpriteAtlas("Content/Atlases/CropsProps.atlas");
 
             _seedInventory = new int[CropTypeInfo.Count];
-            _seedInventory[(int)CropType.Wheat] = 5;
+            _seedInventory[(int)CropType.Wheat]     = GameConfig.NewGameStartingWheatSeeds;
+            _seedInventory[(int)CropType.Tomato]    = GameConfig.NewGameStartingTomatoSeeds;
+            _seedInventory[(int)CropType.AppleTree] = GameConfig.NewGameStartingAppleTreeSeeds;
 
             CreateInventoryWindow();
 


### PR DESCRIPTION
Closes #316.

New games now start with a small pre-built farm:

- **Monster House** occupying tiles 121–125 × 0–4 (anchor 123,2) and **Crop Storage** occupying tiles 126–128 × 0–3 (anchor 127,2). The issue's "121,0"/"126,0" are interpreted as top-left corners so both buildings fit fully inside the farm zone; spawned via the same no-cost `SpawnRestoredBuilding` path the load-restore uses.
- **Starter Slime** housed in the Monster House with Farming proficiency **7** (fishing/cooking fixed at 3 for a deterministic start) and `Job` pre-assigned to **Farming** — `FarmTaskCoordinator` auto-spawns its farm worker with no extra wiring. Recruit/purchase paths still default to `Job = None`; the pre-assignment applies only to this scripted monster. Its type is also marked in `DefeatedMonsterService` to keep the #283 invariant (housed ⇒ defeated) true before the first save.
- **Seeds:** 12 wheat, 6 tomato, 2 apple tree (was 5 wheat).
- **Potions:** 5 HP + 5 MP (was 5 HP only).
- **Starting weapon:** each job begins with the strictly weakest weapon it can equip, pre-equipped via new AOT-safe `JobStartingWeapons`: Knight → Rusty Blade, Thief/Mage → Rusty Dagger, Priest → Mallet. **Monk and Archer have no weapon items at all (no WeaponKnuckle/WeaponBow gear exists) — tracked in #317**, which also notes `Hero.TryEquip` lacks a `WeaponBow` case.

Also in this PR:

- **Idle wander east bound:** idle farming monsters no longer roam to the map's east edge. Wander targets are clamped to at most **5 tiles east of the rightmost farm object** — a placed building (using its footprint's east edge) or a tilled/ready-to-till tile — via new `FarmTaskCoordinator.GetRightmostFarmObjectTileX()`. Falls back to the previous full-farm range when no farm objects exist.

All counts/positions are centralized as `GameConfig.NewGame*` / `GameConfig.Farm*` constants. Everything persists under the existing save v17 format — no save-format change; loading an existing save gains none of this content.

## Testing

- `dotnet test PitHero.Tests`: 1486 passed, 0 failed (baseline 0), including new `JobStartingWeaponsTests` (per-job mapping, job-restriction check, real `Hero.TryEquip` round-trip) and `FarmTaskCoordinatorTests` coverage of the rightmost-farm-object computation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)