### PR TITLE
Page the Monsters and Harvested Crops aggregate UIs

### DIFF
--- a/PitHero.Tests/UI/PageCursorTests.cs
+++ b/PitHero.Tests/UI/PageCursorTests.cs
@@ -1,0 +1,120 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.UI;
+
+namespace PitHero.Tests.UI
+{
+    /// <summary>
+    /// Covers the page arithmetic behind the "&lt; n &gt;" pager used by the aggregate Harvested Crops
+    /// and Monsters views: wraparound in both directions, and clamping when pages disappear because a
+    /// building was sold while the window was closed.
+    /// </summary>
+    [TestClass]
+    public class PageCursorTests
+    {
+        private static PageCursor NewCursor(int pageCount)
+        {
+            var cursor = new PageCursor();
+            cursor.SetPageCount(pageCount);
+            return cursor;
+        }
+
+        [TestMethod]
+        public void SetPageCount_StartsOnFirstPage()
+        {
+            Assert.AreEqual(0, NewCursor(3).PageIndex, "A freshly configured cursor should show page 1");
+        }
+
+        [TestMethod]
+        public void Next_AdvancesThenWrapsToFirstPage()
+        {
+            var cursor = NewCursor(3);
+
+            cursor.Next();
+            Assert.AreEqual(1, cursor.PageIndex);
+            cursor.Next();
+            Assert.AreEqual(2, cursor.PageIndex);
+            cursor.Next();
+            Assert.AreEqual(0, cursor.PageIndex, "Advancing past the last page should wrap to the first");
+        }
+
+        [TestMethod]
+        public void Previous_FromFirstPageWrapsToLastPage()
+        {
+            var cursor = NewCursor(3);
+
+            cursor.Previous();
+            Assert.AreEqual(2, cursor.PageIndex, "Going back from page 1 should wrap to the last page");
+        }
+
+        [TestMethod]
+        public void Step_IsANoOpWithASinglePage()
+        {
+            var cursor = NewCursor(1);
+
+            Assert.IsFalse(cursor.Next(), "A single page has nowhere to step to");
+            Assert.IsFalse(cursor.Previous(), "A single page has nowhere to step to");
+            Assert.AreEqual(0, cursor.PageIndex);
+            Assert.IsFalse(cursor.HasMultiplePages, "A single page should hide the pager");
+        }
+
+        [TestMethod]
+        public void Step_IsANoOpWithNoPages()
+        {
+            var cursor = NewCursor(0);
+
+            Assert.IsFalse(cursor.Next());
+            Assert.AreEqual(0, cursor.PageIndex, "A cursor with no pages should stay at index 0");
+            Assert.IsFalse(cursor.HasMultiplePages, "No pages should hide the pager");
+        }
+
+        [TestMethod]
+        public void HasMultiplePages_IsTrueOnlyBeyondOnePage()
+        {
+            Assert.IsTrue(NewCursor(2).HasMultiplePages, "Two buildings should show the pager");
+        }
+
+        [TestMethod]
+        public void SetPageCount_ClampsWhenPageCountShrinks()
+        {
+            var cursor = NewCursor(4);
+            cursor.Previous();
+            Assert.AreEqual(3, cursor.PageIndex);
+
+            // Two storages sold while the window was closed.
+            cursor.SetPageCount(2);
+            Assert.AreEqual(1, cursor.PageIndex, "The page index should clamp to the new last page");
+        }
+
+        [TestMethod]
+        public void SetPageCount_ClampsToZeroWhenEveryPageDisappears()
+        {
+            var cursor = NewCursor(3);
+            cursor.Next();
+
+            cursor.SetPageCount(0);
+            Assert.AreEqual(0, cursor.PageIndex, "With no pages left the index should fall back to 0");
+        }
+
+        [TestMethod]
+        public void SetPageCount_KeepsThePageWhenTheCountGrows()
+        {
+            var cursor = NewCursor(2);
+            cursor.Next();
+            Assert.AreEqual(1, cursor.PageIndex);
+
+            cursor.SetPageCount(5);
+            Assert.AreEqual(1, cursor.PageIndex, "Adding a storage should not move the player off their page");
+        }
+
+        [TestMethod]
+        public void Reset_ReturnsToTheFirstPage()
+        {
+            var cursor = NewCursor(3);
+            cursor.Next();
+            Assert.AreEqual(1, cursor.PageIndex);
+
+            cursor.Reset();
+            Assert.AreEqual(0, cursor.PageIndex, "Reset should return the cursor to page 1");
+        }
+    }
+}

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -316,6 +316,7 @@ AddMonsterConfirmPrompt,Add {0} for {1} Gold
 # Crop Storage options (issue #285)
 ButtonMoveAllCrops,Move all crops
 ButtonSellAllCrops,Sell all crops
+ButtonSellTheseCrops,Sell these crops
 ButtonSellBuilding,Sell building
 ButtonSell,Sell
 DialogMoveCropsPrompt,Really move and redistribute crops to other storages?

