### PR TITLE
Automate monster job assignments

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,8 @@
       "Bash(Select-Object FullName)",
       "Bash(\"C:\\\\Users\\\\rpill\\\\Devroot\\\\PitHero\\\\Nez\\\\DefaultContentSource\\\\FNAShaderCompiler\\\\fxc.exe\" /T fx_2_0 ColorGrading.fx /Fo ColorGrading.fxb)",
       "PowerShell(dotnet build *)",
-      "PowerShell(dotnet test *)"
+      "PowerShell(dotnet test *)",
+      "mcp__github__update_pull_request"
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,7 @@ Design docs under `PitHero/docs/` (kept as standalone references — don't dupli
 - `PitHero/docs/Permadeath.md` — Hero death, crystal vault, sell-value formula
 - `PitHero/docs/CrystalCeremony.md` — Post-death hero respawn and crystal imbuement at the statue
 - `PitHero/docs/TavernDiningSystem.md` — Kitchen/tavern dining: ticket lifecycle, worker FSM roles, patron + party dining flows, meal buffs, dish pricing, save v18 dining state
+- `PitHero/docs/AutoJobAssignmentSystem.md` — Automated monster job assignment: demand evaluators, pure solver, day/night shifts, reassess cadence, and the step-by-step recipe for adding a new job (e.g. fishing)
 
 **Per-feature docs:**
 - `features/`

--- a/PitHero.Tests/AutoJobAssignmentServiceTests.cs
+++ b/PitHero.Tests/AutoJobAssignmentServiceTests.cs
@@ -96,6 +96,73 @@ namespace PitHero.Tests
             Assert.AreEqual(MonsterJob.Fishing, roster.AlliedMonsters[0].Job);
         }
 
+        // ── Cadence and shift-boundary triggers ──────────────────────────────
+        // A lone monster with zero workload gets Cooking (kitchen base crew) when a
+        // reassessment fires, so a job change is the observable "reassess happened" signal.
+
+        [TestMethod]
+        public void TickCadence_FirstTick_InitializesWithoutReassessing()
+        {
+            var roster = new AlliedMonsterManager();
+            roster.AddAlliedMonster(Monster("Bob", 1, 5, 1, MonsterJob.Farming));
+            var service = CreateHeadlessService(roster);
+
+            service.TickCadence(100f, isNighttime: false);
+
+            Assert.AreEqual(MonsterJob.Farming, roster.AlliedMonsters[0].Job,
+                "First tick only initializes the interval; no reassessment fires");
+        }
+
+        [TestMethod]
+        public void TickCadence_ReassessesAfterInterval()
+        {
+            var roster = new AlliedMonsterManager();
+            roster.AddAlliedMonster(Monster("Bob", 1, 5, 1, MonsterJob.Farming));
+            var service = CreateHeadlessService(roster);
+
+            service.TickCadence(0f, isNighttime: false);
+            service.TickCadence(GameConfig.AutoJobReassessIntervalSeconds - 1f, isNighttime: false);
+            Assert.AreEqual(MonsterJob.Farming, roster.AlliedMonsters[0].Job, "Interval not yet elapsed");
+
+            service.TickCadence(GameConfig.AutoJobReassessIntervalSeconds, isNighttime: false);
+            Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[0].Job, "Interval elapsed — reassess fires");
+        }
+
+        [TestMethod]
+        public void TickCadence_ShiftChange_ReassessesImmediately()
+        {
+            var roster = new AlliedMonsterManager();
+            roster.AddAlliedMonster(Monster("Bob", 1, 5, 1, MonsterJob.Farming));
+            var service = CreateHeadlessService(roster);
+
+            service.TickCadence(0f, isNighttime: false);
+            service.TickCadence(30f, isNighttime: true);
+
+            Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[0].Job,
+                "Day→night boundary reassesses immediately, well before the 60-minute cadence");
+        }
+
+        [TestMethod]
+        public void TickCadence_ShiftChange_RestartsTheInterval()
+        {
+            var roster = new AlliedMonsterManager();
+            var service = CreateHeadlessService(roster);
+
+            service.TickCadence(0f, isNighttime: false);
+            service.TickCadence(50f, isNighttime: true);   // boundary reassess at t=50
+
+            // Now give the monster a job and verify the next cadence fire is 60s after the
+            // boundary (t=110), not 60s after the original init (t=60).
+            roster.AddAlliedMonster(Monster("Bob", 1, 5, 1, MonsterJob.Farming));
+            service.TickCadence(65f, isNighttime: true);
+            Assert.AreEqual(MonsterJob.Farming, roster.AlliedMonsters[0].Job,
+                "Boundary reassess restarted the interval — t=65 is too early");
+
+            service.TickCadence(50f + GameConfig.AutoJobReassessIntervalSeconds, isNighttime: true);
+            Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[0].Job,
+                "Cadence fires one full interval after the boundary reassess");
+        }
+
         // ── Day/night shift segregation ──────────────────────────────────────
 
         [TestMethod]

--- a/PitHero.Tests/AutoJobAssignmentServiceTests.cs
+++ b/PitHero.Tests/AutoJobAssignmentServiceTests.cs
@@ -1,0 +1,198 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero;
+using PitHero.Farming;
+using PitHero.Services;
+using PitHero.Services.AutoJob;
+using RolePlayingFramework.AlliedMonsters;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Tests for AutoJobAssignmentService and the demand evaluators. Services are constructed
+    /// directly (not via Core.Services) for headless safety; ReassessNow() is called directly to
+    /// bypass the in-game-time cadence gate, which never elapses in a headless context.
+    /// </summary>
+    [TestClass]
+    public class AutoJobAssignmentServiceTests
+    {
+        private static AlliedMonster Monster(string name, int fishing, int cooking, int farming,
+            MonsterJob job = MonsterJob.None)
+        {
+            var m = new AlliedMonster(name, "Monster_Slime", fishing, cooking, farming);
+            m.Job = job;
+            return m;
+        }
+
+        private static AutoJobAssignmentService CreateHeadlessService(AlliedMonsterManager roster)
+        {
+            // Null service dependencies: kitchen sees zero backlog, farming sees zero workload.
+            return new AutoJobAssignmentService(roster,
+                new KitchenJobDemandEvaluator(null, null, null),
+                new FarmingJobDemandEvaluator(null, null, null));
+        }
+
+        // ── Service basics ───────────────────────────────────────────────────
+
+        [TestMethod]
+        public void Service_DisabledByDefault()
+        {
+            var service = CreateHeadlessService(new AlliedMonsterManager());
+            Assert.IsFalse(service.Enabled, "AutoJobAssignmentService should be disabled by default");
+        }
+
+        [TestMethod]
+        public void Update_WhenDisabled_IsANoOp()
+        {
+            var roster = new AlliedMonsterManager();
+            roster.AddAlliedMonster(Monster("Bob", 1, 9, 1, MonsterJob.Farming));
+            var service = CreateHeadlessService(roster);
+
+            service.Update();
+
+            Assert.AreEqual(MonsterJob.Farming, roster.AlliedMonsters[0].Job,
+                "Update must not touch assignments while disabled");
+        }
+
+        [TestMethod]
+        public void ReassessNow_AppliesSolverOutputToRoster()
+        {
+            // Zero backlog/workload: kitchen still wants its base crew of 3 (desired, non-min),
+            // farming wants none. The 3 best cooks staff the kitchen; the rest go home.
+            var roster = new AlliedMonsterManager();
+            roster.AddAlliedMonster(Monster("A", 1, 2, 9, MonsterJob.Farming));
+            roster.AddAlliedMonster(Monster("B", 1, 8, 1));
+            roster.AddAlliedMonster(Monster("C", 1, 6, 1));
+            roster.AddAlliedMonster(Monster("D", 1, 4, 1));
+            var service = CreateHeadlessService(roster);
+
+            service.ReassessNow();
+
+            Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[1].Job, "Best cook staffs the kitchen");
+            Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[2].Job, "Second cook staffs the kitchen");
+            Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[3].Job, "Third cook staffs the kitchen");
+            Assert.AreEqual(MonsterJob.None, roster.AlliedMonsters[0].Job,
+                "Former farmer with no farm workload goes home (worst cook of the four)");
+        }
+
+        [TestMethod]
+        public void ReassessNow_EmptyRoster_DoesNotThrow()
+        {
+            var service = CreateHeadlessService(new AlliedMonsterManager());
+            service.ReassessNow();
+        }
+
+        [TestMethod]
+        public void ReassessNow_WithExtraEvaluator_StaffsTheNewJob()
+        {
+            // Extensibility guarantee: registering a fishing evaluator routes workers to Fishing
+            // with zero solver changes.
+            var roster = new AlliedMonsterManager();
+            roster.AddAlliedMonster(Monster("A", 9, 1, 1));
+            var service = new AutoJobAssignmentService(roster, null, null);
+            service.AddEvaluator(new FixedDemandEvaluator(MonsterJob.Fishing, min: 1, desired: 1));
+
+            service.ReassessNow();
+
+            Assert.AreEqual(MonsterJob.Fishing, roster.AlliedMonsters[0].Job);
+        }
+
+        private sealed class FixedDemandEvaluator : IJobDemandEvaluator
+        {
+            private readonly JobDemandEntry _entry;
+            public FixedDemandEvaluator(MonsterJob job, int min, int desired)
+                => _entry = new JobDemandEntry { Job = job, MinWorkers = min, DesiredWorkers = desired, Sticky = false };
+            public MonsterJob Job => _entry.Job;
+            public JobDemandEntry EvaluateDemand(int rosterSize) => _entry;
+        }
+
+        // ── Farming demand math ──────────────────────────────────────────────
+
+        [TestMethod]
+        public void FarmingDemand_ZeroWorkload_WantsNoWorkers()
+        {
+            var d = FarmingJobDemandEvaluator.ComputeDemand(0, 0, rosterSize: 10);
+            Assert.AreEqual(0, d.DesiredWorkers);
+            Assert.AreEqual(0, d.MinWorkers);
+            Assert.IsFalse(d.Sticky, "Farming is not sticky — farmers are released during lulls");
+        }
+
+        [TestMethod]
+        public void FarmingDemand_BaselineScalesByCeilingDivision()
+        {
+            int per = GameConfig.AutoJobFarmCropsPerWorkerBaseline;
+            Assert.AreEqual(1, FarmingJobDemandEvaluator.ComputeDemand(0, 1, 10).DesiredWorkers);
+            Assert.AreEqual(1, FarmingJobDemandEvaluator.ComputeDemand(0, per, 10).DesiredWorkers);
+            Assert.AreEqual(2, FarmingJobDemandEvaluator.ComputeDemand(0, per + 1, 10).DesiredWorkers);
+        }
+
+        [TestMethod]
+        public void FarmingDemand_BurstOutranksBaseline()
+        {
+            // A watering/harvest wave (many outstanding tasks) demands more workers than the
+            // baseline care load alone would.
+            int tasksPer = GameConfig.AutoJobFarmTasksPerWorker;
+            var d = FarmingJobDemandEvaluator.ComputeDemand(tasksPer * 3, careLoad: 1, rosterSize: 10);
+            Assert.AreEqual(3, d.DesiredWorkers, "Burst signal should win when larger than baseline");
+            Assert.AreEqual(1, d.MinWorkers, "At least one farmer whenever any workload exists");
+        }
+
+        [TestMethod]
+        public void FarmingDemand_ClampsToRosterSize()
+        {
+            var d = FarmingJobDemandEvaluator.ComputeDemand(1000, 1000, rosterSize: 4);
+            Assert.AreEqual(4, d.DesiredWorkers, "Demand can never exceed the roster");
+        }
+
+        [TestMethod]
+        public void FarmingEvaluator_CountsPlansFromCropPlantingService()
+        {
+            var planting = new CropPlantingService();
+            var growth = new CropGrowthService(planting);
+            int per = GameConfig.AutoJobFarmCropsPerWorkerBaseline;
+            for (int i = 0; i < per + 1; i++)
+                planting.AddPlan(new PlacedCropPlan { Type = CropType.Wheat, TileX = i, TileY = 0 });
+            var evaluator = new FarmingJobDemandEvaluator(null, growth, planting);
+
+            var d = evaluator.EvaluateDemand(rosterSize: 10);
+
+            Assert.AreEqual(2, d.DesiredWorkers, "Placed plans count toward the baseline care load");
+        }
+
+        // ── Kitchen demand math ──────────────────────────────────────────────
+
+        [TestMethod]
+        public void KitchenDemand_ZeroBacklog_StillWantsBaseCrew()
+        {
+            var d = KitchenJobDemandEvaluator.ComputeDemand(0, rosterSize: 10);
+            Assert.AreEqual(GameConfig.AutoJobKitchenBaseStaff, d.DesiredWorkers,
+                "Kitchen keeps a cook + server + runner crew even with no orders");
+            Assert.AreEqual(0, d.MinWorkers, "Base crew is desired, not mandatory, when there is no backlog");
+            Assert.IsTrue(d.Sticky, "Kitchen workers must never be pulled away");
+        }
+
+        [TestMethod]
+        public void KitchenDemand_BaseCrewClampsToTinyRoster()
+        {
+            var d = KitchenJobDemandEvaluator.ComputeDemand(0, rosterSize: 2);
+            Assert.AreEqual(2, d.DesiredWorkers);
+        }
+
+        [TestMethod]
+        public void KitchenDemand_BacklogAddsExtraWorkers()
+        {
+            int per = GameConfig.AutoJobKitchenBacklogPerExtraWorker;
+            var d = KitchenJobDemandEvaluator.ComputeDemand(per * 2, rosterSize: 10);
+            Assert.AreEqual(GameConfig.AutoJobKitchenBaseStaff + 2, d.DesiredWorkers);
+            Assert.AreEqual(GameConfig.AutoJobKitchenBaseStaff, d.MinWorkers,
+                "With a backlog the base crew becomes mandatory");
+        }
+
+        [TestMethod]
+        public void KitchenDemand_CapsAtMaxWorkers()
+        {
+            var d = KitchenJobDemandEvaluator.ComputeDemand(1000, rosterSize: 20);
+            Assert.AreEqual(GameConfig.AutoJobKitchenMaxWorkers, d.DesiredWorkers,
+                "Kitchen demand is capped at the coordinator's worker limit");
+        }
+    }
+}

--- a/PitHero.Tests/AutoJobAssignmentServiceTests.cs
+++ b/PitHero.Tests/AutoJobAssignmentServiceTests.cs
@@ -16,9 +16,9 @@ namespace PitHero.Tests
     public class AutoJobAssignmentServiceTests
     {
         private static AlliedMonster Monster(string name, int fishing, int cooking, int farming,
-            MonsterJob job = MonsterJob.None)
+            MonsterJob job = MonsterJob.None, string typeName = "Monster_Slime")
         {
-            var m = new AlliedMonster(name, "Monster_Slime", fishing, cooking, farming);
+            var m = new AlliedMonster(name, typeName, fishing, cooking, farming);
             m.Job = job;
             return m;
         }
@@ -94,6 +94,73 @@ namespace PitHero.Tests
             service.ReassessNow();
 
             Assert.AreEqual(MonsterJob.Fishing, roster.AlliedMonsters[0].Job);
