### PR TITLE
Prevent server bus-plate starvation in a busy tavern

### DIFF
--- a/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
+++ b/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
@@ -14,7 +14,8 @@ namespace PitHero.ECS.Components
     /// Server: take up to 3 orders from patrons at its tables (1 server works all 4 tables;
     /// with 2 servers the first works the top pair, the second the bottom pair), post them at
     /// the ticket board, deliver up to 2 cooked dishes from the serving tables (only for its
-    /// own tables), bus finished plates, otherwise wander its table area.
+    /// own tables), bus finished plates (any table — bussing is zone-free), otherwise wander
+    /// its table area.
     /// Cook: read one ticket at the board, gather ingredients at the fridge (waiting for the
     /// runner if the fridge is short), cook at a free station, place the dish on a serving
     /// table — holding it if all three are full.
@@ -239,9 +240,10 @@ namespace PitHero.ECS.Components
 
             var zone = Zone;
 
-            // 0) A plate that has waited too long — in a busy tavern priorities 1-2 always have
-            //    work, so without this age bump bussing starves and plates pile up on tables
-            if (_coordinator.TryClaimBusJob(zone, GameConfig.ServerBusPlateMaxWaitSeconds, out _busJob))
+            // 0) A plate that has waited too long (any table, any zone) — in a busy tavern
+            //    priorities 1-2 always have work, so without this age bump bussing starves
+            //    and plates pile up on tables
+            if (_coordinator.TryClaimBusJob(GameConfig.ServerBusPlateMaxWaitSeconds, out _busJob))
             {
                 _busPickedUp = false;
                 CurrentState = KitchenMonsterState.ServerBusPlate;
@@ -259,8 +261,8 @@ namespace PitHero.ECS.Components
                 CurrentState = KitchenMonsterState.ServerWalkToPatron;
                 return;
             }
-            // 3) Dirty plates at my tables
-            if (_coordinator.TryClaimBusJob(zone, out _busJob))
+            // 3) Dirty plates — any table, any zone (only orders/deliveries are zone-bound)
+            if (_coordinator.TryClaimBusJob(out _busJob))
             {
                 _busPickedUp = false;
                 CurrentState = KitchenMonsterState.ServerBusPlate;
@@ -480,7 +482,16 @@ namespace PitHero.ECS.Components
             // Arrived at the table — place the dish
             Entity dishEntity = null;
             if (TavernSeatConfig.TryGetPlateWorldPosition(c.Ticket.SeatTile, out var platePos))
+            {
+                // Never stack a new meal on an un-bussed empty plate: the server clears the old
+                // plate into their tray as they set the new dish down
+                if (_coordinator.TryClaimBusJobAtPosition(platePos, out var stalePlate)
+                    && stalePlate.DishEntity != null && !stalePlate.DishEntity.IsDestroyed)
+                {
+                    stalePlate.DishEntity.Destroy();
+                }
                 dishEntity = _coordinator.DishService?.SpawnDishAtWorldPos(c.Ticket.Dish, platePos);
+            }
             _coordinator.OnTicketDelivered(c.Ticket, dishEntity);
             _carried.RemoveAt(0);
             BeginNextCarriedLeg();

--- a/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
+++ b/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
@@ -483,12 +483,15 @@ namespace PitHero.ECS.Components
             Entity dishEntity = null;
             if (TavernSeatConfig.TryGetPlateWorldPosition(c.Ticket.SeatTile, out var platePos))
             {
-                // Never stack a new meal on an un-bussed empty plate: the server clears the old
-                // plate into their tray as they set the new dish down
-                if (_coordinator.TryClaimBusJobAtPosition(platePos, out var stalePlate)
-                    && stalePlate.DishEntity != null && !stalePlate.DishEntity.IsDestroyed)
+                // Never stack a new meal on an un-bussed empty plate: the server takes the old
+                // plate in hand as they set the new dish down, then busses it to the sink once
+                // their remaining deliveries are done (a Ticket-less ToSink leg shows the plate
+                // sprite carried to the sink)
+                if (_coordinator.TryClaimBusJobAtPosition(platePos, out var stalePlate))
                 {
-                    stalePlate.DishEntity.Destroy();
+                    if (stalePlate.DishEntity != null && !stalePlate.DishEntity.IsDestroyed)
+                        stalePlate.DishEntity.Destroy();
+                    _carried.Add(new CarriedDish { Ticket = null, ToSink = true });
                 }
                 dishEntity = _coordinator.DishService?.SpawnDishAtWorldPos(c.Ticket.Dish, platePos);
             }

--- a/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
+++ b/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
@@ -239,6 +239,14 @@ namespace PitHero.ECS.Components
 
             var zone = Zone;
 
+            // 0) A plate that has waited too long — in a busy tavern priorities 1-2 always have
+            //    work, so without this age bump bussing starves and plates pile up on tables
+            if (_coordinator.TryClaimBusJob(zone, GameConfig.ServerBusPlateMaxWaitSeconds, out _busJob))
+            {
+                _busPickedUp = false;
+                CurrentState = KitchenMonsterState.ServerBusPlate;
+                return;
+            }
             // 1) Cooked food waiting → deliver
             if (_coordinator.HasReadyDishForZone(zone))
             {

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -182,6 +182,7 @@ namespace PitHero
         public const int KitchenRunnerWanderMaxTileY = 8;
         public const int ServerOrderMemoryLimit = 3;            // orders a server can hold before posting at the board
         public const int ServerCarryDishLimit = 2;              // cooked dishes a server can carry at once
+        public const float ServerBusPlateMaxWaitSeconds = 90f;  // a plate waiting this long jumps ahead of deliveries/orders
         public const float TicketBoardPauseSeconds = 1f;        // pause at the board to post/read a ticket
         public const int KitchenFridgeParPerCrop = 4;           // runner tops the fridge up to this many of each fetched crop
         public const float KitchenRunnerSprintMultiplier = 3f;  // runner speed multiplier while fetching ingredients

--- a/PitHero/Services/KitchenTaskCoordinator.cs
+++ b/PitHero/Services/KitchenTaskCoordinator.cs
@@ -39,7 +39,6 @@ namespace PitHero.Services
         {
             public Entity DishEntity;  // plate entity on the table to be bussed
             public Vector2 WorldPos;   // where to pick it up from
-            public int TableTileY;     // zone filter (top tables y<=4, bottom y>=5)
             public float EnqueuedTime; // Time.TotalTime when queued — drives anti-starvation priority
         }
 
@@ -580,7 +579,6 @@ namespace PitHero.Services
                 {
                     DishEntity = t.PlatedDishEntity,
                     WorldPos = t.PlatedDishEntity.Transform.Position,
-                    TableTileY = t.TableTile.Y,
                     EnqueuedTime = Time.TotalTime,
                 });
                 t.PlatedDishEntity = null;
@@ -683,7 +681,6 @@ namespace PitHero.Services
                     {
                         DishEntity = emptyPlate,
                         WorldPos = platePos,
-                        TableTileY = t.TableTile.Y,
                         EnqueuedTime = Time.TotalTime,
                     });
                 }