--- a/PitHero/UI/HarvestedCropsModeOverlay.cs
+++ b/PitHero/UI/HarvestedCropsModeOverlay.cs
@@ -53,6 +53,8 @@ namespace PitHero.UI
         // One page is 4 rows of 44px (40px slot + 2px pad each side), so 224 fits a full storage
         // without scrolling while keeping the window clear of the top of the screen.
         private const float ScrollHeight = 224f;
+        // Upward nudge off centre so the window clears the bottom UI bars.
+        private const float CenterYBias  = 30f;
 
         // When >= 0, only this Crop Storage building's slots are shown (UniqueId).
         private int _filterBuildingId = -1;
@@ -406,9 +408,21 @@ namespace PitHero.UI
             _inventoryWindow.Pack();
             float w = _inventoryWindow.GetWidth();
             float h = _inventoryWindow.GetHeight();
-            _inventoryWindow.SetPosition(
-                (_stage.GetWidth()  - w) / 2f,
-                (_stage.GetHeight() - h) / 2f - 30f);
+            float stageW = _stage.GetWidth();
+            float stageH = _stage.GetHeight();
+
+            // Sits slightly above centre to clear the bottom UI bars, then is clamped to the stage so a
+            // taller window — an extra button row, a larger slot grid — can never run off the top.
+            float x = (stageW - w) / 2f;
+            float y = (stageH - h) / 2f - CenterYBias;
+            if (y + h > stageH)
+                y = stageH - h;
+            if (y < 0f)
+                y = 0f;
+            if (x < 0f)
+                x = 0f;
+
+            _inventoryWindow.SetPosition(x, y);
             _inventoryWindow.SetVisible(true);
         }
 

--- a/PitHero/UI/HarvestedCropsModeOverlay.cs
+++ b/PitHero/UI/HarvestedCropsModeOverlay.cs
@@ -34,17 +34,25 @@ namespace PitHero.UI
         private CropType _descCropType;
         private int _descCount;
 
-        // Bottom-row buttons. "Sell all" (aggregate) shows only in the all-storages view; "Move all"
-        // and "Sell all" (this storage) show only in the per-storage view.
+        // Bottom-row buttons. "Sell all crops" (aggregate) shows only in the all-storages view;
+        // "Move all crops" and "Sell these crops" act on the storage currently shown.
         private TextButton _sellAllButton;      // aggregate — sells across every storage
         private TextButton _moveAllButton;      // per-storage — redistribute to other storages
-        private TextButton _sellStorageButton;  // per-storage — sell this storage's crops
+        private TextButton _sellStorageButton;  // per-storage — sell the shown storage's crops
         private TextButton _closeButton;
         private Table _buttonRow;
 
-        private const float SlotSize = 40f;
-        private const float WinPad   = 16f;
-        private const int   Columns  = 8;
+        // Aggregate view only: one page per Crop Storage building. Empty in the per-building view.
+        private PagerRow _pagerRow;
+
+        private const float SlotSize     = 40f;
+        private const float WinPad       = 16f;
+        private const int   Columns      = 8;
+        private const float ButtonWidth  = 110f;
+        private const float ButtonHeight = 16f;
+        // One page is 4 rows of 44px (40px slot + 2px pad each side), so 224 fits a full storage
+        // without scrolling while keeping the window clear of the top of the screen.
+        private const float ScrollHeight = 224f;
 
         // When >= 0, only this Crop Storage building's slots are shown (UniqueId).
         private int _filterBuildingId = -1;
@@ -76,38 +84,99 @@ namespace PitHero.UI
         /// <summary>Called when the player enters harvested-crops mode; rebuilds and shows the grid.</summary>
         public void OnEnterHarvestedCropsMode()
         {
+            RefreshViewer();
+        }
+
+        /// <summary>
+        /// Re-lays out the pager and button row for the storage now being shown, rebuilds its slot grid
+        /// and re-packs the window. The pager is laid out first because everything downstream reads the
+        /// page index, which Configure clamps.
+        /// </summary>
+        private void RefreshViewer()
+        {
+            LayoutPager();
             LayoutButtonRow();
             RebuildSlots();
             ShowInventoryWindow();
         }
 
         /// <summary>