+        }
+
+        // ── Day/night shift segregation ──────────────────────────────────────
+
+        [TestMethod]
+        public void ReassessNow_StaffsDayAndNightShiftsIndependently()
+        {
+            // Day monsters (Slime) and nocturnal monsters (Orc) never work at the same time, so
+            // each shift must field its own kitchen crew — even when the day shift has better cooks.
+            var roster = new AlliedMonsterManager();
+            roster.AddAlliedMonster(Monster("DayA", 1, 9, 1));
+            roster.AddAlliedMonster(Monster("DayB", 1, 8, 1));
+            roster.AddAlliedMonster(Monster("DayC", 1, 7, 1));
+            roster.AddAlliedMonster(Monster("DayD", 1, 6, 1));
+            roster.AddAlliedMonster(Monster("NightA", 1, 5, 1, typeName: "Monster_Orc"));
+            roster.AddAlliedMonster(Monster("NightB", 1, 4, 1, typeName: "Monster_Skeleton"));
+            roster.AddAlliedMonster(Monster("NightC", 1, 3, 1, typeName: "Monster_Orc"));
+            roster.AddAlliedMonster(Monster("NightD", 1, 2, 1, typeName: "Monster_Orc"));
+            var service = CreateHeadlessService(roster);
+
+            service.ReassessNow();
+
+            Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[0].Job, "Best day cook staffs the day kitchen");
+            Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[1].Job);
+            Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[2].Job);
+            Assert.AreEqual(MonsterJob.None, roster.AlliedMonsters[3].Job, "Fourth day monster exceeds the base crew");
+            Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[4].Job,
+                "Night shift fields its own kitchen crew despite lower cooking skill than the day shift");
+            Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[5].Job);
+            Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[6].Job);
+            Assert.AreEqual(MonsterJob.None, roster.AlliedMonsters[7].Job, "Fourth night monster exceeds the base crew");
+        }
+
+        [TestMethod]
+        public void ReassessNow_DemandClampsApplyPerShift()
+        {
+            // Kitchen base crew clamps to each shift's own size, not the whole roster's.
+            var roster = new AlliedMonsterManager();
+            roster.AddAlliedMonster(Monster("DayA", 1, 5, 1));
+            roster.AddAlliedMonster(Monster("DayB", 1, 5, 1));
+            roster.AddAlliedMonster(Monster("NightA", 1, 5, 1, typeName: "Monster_Orc"));
+            roster.AddAlliedMonster(Monster("NightB", 1, 5, 1, typeName: "Monster_Skeleton"));
+            var service = CreateHeadlessService(roster);
+
+            service.ReassessNow();
+
+            for (int i = 0; i < 4; i++)
+                Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[i].Job,
+                    $"Monster {i}: with 2 monsters per shift, the whole shift staffs the kitchen");
+        }
+
+        [TestMethod]
+        public void ReassessNow_StickyKitchenProtectionIsPerShift()
+        {
+            // A nocturnal monster already on Cooking must not shield the day shift from staffing
+            // its own kitchen, and vice versa — stickiness applies within each shift group only.
+            var roster = new AlliedMonsterManager();
+            roster.AddAlliedMonster(Monster("Day", 1, 4, 1));
+            roster.AddAlliedMonster(Monster("Night", 1, 4, 1, MonsterJob.Cooking, typeName: "Monster_Orc"));
+            var service = CreateHeadlessService(roster);
+
+            service.ReassessNow();
+
+            Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[0].Job,
+                "Day shift staffs its kitchen even though a night monster already holds a kitchen job");
+            Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[1].Job,
+                "Sticky night kitchen worker keeps the job");
         }
 
         private sealed class FixedDemandEvaluator : IJobDemandEvaluator

--- a/PitHero.Tests/JobAssignmentSolverTests.cs
+++ b/PitHero.Tests/JobAssignmentSolverTests.cs
@@ -1,0 +1,285 @@
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Services.AutoJob;
+using RolePlayingFramework.AlliedMonsters;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Tests for the pure JobAssignmentSolver: sticky/min/desired fill order, proficiency selection
+    /// with deterministic tie-breaks, surplus demotion, and the strict-double-improvement swap pass.
+    /// </summary>
+    [TestClass]
+    public class JobAssignmentSolverTests
+    {
+        private readonly List<MonsterJob> _result = new List<MonsterJob>();
+
+        private static MonsterJobSnapshot Monster(int index, MonsterJob current,
+            int farming, int cooking, int fishing = 1)
+        {
+            return new MonsterJobSnapshot
+            {
+                RosterIndex = index,
+                CurrentJob = current,
+                FarmingProficiency = farming,
+                CookingProficiency = cooking,
+                FishingProficiency = fishing,
+            };
+        }
+
+        private static JobDemandEntry Demand(MonsterJob job, int min, int desired, bool sticky)
+        {
+            return new JobDemandEntry { Job = job, MinWorkers = min, DesiredWorkers = desired, Sticky = sticky };
+        }
+
+        [TestMethod]
+        public void Solve_ZeroDemand_AllMonstersGetNone()
+        {
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.Farming, 9, 9),
+                Monster(1, MonsterJob.None, 5, 5),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Cooking, 0, 0, sticky: true),
+                Demand(MonsterJob.Farming, 0, 0, sticky: false),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            Assert.AreEqual(MonsterJob.None, _result[0], "Non-sticky farmer should be sent home with zero demand");
+            Assert.AreEqual(MonsterJob.None, _result[1], "Unassigned monster should stay None with zero demand");
+        }
+
+        [TestMethod]
+        public void Solve_FarmingDemand_FilledByBestFarmingProficiency()
+        {
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.None, 3, 1),
+                Monster(1, MonsterJob.None, 9, 1),
+                Monster(2, MonsterJob.None, 6, 1),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Farming, 1, 2, sticky: false),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            Assert.AreEqual(MonsterJob.None, _result[0], "Lowest farming skill should stay home");
+            Assert.AreEqual(MonsterJob.Farming, _result[1], "Best farmer should be assigned");
+            Assert.AreEqual(MonsterJob.Farming, _result[2], "Second-best farmer should be assigned");
+        }
+
+        [TestMethod]
+        public void Solve_ProficiencyTie_BrokenByLowestRosterIndex()
+        {
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.None, 5, 1),
+                Monster(1, MonsterJob.None, 5, 1),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Farming, 1, 1, sticky: false),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            Assert.AreEqual(MonsterJob.Farming, _result[0], "Tie should go to the lowest roster index");
+            Assert.AreEqual(MonsterJob.None, _result[1]);
+        }
+
+        [TestMethod]
+        public void Solve_KitchenMin_FilledByCookingSkillBeforeFarmingDesired()
+        {
+            // One monster, kitchen min 1 listed first: kitchen wins even though farming wants 1 too.
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.None, 9, 2),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Cooking, 1, 1, sticky: true),
+                Demand(MonsterJob.Farming, 1, 1, sticky: false),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            Assert.AreEqual(MonsterJob.Cooking, _result[0], "Kitchen minimum outranks farming (demand-list order)");
+        }
+
+        [TestMethod]
+        public void Solve_MinsFillBeforeAnyDesired()
+        {
+            // Two monsters. Cooking min 1 / desired 2, Farming min 1 / desired 1.
+            // Both minimums must fill before cooking's second desired slot takes the last monster.
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.None, 1, 9),
+                Monster(1, MonsterJob.None, 9, 1),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Cooking, 1, 2, sticky: true),
+                Demand(MonsterJob.Farming, 1, 1, sticky: false),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            Assert.AreEqual(MonsterJob.Cooking, _result[0], "Best cook fills the kitchen minimum");
+            Assert.AreEqual(MonsterJob.Farming, _result[1], "Farming minimum fills before kitchen's desired extras");
+        }
+
+        [TestMethod]
+        public void Solve_StickyCookingWorkers_KeptEvenAboveDesired()
+        {
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.Cooking, 1, 4),
+                Monster(1, MonsterJob.Cooking, 1, 6),
+                Monster(2, MonsterJob.Cooking, 1, 8),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Cooking, 0, 1, sticky: true),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            Assert.AreEqual(MonsterJob.Cooking, _result[0], "Sticky worker is never demoted");
+            Assert.AreEqual(MonsterJob.Cooking, _result[1], "Sticky worker is never demoted");
+            Assert.AreEqual(MonsterJob.Cooking, _result[2], "Sticky worker is never demoted");
+        }
+
+        [TestMethod]
+        public void Solve_SurplusFarmers_MoveToKitchenOrHome()
+        {
+            // Three former farmers; farming now wants 1, kitchen wants 1.
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.Farming, 7, 2),
+                Monster(1, MonsterJob.Farming, 5, 9),
+                Monster(2, MonsterJob.Farming, 3, 1),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Cooking, 1, 1, sticky: true),
+                Demand(MonsterJob.Farming, 1, 1, sticky: false),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            Assert.AreEqual(MonsterJob.Farming, _result[0], "Best farmer keeps farming");
+            Assert.AreEqual(MonsterJob.Cooking, _result[1], "Best cook moves to the kitchen");
+            Assert.AreEqual(MonsterJob.None, _result[2], "Surplus worker with no demanded job goes home");
+        }
+
+        [TestMethod]
+        public void Solve_FishingWorkerWithNoFishingDemand_IsReassigned()
+        {
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.Fishing, 8, 1, fishing: 9),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Farming, 1, 1, sticky: false),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            Assert.AreEqual(MonsterJob.Farming, _result[0],
+                "A job with no demand evaluator is non-sticky; its workers are pooled and reassigned");
+        }
+
+        [TestMethod]
+        public void Solve_SwapPass_FiresOnStrictDoubleImprovement()
+        {
+            // Sticky cook (cooking 2, farming 9) and assigned farmer (cooking 9, farming 2):
+            // both jobs strictly improve, so they swap.
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.Cooking, 9, 2),
+                Monster(1, MonsterJob.None, 2, 9),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Cooking, 0, 1, sticky: true),
+                Demand(MonsterJob.Farming, 1, 1, sticky: false),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            Assert.AreEqual(MonsterJob.Farming, _result[0], "Great farmer swaps out of the kitchen");
+            Assert.AreEqual(MonsterJob.Cooking, _result[1], "Great cook swaps into the kitchen");
+        }
+
+        [TestMethod]
+        public void Solve_SwapPass_NoSwapWhenOnlyOneSideImproves()
+        {
+            // Farmer would improve the kitchen (cooking 9 > 5) but the cook is a worse farmer (3 < 6):
+            // farming would lose, so no swap.
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.Cooking, 3, 5),
+                Monster(1, MonsterJob.None, 6, 9),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Cooking, 0, 1, sticky: true),
+                Demand(MonsterJob.Farming, 1, 1, sticky: false),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            Assert.AreEqual(MonsterJob.Cooking, _result[0], "No swap when the other job would lose skill");
+            Assert.AreEqual(MonsterJob.Farming, _result[1]);
+        }
+
+        [TestMethod]
+        public void Solve_RosterSmallerThanDemand_MinsFillInDemandListOrder()
+        {
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.None, 5, 5),
+                Monster(1, MonsterJob.None, 5, 5),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Cooking, 3, 3, sticky: true),
+                Demand(MonsterJob.Farming, 2, 2, sticky: false),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            Assert.AreEqual(MonsterJob.Cooking, _result[0], "First-listed demand takes the whole short roster");
+            Assert.AreEqual(MonsterJob.Cooking, _result[1], "First-listed demand takes the whole short roster");
+        }
+
+        [TestMethod]
+        public void Solve_IsDeterministicAcrossRepeatedSolves()
+        {
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.Farming, 4, 7),
+                Monster(1, MonsterJob.Cooking, 7, 4),
+                Monster(2, MonsterJob.None, 5, 5),
+                Monster(3, MonsterJob.None, 5, 5),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Cooking, 1, 2, sticky: true),
+                Demand(MonsterJob.Farming, 1, 2, sticky: false),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+            var first = new List<MonsterJob>(_result);
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            CollectionAssert.AreEqual(first, _result, "Same inputs must always produce the same assignments");
+        }
+    }
+}

--- a/PitHero.Tests/SaveLoadTests.cs
+++ b/PitHero.Tests/SaveLoadTests.cs
@@ -692,7 +692,8 @@ namespace PitHero.Tests
 
         /// <summary>
         /// Verifies that a v17 save (a byte-exact prefix of the current format — no dining
-        /// section 33 and no automation section 34) still loads, with defaults for both.
+        /// section 33, automation section 34, or auto-dine section 35) still loads, with
+        /// defaults for all three.
         /// </summary>
         [TestMethod]
         public void SaveData_V17File_LoadsWithDefaultDining()
@@ -720,8 +721,8 @@ namespace PitHero.Tests
             }
 
             // Section 33 = FavoriteDishId + EatAtTavern + count + 3 records of (2 ints + 3 bools);
-            // section 34 = AutomateMonsterJobs (1 bool)
-            int tailLength = 2 * intSize + boolSize + 3 * (2 * intSize + 3 * boolSize) + boolSize;
+            // section 34 = AutomateMonsterJobs (1 bool); section 35 = PartyAutoDineResume (1 bool)
+            int tailLength = 2 * intSize + boolSize + 3 * (2 * intSize + 3 * boolSize) + 2 * boolSize;
             byte[] v17Bytes = new byte[currentBytes.Length - tailLength];
             System.Array.Copy(currentBytes, v17Bytes, v17Bytes.Length);
 
@@ -743,6 +744,36 @@ namespace PitHero.Tests
             Assert.IsNotNull(loaded.PartyDining, "v17 load should get default dining records");
             Assert.AreEqual(-1, loaded.PartyDining[0].OrderedDishId, "default dining record expected");
             Assert.IsFalse(loaded.AutomateMonsterJobs, "v17 load should default AutomateMonsterJobs");
+        }
+
+        /// <summary>
+        /// Verifies that PartyAutoDineResume round-trips through Persist/Recover, so a save made
+        /// mid-breakfast still auto-resumes the party after reload.
+        /// </summary>
+        [TestMethod]
+        public void SaveData_V20_PartyAutoDineResume_RoundTrip()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "pithero_v20_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var dataStore = new FileDataStore(tempDir);
+
+                var original = new SaveData();
+                original.PartyAutoDineResume = true;
+
+                dataStore.Save("v20_autodine.bin", original);
+
+                var loaded = new SaveData();
+                dataStore.Load("v20_autodine.bin", loaded);
+
+                Assert.AreEqual(true, loaded.PartyAutoDineResume, "PartyAutoDineResume should round-trip");
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
+            }
         }
 
         /// <summary>

--- a/PitHero.Tests/SaveLoadTests.cs
+++ b/PitHero.Tests/SaveLoadTests.cs
@@ -777,6 +777,60 @@ namespace PitHero.Tests
         }
 
         /// <summary>
+        /// Verifies the legacy inference for pre-v20 saves: a reloaded member with a meal still
+        /// in progress means the party auto-resumes when done; with no open orders it does not.
+        /// </summary>
+        [TestMethod]
+        public void SaveData_PreV20File_InfersAutoDineResumeFromOpenOrders()
+        {
+            Assert.IsTrue(LoadAsV19(openOrder: true).PartyAutoDineResume,
+                "Pre-v20 file with an open order should infer PartyAutoDineResume = true");
+            Assert.IsFalse(LoadAsV19(openOrder: false).PartyAutoDineResume,
+                "Pre-v20 file with no open orders should leave PartyAutoDineResume = false");
+        }
+
+        /// <summary>Writes a current save, truncates section 35, and patches the header to v19.</summary>
+        private static SaveData LoadAsV19(bool openOrder)
+        {
+            var ms = new MemoryStream();
+            using (var writer = new BinaryPersistableWriter(ms))
+            {
+                var original = new SaveData();
+                if (openOrder)
+                {
+                    original.PartyDining = SaveData.CreateDefaultDiningRecords();
+                    original.PartyDining[1].OrderedDishId = 3;
+                    original.PartyDining[1].HasEatenToday = false;
+                }
+                writer.Write(original);
+            }
+            byte[] v20Bytes = ms.ToArray();
+
+            // Measure the writer's bool encoding so the section-35 tail length is exact
+            var probe = new MemoryStream();
+            int boolSize;
+            using (var probeWriter = new BinaryPersistableWriter(probe))
+            {
+                probeWriter.Write(false);
+                boolSize = (int)probe.Length;
+            }
+
+            byte[] v19Bytes = new byte[v20Bytes.Length - boolSize];
+            System.Array.Copy(v20Bytes, v19Bytes, v19Bytes.Length);
+
+            // Patch the header to version 19 (little-endian int)
+            v19Bytes[0] = 19;
+            v19Bytes[1] = 0;
+            v19Bytes[2] = 0;
+            v19Bytes[3] = 0;
+
+            var loaded = new SaveData();
+            using (var rdr = new BinaryPersistableReader(new MemoryStream(v19Bytes)))
+                rdr.ReadPersistableInto(loaded);
+            return loaded;
+        }
+
+        /// <summary>
         /// Verifies that AutomateMonsterJobs round-trips through Persist/Recover (issue #321).
         /// </summary>
         [TestMethod]