@@ -906,24 +903,22 @@ namespace PitHero.Services
             }
         }
 
-        /// <summary>Next pending bus job for the zone's server. Removes it from the queue.</summary>
-        public bool TryClaimBusJob(ServerZone zone, out BusJob job)
-            => TryClaimBusJob(zone, 0f, out job);
+        /// <summary>Next pending bus job. Removes it from the queue.</summary>
+        public bool TryClaimBusJob(out BusJob job)
+            => TryClaimBusJob(0f, out job);
 
         /// <summary>
-        /// Claims the oldest bus job in the zone that has waited at least minAgeSeconds
-        /// (0 = any). Removes it from the queue. The age gate lets servers bump long-waiting
-        /// plates ahead of order-taking so a busy tavern can't starve bussing forever.
+        /// Claims the oldest bus job that has waited at least minAgeSeconds (0 = any). Removes it
+        /// from the queue. Bussing is deliberately zone-free — any server may clear any table —
+        /// and the age gate lets servers bump long-waiting plates ahead of order-taking so a busy
+        /// tavern can't starve bussing forever. (Order-taking and delivery stay zone-restricted.)
         /// </summary>
-        public bool TryClaimBusJob(ServerZone zone, float minAgeSeconds, out BusJob job)
+        public bool TryClaimBusJob(float minAgeSeconds, out BusJob job)
         {
             int oldest = -1;
             float oldestTime = float.MaxValue;
             for (int i = 0; i < _busJobs.Count; i++)
             {
-                var tableTile = new Point(0, _busJobs[i].TableTileY);
-                if (!ZoneContainsTable(zone, tableTile))
-                    continue;
                 if (Time.TotalTime - _busJobs[i].EnqueuedTime < minAgeSeconds)
                     continue;
                 if (_busJobs[i].EnqueuedTime < oldestTime)
@@ -940,6 +935,26 @@ namespace PitHero.Services
             job = _busJobs[oldest];
             _busJobs.RemoveAt(oldest);
             return true;
+        }
+
+        /// <summary>
+        /// Claims the pending bus job whose plate sits at the given world position (within half a
+        /// tile), if any. Called by a delivering server right before it sets a new dish down, so a
+        /// new meal is never stacked on top of an un-bussed empty plate.
+        /// </summary>
+        public bool TryClaimBusJobAtPosition(Vector2 platePos, out BusJob job)
+        {
+            const float maxDistSq = 16f * 16f;
+            for (int i = 0; i < _busJobs.Count; i++)
+            {
+                if (Vector2.DistanceSquared(_busJobs[i].WorldPos, platePos) > maxDistSq)
+                    continue;
+                job = _busJobs[i];
+                _busJobs.RemoveAt(i);
+                return true;
+            }
+            job = default;
+            return false;
         }
 
         // ── Runner API ───────────────────────────────────────────────────────────

--- a/PitHero/Services/KitchenTaskCoordinator.cs
+++ b/PitHero/Services/KitchenTaskCoordinator.cs
@@ -37,9 +37,10 @@ namespace PitHero.Services
 
         public struct BusJob
         {
-            public Entity DishEntity; // plate entity on the table to be bussed
-            public Vector2 WorldPos;  // where to pick it up from
-            public int TableTileY;    // zone filter (top tables y<=4, bottom y>=5)
+            public Entity DishEntity;  // plate entity on the table to be bussed
+            public Vector2 WorldPos;   // where to pick it up from
+            public int TableTileY;     // zone filter (top tables y<=4, bottom y>=5)
+            public float EnqueuedTime; // Time.TotalTime when queued — drives anti-starvation priority
         }
 
         private struct OrphanDish
@@ -580,6 +581,7 @@ namespace PitHero.Services
                     DishEntity = t.PlatedDishEntity,
                     WorldPos = t.PlatedDishEntity.Transform.Position,
                     TableTileY = t.TableTile.Y,
+                    EnqueuedTime = Time.TotalTime,
                 });
                 t.PlatedDishEntity = null;
             }