-        /// Rebuilds the bottom button row. The all-storages (aggregate) view offers "Sell all crops"
-        /// across every storage; the per-storage view offers "Move all crops" (when another storage
-        /// exists) and "Sell all crops" for that one storage — both only while it holds crops.
+        /// Points the pager at one page per Crop Storage. Only the aggregate view is paged — the
+        /// per-building view opened from the building context menu already shows a single storage.
+        /// </summary>
+        private void LayoutPager()
+        {
+            int pageCount = _filterBuildingId >= 0
+                ? 0
+                : GetStorageBuildings(Core.Services?.GetService<BuildingService>()).Count;
+            _pagerRow.Configure(pageCount);
+        }
+
+        /// <summary>
+        /// Rebuilds the bottom button row. "Sell all crops" (every storage at once) is offered only in
+        /// the aggregate view; "Move all crops" (when another storage exists) and "Sell these crops"
+        /// act on the storage currently shown, and appear only while it holds crops.
         /// </summary>
         private void LayoutButtonRow()
         {
             _buttonRow.Clear();
             var storage = Core.Services.GetService<CropStorageInventoryService>();
             var buildingService = Core.Services.GetService<BuildingService>();
-            if (_filterBuildingId < 0)
-            {
-                // Aggregate view: offer "Sell all" only when at least one storage holds crops.
-                if (AnyStorageHasCrops(storage, buildingService))
-                    _buttonRow.Add(_sellAllButton).Width(120f).SetPadRight(8f);
-            }
-            else
-            {
-                bool hasCrops = storage != null && !storage.IsEmpty(_filterBuildingId);
-                bool otherStorageExists = (buildingService?.CropStorageCount ?? 0) > 1;
 
-                if (hasCrops && otherStorageExists)
-                    _buttonRow.Add(_moveAllButton).Width(120f).SetPadRight(8f);
-                if (hasCrops)
-                    _buttonRow.Add(_sellStorageButton).Width(120f).SetPadRight(8f);
+            if (_filterBuildingId < 0 && AnyStorageHasCrops(storage, buildingService))
+                _buttonRow.Add(_sellAllButton).Width(ButtonWidth).SetMinHeight(ButtonHeight).SetPadRight(8f);
+
+            int shownId = CurrentPageBuildingId;
+            bool hasCrops = storage != null && shownId >= 0 && !storage.IsEmpty(shownId);
+            bool otherStorageExists = (buildingService?.CropStorageCount ?? 0) > 1;
+
+            if (hasCrops && otherStorageExists)
+                _buttonRow.Add(_moveAllButton).Width(ButtonWidth).SetMinHeight(ButtonHeight).SetPadRight(8f);
+            if (hasCrops)
+                _buttonRow.Add(_sellStorageButton).Width(ButtonWidth).SetMinHeight(ButtonHeight).SetPadRight(8f);
+
+            _buttonRow.Add(_closeButton).Width(100f).SetMinHeight(ButtonHeight);
+        }
+
+        /// <summary>
+        /// Crop Storage buildings in stable UniqueId order — the order pages are numbered in. Collapses
+        /// to the single filtered storage in the per-building view.
+        /// </summary>
+        private System.Collections.Generic.List<PlacedBuilding> GetStorageBuildings(BuildingService buildingService)
+        {
+            var result = new System.Collections.Generic.List<PlacedBuilding>();
+            if (buildingService == null)
+                return result;
+
+            var all = buildingService.GetAll();
+            for (int i = 0; i < all.Count; i++)
+            {
+                if (all[i].Type != BuildingType.CropStorage)
+                    continue;
+                if (_filterBuildingId >= 0 && all[i].UniqueId != _filterBuildingId)
+                    continue;
+                result.Add(all[i]);
             }
-            _buttonRow.Add(_closeButton).Width(100f);
+            result.Sort((a, b) => a.UniqueId.CompareTo(b.UniqueId));
+            return result;
+        }
+
+        /// <summary>
+        /// UniqueId of the storage the per-storage actions apply to: the filtered building in the
+        /// per-building view, or the current page's building in the aggregate view. -1 when no storage
+        /// is being shown.
+        /// </summary>
+        private int CurrentPageBuildingId
+        {
+            get
+            {
+                if (_filterBuildingId >= 0)
+                    return _filterBuildingId;
+
+                var buildings = GetStorageBuildings(Core.Services?.GetService<BuildingService>());
+                int page = _pagerRow?.PageIndex ?? 0;
+                return (page >= 0 && page < buildings.Count) ? buildings[page].UniqueId : -1;
+            }
         }
 
         /// <summary>True if any Crop Storage building currently holds at least one harvested crop.</summary>
@@ -122,10 +191,10 @@ namespace PitHero.UI
             return false;
         }
 
-        /// <summary>Redistributes this storage's crops across the other storages (with confirmation).</summary>
+        /// <summary>Redistributes the shown storage's crops across the other storages (with confirmation).</summary>
         private void OnMoveAllStorageClicked()
         {
-            int buildingId = _filterBuildingId;
+            int buildingId = CurrentPageBuildingId;
             if (buildingId < 0)
                 return;
 
@@ -136,17 +205,15 @@ namespace PitHero.UI
                     Core.Services.GetService<CropStorageInventoryService>()
                         ?.MoveAllCropsToOtherStorages(buildingId);
                     _descWindow?.SetVisible(false);
-                    LayoutButtonRow();
-                    RebuildSlots();
-                    ShowInventoryWindow();
+                    RefreshViewer();
                 });
             dialog.Show(_stage);
         }
 