--- a/PitHero.Tests/SaveLoadTests.cs
+++ b/PitHero.Tests/SaveLoadTests.cs
@@ -691,8 +691,8 @@ namespace PitHero.Tests
         }
 
         /// <summary>
-        /// Verifies that a v17 save (a byte-exact prefix of v18 — no dining section 33) still
-        /// loads, with dining state falling back to defaults.
+        /// Verifies that a v17 save (a byte-exact prefix of the current format — no dining
+        /// section 33 and no automation section 34) still loads, with defaults for both.
         /// </summary>
         [TestMethod]
         public void SaveData_V17File_LoadsWithDefaultDining()
@@ -706,9 +706,9 @@ namespace PitHero.Tests
                 original.EatAtTavern = true;
                 writer.Write(original);
             }
-            byte[] v18Bytes = ms.ToArray();
+            byte[] currentBytes = ms.ToArray();
 
-            // Measure the writer's int/bool encodings so the section-33 tail length is exact
+            // Measure the writer's int/bool encodings so the sections-33/34 tail length is exact
             var probe = new MemoryStream();
             int intSize, boolSize;
             using (var probeWriter = new BinaryPersistableWriter(probe))
@@ -719,10 +719,11 @@ namespace PitHero.Tests
                 boolSize = (int)probe.Length - intSize;
             }
 
-            // Section 33 = FavoriteDishId + EatAtTavern + count + 3 records of (2 ints + 3 bools)
-            int tailLength = 2 * intSize + boolSize + 3 * (2 * intSize + 3 * boolSize);
-            byte[] v17Bytes = new byte[v18Bytes.Length - tailLength];
-            System.Array.Copy(v18Bytes, v17Bytes, v17Bytes.Length);
+            // Section 33 = FavoriteDishId + EatAtTavern + count + 3 records of (2 ints + 3 bools);
+            // section 34 = AutomateMonsterJobs (1 bool)
+            int tailLength = 2 * intSize + boolSize + 3 * (2 * intSize + 3 * boolSize) + boolSize;
+            byte[] v17Bytes = new byte[currentBytes.Length - tailLength];
+            System.Array.Copy(currentBytes, v17Bytes, v17Bytes.Length);
 
             // Patch the header to version 17 (little-endian int)
             v17Bytes[0] = 17;
@@ -741,6 +742,36 @@ namespace PitHero.Tests
             Assert.IsFalse(loaded.EatAtTavern, "v17 load should default EatAtTavern");
             Assert.IsNotNull(loaded.PartyDining, "v17 load should get default dining records");
             Assert.AreEqual(-1, loaded.PartyDining[0].OrderedDishId, "default dining record expected");
+            Assert.IsFalse(loaded.AutomateMonsterJobs, "v17 load should default AutomateMonsterJobs");
+        }
+
+        /// <summary>
+        /// Verifies that AutomateMonsterJobs round-trips through Persist/Recover (issue #321).
+        /// </summary>
+        [TestMethod]
+        public void SaveData_V19_AutomateMonsterJobs_RoundTrip()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "pithero_v19_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var dataStore = new FileDataStore(tempDir);
+
+                var original = new SaveData();
+                original.AutomateMonsterJobs = true;
+
+                dataStore.Save("v19_automation.bin", original);
+
+                var loaded = new SaveData();
+                dataStore.Load("v19_automation.bin", loaded);
+
+                Assert.AreEqual(true, loaded.AutomateMonsterJobs, "AutomateMonsterJobs should round-trip");
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
+            }
         }
 
         /// <summary>

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -298,7 +298,9 @@ AddMonsterWindowTitle,Add Monsters
 AddMonsterRemainingSpace,Remaining Space: {0}
 AddMonsterDaytimeLabel,Daytime
 AddMonsterNocturnalLabel,Nocturnal
-TabAutoShop,Auto Shop
+TabAutomation,Automation
+SettingsAutomateMonsterJobs,Automate monster jobs
+SettingsAutomateMonsterJobsTooltip,System will handle monster job assignments. Player can not assign monster jobs with this enabled
 SettingsAutomateSeedPurchases,Auto-Purchase Seeds
 SettingsAutoShopGoldBuffer,Gold Buffer: {0}
 SettingsAutomateSeedPurchasesTooltip,Buy seeds for planned crops as soon as gold is available

--- a/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
+++ b/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
@@ -275,11 +275,17 @@ namespace PitHero.ECS.Components
         /// <summary>
         /// Picks the next order target in the zone: party members first (their table must be in
         /// this zone), then the nearest waiting patron. Sets _targetPatron/_targetPartySlot.
+        /// Only targets someone whose order can actually be created — a full ticket board (or,
+        /// for walk-ins, an empty pantry) would make TakeOrderAtTarget fail silently and the
+        /// server would livelock standing at the seat, re-picking the same target forever.
         /// </summary>
         private bool TryPickNextOrderTarget(ServerZone zone)
         {
             _targetPatron = null;
             _targetPartySlot = -1;
+
+            if (!_coordinator.HasTicketCapacity)
+                return false;
 
             var partyTable = TavernSeatConfig.GetTableTile(KitchenTaskCoordinator.GetPartySeatTile(0));
             if (KitchenTaskCoordinator.ZoneContainsTable(zone, partyTable)
@@ -290,6 +296,8 @@ namespace PitHero.ECS.Components
                 return true;
             }
 
+            if (!_coordinator.HasAnyOrderableDish())
+                return false;
             _targetPatron = FindPatronNeedingOrder(zone);
             return _targetPatron != null;
         }
@@ -588,11 +596,15 @@ namespace PitHero.ECS.Components
 
         private bool HasOrderWork(ServerZone zone)
         {
+            // Mirrors TryPickNextOrderTarget's guards so wandering isn't interrupted for an
+            // order that could never be created (full board / empty pantry)
+            if (!_coordinator.HasTicketCapacity)
+                return false;
             var partyTable = TavernSeatConfig.GetTableTile(KitchenTaskCoordinator.GetPartySeatTile(0));
             if (KitchenTaskCoordinator.ZoneContainsTable(zone, partyTable)
                 && _coordinator.TryGetNextPartyOrder(out _, out _))
                 return true;
-            return FindPatronNeedingOrder(zone) != null;
+            return _coordinator.HasAnyOrderableDish() && FindPatronNeedingOrder(zone) != null;
         }
 
         private Entity FindPatronNeedingOrder(ServerZone zone)

--- a/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
+++ b/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
@@ -14,7 +14,8 @@ namespace PitHero.ECS.Components
     /// Server: take up to 3 orders from patrons at its tables (1 server works all 4 tables;
     /// with 2 servers the first works the top pair, the second the bottom pair), post them at
     /// the ticket board, deliver up to 2 cooked dishes from the serving tables (only for its
-    /// own tables), bus finished plates, otherwise wander its table area.
+    /// own tables), bus finished plates (any table — bussing is zone-free), otherwise wander
+    /// its table area.
     /// Cook: read one ticket at the board, gather ingredients at the fridge (waiting for the
     /// runner if the fridge is short), cook at a free station, place the dish on a serving
     /// table — holding it if all three are full.
@@ -239,9 +240,10 @@ namespace PitHero.ECS.Components
 
             var zone = Zone;
 
-            // 0) A plate that has waited too long — in a busy tavern priorities 1-2 always have
-            //    work, so without this age bump bussing starves and plates pile up on tables
-            if (_coordinator.TryClaimBusJob(zone, GameConfig.ServerBusPlateMaxWaitSeconds, out _busJob))
+            // 0) A plate that has waited too long (any table, any zone) — in a busy tavern
+            //    priorities 1-2 always have work, so without this age bump bussing starves
+            //    and plates pile up on tables
+            if (_coordinator.TryClaimBusJob(GameConfig.ServerBusPlateMaxWaitSeconds, out _busJob))
             {
                 _busPickedUp = false;
                 CurrentState = KitchenMonsterState.ServerBusPlate;
@@ -259,8 +261,8 @@ namespace PitHero.ECS.Components
                 CurrentState = KitchenMonsterState.ServerWalkToPatron;
                 return;
             }
-            // 3) Dirty plates at my tables
-            if (_coordinator.TryClaimBusJob(zone, out _busJob))
+            // 3) Dirty plates — any table, any zone (only orders/deliveries are zone-bound)
+            if (_coordinator.TryClaimBusJob(out _busJob))
             {
                 _busPickedUp = false;
                 CurrentState = KitchenMonsterState.ServerBusPlate;
@@ -480,7 +482,16 @@ namespace PitHero.ECS.Components
             // Arrived at the table — place the dish
             Entity dishEntity = null;
             if (TavernSeatConfig.TryGetPlateWorldPosition(c.Ticket.SeatTile, out var platePos))
+            {
+                // Never stack a new meal on an un-bussed empty plate: the server clears the old
+                // plate into their tray as they set the new dish down
+                if (_coordinator.TryClaimBusJobAtPosition(platePos, out var stalePlate)
+                    && stalePlate.DishEntity != null && !stalePlate.DishEntity.IsDestroyed)
+                {
+                    stalePlate.DishEntity.Destroy();
+                }
                 dishEntity = _coordinator.DishService?.SpawnDishAtWorldPos(c.Ticket.Dish, platePos);
+            }
             _coordinator.OnTicketDelivered(c.Ticket, dishEntity);
             _carried.RemoveAt(0);
             BeginNextCarriedLeg();

--- a/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
+++ b/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
@@ -483,12 +483,15 @@ namespace PitHero.ECS.Components
             Entity dishEntity = null;
             if (TavernSeatConfig.TryGetPlateWorldPosition(c.Ticket.SeatTile, out var platePos))
             {
-                // Never stack a new meal on an un-bussed empty plate: the server clears the old
-                // plate into their tray as they set the new dish down
-                if (_coordinator.TryClaimBusJobAtPosition(platePos, out var stalePlate)
-                    && stalePlate.DishEntity != null && !stalePlate.DishEntity.IsDestroyed)
+                // Never stack a new meal on an un-bussed empty plate: the server takes the old
+                // plate in hand as they set the new dish down, then busses it to the sink once
+                // their remaining deliveries are done (a Ticket-less ToSink leg shows the plate
+                // sprite carried to the sink)
+                if (_coordinator.TryClaimBusJobAtPosition(platePos, out var stalePlate))
                 {
-                    stalePlate.DishEntity.Destroy();
+                    if (stalePlate.DishEntity != null && !stalePlate.DishEntity.IsDestroyed)
+                        stalePlate.DishEntity.Destroy();
+                    _carried.Add(new CarriedDish { Ticket = null, ToSink = true });
                 }
                 dishEntity = _coordinator.DishService?.SpawnDishAtWorldPos(c.Ticket.Dish, platePos);
             }

--- a/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
+++ b/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
@@ -239,6 +239,14 @@ namespace PitHero.ECS.Components
 
             var zone = Zone;
 
+            // 0) A plate that has waited too long — in a busy tavern priorities 1-2 always have
+            //    work, so without this age bump bussing starves and plates pile up on tables
+            if (_coordinator.TryClaimBusJob(zone, GameConfig.ServerBusPlateMaxWaitSeconds, out _busJob))
+            {
+                _busPickedUp = false;
+                CurrentState = KitchenMonsterState.ServerBusPlate;
+                return;
+            }
             // 1) Cooked food waiting → deliver
             if (_coordinator.HasReadyDishForZone(zone))
             {

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -217,6 +217,7 @@ namespace PitHero.ECS.Scenes
             Core.Services.GetService<Services.KitchenTaskCoordinator>()?.Detach();
             Core.Services.RemoveService(typeof(Services.KitchenTaskCoordinator));
             Core.Services.RemoveService(typeof(Services.PartyDiningService));
+            Core.Services.RemoveService(typeof(Services.AutoJobAssignmentService));
             Core.Services.RemoveService(typeof(Services.DishEntityService));
             Core.Services.RemoveService(typeof(Services.KitchenHatService));
             Core.Services.RemoveService(typeof(MercenaryManager));
@@ -309,6 +310,16 @@ namespace PitHero.ECS.Scenes
             var partyDiningService = new Services.PartyDiningService();
             kitchenCoordinator.SetPartyOrderSource(partyDiningService);
             Core.Services.AddService(partyDiningService);
+
+            // Auto job assignment service reassigns monster jobs from workload demand (issue #321)
+            var autoJobAssignmentService = new Services.AutoJobAssignmentService(
+                alliedMonsterManager,
+                new Services.AutoJob.KitchenJobDemandEvaluator(kitchenCoordinator,
+                    mercenaryManager, partyDiningService),
+                new Services.AutoJob.FarmingJobDemandEvaluator(farmTaskCoordinator,
+                    Core.Services.GetService<Services.CropGrowthService>(),
+                    Core.Services.GetService<Services.CropPlantingService>()));
+            Core.Services.AddService(autoJobAssignmentService);
 
             // Initialize hero promotion service (handles mercenary promotions and hero crystal ceremonies after death)
             _heroPromotionService = new Services.HeroPromotionService(this);
@@ -508,7 +519,10 @@ namespace PitHero.ECS.Scenes
                         autoCropSellSvc.Designations[i] = pendingData.AutoSellCropDesignations[i];
                 }
             }
-            _settingsUI?.SyncAutoShopControlsFromService();
+            var autoJobSvc = Core.Services.GetService<Services.AutoJobAssignmentService>();
+            if (autoJobSvc != null)
+                autoJobSvc.Enabled = pendingData.AutomateMonsterJobs;
+            _settingsUI?.SyncAutomationControlsFromService();
 
             // Rebuild the plant queue now that both tile states and crop plans are restored
             Core.Services.GetService<Services.FarmTaskCoordinator>()?.RescanForPlanting();
@@ -2325,6 +2339,7 @@ namespace PitHero.ECS.Scenes
                     Core.Services.GetService<TileStateService>(), cropsAtlas);
                 Core.Services.GetService<Services.AutoSeedPurchaseService>()?.Update();
                 Core.Services.GetService<Services.AutoCropSellService>()?.Update();
+                Core.Services.GetService<Services.AutoJobAssignmentService>()?.Update();
             }
 
             // Check if a living hero who respawned without a crystal has arrived at the statue

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -182,6 +182,7 @@ namespace PitHero
         public const int KitchenRunnerWanderMaxTileY = 8;
         public const int ServerOrderMemoryLimit = 3;            // orders a server can hold before posting at the board
         public const int ServerCarryDishLimit = 2;              // cooked dishes a server can carry at once
