### PR TITLE
Fix half window size sticking at Normal after loading a save

### DIFF
--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -324,6 +324,11 @@ namespace PitHero.ECS.Scenes
 
             EmitWelcomeMessage();
 
+            // Clear any UI window count leaked from the previous scene (windows destroyed by a
+            // scene swap never run their close path) and re-apply the persistent window size —
+            // otherwise the deferred size restore never fires again after loading a save.
+            UI.UIWindowManager.ResetForNewScene();
+
             _isInitializationComplete = true;
         }
 

--- a/PitHero/UI/UIWindowManager.cs
+++ b/PitHero/UI/UIWindowManager.cs
@@ -167,6 +167,25 @@ namespace PitHero.UI
         }
 
         /// <summary>
+        /// Called when a new game scene begins. UI windows counted in the previous scene were
+        /// destroyed with it without ever running their close path (e.g. loading a save from the
+        /// Settings window), so a stale count would defer the persistent-size restore forever.
+        /// Clears the count and re-applies the persistent size, since a scene swap can happen
+        /// while the window is at the temporary Normal size UI viewing uses.
+        /// </summary>
+        public static void ResetForNewScene()
+        {
+            if (_openUIWindowCount != 0)
+            {
+                Debug.Log($"[UIWindowManager] Clearing leaked open-window count ({_openUIWindowCount}) on scene change");
+                _openUIWindowCount = 0;
+            }
+
+            if (_isInitialized)
+                ApplyPersistentWindowSize();
+        }
+
+        /// <summary>
         /// Gets the current window size mode
         /// </summary>
         private static WindowSizeMode GetCurrentWindowSize()


### PR DESCRIPTION
## Bug

After loading a save, selecting the **Half** window size in Settings has no effect — the radio button shows Half but the window stays Normal for the rest of the session. Log signature:

```
[UIWindowManager] UI window closing (count: 1)
[UIWindowManager] Other UI windows still open, deferring persistent size restore
[UIWindowManager] UI window opening (count: 2)
[UIWindowManager] Another UI window already open, keeping persistent size: Half
```

## Root cause

`UIWindowManager` is static and applies the persistent window size only when its open-window count returns to 0 (windows are temporarily restored to Normal while any UI is up). The Load dialog is launched from the Settings window, so at load time the count is ≥1 — and `PerformLoad` swaps the scene, destroying the Settings window **without ever running its close path**. The leaked count survives the scene swap, so after loading, every open/close cycles 2→1→2→1 and never reaches 0: the deferred restore (and with it the Half option) never fires again.

There's a second latent bug in the same flow: even with the count fixed, the first window opened after load would capture the current *physical* size (Normal, from the pre-load temporary restore) as the persistent preference, silently wiping the player's Half setting.

## Fix

New `UIWindowManager.ResetForNewScene()`, called at the end of `MainGameScene.Begin()`: clears any leaked open-window count (all counted windows died with the previous scene) and re-applies the persistent size so the physical window matches the stored preference again. No-ops at first boot (count 0, manager not yet initialized).

## Verification

* `dotnet build` clean, full test suite: **1524 passed, 0 failed**.
* Manual repro path: set Half → open Settings → Load a save → after load, toggle Half/Normal in Settings — sizes now apply on window close, and the stored Half preference survives the load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)