-        /// <summary>Sells every harvested crop in this one storage (with confirmation).</summary>
+        /// <summary>Sells every harvested crop in the shown storage (with confirmation).</summary>
         private void OnSellStorageClicked()
         {
-            int buildingId = _filterBuildingId;
+            int buildingId = CurrentPageBuildingId;
             var storage = Core.Services.GetService<CropStorageInventoryService>();
             if (buildingId < 0 || storage == null)
                 return;
@@ -159,7 +226,7 @@ namespace PitHero.UI
 
             int totalGold = gold;
             string prompt = string.Format(GetText(UITextKey.DialogSellStorageCropsPrompt), totalGold);
-            var dialog = new ConfirmationDialog(GetText(UITextKey.ButtonSellAllCrops), prompt,
+            var dialog = new ConfirmationDialog(GetText(UITextKey.ButtonSellTheseCrops), prompt,
                 PitHeroSkin.CreateSkin(),
                 onYes: () =>
                 {
@@ -176,9 +243,7 @@ namespace PitHero.UI
 #endif
                     storage.ClearBuilding(buildingId);
                     _descWindow?.SetVisible(false);
-                    LayoutButtonRow();
-                    RebuildSlots();
-                    ShowInventoryWindow();
+                    RefreshViewer();
                 });
             dialog.Show(_stage);
         }
@@ -229,9 +294,7 @@ namespace PitHero.UI
                         if (all[b].Type == BuildingType.CropStorage)
                             storage.ClearBuilding(all[b].UniqueId);
                     _descWindow?.SetVisible(false);
-                    LayoutButtonRow();
-                    RebuildSlots();
-                    ShowInventoryWindow();
+                    RefreshViewer();
                 });
             dialog.Show(_stage);
         }
@@ -242,6 +305,7 @@ namespace PitHero.UI
             _inventoryWindow?.SetVisible(false);
             _descWindow?.SetVisible(false);
             _filterBuildingId = -1;
+            _pagerRow?.Reset();
         }
 
         /// <summary>
@@ -268,7 +332,12 @@ namespace PitHero.UI
             _slotTable = new Table();
             var scroll = new ScrollPane(_slotTable, skin, "ph-default");
             scroll.SetScrollingDisabled(true, false);
-            outer.Add(scroll).Width(SlotSize * Columns + 48f).Height(240f);
+            outer.Add(scroll).Width(SlotSize * Columns + 48f).Height(ScrollHeight);
+            outer.Row();
+
+            _pagerRow = new PagerRow(skin);
+            _pagerRow.OnPageChanged += RefreshViewer;
+            outer.Add(_pagerRow);
             outer.Row();
 
             _buttonRow = new Table();
@@ -276,7 +345,7 @@ namespace PitHero.UI
             _sellAllButton.OnClicked += (_) => OnSellAllClicked();
             _moveAllButton = new TextButton(GetText(UITextKey.ButtonMoveAllCrops), skin, "ph-default");
             _moveAllButton.OnClicked += (_) => OnMoveAllStorageClicked();
-            _sellStorageButton = new TextButton(GetText(UITextKey.ButtonSellAllCrops), skin, "ph-default");
+            _sellStorageButton = new TextButton(GetText(UITextKey.ButtonSellTheseCrops), skin, "ph-default");
             _sellStorageButton.OnClicked += (_) => OnSellStorageClicked();
             _closeButton = new TextButton(GetText(UITextKey.ButtonClose), skin, "ph-default");
             _closeButton.OnClicked += (_) => RequestExitHarvestedCropsMode?.Invoke();
@@ -296,49 +365,38 @@ namespace PitHero.UI
             if (storage == null || buildingService == null)
                 return;
 
-            // Crop Storage buildings in stable UniqueId order so the grid layout never reshuffles.
-            var all = buildingService.GetAll();
-            var storageBuildings = new System.Collections.Generic.List<PlacedBuilding>();
-            for (int i = 0; i < all.Count; i++)
-            {
-                if (all[i].Type != BuildingType.CropStorage)
-                    continue;
-                if (_filterBuildingId >= 0 && all[i].UniqueId != _filterBuildingId)
-                    continue;
-                storageBuildings.Add(all[i]);
-            }
-            storageBuildings.Sort((a, b) => a.UniqueId.CompareTo(b.UniqueId));
+            // One storage per page, so the grid is always a single 8x4 block belonging to one building.
+            int buildingId = CurrentPageBuildingId;
+            if (buildingId < 0)
+                return;
 
+            var slots = storage.GetSlots(buildingId);
             int col = 0;