+        public const float ServerBusPlateMaxWaitSeconds = 90f;  // a plate waiting this long jumps ahead of deliveries/orders
         public const float TicketBoardPauseSeconds = 1f;        // pause at the board to post/read a ticket
         public const int KitchenFridgeParPerCrop = 4;           // runner tops the fridge up to this many of each fetched crop
         public const float KitchenRunnerSprintMultiplier = 3f;  // runner speed multiplier while fetching ingredients

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -187,6 +187,10 @@ namespace PitHero
         public const int KitchenFridgeParPerCrop = 4;           // runner tops the fridge up to this many of each fetched crop
         public const float KitchenRunnerSprintMultiplier = 3f;  // runner speed multiplier while fetching ingredients
         public const float ServerWanderPauseSeconds = 2.5f;     // idle pause between server wander hops
+        // A patron whose assigned seat still has an un-bussed plate waits here until it's cleared
+        public const int TavernDoorWaitTileX = 100;
+        public const int TavernDoorWaitTileY = 6;
+
         // Tavern dining area bounds (server zones and wandering)
         public const int TavernAreaMinTileX = 91;
         public const int TavernAreaMaxTileX = 99;

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -219,6 +219,14 @@ namespace PitHero
         public const float DishTipMinPercent = 0.05f;           // tip is 5-15% of dish price, rounded up
         public const float DishTipMaxPercent = 0.15f;
 
+        // Automated monster job assignment (issue #321)
+        public const float AutoJobReassessIntervalSeconds = 60f;   // scaled seconds between reassessments (60 in-game minutes)
+        public const int AutoJobFarmTasksPerWorker = 6;            // burst demand: outstanding farm tasks each farmer can absorb
+        public const int AutoJobFarmCropsPerWorkerBaseline = 12;   // quiet-period demand: crops + plans each farmer can tend
+        public const int AutoJobKitchenBaseStaff = 3;              // cook + server + runner minimum (no runner -> fridge runs dry)
+        public const int AutoJobKitchenBacklogPerExtraWorker = 3;  // tickets/patrons per extra kitchen worker beyond base staff
+        public const int AutoJobKitchenMaxWorkers = 7;             // mirrors KitchenTaskCoordinator role-post cap
+
         // Camera Configuration
         public const float CameraDefaultZoom = 1f; // default zoom level
         public const float CameraMinimumZoom = 0.5f; // can't zoom out past default for normal maps

--- a/PitHero/Services/AutoJob/FarmingJobDemandEvaluator.cs
+++ b/PitHero/Services/AutoJob/FarmingJobDemandEvaluator.cs
@@ -1,0 +1,57 @@
+using RolePlayingFramework.AlliedMonsters;
+
+namespace PitHero.Services.AutoJob
+{
+    /// <summary>
+    /// Farming demand: the larger of a burst signal (outstanding till/plant/water/harvest tasks — spikes
+    /// during watering and harvest waves) and a baseline signal (crops + plans under care — keeps a
+    /// skeleton crew during quiet growth periods).
+    /// </summary>
+    public sealed class FarmingJobDemandEvaluator : IJobDemandEvaluator
+    {
+        private readonly FarmTaskCoordinator _coordinator;
+        private readonly CropGrowthService _cropGrowth;
+        private readonly CropPlantingService _cropPlanting;
+
+        /// <summary>All dependencies are optional so the evaluator can run headless in tests.</summary>
+        public FarmingJobDemandEvaluator(FarmTaskCoordinator coordinator,
+            CropGrowthService cropGrowth, CropPlantingService cropPlanting)
+        {
+            _coordinator = coordinator;
+            _cropGrowth = cropGrowth;
+            _cropPlanting = cropPlanting;
+        }
+
+        /// <inheritdoc/>
+        public MonsterJob Job => MonsterJob.Farming;
+
+        /// <inheritdoc/>
+        public JobDemandEntry EvaluateDemand(int rosterSize)
+        {
+            int outstanding = _coordinator != null ? _coordinator.OutstandingTaskCount : 0;
+            int careLoad = (_cropGrowth != null ? _cropGrowth.CropCount : 0)
+                + (_cropPlanting != null ? _cropPlanting.PlanCount : 0);
+            return ComputeDemand(outstanding, careLoad, rosterSize);
+        }
+
+        /// <summary>Pure demand math: max of the burst and baseline worker counts, clamped to the roster.</summary>
+        public static JobDemandEntry ComputeDemand(int outstandingTasks, int careLoad, int rosterSize)
+        {
+            int burst = CeilDiv(outstandingTasks, GameConfig.AutoJobFarmTasksPerWorker);
+            int baseline = CeilDiv(careLoad, GameConfig.AutoJobFarmCropsPerWorkerBaseline);
+            int desired = burst > baseline ? burst : baseline;
+            if (desired > rosterSize)
+                desired = rosterSize;
+
+            return new JobDemandEntry
+            {
+                Job = MonsterJob.Farming,
+                MinWorkers = desired > 0 ? 1 : 0,
+                DesiredWorkers = desired,
+                Sticky = false,
+            };
+        }
+
+        private static int CeilDiv(int value, int per) => (value + per - 1) / per;
+    }
+}

--- a/PitHero/Services/AutoJob/IJobDemandEvaluator.cs
+++ b/PitHero/Services/AutoJob/IJobDemandEvaluator.cs
@@ -1,0 +1,14 @@
+using RolePlayingFramework.AlliedMonsters;
+
+namespace PitHero.Services.AutoJob
+{
+    /// <summary>Per-job demand provider for the auto job assignment system. Add one per automatable job.</summary>
+    public interface IJobDemandEvaluator
+    {
+        /// <summary>The job this evaluator staffs.</summary>
+        MonsterJob Job { get; }
+
+        /// <summary>Computes how many workers this job wants right now, given the roster size.</summary>
+        JobDemandEntry EvaluateDemand(int rosterSize);
+    }
+}

--- a/PitHero/Services/AutoJob/JobAssignmentSolver.cs
+++ b/PitHero/Services/AutoJob/JobAssignmentSolver.cs
@@ -1,0 +1,191 @@
+using System.Collections.Generic;
+using RolePlayingFramework.AlliedMonsters;
+
+namespace PitHero.Services.AutoJob
+{
+    /// <summary>How many workers a job wants, and whether its current workers are protected from demotion.</summary>
+    public struct JobDemandEntry
+    {
+        /// <summary>The job this demand entry staffs.</summary>
+        public MonsterJob Job;
+
+        /// <summary>Workers filled before any job's desired slots.</summary>
+        public int MinWorkers;
+
+        /// <summary>Workers filled after all jobs' minimums, in demand-list order.</summary>
+        public int DesiredWorkers;
+
+        /// <summary>When true, monsters currently on this job are never demoted (kitchen rule).</summary>
+        public bool Sticky;
+    }
+
+    /// <summary>Immutable view of one roster monster used by the solver.</summary>
+    public struct MonsterJobSnapshot
+    {
+        /// <summary>Index of this monster in the roster list; used as the deterministic tie-breaker.</summary>
+        public int RosterIndex;
+
+        /// <summary>The monster's job before this solve.</summary>
+        public MonsterJob CurrentJob;
+
+        /// <summary>Farming proficiency rating, 1–9.</summary>
+        public int FarmingProficiency;
+
+        /// <summary>Cooking proficiency rating, 1–9.</summary>
+        public int CookingProficiency;
+
+        /// <summary>Fishing proficiency rating, 1–9.</summary>
+        public int FishingProficiency;
+    }
+
+    /// <summary>
+    /// Pure, deterministic assignment solver: fills each job's minimum staffing first (by proficiency),
+    /// then desired staffing, honoring sticky jobs whose workers are never demoted. Monsters left
+    /// unassigned get MonsterJob.None so the coordinators send them home.
+    /// </summary>
+    public static class JobAssignmentSolver
+    {
+        /// <summary>Returns the monster's proficiency for the given job (0 for None or unknown jobs).</summary>
+        public static int GetProficiency(in MonsterJobSnapshot m, MonsterJob job)
+        {
+            switch (job)
+            {
+                case MonsterJob.Farming: return m.FarmingProficiency;
+                case MonsterJob.Cooking: return m.CookingProficiency;
+                case MonsterJob.Fishing: return m.FishingProficiency;
+                default: return 0;
+            }
+        }
+
+        /// <summary>
+        /// Computes new assignments. resultJobs is cleared and refilled parallel to monsters.
+        /// Deterministic: candidate ties are broken by lowest RosterIndex. Allocation-free beyond
+        /// growth of the caller's result list.
+        /// </summary>
+        public static void Solve(List<MonsterJobSnapshot> monsters, List<JobDemandEntry> demands,
+            List<MonsterJob> resultJobs)
+        {
+            resultJobs.Clear();
+            for (int i = 0; i < monsters.Count; i++)
+                resultJobs.Add(MonsterJob.None);
+
+            // Sticky pass: workers on a sticky job keep it unconditionally, even above desired count.
+            for (int i = 0; i < monsters.Count; i++)
+            {
+                var current = monsters[i].CurrentJob;
+                if (current == MonsterJob.None)
+                    continue;
+                for (int d = 0; d < demands.Count; d++)
+                {
+                    if (demands[d].Sticky && demands[d].Job == current)
+                    {
+                        resultJobs[i] = current;
+                        break;
+                    }
+                }
+            }
+
+            FillPass(monsters, demands, resultJobs, true);
+            FillPass(monsters, demands, resultJobs, false);
+            SwapPass(monsters, demands, resultJobs);
+        }
+
+        /// <summary>Fills each demand up to MinWorkers (minPass) or DesiredWorkers by best proficiency.</summary>
+        private static void FillPass(List<MonsterJobSnapshot> monsters, List<JobDemandEntry> demands,
+            List<MonsterJob> resultJobs, bool minPass)
+        {
+            for (int d = 0; d < demands.Count; d++)
+            {
+                var demand = demands[d];
+                int target = minPass ? demand.MinWorkers : demand.DesiredWorkers;
+                int assigned = CountAssigned(resultJobs, demand.Job);
+                while (assigned < target)
+                {
+                    int best = -1;
+                    int bestProficiency = -1;
+                    for (int i = 0; i < monsters.Count; i++)
+                    {
+                        if (resultJobs[i] != MonsterJob.None)
+                            continue;
+                        int proficiency = GetProficiency(monsters[i], demand.Job);
+                        if (proficiency > bestProficiency)
+                        {
+                            best = i;
+                            bestProficiency = proficiency;
+                        }
+                    }
+                    if (best < 0)
+                        break;
+                    resultJobs[best] = demand.Job;
+                    assigned++;
+                }
+            }
+        }
+
+        /// <summary>
+        /// One deterministic improvement pass: a sticky worker swaps jobs with a non-sticky worker only
+        /// when BOTH jobs strictly gain proficiency, so assignments never oscillate between solves.
+        /// </summary>
+        private static void SwapPass(List<MonsterJobSnapshot> monsters, List<JobDemandEntry> demands,
+            List<MonsterJob> resultJobs)
+        {
+            for (int d = 0; d < demands.Count; d++)
+            {
+                if (!demands[d].Sticky)
+                    continue;
+                var stickyJob = demands[d].Job;
+                for (int w = 0; w < monsters.Count; w++)
+                {
+                    if (resultJobs[w] != stickyJob || monsters[w].CurrentJob != stickyJob)
+                        continue;
+                    int best = -1;
+                    int bestGain = 0;
+                    for (int f = 0; f < monsters.Count; f++)
+                    {
+                        var otherJob = resultJobs[f];
+                        if (otherJob == MonsterJob.None || otherJob == stickyJob)
+                            continue;
+                        if (IsSticky(demands, otherJob) && monsters[f].CurrentJob == otherJob)
+                            continue;
+                        int stickyGain = GetProficiency(monsters[f], stickyJob) - GetProficiency(monsters[w], stickyJob);
+                        int otherGain = GetProficiency(monsters[w], otherJob) - GetProficiency(monsters[f], otherJob);
+                        if (stickyGain <= 0 || otherGain <= 0)
+                            continue;
+                        if (stickyGain + otherGain > bestGain)
+                        {
+                            best = f;
+                            bestGain = stickyGain + otherGain;
+                        }
+                    }
+                    if (best >= 0)
+                    {
+                        var tmp = resultJobs[w];
+                        resultJobs[w] = resultJobs[best];
+                        resultJobs[best] = tmp;
+                    }
+                }
+            }
+        }
+
+        private static bool IsSticky(List<JobDemandEntry> demands, MonsterJob job)
+        {
+            for (int d = 0; d < demands.Count; d++)
+            {
+                if (demands[d].Job == job)
+                    return demands[d].Sticky;
+            }
+            return false;
+        }
+
+        private static int CountAssigned(List<MonsterJob> resultJobs, MonsterJob job)
+        {
+            int count = 0;
+            for (int i = 0; i < resultJobs.Count; i++)
+            {
+                if (resultJobs[i] == job)
+                    count++;
+            }
+            return count;
+        }
+    }
+}

--- a/PitHero/Services/AutoJob/KitchenJobDemandEvaluator.cs
+++ b/PitHero/Services/AutoJob/KitchenJobDemandEvaluator.cs
@@ -1,0 +1,60 @@
+using RolePlayingFramework.AlliedMonsters;
+
+namespace PitHero.Services.AutoJob
+{
+    /// <summary>
+    /// Kitchen demand: a base crew of cook + server + runner whenever any monsters are available
+    /// (the kitchen must be open before tickets or party dining can flow, and without a runner the
+    /// fridge runs dry), plus extra workers as the order backlog grows, capped at the coordinator's
+    /// worker limit. Sticky: kitchen workers are never pulled away by the solver.
+    /// </summary>
+    public sealed class KitchenJobDemandEvaluator : IJobDemandEvaluator
+    {
+        private readonly KitchenTaskCoordinator _coordinator;
+        private readonly MercenaryManager _mercenaryManager;
+        private readonly PartyDiningService _partyDining;
+
+        /// <summary>All dependencies are optional so the evaluator can run headless in tests.</summary>
+        public KitchenJobDemandEvaluator(KitchenTaskCoordinator coordinator,
+            MercenaryManager mercenaryManager, PartyDiningService partyDining)
+        {
+            _coordinator = coordinator;
+            _mercenaryManager = mercenaryManager;
+            _partyDining = partyDining;
+        }
+
+        /// <inheritdoc/>
+        public MonsterJob Job => MonsterJob.Cooking;
+
+        /// <inheritdoc/>
+        public JobDemandEntry EvaluateDemand(int rosterSize)
+        {
+            int backlog = (_coordinator != null ? _coordinator.ActiveTicketCount : 0)
+                + (_mercenaryManager != null ? _mercenaryManager.CountSeatedPatrons() : 0)
+                + (_partyDining != null ? _partyDining.CountPendingPartyDiners() : 0);
+            return ComputeDemand(backlog, rosterSize);
+        }
+
+        /// <summary>Pure demand math: base crew plus one extra worker per backlog block, capped.</summary>
+        public static JobDemandEntry ComputeDemand(int backlog, int rosterSize)
+        {
+            int baseStaff = GameConfig.AutoJobKitchenBaseStaff;
+            if (baseStaff > rosterSize)
+                baseStaff = rosterSize;
+
+            int desired = baseStaff + backlog / GameConfig.AutoJobKitchenBacklogPerExtraWorker;
+            if (desired > GameConfig.AutoJobKitchenMaxWorkers)
+                desired = GameConfig.AutoJobKitchenMaxWorkers;
+
+            int min = backlog > 0 ? (baseStaff < desired ? baseStaff : desired) : 0;
+
+            return new JobDemandEntry
+            {
+                Job = MonsterJob.Cooking,
+                MinWorkers = min,
+                DesiredWorkers = desired,
+                Sticky = true,
+            };
+        }
+    }
+}

--- a/PitHero/Services/AutoJobAssignmentService.cs
+++ b/PitHero/Services/AutoJobAssignmentService.cs
@@ -26,6 +26,7 @@ namespace PitHero.Services
         private readonly List<MonsterJob> _resultJobs = new List<MonsterJob>(64);
 
         private float _lastAssessSeconds = -1f;