@@ -682,6 +684,7 @@ namespace PitHero.Services
                         DishEntity = emptyPlate,
                         WorldPos = platePos,
                         TableTileY = t.TableTile.Y,
+                        EnqueuedTime = Time.TotalTime,
                     });
                 }
             }
@@ -905,18 +908,38 @@ namespace PitHero.Services
 
         /// <summary>Next pending bus job for the zone's server. Removes it from the queue.</summary>
         public bool TryClaimBusJob(ServerZone zone, out BusJob job)
+            => TryClaimBusJob(zone, 0f, out job);
+
+        /// <summary>
+        /// Claims the oldest bus job in the zone that has waited at least minAgeSeconds
+        /// (0 = any). Removes it from the queue. The age gate lets servers bump long-waiting
+        /// plates ahead of order-taking so a busy tavern can't starve bussing forever.
+        /// </summary>
+        public bool TryClaimBusJob(ServerZone zone, float minAgeSeconds, out BusJob job)
         {
+            int oldest = -1;
+            float oldestTime = float.MaxValue;
             for (int i = 0; i < _busJobs.Count; i++)
             {
                 var tableTile = new Point(0, _busJobs[i].TableTileY);
                 if (!ZoneContainsTable(zone, tableTile))
                     continue;
-                job = _busJobs[i];
-                _busJobs.RemoveAt(i);
-                return true;
+                if (Time.TotalTime - _busJobs[i].EnqueuedTime < minAgeSeconds)
+                    continue;
+                if (_busJobs[i].EnqueuedTime < oldestTime)
+                {
+                    oldestTime = _busJobs[i].EnqueuedTime;
+                    oldest = i;
+                }
             }
-            job = default;
-            return false;
+            if (oldest < 0)
+            {
+                job = default;
+                return false;
+            }
+            job = _busJobs[oldest];
+            _busJobs.RemoveAt(oldest);
+            return true;
         }
 
         // ── Runner API ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Bug

In a busy tavern, servers stop bussing empty plates after patrons finish eating; plates accumulate on tables and new meals eventually get delivered on top of them.

## Root cause

`ServerDecide_Tick` (KitchenMonsterStateMachine) works in strict priority order: (1) deliver ready dishes, (2) take orders from waiting patrons, (3) bus dirty plates, (4) wander. With patrons arriving every 1–2 minutes into 9 seats and a well-staffed kitchen (e.g. via the #321 automation) there is almost always a ready dish or a waiting patron, so priority 3 never runs — bussing starves indefinitely. The bussing state machine itself works fine; the jobs just never get claimed.

## Fix

Three layers:

* **Anti-starvation age bump**: `BusJob` records `EnqueuedTime`; a plate that has waited `GameConfig.ServerBusPlateMaxWaitSeconds` (90s) jumps to top priority — ahead of deliveries and order-taking — oldest first. Under normal load nothing changes (deliver-first).
* **Zone-free bussing**: any server may claim any table's bus job, spreading the cleanup load across the whole staff. Order-taking and dish delivery remain restricted to the server's designated zone.
* **Hard no-stacking guarantee with believable visuals**: right before a delivering server sets a new dish down, it claims any pending empty plate at that exact plate position (`TryClaimBusJobAtPosition`), takes it in hand, and places the new dish. The plate is queued as a Ticket-less ToSink carry leg, so after finishing their remaining deliveries the server visibly carries the plate (plate sprite in hand) to the kitchen sink and disposes of it — no plate ever vanishes in place, and a meal can never be placed on top of an un-bussed empty plate, regardless of load.

## Verification

* `dotnet build` clean; full test suite **1524 passed, 0 failed**.
* Manual playtest: fill the tavern (automation on so the kitchen keeps up), let several patrons finish eating — plates should be collected within ~90s by whichever server frees up first; when a table is re-served while its empty plate is still out, the server should pick the plate up as they set the new dish down and then walk it to the sink after their deliveries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)