-            for (int b = 0; b < storageBuildings.Count; b++)
+            for (int s = 0; s < slots.Count; s++)
             {
-                var slots = storage.GetSlots(storageBuildings[b].UniqueId);
-                for (int s = 0; s < slots.Count; s++)
+                var slot = slots[s];
+                if (slot.IsEmpty)
                 {
-                    var slot = slots[s];
-                    if (slot.IsEmpty)
-                    {
-                        // Empty slot: render the inventory-slot background only.
-                        var blank = new HarvestSlotButton(null, slot.Type, 0, null);
-                        _slotTable.Add(blank).Size(SlotSize, SlotSize).Pad(2f);
-                    }
-                    else
-                    {
-                        var sprite = _cropsAtlas.GetSprite(CropConfig.GetHarvestSpriteName(slot.Type));
-                        var cell = new HarvestSlotButton(sprite, slot.Type, slot.Count,
-                            GetHarvestName(slot.Type));
-                        int capturedBuildingId = storageBuildings[b].UniqueId;
-                        int capturedSlot = s;
-                        var captured = slot.Type;
-                        int capturedCount = slot.Count;
-                        cell.OnClicked += () => ShowDescription(capturedBuildingId, capturedSlot, captured, capturedCount);
-                        _slotTable.Add(cell).Size(SlotSize, SlotSize).Pad(2f);
-                    }
-
-                    col++;
-                    if (col % Columns == 0)
-                        _slotTable.Row();
+                    // Empty slot: render the inventory-slot background only.
+                    var blank = new HarvestSlotButton(null, slot.Type, 0, null);
+                    _slotTable.Add(blank).Size(SlotSize, SlotSize).Pad(2f);
                 }
+                else
+                {
+                    var sprite = _cropsAtlas.GetSprite(CropConfig.GetHarvestSpriteName(slot.Type));
+                    var cell = new HarvestSlotButton(sprite, slot.Type, slot.Count,
+                        GetHarvestName(slot.Type));
+                    int capturedBuildingId = buildingId;
+                    int capturedSlot = s;
+                    var captured = slot.Type;
+                    int capturedCount = slot.Count;
+                    cell.OnClicked += () => ShowDescription(capturedBuildingId, capturedSlot, captured, capturedCount);
+                    _slotTable.Add(cell).Size(SlotSize, SlotSize).Pad(2f);
+                }
+
+                col++;
+                if (col % Columns == 0)
+                    _slotTable.Row();
             }
         }
 
@@ -434,9 +492,7 @@ namespace PitHero.UI
                         storage?.ClearSlot(buildingId, slotIndex);
                     }
                     _descWindow.SetVisible(false);
-                    LayoutButtonRow();
-                    RebuildSlots();
-                    ShowInventoryWindow();
+                    RefreshViewer();
                 });
             dialog.Show(_stage);
         }

--- a/PitHero/UI/MonsterUI.cs
+++ b/PitHero/UI/MonsterUI.cs
@@ -3,6 +3,7 @@ using Nez;
 using Nez.UI;
 using PitHero.Config;
 using PitHero.Services;
+using PitHero.Util;
 using RolePlayingFramework.AlliedMonsters;
 
 namespace PitHero.UI
@@ -33,6 +34,9 @@ namespace PitHero.UI
 
         // When >= 0, the roster is filtered to monsters living in this Monster House (UniqueId).
         private int _houseFilterId = -1;
+
+        // Aggregate view only: one page per Monster House. Empty in the per-house view.
+        private PagerRow _pagerRow;
 
         private const float SpriteSize = 32f;
         private static readonly Color BrownColor = new Color(71, 36, 7);
@@ -123,6 +127,7 @@ namespace PitHero.UI
         {
             // Normal toggle always shows the full roster.
             _houseFilterId = -1;
+            _pagerRow?.Reset();
 
             // Properly close Settings UI if it's open (single window policy)
             _settingsUI?.ForceCloseSettings();
@@ -155,7 +160,8 @@ namespace PitHero.UI
         private void CreateMonsterWindow(Skin skin)
         {
             _monsterWindow = new Window(GetText(TextType.UI, UITextKey.WindowMonsters), skin);
-            _monsterWindow.SetSize(460f, 280f);
+            // Nearly the full 360px virtual stage height, so the roster list fills the window.
+            _monsterWindow.SetSize(460f, 340f);
 
             _monsterListTable = new Table();
             _monsterListTable.Top().Left();
@@ -163,7 +169,18 @@ namespace PitHero.UI
             _scrollPane = new ScrollPane(_monsterListTable, skin, "ph-default");
             _scrollPane.SetScrollingDisabled(true, false);
             _scrollPane.SetFadeScrollBars(false);
-            _monsterWindow.Add(_scrollPane).Expand().Fill().Pad(4f);
+            // Content table so the pager can sit under the list without disturbing the window's title
+            // bar. The pager takes its height from the scroll pane's expanding cell, so the window keeps
+            // its fixed size whether or not there is more than one house to page through.
+            var content = new Table();
+            content.Add(_scrollPane).Expand().Fill().Pad(4f);
+            content.Row();
+
+            _pagerRow = new PagerRow(skin);
+            _pagerRow.OnPageChanged += RefreshMonsterList;
+            content.Add(_pagerRow).SetPadBottom(4f);
+
+            _monsterWindow.Add(content).Expand().Fill();
             _monsterWindow.SetVisible(false);
         }
 
@@ -191,7 +208,51 @@ namespace PitHero.UI
                 if (pauseService != null)
                     pauseService.IsPaused = false;
                 _houseFilterId = -1;
+                _pagerRow?.Reset();
             }