+        private bool _wasNighttime;
 
         /// <summary>Whether automatic job assignment is active.</summary>
         public bool Enabled { get; set; } = false;
@@ -64,17 +65,37 @@ namespace PitHero.Services
             if (time == null)
                 return;
 
-            float now = time.AccumulatedSeconds;
-            if (_lastAssessSeconds < 0f || now < _lastAssessSeconds)
+            TickCadence(time.AccumulatedSeconds, time.IsNighttime);
+        }
+
+        /// <summary>
+        /// Cadence bookkeeping, separated from Update for headless testing: fires ReassessNow every
+        /// GameConfig.AutoJobReassessIntervalSeconds, and immediately at the day/night shift change
+        /// (6AM/10PM) so the incoming shift is right-sized to the current workload instead of
+        /// running on counts up to an hour stale.
+        /// </summary>
+        public void TickCadence(float nowSeconds, bool isNighttime)
+        {
+            if (_lastAssessSeconds < 0f || nowSeconds < _lastAssessSeconds)
             {
                 // First tick after enable/load, or time rewound by a load — restart the interval.
-                _lastAssessSeconds = now;
+                _lastAssessSeconds = nowSeconds;
+                _wasNighttime = isNighttime;
                 return;
             }
-            if (now - _lastAssessSeconds < GameConfig.AutoJobReassessIntervalSeconds)
+
+            if (isNighttime != _wasNighttime)
+            {
+                _wasNighttime = isNighttime;
+                _lastAssessSeconds = nowSeconds;
+                ReassessNow();
+                return;
+            }
+
+            if (nowSeconds - _lastAssessSeconds < GameConfig.AutoJobReassessIntervalSeconds)
                 return;
 
-            _lastAssessSeconds = now;
+            _lastAssessSeconds = nowSeconds;
             ReassessNow();
         }
 

--- a/PitHero/Services/AutoJobAssignmentService.cs
+++ b/PitHero/Services/AutoJobAssignmentService.cs
@@ -1,0 +1,114 @@
+using System.Collections.Generic;
+using Nez;
+using PitHero.Services.AutoJob;
+using RolePlayingFramework.AlliedMonsters;
+
+namespace PitHero.Services
+{
+    /// <summary>
+    /// Automates allied-monster job assignment (issue #321). When enabled, reassesses per-job worker
+    /// demand every GameConfig.AutoJobReassessIntervalSeconds of in-game time (60 in-game minutes)
+    /// and reassigns monsters via JobAssignmentSolver. The coordinators reconcile worker entities off
+    /// AlliedMonster.Job every frame, so writing the job field is the entire assignment action.
+    /// </summary>
+    public class AutoJobAssignmentService
+    {
+        private readonly AlliedMonsterManager _alliedMonsters;
+        private readonly List<IJobDemandEvaluator> _evaluators = new List<IJobDemandEvaluator>(4);
+
+        // Scratch lists reused across reassessments (roster is capped well below 64).
+        private readonly List<MonsterJobSnapshot> _snapshots = new List<MonsterJobSnapshot>(64);
+        private readonly List<JobDemandEntry> _demands = new List<JobDemandEntry>(4);
+        private readonly List<MonsterJob> _resultJobs = new List<MonsterJob>(64);
+
+        private float _lastAssessSeconds = -1f;
+
+        /// <summary>Whether automatic job assignment is active.</summary>
+        public bool Enabled { get; set; } = false;
+
+        /// <summary>
+        /// Initialises the service with the roster and the initial demand evaluators, in priority order
+        /// (kitchen first: its small sticky crew is staffed before farming absorbs the rest).
+        /// </summary>
+        public AutoJobAssignmentService(AlliedMonsterManager alliedMonsters,
+            KitchenJobDemandEvaluator kitchenEvaluator, FarmingJobDemandEvaluator farmingEvaluator)
+        {
+            _alliedMonsters = alliedMonsters;
+            if (kitchenEvaluator != null)
+                _evaluators.Add(kitchenEvaluator);
+            if (farmingEvaluator != null)
+                _evaluators.Add(farmingEvaluator);
+        }
+
+        /// <summary>Registers an additional demand evaluator (future jobs, e.g. fishing).</summary>
+        public void AddEvaluator(IJobDemandEvaluator evaluator)
+        {
+            if (evaluator != null)
+                _evaluators.Add(evaluator);
+        }
+
+        /// <summary>
+        /// Advances the reassessment cadence. Called once per game frame while the game is unpaused;
+        /// keyed to InGameTimeService so pausing never advances the timer.
+        /// </summary>
+        public void Update()
+        {
+            if (!Enabled)
+                return;
+
+            var time = Core.Instance != null ? Core.Services.GetService<InGameTimeService>() : null;
+            if (time == null)
+                return;
+
+            float now = time.AccumulatedSeconds;
+            if (_lastAssessSeconds < 0f || now < _lastAssessSeconds)
+            {
+                // First tick after enable/load, or time rewound by a load — restart the interval.
+                _lastAssessSeconds = now;
+                return;
+            }
+            if (now - _lastAssessSeconds < GameConfig.AutoJobReassessIntervalSeconds)
+                return;
+
+            _lastAssessSeconds = now;
+            ReassessNow();
+        }
+
+        /// <summary>
+        /// Runs one demand evaluation + solve + apply pass immediately, bypassing the cadence gate.
+        /// Called when the player first enables automation so assignments take effect at once.
+        /// </summary>
+        public void ReassessNow()
+        {
+            if (_alliedMonsters == null)
+                return;
+
+            var roster = _alliedMonsters.AlliedMonsters;
+            _snapshots.Clear();
+            for (int i = 0; i < roster.Count; i++)
+            {
+                var m = roster[i];
+                _snapshots.Add(new MonsterJobSnapshot
+                {
+                    RosterIndex = i,
+                    CurrentJob = m.Job,
+                    FarmingProficiency = m.FarmingProficiency,
+                    CookingProficiency = m.CookingProficiency,
+                    FishingProficiency = m.FishingProficiency,
+                });
+            }
+
+            _demands.Clear();
+            for (int i = 0; i < _evaluators.Count; i++)
+                _demands.Add(_evaluators[i].EvaluateDemand(roster.Count));
+
+            JobAssignmentSolver.Solve(_snapshots, _demands, _resultJobs);
+
+            for (int i = 0; i < roster.Count; i++)
+            {
+                if (roster[i].Job != _resultJobs[i])
+                    roster[i].Job = _resultJobs[i];
+            }
+        }
+    }
+}

--- a/PitHero/Services/AutoJobAssignmentService.cs
+++ b/PitHero/Services/AutoJobAssignmentService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Nez;
+using PitHero.Config;
 using PitHero.Services.AutoJob;
 using RolePlayingFramework.AlliedMonsters;
 
@@ -8,8 +9,11 @@ namespace PitHero.Services
     /// <summary>
     /// Automates allied-monster job assignment (issue #321). When enabled, reassesses per-job worker
     /// demand every GameConfig.AutoJobReassessIntervalSeconds of in-game time (60 in-game minutes)
-    /// and reassigns monsters via JobAssignmentSolver. The coordinators reconcile worker entities off
-    /// AlliedMonster.Job every frame, so writing the job field is the entire assignment action.
+    /// and reassigns monsters via JobAssignmentSolver. Day and nocturnal monsters are disjoint
+    /// workforces (MonsterScheduleConfig: 6AM–10PM vs 10PM–6AM), so each shift is solved separately
+    /// and every job gets both a day crew and a night crew. The coordinators reconcile worker
+    /// entities off AlliedMonster.Job every frame, so writing the job field is the entire
+    /// assignment action.
     /// </summary>
     public class AutoJobAssignmentService
     {
@@ -77,17 +81,29 @@ namespace PitHero.Services
         /// <summary>
         /// Runs one demand evaluation + solve + apply pass immediately, bypassing the cadence gate.
         /// Called when the player first enables automation so assignments take effect at once.
+        /// Solves the day shift and the night shift independently — the two groups never work at
+        /// the same time, so each must staff every job on its own.
         /// </summary>
         public void ReassessNow()
         {
             if (_alliedMonsters == null)
                 return;
 
+            ReassessShift(nocturnal: false);
+            ReassessShift(nocturnal: true);
+        }
+
+        /// <summary>Evaluates demand for one shift's roster and applies the solver's assignments to it.</summary>
+        private void ReassessShift(bool nocturnal)
+        {
             var roster = _alliedMonsters.AlliedMonsters;
+
             _snapshots.Clear();
             for (int i = 0; i < roster.Count; i++)
             {
                 var m = roster[i];
+                if (MonsterScheduleConfig.IsNocturnal(m.MonsterTypeName) != nocturnal)
+                    continue;
                 _snapshots.Add(new MonsterJobSnapshot
                 {
                     RosterIndex = i,
@@ -97,17 +113,20 @@ namespace PitHero.Services
                     FishingProficiency = m.FishingProficiency,
                 });
             }
+            if (_snapshots.Count == 0)
+                return;
 
             _demands.Clear();
             for (int i = 0; i < _evaluators.Count; i++)
-                _demands.Add(_evaluators[i].EvaluateDemand(roster.Count));
+                _demands.Add(_evaluators[i].EvaluateDemand(_snapshots.Count));
 
             JobAssignmentSolver.Solve(_snapshots, _demands, _resultJobs);
 
-            for (int i = 0; i < roster.Count; i++)
+            for (int i = 0; i < _snapshots.Count; i++)
             {
-                if (roster[i].Job != _resultJobs[i])
-                    roster[i].Job = _resultJobs[i];
+                var monster = roster[_snapshots[i].RosterIndex];
+                if (monster.Job != _resultJobs[i])
+                    monster.Job = _resultJobs[i];
             }
         }
     }

--- a/PitHero/Services/CropGrowthService.cs
+++ b/PitHero/Services/CropGrowthService.cs
@@ -40,6 +40,9 @@ namespace PitHero.Services
         /// <summary>Returns true if a crop has been planted at the given tile.</summary>
         public bool HasCrop(Point tile) => _crops.ContainsKey(tile);
 
+        /// <summary>Number of crops currently planted in the world.</summary>
+        public int CropCount => _crops.Count;
+
         /// <summary>Returns the type of the planted crop at the given tile, or null if none.</summary>
         public CropType? GetCropType(Point tile)
         {

--- a/PitHero/Services/CropPlantingService.cs
+++ b/PitHero/Services/CropPlantingService.cs
@@ -40,6 +40,9 @@ namespace PitHero.Services
         /// <summary>Returns true if a planting plan exists at the given tile.</summary>
         public bool HasPlan(Point tile) => _tileIndex.ContainsKey(tile);
 
+        /// <summary>Number of crop plans currently placed (planted or awaiting planting).</summary>
+        public int PlanCount => _plans.Count;
+
         /// <summary>Returns the crop type of the plan at a tile, or null if none exists.</summary>
         public CropType? GetPlanType(Point tile)
         {

--- a/PitHero/Services/FarmTaskCoordinator.cs
+++ b/PitHero/Services/FarmTaskCoordinator.cs
@@ -72,6 +72,10 @@ namespace PitHero.Services
         /// <summary>Number of actions waiting in the till queue (excludes claimed actions).</summary>
         public int PendingActionCount => _queue.Count;
 
+        /// <summary>Total outstanding farm tasks across all queues (queued + claimed by workers).</summary>
+        public int OutstandingTaskCount => _tracked.Count + _plantTracked.Count + _waterTracked.Count
+            + _harvestTracked.Count + _destroyTracked.Count + _pickupTracked.Count;
+
         public FarmTaskCoordinator(TileStateService tileState, BuildingService buildingService,
             int mapWidthTiles, int mapHeightTiles, AlliedMonsterManager alliedMonsters = null,
             TilledTileService tilledTileService = null,

--- a/PitHero/Services/KitchenTaskCoordinator.cs
+++ b/PitHero/Services/KitchenTaskCoordinator.cs
@@ -71,7 +71,8 @@ namespace PitHero.Services
         public FarmPathfinder Pathfinder { get; }
 
         // ── Tickets / board ─────────────────────────────────────────────────────
-        private readonly List<KitchenTicket> _tickets = new List<KitchenTicket>(16);
+        private const int MaxOpenTickets = 16;
+        private readonly List<KitchenTicket> _tickets = new List<KitchenTicket>(MaxOpenTickets);
         private int _nextTicketId;
 
         // ── Fridge inventory (kitchen-local crop stock) ─────────────────────────
@@ -101,6 +102,25 @@ namespace PitHero.Services
 
         /// <summary>Number of open kitchen tickets (any state) — the order backlog.</summary>
         public int ActiveTicketCount => _tickets.Count;
+
+        /// <summary>True while the ticket board has room for another order.</summary>
+        public bool HasTicketCapacity => _tickets.Count < MaxOpenTickets;
+
+        /// <summary>
+        /// True when at least one dish is fully coverable from fridge + storage. Servers must
+        /// check this (and HasTicketCapacity) before walking to a waiting patron: when no order
+        /// can possibly be created, targeting the patron anyway livelocks the server standing at
+        /// the seat, re-selecting the same patron every decide pass.
+        /// </summary>
+        public bool HasAnyOrderableDish()
+        {
+            for (int d = 0; d < DishTypeInfo.Count; d++)
+            {
+                if (CanCoverRecipe((DishType)d))
+                    return true;
+            }
+            return false;
+        }
 
         // ── Constructor ─────────────────────────────────────────────────────────
 
@@ -426,7 +446,7 @@ namespace PitHero.Services
         public KitchenTicket CreateTicket(DishType dish, bool isParty, int partySlot,
             Entity patronEntity, Point seatTile)
         {
-            if (_tickets.Count >= 16)
+            if (_tickets.Count >= MaxOpenTickets)
                 return null;
 
             EnsureServices();
@@ -500,7 +520,7 @@ namespace PitHero.Services
         /// </summary>
         public KitchenTicket CreateTicketPreReserved(DishType dish, int partySlot)
         {
-            if (_tickets.Count >= 16)
+            if (_tickets.Count >= MaxOpenTickets)
                 return null;
 
             var def = DishConfig.GetDefinition(dish);

--- a/PitHero/Services/KitchenTaskCoordinator.cs
+++ b/PitHero/Services/KitchenTaskCoordinator.cs
@@ -39,7 +39,6 @@ namespace PitHero.Services
         {
             public Entity DishEntity;  // plate entity on the table to be bussed
             public Vector2 WorldPos;   // where to pick it up from
-            public int TableTileY;     // zone filter (top tables y<=4, bottom y>=5)
             public float EnqueuedTime; // Time.TotalTime when queued — drives anti-starvation priority
         }
 
@@ -580,7 +579,6 @@ namespace PitHero.Services
                 {
                     DishEntity = t.PlatedDishEntity,
                     WorldPos = t.PlatedDishEntity.Transform.Position,
-                    TableTileY = t.TableTile.Y,
                     EnqueuedTime = Time.TotalTime,
                 });
                 t.PlatedDishEntity = null;
@@ -683,7 +681,6 @@ namespace PitHero.Services
                     {
                         DishEntity = emptyPlate,
                         WorldPos = platePos,
-                        TableTileY = t.TableTile.Y,
                         EnqueuedTime = Time.TotalTime,
                     });
                 }
@@ -906,24 +903,22 @@ namespace PitHero.Services
             }
         }
 
-        /// <summary>Next pending bus job for the zone's server. Removes it from the queue.</summary>
-        public bool TryClaimBusJob(ServerZone zone, out BusJob job)
-            => TryClaimBusJob(zone, 0f, out job);
+        /// <summary>Next pending bus job. Removes it from the queue.</summary>
+        public bool TryClaimBusJob(out BusJob job)
+            => TryClaimBusJob(0f, out job);
 
         /// <summary>
-        /// Claims the oldest bus job in the zone that has waited at least minAgeSeconds
-        /// (0 = any). Removes it from the queue. The age gate lets servers bump long-waiting
-        /// plates ahead of order-taking so a busy tavern can't starve bussing forever.
+        /// Claims the oldest bus job that has waited at least minAgeSeconds (0 = any). Removes it
+        /// from the queue. Bussing is deliberately zone-free — any server may clear any table —
+        /// and the age gate lets servers bump long-waiting plates ahead of order-taking so a busy
+        /// tavern can't starve bussing forever. (Order-taking and delivery stay zone-restricted.)
         /// </summary>
-        public bool TryClaimBusJob(ServerZone zone, float minAgeSeconds, out BusJob job)
+        public bool TryClaimBusJob(float minAgeSeconds, out BusJob job)
         {
             int oldest = -1;
             float oldestTime = float.MaxValue;
             for (int i = 0; i < _busJobs.Count; i++)
             {
-                var tableTile = new Point(0, _busJobs[i].TableTileY);
-                if (!ZoneContainsTable(zone, tableTile))
-                    continue;
                 if (Time.TotalTime - _busJobs[i].EnqueuedTime < minAgeSeconds)
                     continue;
                 if (_busJobs[i].EnqueuedTime < oldestTime)
@@ -940,6 +935,26 @@ namespace PitHero.Services
             job = _busJobs[oldest];
             _busJobs.RemoveAt(oldest);
             return true;
+        }
+
+        /// <summary>
+        /// Claims the pending bus job whose plate sits at the given world position (within half a
+        /// tile), if any. Called by a delivering server right before it sets a new dish down, so a
+        /// new meal is never stacked on top of an un-bussed empty plate.
+        /// </summary>
+        public bool TryClaimBusJobAtPosition(Vector2 platePos, out BusJob job)
+        {
+            const float maxDistSq = 16f * 16f;
+            for (int i = 0; i < _busJobs.Count; i++)
+            {
+                if (Vector2.DistanceSquared(_busJobs[i].WorldPos, platePos) > maxDistSq)
+                    continue;
+                job = _busJobs[i];
+                _busJobs.RemoveAt(i);
+                return true;
+            }
+            job = default;
+            return false;
         }
 
         // ── Runner API ───────────────────────────────────────────────────────────

--- a/PitHero/Services/KitchenTaskCoordinator.cs
+++ b/PitHero/Services/KitchenTaskCoordinator.cs
@@ -962,6 +962,23 @@ namespace PitHero.Services
         }
 
         /// <summary>
+        /// True while a pending (unclaimed) bus job's plate sits at the given world position
+        /// (within half a tile). Arriving patrons wait at the tavern door while this holds so
+        /// they never sit down at a table with a dirty plate; once a server claims the job the
+        /// plate is moments from being cleared, so the patron may start walking in.
+        /// </summary>
+        public bool HasPendingBusJobAt(Vector2 platePos)
+        {
+            const float maxDistSq = 16f * 16f;
+            for (int i = 0; i < _busJobs.Count; i++)
+            {
+                if (Vector2.DistanceSquared(_busJobs[i].WorldPos, platePos) <= maxDistSq)
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
         /// Claims the pending bus job whose plate sits at the given world position (within half a
         /// tile), if any. Called by a delivering server right before it sets a new dish down, so a
         /// new meal is never stacked on top of an un-bussed empty plate.

--- a/PitHero/Services/KitchenTaskCoordinator.cs
+++ b/PitHero/Services/KitchenTaskCoordinator.cs
@@ -37,9 +37,10 @@ namespace PitHero.Services
 
         public struct BusJob
         {
-            public Entity DishEntity; // plate entity on the table to be bussed
-            public Vector2 WorldPos;  // where to pick it up from
-            public int TableTileY;    // zone filter (top tables y<=4, bottom y>=5)
+            public Entity DishEntity;  // plate entity on the table to be bussed
+            public Vector2 WorldPos;   // where to pick it up from
+            public int TableTileY;     // zone filter (top tables y<=4, bottom y>=5)
+            public float EnqueuedTime; // Time.TotalTime when queued — drives anti-starvation priority
         }
 
         private struct OrphanDish
@@ -580,6 +581,7 @@ namespace PitHero.Services
                     DishEntity = t.PlatedDishEntity,
                     WorldPos = t.PlatedDishEntity.Transform.Position,
                     TableTileY = t.TableTile.Y,
+                    EnqueuedTime = Time.TotalTime,
                 });
                 t.PlatedDishEntity = null;
             }
@@ -682,6 +684,7 @@ namespace PitHero.Services
                         DishEntity = emptyPlate,
                         WorldPos = platePos,
                         TableTileY = t.TableTile.Y,
+                        EnqueuedTime = Time.TotalTime,
                     });
                 }
             }
@@ -905,18 +908,38 @@ namespace PitHero.Services
 
         /// <summary>Next pending bus job for the zone's server. Removes it from the queue.</summary>
         public bool TryClaimBusJob(ServerZone zone, out BusJob job)
+            => TryClaimBusJob(zone, 0f, out job);
+
+        /// <summary>
+        /// Claims the oldest bus job in the zone that has waited at least minAgeSeconds
+        /// (0 = any). Removes it from the queue. The age gate lets servers bump long-waiting
+        /// plates ahead of order-taking so a busy tavern can't starve bussing forever.
+        /// </summary>
+        public bool TryClaimBusJob(ServerZone zone, float minAgeSeconds, out BusJob job)
         {
+            int oldest = -1;
+            float oldestTime = float.MaxValue;
             for (int i = 0; i < _busJobs.Count; i++)
             {
                 var tableTile = new Point(0, _busJobs[i].TableTileY);
                 if (!ZoneContainsTable(zone, tableTile))
                     continue;
-                job = _busJobs[i];
-                _busJobs.RemoveAt(i);
-                return true;
+                if (Time.TotalTime - _busJobs[i].EnqueuedTime < minAgeSeconds)
+                    continue;
+                if (_busJobs[i].EnqueuedTime < oldestTime)
+                {
+                    oldestTime = _busJobs[i].EnqueuedTime;
+                    oldest = i;
+                }
             }
-            job = default;
-            return false;
+            if (oldest < 0)
+            {
+                job = default;
+                return false;
+            }
+            job = _busJobs[oldest];
+            _busJobs.RemoveAt(oldest);
+            return true;
         }
 
         // ── Runner API ───────────────────────────────────────────────────────────

--- a/PitHero/Services/KitchenTaskCoordinator.cs
+++ b/PitHero/Services/KitchenTaskCoordinator.cs
@@ -99,6 +99,9 @@ namespace PitHero.Services
         /// <summary>True when ≥1 cook and ≥1 server are assigned and awake.</summary>
         public bool IsKitchenOpen => _cook1WorkerIdx >= 0 && _server1WorkerIdx >= 0;
 
+        /// <summary>Number of open kitchen tickets (any state) — the order backlog.</summary>
+        public int ActiveTicketCount => _tickets.Count;
+
         // ── Constructor ─────────────────────────────────────────────────────────
 
         public KitchenTaskCoordinator(AlliedMonsterManager alliedMonsters,
@@ -169,7 +172,8 @@ namespace PitHero.Services
 
             // Assign roles in order: cook1, server1, runner1, cook2, server2, runner2, cook3.
             // Stations and zones are claimed dynamically by the FSMs.
-            int postCount = _wantedAssignments.Count < 7 ? _wantedAssignments.Count : 7;
+            int postCount = _wantedAssignments.Count < GameConfig.AutoJobKitchenMaxWorkers
+                ? _wantedAssignments.Count : GameConfig.AutoJobKitchenMaxWorkers;
             for (int i = 0; i < postCount; i++)
             {
                 KitchenRole role;

--- a/PitHero/Services/MercenaryManager.cs
+++ b/PitHero/Services/MercenaryManager.cs
@@ -678,6 +678,22 @@ namespace PitHero.Services
             }).ToList();
         }
 
+        /// <summary>Number of unhired mercenaries currently seated as tavern patrons.</summary>
+        public int CountSeatedPatrons()
+        {
+            int count = 0;
+            for (int i = 0; i < _mercenaryEntities.Count; i++)
+            {
+                var entity = _mercenaryEntities[i];
+                if (entity == null)
+                    continue;
+                var comp = entity.GetComponent<MercenaryComponent>();
+                if (comp != null && !comp.IsHired && entity.HasComponent<ECS.Components.TavernPatronComponent>())
+                    count++;
+            }
+            return count;
+        }
+
         /// <summary>Gets an available tavern position</summary>
         private Point? GetAvailableTavernPosition()
         {

--- a/PitHero/Services/MercenaryManager.cs
+++ b/PitHero/Services/MercenaryManager.cs
@@ -295,7 +295,7 @@ namespace PitHero.Services
             var tileMover = mercEntity.GetComponent<TileByTileMover>();
             var mercComponent = mercEntity.GetComponent<MercenaryComponent>();
             var pathfinding = mercEntity.GetComponent<PathfindingActorComponent>();
-            
+
             if (tileMover == null || mercComponent == null || pathfinding == null)
                 yield break;
 
@@ -311,43 +311,90 @@ namespace PitHero.Services
             if (mercComponent.IsBeingRemoved)
                 yield break;
 
-            // Calculate current tile position
+            // The assigned seat's table still has an un-bussed plate: wait at the tavern door
+            // until a server clears it. A server only takes orders from seated patrons, so a
+            // patron waiting at the door adds no ordering pressure while the backlog drains.
+            if (HasUnbussedPlateAtSeat(tavernPosition))
+            {
+                var doorTile = new Point(GameConfig.TavernDoorWaitTileX, GameConfig.TavernDoorWaitTileY);
+                yield return WalkMercPath(mercEntity, doorTile);
+                if (mercComponent.IsHired || mercComponent.IsBeingRemoved)
+                    yield break;
+
+                mercEntity.GetComponent<ActorFacingComponent>()?.SetFacing(Direction.Left);
+                Debug.Log($"[MercenaryManager] Mercenary {mercComponent.LinkedMercenary.Name} waiting at the door for a dirty table to be cleared");
+                while (HasUnbussedPlateAtSeat(tavernPosition))
+                {
+                    if (mercComponent.IsHired || mercComponent.IsBeingRemoved)
+                        yield break;
+                    yield return Coroutine.WaitForSeconds(0.25f);
+                }
+            }
+
+            yield return WalkMercPath(mercEntity, tavernPosition);
+            if (mercComponent.IsHired || mercComponent.IsBeingRemoved)
+                yield break;
+
+            // Arrived at tavern position
+            mercComponent.IsWaitingInTavern = true;
+
+            // Add patron component so the kitchen system can serve this merc as a dining customer.
+            // Patience starts immediately since the merc is now seated.
+            if (!mercEntity.HasComponent<ECS.Components.TavernPatronComponent>())
+            {
+                var patronComp = mercEntity.AddComponent(new ECS.Components.TavernPatronComponent());
+                patronComp.SeatTile = tavernPosition;
+            }
+
+            Debug.Log($"[MercenaryManager] Mercenary {mercComponent.LinkedMercenary.Name} arrived at tavern");
+        }
+
+        /// <summary>
+        /// Walks the mercenary tile-by-tile along an A* path to the target. Returns early
+        /// (without reaching the target) if the merc is hired or dismissed mid-walk — callers
+        /// must re-check those flags after the walk completes.
+        /// </summary>
+        private System.Collections.IEnumerator WalkMercPath(Entity mercEntity, Point targetTile)
+        {
+            var tileMover = mercEntity.GetComponent<TileByTileMover>();
+            var mercComponent = mercEntity.GetComponent<MercenaryComponent>();
+            var pathfinding = mercEntity.GetComponent<PathfindingActorComponent>();
+            if (tileMover == null || mercComponent == null || pathfinding == null)
+                yield break;
+
             var currentPos = mercEntity.Transform.Position;
             var currentTile = new Point(
                 (int)(currentPos.X / GameConfig.TileSize),
                 (int)(currentPos.Y / GameConfig.TileSize)
             );
 
-            // Calculate A* path to tavern
-            var path = pathfinding.CalculatePath(currentTile, tavernPosition);
-            
+            var path = pathfinding.CalculatePath(currentTile, targetTile);
             if (path == null || path.Count == 0)
             {
-                Debug.Warn($"[MercenaryManager] Could not find path to tavern for {mercComponent.LinkedMercenary.Name}");
+                Debug.Warn($"[MercenaryManager] Could not find path to ({targetTile.X},{targetTile.Y}) for {mercComponent.LinkedMercenary.Name}");
                 yield break;
             }
 
             Debug.Log($"[MercenaryManager] Mercenary {mercComponent.LinkedMercenary.Name} found path with {path.Count} steps");
 
-            // Follow the path
             for (int i = 0; i < path.Count; i++)
             {
                 // Check if mercenary was hired or dismissed during the walk
                 if (mercComponent.IsHired || mercComponent.IsBeingRemoved)
                 {
-                    Debug.Log($"[MercenaryManager] Mercenary {mercComponent.LinkedMercenary.Name} was hired/dismissed during walk to tavern - stopping tavern walk");
+                    Debug.Log($"[MercenaryManager] Mercenary {mercComponent.LinkedMercenary.Name} was hired/dismissed during walk - stopping");
                     yield break;
                 }
 
-                var targetTile = path[i];
+                var stepTile = path[i];
                 var currentTilePos = new Point(
                     (int)(mercEntity.Transform.Position.X / GameConfig.TileSize),
                     (int)(mercEntity.Transform.Position.Y / GameConfig.TileSize)
                 );
 
                 // Determine direction to move
-                var dx = targetTile.X - currentTilePos.X;
-                var dy = targetTile.Y - currentTilePos.Y;
+                var dx = stepTile.X - currentTilePos.X;
+                var dy = stepTile.Y - currentTilePos.Y;
 
                 Direction? direction = null;
                 if (dx > 0) direction = Direction.Right;
@@ -362,10 +409,9 @@ namespace PitHero.Services
                     // Wait for movement to complete
                     while (tileMover.IsMoving)
                     {
-                        // Also check during movement if mercenary was hired or dismissed
                         if (mercComponent.IsHired || mercComponent.IsBeingRemoved)
                         {
-                            Debug.Log($"[MercenaryManager] Mercenary {mercComponent.LinkedMercenary.Name} was hired/dismissed during movement - stopping tavern walk");
+                            Debug.Log($"[MercenaryManager] Mercenary {mercComponent.LinkedMercenary.Name} was hired/dismissed during movement - stopping");
                             yield break;
                         }
                         yield return null;
@@ -375,19 +421,16 @@ namespace PitHero.Services
                 // Small delay between moves
                 yield return Coroutine.WaitForSeconds(0.05f);
             }
+        }
 
-            // Arrived at tavern position
-            mercComponent.IsWaitingInTavern = true;
-
-            // Add patron component so the kitchen system can serve this merc as a dining customer.
-            // Patience starts immediately since the merc is now seated.
-            if (!mercEntity.HasComponent<ECS.Components.TavernPatronComponent>())
-            {
-                var patronComp = mercEntity.AddComponent(new ECS.Components.TavernPatronComponent());
-                patronComp.SeatTile = tavernPosition;
-            }
-
-            Debug.Log($"[MercenaryManager] Mercenary {mercComponent.LinkedMercenary.Name} arrived at tavern");
+        /// <summary>True while the seat's table plate spot still holds an un-bussed empty plate.</summary>
+        private static bool HasUnbussedPlateAtSeat(Point seatTile)
+        {
+            var coordinator = Core.Services.GetService<KitchenTaskCoordinator>();
+            if (coordinator == null)
+                return false;
+            return Config.TavernSeatConfig.TryGetPlateWorldPosition(seatTile, out var platePos)
+                && coordinator.HasPendingBusJobAt(platePos);
         }
 
         /// <summary>Coroutine to walk mercenary offscreen (pathfind to exit point, then slide 64 pixels down) then remove them</summary>

--- a/PitHero/Services/PartyDiningService.cs
+++ b/PitHero/Services/PartyDiningService.cs
@@ -122,6 +122,20 @@ namespace PitHero.Services
             }
         }
 