+        }
+
+        /// <summary>
+        /// Monster House buildings in stable UniqueId order — the order pages are numbered in.
+        /// </summary>
+        private System.Collections.Generic.List<PlacedBuilding> GetMonsterHouses()
+        {
+            var result = new System.Collections.Generic.List<PlacedBuilding>();
+            var buildingService = Core.Services?.GetService<BuildingService>();
+            if (buildingService == null)
+                return result;
+
+            var all = buildingService.GetAll();
+            for (int i = 0; i < all.Count; i++)
+                if (all[i].Type == BuildingType.MonsterHouse)
+                    result.Add(all[i]);
+
+            result.Sort((a, b) => a.UniqueId.CompareTo(b.UniqueId));
+            return result;
+        }
+
+        private static bool IsLiveHouse(System.Collections.Generic.List<PlacedBuilding> houses, int houseId)
+        {
+            for (int i = 0; i < houses.Count; i++)
+                if (houses[i].UniqueId == houseId)
+                    return true;
+            return false;
+        }
+
+        /// <summary>
+        /// Whether a monster belongs on the page currently shown. With no houses placed everything is
+        /// listed. Monsters carrying a dangling MonsterHouseId — recruited before house-linking, or
+        /// outliving a sold house, until FarmTaskCoordinator re-homes them — are folded onto page 1 so
+        /// that no monster becomes unreachable.
+        /// </summary>
+        private static bool ShouldShowMonster(AlliedMonster monster, int targetHouseId, bool foldOrphans,
+            System.Collections.Generic.List<PlacedBuilding> houses)
+        {
+            if (targetHouseId < 0)
+                return true;
+            if (monster.MonsterHouseId == targetHouseId)
+                return true;
+            return foldOrphans && !IsLiveHouse(houses, monster.MonsterHouseId);
         }
 
         private void RefreshMonsterList()
@@ -199,14 +260,32 @@ namespace PitHero.UI
             _monsterListTable.Clear();
             var manager = Core.Services.GetService<AlliedMonsterManager>();
 
-            // Count how many monsters will actually be shown (respecting any house filter).
+            // One page per Monster House in the aggregate view; the per-house view is never paged.
+            var houses = GetMonsterHouses();
+            _pagerRow.Configure(_houseFilterId >= 0 ? 0 : houses.Count);
+
+            // The house whose monsters are listed: the filtered one, or the current page's.
+            int targetHouseId = _houseFilterId;
+            bool foldOrphans = false;
+            if (targetHouseId < 0)
+            {
+                int page = _pagerRow.PageIndex;
+                if (page >= 0 && page < houses.Count)
+                {
+                    targetHouseId = houses[page].UniqueId;
+                    foldOrphans = page == 0;
+                }
+            }
+
+            // Count how many monsters will actually be shown; must match the render loop below or the
+            // "no monsters" fallback desyncs from the rows drawn.
             int visibleCount = 0;
             if (manager != null)
             {
                 var roster = manager.AlliedMonsters;
                 for (int i = 0; i < roster.Count; i++)
                 {
-                    if (_houseFilterId >= 0 && roster[i].MonsterHouseId != _houseFilterId)
+                    if (!ShouldShowMonster(roster[i], targetHouseId, foldOrphans, houses))
                         continue;
                     visibleCount++;
                 }
@@ -247,8 +326,8 @@ namespace PitHero.UI
             {
                 var monster = monsters[i];
 
-                // Skip monsters that don't live in the filtered house (when a filter is active).
-                if (_houseFilterId >= 0 && monster.MonsterHouseId != _houseFilterId)
+                // Skip monsters that don't belong to the house currently being shown.
+                if (!ShouldShowMonster(monster, targetHouseId, foldOrphans, houses))
                     continue;
 
                 // Build a row: [48x48 sprite cell] [textTable] [jobTable]
@@ -434,6 +513,7 @@ namespace PitHero.UI
                 if (pauseService != null)
                     pauseService.IsPaused = false;
                 _houseFilterId = -1;
+                _pagerRow?.Reset();
                 Debug.Log("[MonsterUI] Monster window force closed by single window policy");
             }
         }