+        /// <summary>Party members who still intend to eat at the tavern today (0 when EatAtTavern is off).</summary>
+        public int CountPendingPartyDiners()
+        {
+            if (!EatAtTavern)
+                return 0;
+            int count = 0;
+            for (int slot = 0; slot < PartySlots; slot++)
+            {
+                if (!_slots[slot].HasEatenToday && GetCombatant(slot) != null)
+                    count++;
+            }
+            return count;
+        }
+
         // ── Entry points ────────────────────────────────────────────────────────
 
         /// <summary>

--- a/PitHero/Services/PartyDiningService.cs
+++ b/PitHero/Services/PartyDiningService.cs
@@ -63,6 +63,17 @@ namespace PitHero.Services
         public void MarkPendingReloadDining() => _pendingReloadDining = true;
 
         /// <summary>
+        /// True while a breakfast trip should auto-resume adventuring once everyone has eaten
+        /// or been skipped. Persisted: a save made mid-breakfast must restore this, or the
+        /// reloaded party finishes eating and then sits at the tavern forever.
+        /// </summary>
+        public bool AutoResumeWhenDone
+        {
+            get => _autoResumeWhenDone;
+            set => _autoResumeWhenDone = value;
+        }
+
+        /// <summary>
         /// Restores dining state from a save (call after hero + hired mercs are restored).
         /// Re-registers active meal buffs (no HP/MP re-restore) and, when a member has an open
         /// order, schedules the party's return trip to the tavern. Crops were already deducted
@@ -75,6 +86,7 @@ namespace PitHero.Services
 
             FavoriteDishId = data.FavoriteDishId;
             EatAtTavern = data.EatAtTavern;
+            _autoResumeWhenDone = data.PartyAutoDineResume;
 
             if (data.PartyDining == null)
                 return;
@@ -374,6 +386,11 @@ namespace PitHero.Services
         private void CheckAllDone()
         {
             if (!_autoResumeWhenDone)
+                return;
+
+            // Reload-in-progress: Stop mode hasn't been re-entered yet, so the guard below
+            // would wrongly clear the restored auto-resume flag
+            if (_pendingReloadDining)
                 return;
 
             var hero = GetHeroComponent();

--- a/PitHero/Services/SaveData.cs
+++ b/PitHero/Services/SaveData.cs
@@ -255,12 +255,12 @@ namespace PitHero.Services
     public class SaveData : IPersistable
     {
         /// <summary>Current save file version.</summary>
-        public const int CurrentVersion = 19;
+        public const int CurrentVersion = 20;
 
         /// <summary>
-        /// Oldest save file version this build can still load. v17 and v18 files are byte-exact
-        /// prefixes of v19 (sections 33 dining and 34 automation were appended at the end), so
-        /// they load with default state for the missing sections.
+        /// Oldest save file version this build can still load. v17–v19 files are byte-exact
+        /// prefixes of v20 (sections 33 dining, 34 automation, and 35 auto-dine resume were
+        /// appended at the end), so they load with default state for the missing sections.
         /// </summary>
         public const int MinSupportedVersion = 17;
 
@@ -503,6 +503,10 @@ namespace PitHero.Services
         // Automation (issue #321, v19)
         /// <summary>Whether automatic monster job assignment is enabled.</summary>
         public bool AutomateMonsterJobs = false;
+
+        // Auto-dine resume (v20)
+        /// <summary>Whether a breakfast trip in progress should auto-resume adventuring when done.</summary>
+        public bool PartyAutoDineResume = false;
 
         /// <summary>Initializes a new SaveData with default empty collections.</summary>
         public SaveData()
@@ -906,6 +910,9 @@ namespace PitHero.Services
 
             // 34. Automation (issue #321)
             writer.Write(AutomateMonsterJobs);
+
+            // 35. Auto-dine resume (v20)
+            writer.Write(PartyAutoDineResume);
         }
 
         /// <summary>Reads all game state from the persistence reader.</summary>
@@ -1299,6 +1306,10 @@ namespace PitHero.Services
             // 34. Automation (issue #321, v19+). Older files end at section 33 — default false.
             if (fileVersion >= 19)
                 AutomateMonsterJobs = reader.ReadBool();
+
+            // 35. Auto-dine resume (v20+). Older files end at section 34 — default false.
+            if (fileVersion >= 20)
+                PartyAutoDineResume = reader.ReadBool();
         }
 
         /// <summary>Writes a Color as four individual int components (R, G, B, A).</summary>

--- a/PitHero/Services/SaveData.cs
+++ b/PitHero/Services/SaveData.cs
@@ -1307,9 +1307,25 @@ namespace PitHero.Services
             if (fileVersion >= 19)
                 AutomateMonsterJobs = reader.ReadBool();
 
-            // 35. Auto-dine resume (v20+). Older files end at section 34 — default false.
+            // 35. Auto-dine resume (v20+). Legacy files can't distinguish a manual Stop from a
+            // breakfast trip, so infer: a reloaded member with a meal still in progress means
+            // the party should stand up when everyone finishes — otherwise they'd sit at the
+            // tavern forever waiting for a Play press.
             if (fileVersion >= 20)
+            {
                 PartyAutoDineResume = reader.ReadBool();
+            }
+            else if (PartyDining != null)
+            {
+                for (int i = 0; i < PartyDining.Length; i++)
+                {
+                    if (PartyDining[i].OrderedDishId >= 0 && !PartyDining[i].HasEatenToday)
+                    {
+                        PartyAutoDineResume = true;
+                        break;
+                    }
+                }
+            }
         }
 
         /// <summary>Writes a Color as four individual int components (R, G, B, A).</summary>

--- a/PitHero/Services/SaveData.cs
+++ b/PitHero/Services/SaveData.cs
@@ -255,12 +255,12 @@ namespace PitHero.Services
     public class SaveData : IPersistable
     {
         /// <summary>Current save file version.</summary>
-        public const int CurrentVersion = 18;
+        public const int CurrentVersion = 19;
 
         /// <summary>
-        /// Oldest save file version this build can still load. v17 files are a byte-exact
-        /// prefix of v18 (the dining section 33 was appended at the end), so they load with
-        /// default dining state.
+        /// Oldest save file version this build can still load. v17 and v18 files are byte-exact
+        /// prefixes of v19 (sections 33 dining and 34 automation were appended at the end), so
+        /// they load with default state for the missing sections.
         /// </summary>
         public const int MinSupportedVersion = 17;
 
@@ -499,6 +499,10 @@ namespace PitHero.Services
 
         /// <summary>Per-party-slot dining records: 0 = hero, 1/2 = hired mercenaries.</summary>
         public SavedDiningRecord[] PartyDining;
+
+        // Automation (issue #321, v19)
+        /// <summary>Whether automatic monster job assignment is enabled.</summary>
+        public bool AutomateMonsterJobs = false;
 
         /// <summary>Initializes a new SaveData with default empty collections.</summary>
         public SaveData()
@@ -899,6 +903,9 @@ namespace PitHero.Services
                 writer.Write(PartyDining[i].MealDishId);
                 writer.Write(PartyDining[i].MealDeluxe);
             }
+
+            // 34. Automation (issue #321)
+            writer.Write(AutomateMonsterJobs);
         }
 
         /// <summary>Reads all game state from the persistence reader.</summary>
@@ -1288,6 +1295,10 @@ namespace PitHero.Services
                         PartyDining[i] = record;
                 }
             }
+
+            // 34. Automation (issue #321, v19+). Older files end at section 33 — default false.
+            if (fileVersion >= 19)
+                AutomateMonsterJobs = reader.ReadBool();
         }
 
         /// <summary>Writes a Color as four individual int components (R, G, B, A).</summary>

--- a/PitHero/Services/SaveLoadService.cs
+++ b/PitHero/Services/SaveLoadService.cs
@@ -794,6 +794,11 @@ namespace PitHero.Services
                 }
             }
 
+            // Automation (v19+)
+            var autoJobAssignmentService = Core.Services.GetService<AutoJobAssignmentService>();
+            if (autoJobAssignmentService != null)
+                data.AutomateMonsterJobs = autoJobAssignmentService.Enabled;
+
             return data;
         }
 

--- a/PitHero/Services/SaveLoadService.cs
+++ b/PitHero/Services/SaveLoadService.cs
@@ -799,6 +799,10 @@ namespace PitHero.Services
             if (autoJobAssignmentService != null)
                 data.AutomateMonsterJobs = autoJobAssignmentService.Enabled;
 
+            // Auto-dine resume (v20+)
+            if (partyDiningService != null)
+                data.PartyAutoDineResume = partyDiningService.AutoResumeWhenDone;
+
             return data;
         }
 

--- a/PitHero/UI/MonsterUI.cs
+++ b/PitHero/UI/MonsterUI.cs
@@ -259,6 +259,7 @@ namespace PitHero.UI
         {
             _monsterListTable.Clear();
             var manager = Core.Services.GetService<AlliedMonsterManager>();
+            bool jobsAutomated = Core.Services.GetService<Services.AutoJobAssignmentService>()?.Enabled ?? false;
 
             // One page per Monster House in the aggregate view; the per-house view is never paged.
             var houses = GetMonsterHouses();
@@ -439,17 +440,22 @@ namespace PitHero.UI
                             ImageUp = new SpriteDrawable(jobSprite)
                         };
                         var jobBtn = new HoverableImageButton(btnStyle, jobName);
+                        // With automation on, the system owns assignments: buttons stay visible
+                        // (active job bright, others dimmed harder) but never accept clicks.
                         jobBtn.GetImage().SetColor(isSelected
                             ? Color.White
-                            : new Color(128, 128, 128, 200));
+                            : (jobsAutomated ? new Color(80, 80, 80, 140) : new Color(128, 128, 128, 200)));
 
-                        var closuredMonster = capturedMonster;
-                        var closuredJob = jobValue;
-                        jobBtn.OnClicked += (_) =>
+                        if (!jobsAutomated)
                         {
-                            closuredMonster.Job = closuredJob;
-                            RefreshMonsterList();
-                        };
+                            var closuredMonster = capturedMonster;
+                            var closuredJob = jobValue;
+                            jobBtn.OnClicked += (_) =>
+                            {
+                                closuredMonster.Job = closuredJob;
+                                RefreshMonsterList();
+                            };
+                        }
 
                         buttonsTable.Add(jobBtn).Size(32f, 32f).Pad(1f);
                     }

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -25,7 +25,7 @@ namespace PitHero.UI
         private Tab _windowTab;
         private Tab _sessionTab;
         private Tab _buttonsTab;
-        private Tab _autoShopTab;
+        private Tab _automationTab;
 
         // Window positioning controls
         private EnhancedSlider _yOffsetSlider;
@@ -59,7 +59,8 @@ namespace PitHero.UI
         private Label _replenishHPThresholdLabel;
         private Label _replenishMPThresholdLabel;
 
-        // Auto Shop tab controls
+        // Automation tab controls
+        private HoverableCheckBox _automateMonsterJobsCheckBox;
         private HoverableCheckBox _automateSeedsCheckBox;
         private EnhancedSlider _goldBufferSlider;
         private HoverableLabel _goldBufferLabel;
@@ -487,14 +488,14 @@ namespace PitHero.UI
             PopulateWindowTab(_windowTab, skin);
             PopulateSessionTab(_sessionTab, skin);
             PopulateButtonsTab(_buttonsTab, skin);
-            _autoShopTab = new Tab(GetText(TextType.UI, UITextKey.TabAutoShop), tabStyle);
-            PopulateAutoShopTab(_autoShopTab, skin);
+            _automationTab = new Tab(GetText(TextType.UI, UITextKey.TabAutomation), tabStyle);
+            PopulateAutomationTab(_automationTab, skin);
 
             // Add tabs to TabPane
             _tabPane.AddTab(_windowTab);
             _tabPane.AddTab(_sessionTab);
             _tabPane.AddTab(_buttonsTab);
-            _tabPane.AddTab(_autoShopTab);
+            _tabPane.AddTab(_automationTab);
 
             // Add TabPane to settings window
             _settingsWindow.Add(_tabPane).Expand().Fill().Pad(0); // No cell padding - tabs flush with window edges
@@ -844,11 +845,31 @@ namespace PitHero.UI
             buttonsTab.Add(buttonsTable).Expand().Top().Left();
         }
 
-        /// <summary>Populates the Auto Shop tab with seed-purchase automation controls.</summary>
-        private void PopulateAutoShopTab(Tab autoShopTab, Skin skin)
+        /// <summary>Populates the Automation tab with monster-job, seed-purchase, and crop-sell automation controls.</summary>
+        private void PopulateAutomationTab(Tab automationTab, Skin skin)
         {
             var autoShopTable = new Table();
             autoShopTable.Pad(20);
+
+            string monsterJobsTooltip = GetText(TextType.UI, UITextKey.SettingsAutomateMonsterJobsTooltip);
+            _automateMonsterJobsCheckBox = new HoverableCheckBox(
+                GetText(TextType.UI, UITextKey.SettingsAutomateMonsterJobs),
+                skin,
+                monsterJobsTooltip,
+                _stage);
+            _automateMonsterJobsCheckBox.IsChecked = false;
+            _automateMonsterJobsCheckBox.OnChanged += (isChecked) =>
+            {
+                var svc = Core.Services?.GetService<AutoJobAssignmentService>();
+                if (svc != null)
+                {
+                    svc.Enabled = isChecked;
+                    if (isChecked)
+                        svc.ReassessNow();
+                }
+            };
+            autoShopTable.Add(_automateMonsterJobsCheckBox).Left().SetPadBottom(15f);
+            autoShopTable.Row();
 
             string checkboxTooltip = GetText(TextType.UI, UITextKey.SettingsAutomateSeedPurchasesTooltip);
             _automateSeedsCheckBox = new HoverableCheckBox(
@@ -914,15 +935,19 @@ namespace PitHero.UI
             _designateCropsButton.SetVisible(false);
             autoShopTable.Add(_designateCropsButton).Left().Width(140f);
 
-            autoShopTab.Add(autoShopTable).Expand().Top().Left();
+            automationTab.Add(autoShopTable).Expand().Top().Left();
         }
 
         /// <summary>
-        /// Reads AutoSeedPurchaseService state and syncs the Auto Shop tab controls.
+        /// Reads the automation services' state and syncs the Automation tab controls.
         /// Called after load to reflect persisted settings.
         /// </summary>
-        public void SyncAutoShopControlsFromService()
+        public void SyncAutomationControlsFromService()
         {
+            var autoJobSvc = Core.Services?.GetService<AutoJobAssignmentService>();
+            if (autoJobSvc != null && _automateMonsterJobsCheckBox != null)
+                _automateMonsterJobsCheckBox.IsChecked = autoJobSvc.Enabled;
+
             var svc = Core.Services?.GetService<AutoSeedPurchaseService>();
             if (svc == null) return;
 

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -310,7 +310,9 @@ namespace PitHero
         public const string AddMonsterConfirmPrompt = "AddMonsterConfirmPrompt";
         public const string ConsoleTrapTriggered = "ConsoleTrapTriggered";
         public const string ConsoleTrapDisarmed = "ConsoleTrapDisarmed";
-        public const string TabAutoShop = "TabAutoShop";
+        public const string TabAutomation = "TabAutomation";
+        public const string SettingsAutomateMonsterJobs = "SettingsAutomateMonsterJobs";
+        public const string SettingsAutomateMonsterJobsTooltip = "SettingsAutomateMonsterJobsTooltip";
         public const string SettingsAutomateSeedPurchases = "SettingsAutomateSeedPurchases";
         public const string SettingsAutoShopGoldBuffer = "SettingsAutoShopGoldBuffer";
         public const string SettingsAutomateSeedPurchasesTooltip = "SettingsAutomateSeedPurchasesTooltip";

--- a/PitHero/docs/AutoJobAssignmentSystem.md
+++ b/PitHero/docs/AutoJobAssignmentSystem.md
@@ -1,0 +1,112 @@
+# Auto Job Assignment System (issue #321)
+
+Automates allied-monster job assignment. When the player enables **Settings → Automation →
+"Automate monster jobs"**, `AutoJobAssignmentService` periodically measures per-job workload
+("demand") and rewrites each monster's `AlliedMonster.Job`. That field write is the *entire*
+assignment action: `FarmTaskCoordinator.Update()` and `KitchenTaskCoordinator.Update()` reconcile
+worker entities against `Job` + awake state every frame, so no entity or FSM code is involved in
+assignment.
+
+## Components
+
+| Piece | File | Role |
+|---|---|---|
+| `AutoJobAssignmentService` | `PitHero/Services/AutoJobAssignmentService.cs` | Cadence + snapshot + apply loop. Registered/ticked/unloaded in `MainGameScene` (`Begin`, `Update` unpaused block, `Unload`). |
+| `JobAssignmentSolver` | `PitHero/Services/AutoJob/JobAssignmentSolver.cs` | Pure static solver. No service or ECS dependencies — fully unit-testable. |
+| `IJobDemandEvaluator` | `PitHero/Services/AutoJob/IJobDemandEvaluator.cs` | One per automatable job: reports how many workers the job wants right now. |
+| `FarmingJobDemandEvaluator` | `PitHero/Services/AutoJob/FarmingJobDemandEvaluator.cs` | Farming demand (non-sticky). |
+| `KitchenJobDemandEvaluator` | `PitHero/Services/AutoJob/KitchenJobDemandEvaluator.cs` | Kitchen demand (sticky). |
+| UI gating | `PitHero/UI/SettingsUI.cs` (checkbox), `PitHero/UI/MonsterUI.cs` (job buttons non-clickable while enabled) | |
+| Persistence | `SaveData.AutomateMonsterJobs` (v19, section 34) → `AutoJobAssignmentService.Enabled` | Loading never forces a reshuffle; persisted jobs stand until the next cadence tick. |
+
+Tunables live in `GameConfig` under the `AutoJob*` prefix.
+
+## When reassessment runs
+
+`Update()` (per unpaused frame) calls `TickCadence(nowSeconds, isNighttime)`, which fires
+`ReassessNow()`:
+
+1. Every `GameConfig.AutoJobReassessIntervalSeconds` (60 scaled seconds = 60 in-game minutes),
+   measured on `InGameTimeService.AccumulatedSeconds` so pausing never advances the timer. A
+   `now < last` guard restarts the interval after a load rewinds time.
+2. Immediately when `IsNighttime` flips (6AM / 10PM shift change), restarting the interval.
+3. Immediately when the player first checks the checkbox (`SettingsUI` calls `ReassessNow()`).
+
+## Day/night shifts are solved independently
+
+Day monsters (work 6AM–10PM) and nocturnal monsters (10PM–6AM; see
+`MonsterScheduleConfig.IsNocturnal`) are **disjoint workforces that never work at the same time**.
+`ReassessNow()` partitions the roster by `IsNocturnal(MonsterTypeName)` and runs demand + solve
+separately per shift, so every job gets both a day crew and a night crew. Demand clamps
+(`rosterSize`) always refer to the *shift's* size, not the whole roster. Asleep monsters are
+assigned normally — the coordinators keep them home until their work window.
+
+## The solver
+
+`JobAssignmentSolver.Solve(monsters, demands, resultJobs)` — deterministic (ties break on lowest
+`RosterIndex`), allocation-free, all `for` loops:
+
+1. **Sticky pass** — monsters whose `CurrentJob` matches a demand entry with `Sticky = true` keep
+   that job unconditionally, even above `DesiredWorkers` (kitchen workers are never demoted).
+2. **Min pass** — each demand, in list order, fills up to `MinWorkers` from unassigned monsters by
+   highest proficiency for that job.
+3. **Desired pass** — same, up to `DesiredWorkers`.
+4. **Swap pass** — a sticky worker swaps with a non-sticky assignee only when **both** jobs
+   strictly gain proficiency (prevents oscillation between reassessments).
+5. Everyone unassigned gets `MonsterJob.None` → the coordinators send them home.
+
+A monster holding a job with **no demand entry** is non-sticky by definition and gets pooled and
+reassigned — this is the extensibility guarantee (a Fishing-assigned monster before a fishing
+evaluator exists just returns to the pool).
+
+## Current demand models
+
+- **Kitchen** (`Sticky = true`, listed first so its small crew staffs before farming absorbs the
+  rest): base crew `AutoJobKitchenBaseStaff` = 3 — **cook + server + runner; never less, a
+  runner-less kitchen runs the fridge dry** — plus one worker per
+  `AutoJobKitchenBacklogPerExtraWorker` backlog items (open tickets + seated patrons + pending
+  party diners), capped at `AutoJobKitchenMaxWorkers` (mirrors the coordinator's role-post cap).
+  `MinWorkers` = base crew only when backlog > 0.
+- **Farming** (`Sticky = false`): `max(burst, baseline)` where burst =
+  `FarmTaskCoordinator.OutstandingTaskCount / AutoJobFarmTasksPerWorker` (catches watering/harvest
+  waves) and baseline = `(CropCount + PlanCount) / AutoJobFarmCropsPerWorkerBaseline` (quiet
+  growth periods), ceil-divided, clamped to shift size. Released farmers become the pool that
+  staffs the kitchen or goes home.
+
+Workload getters added for this system: `FarmTaskCoordinator.OutstandingTaskCount`,
+`KitchenTaskCoordinator.ActiveTicketCount`, `CropGrowthService.CropCount`,
+`CropPlantingService.PlanCount`, `MercenaryManager.CountSeatedPatrons()`,
+`PartyDiningService.CountPendingPartyDiners()`.
+
+## Adding a new job (e.g. Fishing)
+
+The solver never changes. Steps:
+
+1. The job must already exist in `MonsterJob` and have a coordinator/FSM work loop that
+   spawns/despawns workers off `AlliedMonster.Job` (fishing has the enum value but no work loop
+   yet — build that first, mirroring `FarmTaskCoordinator`).
+2. Create `PitHero/Services/AutoJob/FishingJobDemandEvaluator.cs` implementing
+   `IJobDemandEvaluator`: report `Job = MonsterJob.Fishing` and a `JobDemandEntry` computed from
+   whatever workload signal fits (keep the arithmetic in a `public static ComputeDemand(...)` so
+   it's unit-testable headless, like the existing evaluators; take service dependencies as
+   nullable constructor params).
+3. Decide `Sticky`: true only if pulling workers off the job mid-shift is harmful (kitchen-style
+   continuity); false if workers can be freely rebalanced (farming-style).
+4. Register it in `MainGameScene.Begin()` via `autoJobAssignmentService.AddEvaluator(...)` —
+   or add a constructor parameter if it should always exist. **List order = priority order** for
+   the min/desired fill passes.
+5. Add `GameConfig` constants for its tunables (`AutoJob*` prefix).
+6. Proficiency: `JobAssignmentSolver.GetProficiency` already maps `MonsterJob.Fishing` →
+   `FishingProficiency`. A brand-new job beyond the existing three needs a case added there.
+7. Tests: evaluator math cases in `AutoJobAssignmentServiceTests` (pattern:
+   `FarmingDemand_*` / `KitchenDemand_*`), plus a solver staffing case if the job introduces a
+   new demand shape.
+
+## Testing
+
+- `PitHero.Tests/JobAssignmentSolverTests.cs` — solver passes, tie-breaks, stickiness, swaps,
+  extensibility.
+- `PitHero.Tests/AutoJobAssignmentServiceTests.cs` — service wiring, cadence/shift-boundary
+  triggers (`TickCadence` is public precisely so tests can drive it without `Core.Services`),
+  per-shift segregation, evaluator math. Construct everything directly (no `Core.Services`);
+  evaluators accept null dependencies for headless runs.


### PR DESCRIPTION
Closes #321

## What

* Renames the Settings **"Auto Shop"** tab to **"Automation"**.
* Adds an **"Automate monster jobs"** checkbox with the tooltip from the issue. Enabling it triggers an immediate assessment; the system then reassesses every **60 in-game minutes** (60 scaled seconds, keyed to `InGameTimeService` so pausing never advances the timer), and **immediately at the day/night shift change** (6AM/10PM) so the incoming shift is right-sized to the current workload.
* While automation is on, the Monster window's job buttons are **non-clickable**: the system-selected job stays bright, the others are dimmed harder, and no click handlers are wired.
* Also includes **kitchen/tavern service fixes** surfaced while playtesting this feature (automation keeps the kitchen staffed enough to stress the tavern; see below).

## How it works

* **`JobAssignmentSolver`** (pure, static, headless-testable): sticky pass → min-staff pass → desired-staff pass → swap pass. Assignment is just writing `AlliedMonster.Job` — the farm/kitchen coordinators reconcile worker entities every frame.
* **Day/night shifts solved independently**: day monsters (6AM–10PM) and nocturnal monsters (10PM–6AM) are disjoint workforces that never overlap, so `ReassessNow` partitions the roster by `MonsterScheduleConfig.IsNocturnal` and solves each shift separately (demand clamped to that shift's size). Every job gets both a day crew and a night crew — the kitchen stays staffed around the clock. The shift boundary also fires an immediate reassess (and restarts the cadence interval) so crew sizes never run on counts up to an hour stale.
* **`IJobDemandEvaluator`** per job (extensible — fishing later is one new evaluator, zero solver changes):
  * **Kitchen** (sticky, listed first): base crew of **cook + server + runner** (without a runner the fridge runs dry) plus one extra worker per 3 backlog items (tickets + seated patrons + pending party diners), capped at the coordinator's 7-worker limit. Kitchen workers are never pulled away; the swap pass exchanges a kitchen worker with a farmer only when **both** jobs strictly gain proficiency, so assignments never oscillate.
  * **Farming** (non-sticky): `max(burst, baseline)` where burst = outstanding till/plant/water/harvest/destroy/pickup tasks ÷ 6 (catches watering/harvest spikes) and baseline = (crops + plans) ÷ 12 (quiet growth periods). Released farmers become the pool that staffs the kitchen or goes home (`Job = None`).
* New public workload getters: `FarmTaskCoordinator.OutstandingTaskCount`, `KitchenTaskCoordinator.ActiveTicketCount`, `CropGrowthService.CropCount`, `CropPlantingService.PlanCount`, `MercenaryManager.CountSeatedPatrons()`, `PartyDiningService.CountPendingPartyDiners()`.
* Tunables live in `GameConfig` (`AutoJob*` constants); the kitchen coordinator's literal 7-worker cap now uses the shared constant.

## Kitchen/tavern service fixes

**Plate bussing starved in a busy tavern** (empty plates piled up; meals delivered on top of them). `ServerDecide_Tick` prioritizes delivering and order-taking above bussing, and a saturated tavern always has such work. Fixed in four layers:

* **Anti-starvation age bump**: `BusJob` records `EnqueuedTime`; a plate that has waited `GameConfig.ServerBusPlateMaxWaitSeconds` (90s) jumps to top priority, oldest first. Under normal load nothing changes (deliver-first).
* **Zone-free bussing**: any server may claim any table's bus job. Order-taking and dish delivery remain restricted to the server's designated zone.
* **Hard no-stacking guarantee with believable visuals**: right before setting a new dish down, the delivering server claims any pending empty plate at that plate position (`TryClaimBusJobAtPosition`), takes it in hand, places the new dish, and — after finishing remaining deliveries — visibly carries the plate to the kitchen sink (Ticket-less ToSink carry leg). A meal can never be placed on top of an un-bussed empty plate.
* **Patrons wait at the door for dirty tables**: an arriving patron whose assigned seat still has a pending bus job walks to the tavern door (100,6) and waits there until a server claims the plate, then proceeds to sit. Servers only take orders from seated patrons (`TavernPatronComponent` is added on arrival at the seat), so a waiting patron generates no ordering pressure — the plate backlog drains naturally under the existing priorities. Patience only starts once seated.

**Servers livelocked at patron seats when no order could be created** (both servers frozen in place, tavern stalled — observed when no dish recipe was coverable from stock). `TakeOrderAtTarget` fails silently when no dish is coverable from fridge + storage or the 16-ticket board is full, leaving the patron `WaitingToOrder`; `ServerDecide` then re-targeted the same patron every pass while already standing at the seat. `TryPickNextOrderTarget` and `HasOrderWork` now check `HasTicketCapacity` and (for walk-ins) `HasAnyOrderableDish` before targeting anyone; when no order can possibly succeed, servers fall through to bussing/wandering and patrons wait until stock arrives or patience expires. Ticket cap extracted to `MaxOpenTickets`.

**Party stuck at the tavern after a reloaded mid-breakfast seating.** A save made during a morning auto-dine trip restores its open orders and re-enters Stop mode on load, but the auto-resume flag lived only in memory (`BeginAutoDine`) — so the reloaded party finished breakfast and then sat at the tavern until the player manually pressed Play. The flag is now persisted (`PartyAutoDineResume`, save **v20**, section 35) and restored in `RestoreFromSave`; `CheckAllDone` also defers its Stop-mode guard while the reload is pending. Pre-v20 files infer the flag: a restored member with a meal still in progress means the party should stand up when everyone finishes. Manual Stop-mode seatings saved by the new build still never auto-resume.

## Persistence

* Save format now **v20**: v19 added `AutomateMonsterJobs` (section 34), v20 adds `PartyAutoDineResume` (section 35). v17–v19 files remain byte-exact prefixes and load with defaults (plus the auto-dine inference above). Loading does **not** force a job reshuffle — persisted jobs stand until the next cadence tick.

## Tests

* `JobAssignmentSolverTests` — fill order, proficiency selection with deterministic tie-breaks, sticky protection, surplus demotion, strict-double-improvement swaps, extensibility (fishing worker with no demand gets reassigned).
* `AutoJobAssignmentServiceTests` — disabled no-op, roster application, cadence + shift-boundary triggers, day/night shift segregation, farming/kitchen demand math.
* `SaveLoadTests` — v19 + v20 round-trips; pre-v20 auto-dine inference (open order → resume, none → don't); v17-prefix test updated for sections 34–35.
* Full suite: **1560 passed, 0 failed** (baseline maintained).

## Manual playtest notes

* Automation basics: tab rename, tooltip, non-clickable job buttons, immediate assessment on enable, save/reload of the checkbox.
* Kitchen under load: fill the tavern with automation on — empty plates collected within ~90s; a re-served table gets its old plate taken in hand as the new dish lands, then carried to the sink; a patron arriving while their seat has a dirty plate waits at the door (100,6) and sits only after a server claims the plate.
* No coverable dishes: servers keep bussing/wandering (not freezing at seats) and resume order-taking once suitable crops are stored.
* Mid-breakfast save/reload: party finishes breakfast after the reload and gets up on its own (skipped members don't block); a manually-stopped party stays seated as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)