--- a/PitHero/UI/PageCursor.cs
+++ b/PitHero/UI/PageCursor.cs
@@ -1,0 +1,52 @@
+namespace PitHero.UI
+{
+    /// <summary>
+    /// The page state behind <see cref="PagerRow"/>, kept separate from the widgets so the arithmetic
+    /// (wraparound, clamping when pages disappear) is exercisable without a graphics device.
+    /// </summary>
+    public class PageCursor
+    {
+        private int _pageCount;
+        private int _pageIndex;
+
+        /// <summary>Zero-based index of the page currently shown.</summary>
+        public int PageIndex => _pageIndex;
+
+        /// <summary>Total number of pages, as last set by <see cref="SetPageCount"/>.</summary>
+        public int PageCount => _pageCount;
+
+        /// <summary>Whether there is anything to page through; false hides the pager entirely.</summary>
+        public bool HasMultiplePages => _pageCount > 1;
+
+        /// <summary>
+        /// Sets the number of pages, clamping the current page into range — pages disappear when a
+        /// building is sold while the window is closed. Pass 0 to disable paging.
+        /// </summary>
+        public void SetPageCount(int pageCount)
+        {
+            _pageCount = pageCount > 0 ? pageCount : 0;
+            if (_pageIndex >= _pageCount)
+                _pageIndex = _pageCount > 0 ? _pageCount - 1 : 0;
+        }
+
+        /// <summary>Advances one page, wrapping past the last back to the first. True if the page moved.</summary>
+        public bool Next() => Step(1);
+
+        /// <summary>Goes back one page, wrapping past the first back to the last. True if the page moved.</summary>
+        public bool Previous() => Step(-1);
+
+        /// <summary>Returns to the first page.</summary>
+        public void Reset()
+        {
+            _pageIndex = 0;
+        }
+
+        private bool Step(int delta)
+        {
+            if (_pageCount <= 1)
+                return false;
+            _pageIndex = (_pageIndex + delta + _pageCount) % _pageCount;
+            return true;
+        }
+    }
+}

--- a/PitHero/UI/PagerRow.cs
+++ b/PitHero/UI/PagerRow.cs
@@ -1,0 +1,90 @@
+using Nez.UI;
+
+namespace PitHero.UI
+{
+    /// <summary>
+    /// A "&lt; n &gt;" page selector: previous/next arrows flanking a 1-based page number, wrapping from
+    /// the last page back to the first and vice versa. Populates itself only when there is more than
+    /// one page, so it occupies no layout space when there is nothing to page through.
+    /// Page state lives in <see cref="PageCursor"/>.
+    /// </summary>
+    public class PagerRow : Table
+    {
+        private const float ArrowWidth  = 30f;
+        private const float ArrowHeight = 24f;
+        private const float LabelWidth  = 40f;
+        // The skin's nine-patch button padding makes the "<" render wider than its cell, pushing the
+        // optical centre left; nudge the number back to sit between the two arrows.
+        private const float LabelPadLeft = 8f;
+
+        private readonly TextButton _prevButton;
+        private readonly TextButton _nextButton;
+        private readonly Label _pageLabel;
+        private readonly PageCursor _cursor = new PageCursor();
+
+        private bool _populated;
+
+        /// <summary>Fired after the shown page changes; the owner should rebuild its contents.</summary>
+        public event System.Action OnPageChanged;
+
+        /// <summary>Zero-based index of the page currently shown. Valid once Configure has been called.</summary>
+        public int PageIndex => _cursor.PageIndex;
+
+        public PagerRow(Skin skin)
+        {
+            _prevButton = new TextButton("<", skin, "ph-default");
+            _prevButton.OnClicked += (_) => PreviousPage();
+            _nextButton = new TextButton(">", skin, "ph-default");
+            _nextButton.OnClicked += (_) => NextPage();
+            _pageLabel = new Label("1", skin, "ph-default");
+            // Qualified: the inherited Table.Align(int) method otherwise shadows the Align class here.
+            _pageLabel.SetAlignment(Nez.UI.Align.Center);
+        }
+
+        /// <summary>
+        /// Points the pager at <paramref name="pageCount"/> pages, clamping the current page into range.
+        /// Pass 0 to disable paging entirely. Only rebuilds the cells when visibility actually flips, so
+        /// stepping pages never re-adds the button that is mid-click.
+        /// </summary>
+        public void Configure(int pageCount)
+        {
+            _cursor.SetPageCount(pageCount);
+
+            bool shouldShow = _cursor.HasMultiplePages;
+            if (shouldShow != _populated)
+            {
+                Clear();
+                if (shouldShow)
+                {
+                    Add(_prevButton).Size(ArrowWidth, ArrowHeight);
+                    Add(_pageLabel).Width(LabelWidth).SetPadLeft(LabelPadLeft);
+                    Add(_nextButton).Size(ArrowWidth, ArrowHeight);
+                }
+                _populated = shouldShow;
+            }
+
+            if (shouldShow)
+                _pageLabel.SetText((_cursor.PageIndex + 1).ToString());
+        }
+
+        /// <summary>Shows the next page, wrapping from the last page back to the first.</summary>
+        public void NextPage()
+        {
+            if (_cursor.Next())
+                OnPageChanged?.Invoke();
+        }
+
+        /// <summary>Shows the previous page, wrapping from the first page back to the last.</summary>
+        public void PreviousPage()
+        {
+            if (_cursor.Previous())
+                OnPageChanged?.Invoke();
+        }
+
+        /// <summary>Returns to the first page; call whenever the owning window closes.</summary>
+        public void Reset()
+        {
+            _cursor.Reset();
+        }
+    }
+}

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -13,6 +13,7 @@ namespace PitHero
         public const string ButtonAddMonsters = "ButtonAddMonsters";
         public const string ButtonMoveAllCrops = "ButtonMoveAllCrops";
         public const string ButtonSellAllCrops = "ButtonSellAllCrops";
+        public const string ButtonSellTheseCrops = "ButtonSellTheseCrops";
         public const string ButtonSellBuilding = "ButtonSellBuilding";
         public const string ButtonSell = "ButtonSell";
         public const string ButtonSave = "ButtonSave";


### PR DESCRIPTION
Fixes #322

The aggregate **Harvested Crops** and **Monsters** views concatenated every building's contents into one long scrolling list, with no way to tell which storage a crop stack sat in or which house a monster lived in. Both are now paged, one page per building, with a `< n >` pager where `n` is the storage/house number, wrapping 1 → n → 1.

Paging applies **only** to the aggregate views. The per-building views opened from the building context menu are unchanged.

## Changes

**New shared control**
- `PitHero/UI/PageCursor.cs` — pure page state (wraparound, clamping when pages disappear), no graphics dependency
- `PitHero/UI/PagerRow.cs` — the `< n >` widget, following the `CrystalCreationDialog` cycler idiom (plain `TextButton` arrows with explicit `.Size()`, since the skin forces 25px text padding). Rebuilds its cells only when visibility flips, so stepping a page never re-adds the button that is mid-click.

**Harvested Crops** (`HarvestedCropsModeOverlay`)
- One page per Crop Storage in `UniqueId` order. The page number is a **derived 1-based ordinal**, not the raw `UniqueId` — ids are global across building types, so the first storage is id 2 on a new game.
- Extracted `GetStorageBuildings()` out of `RebuildSlots`, and added `CurrentPageBuildingId` so the per-storage actions work unchanged in both the paged and context-menu views.
- The paged aggregate view now also offers **Move all crops** / **Sell these crops** for the storage on screen, alongside the global **Sell all crops**.
- Four repeated `LayoutButtonRow(); RebuildSlots(); ShowInventoryWindow();` call sites collapsed into one `RefreshViewer()`.
- The window was positioned at `(stageH - h) / 2 - 30`, an unconditional upward bias that pushed the top off-screen once the content grew tall enough. The bias is preserved (now named `CenterYBias`) and the result clamped to the stage, so a taller window can never clip — matching the clamping `MonsterUI.PositionWindow` already does.

**Monsters** (`MonsterUI`)
- One page per Monster House. Empty houses still get a page, so the page number always matches the house number.
- The filter is applied in both the `visibleCount` pre-pass and the render loop, so the "no monsters" fallback cannot desync from the rows drawn.
- Window contents wrapped in an inner content `Table` (matching `SecondChanceShopUI` and the crops overlay) rather than adding rows directly to the `Window`.

**New localization key** — `ButtonSellTheseCrops,Sell these crops`. The per-storage sell button previously reused `ButtonSellAllCrops`, which would have been ambiguous next to the global sell button in the same row.

## Note on orphaned monsters

`FarmTaskCoordinator.SpawnWorker` re-homes monsters lazily, so a monster can transiently carry `MonsterHouseId = -1` or an id whose house was sold. Strict house-keyed paging would have made such a monster invisible — a regression against the previous full-roster view. Those are folded onto page 1.

## Testing

- `dotnet build` clean
- `dotnet test` — 1524 passed, 0 failed (matches baseline)
- `PageCursorTests` (10 cases) covers wraparound in both directions, no-op stepping at 0/1 pages, clamping when the count shrinks, and holding position when it grows

The orphan predicate is not unit-tested: it is private, and `GenerateAssemblyInfo` is off in `PitHero.csproj`, so exposing it would require new assembly-level plumbing — disproportionate for four lines of boolean logic.

## Not verified

**The layout has not been visually confirmed.** The pager only appears with two or more storages/houses, which needs real gameplay to reach, and there is no CLI arg to skip the title screen. The game launches without exception, but that only reaches the title screen — both new UI paths are built in `MainGameScene`.

The stage clamp above makes clipping structurally impossible regardless of content size, but it does not confirm the proportions read well. Sizing values worth a look during playtest:
- Pager number offset — a fixed `LabelPadLeft = 8f` compensates for the skin's nine-patch padding making `<` render wider than its cell
- Monster window `460x340` (stage is 360 tall)
- Crops scroll pane `224f` — a page needs 176px (4 rows × 44px), leaving 48px headroom

🤖 Generated with [Claude Code](https://claude.com/claude-code)