### PR TITLE
Kitchen cooking improvements (#327)

### DIFF
--- a/PitHero.Tests/KitchenFlowPathTests.cs
+++ b/PitHero.Tests/KitchenFlowPathTests.cs
@@ -156,6 +156,13 @@ namespace PitHero.Tests
                     $"serving table {slot} approach tile is a wall");
             }
 
+            // Every tile a cook can pick while pottering between tickets must be walkable,
+            // otherwise PickCookWanderTarget burns its 8 attempts and the cook freezes anyway
+            for (int x = GameConfig.KitchenCookWanderMinTileX; x <= GameConfig.KitchenCookWanderMaxTileX; x++)
+                for (int y = GameConfig.KitchenCookWanderMinTileY; y <= GameConfig.KitchenCookWanderMaxTileY; y++)
+                    Assert.IsTrue(pathfinder.IsPassable(new Point(x, y)),
+                        $"cook wander tile ({x},{y}) is a wall");
+
             // The kitchen room is actually enclosed (regression guard for the wall seeding itself)
             Assert.IsFalse(pathfinder.IsPassable(new Point(81, 2)), "kitchen west wall missing");
             Assert.IsFalse(pathfinder.IsPassable(new Point(88, 2)), "kitchen east wall missing");

--- a/PitHero.Tests/KitchenServiceLoopTests.cs
+++ b/PitHero.Tests/KitchenServiceLoopTests.cs
@@ -52,6 +52,7 @@ namespace PitHero.Tests
         public void Cleanup()
         {
             Time.DeltaTime = 0f;
+            Time.TotalTime = 0f;
         }
 
         /// <summary>Deposits exactly enough crops in storage to cover N servings of the dish.</summary>
@@ -418,6 +419,117 @@ namespace PitHero.Tests
 
             Assert.IsTrue(KitchenTaskCoordinator.ZoneContainsTable(ServerZone.AllTables, new Point(93, 3)));
             Assert.IsTrue(KitchenTaskCoordinator.ZoneContainsTable(ServerZone.AllTables, new Point(97, 7)));
+        }
+
+        // ── Role mix (issue #327: runners bus plates, so the third one is worth staffing) ──
+
+        private static System.Collections.Generic.List<KitchenRole> RoleMix(int postCount)
+        {
+            var roles = new System.Collections.Generic.List<KitchenRole>();
+            KitchenTaskCoordinator.FillRoleMix(postCount, roles);
+            return roles;
+        }
+
+        [TestMethod]
+        public void RoleMix_GrowsCookServerRunnerAndEndsWithAThirdRunner()
+        {
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    KitchenRole.Cook, KitchenRole.Server, KitchenRole.Runner,
+                    KitchenRole.Cook, KitchenRole.Server, KitchenRole.Runner,
+                    KitchenRole.Cook, KitchenRole.Runner,
+                },
+                RoleMix(KitchenTaskCoordinator.MaxWorkerPosts));
+        }
+
+        [TestMethod]
+        public void RoleMix_FirstTwoPostsOpenTheKitchen()
+        {
+            // IsKitchenOpen needs a cook AND a server, so those must be posts 0 and 1
+            CollectionAssert.AreEqual(new[] { KitchenRole.Cook }, RoleMix(1));
+            CollectionAssert.AreEqual(new[] { KitchenRole.Cook, KitchenRole.Server }, RoleMix(2));
+            CollectionAssert.AreEqual(
+                new[] { KitchenRole.Cook, KitchenRole.Server, KitchenRole.Runner }, RoleMix(3));
+        }
+
+        [TestMethod]
+        public void RoleMix_RespectsPerRoleCapsAndNeverExceedsMaxPosts()
+        {
+            var roles = RoleMix(99);
+            Assert.AreEqual(KitchenTaskCoordinator.MaxWorkerPosts, roles.Count,
+                "role mix must clamp to the total number of posts");
+            Assert.AreEqual(GameConfig.MaxKitchenCooks, roles.FindAll(r => r == KitchenRole.Cook).Count);
+            Assert.AreEqual(GameConfig.MaxKitchenServers, roles.FindAll(r => r == KitchenRole.Server).Count);
+            Assert.AreEqual(GameConfig.MaxKitchenRunners, roles.FindAll(r => r == KitchenRole.Runner).Count);
+            Assert.AreEqual(GameConfig.AutoJobKitchenMaxWorkers, KitchenTaskCoordinator.MaxWorkerPosts,
+                "the auto-job cap must mirror the coordinator's post cap");
+        }
+
+        // ── Bus queue (issue #327: runners own plate clearing) ──
+
+        private static KitchenTaskCoordinator.BusJob MakeBusJob(Vector2 pos, float enqueuedTime)
+        {
+            var plate = new Entity("test-plate");
+            plate.SetPosition(pos);
+            return new KitchenTaskCoordinator.BusJob
+            {
+                DishEntity = plate,
+                WorldPos = pos,
+                EnqueuedTime = enqueuedTime,
+            };
+        }
+
+        [TestMethod]
+        public void BusJob_ReleasedByDepartingRunner_IsReclaimableAndStillBlocksTheSeat()
+        {
+            var pos = new Vector2(100f, 200f);
+            var job = MakeBusJob(pos, 0f);
+
+            // The runner walking to the plate is sent home before picking it up
+            _coordinator.ReleaseBusJob(job);
+            Assert.IsTrue(_coordinator.HasPendingBusJob);
+            Assert.IsTrue(_coordinator.HasPendingBusJobAt(pos),
+                "a released plate is still on the table, so arriving patrons must still see it");
+
+            Assert.IsTrue(_coordinator.TryClaimBusJob(out var reclaimed));
+            Assert.AreSame(job.DishEntity, reclaimed.DishEntity, "released bus job not reclaimable");
+            Assert.AreEqual(0f, reclaimed.EnqueuedTime,
+                "the original enqueue time must survive so the plate keeps its place in line");
+            Assert.IsFalse(_coordinator.HasPendingBusJob);
+        }
+
+        [TestMethod]
+        public void BusJob_ReleaseIsIdempotentAndIgnoresAlreadyCarriedPlates()
+        {
+            var job = MakeBusJob(new Vector2(100f, 200f), 0f);
+            _coordinator.ReleaseBusJob(job);
+            _coordinator.ReleaseBusJob(job);
+
+            Assert.IsTrue(_coordinator.TryClaimBusJob(out _));
+            Assert.IsFalse(_coordinator.TryClaimBusJob(out _), "double release must not duplicate the plate");
+
+            // A plate already in hand had its entity destroyed at pickup — nothing to put back
+            _coordinator.ReleaseBusJob(default);
+            Assert.IsFalse(_coordinator.HasPendingBusJob);
+        }
+
+        [TestMethod]
+        public void BusJob_AgeGateClaimsTheOldestWaitingPlateFirst()
+        {
+            Time.TotalTime = 1000f;
+            _coordinator.ReleaseBusJob(MakeBusJob(new Vector2(10f, 10f), 900f));  // 100s old
+            _coordinator.ReleaseBusJob(MakeBusJob(new Vector2(20f, 20f), 990f));  // 10s old
+
+            // Fallback bussing only takes plates past the age gate, oldest first
+            Assert.IsTrue(_coordinator.TryClaimBusJob(GameConfig.ServerBusPlateMaxWaitSeconds, out var aged));
+            Assert.AreEqual(900f, aged.EnqueuedTime);
+            Assert.IsFalse(_coordinator.TryClaimBusJob(GameConfig.ServerBusPlateMaxWaitSeconds, out _),
+                "the fresh plate must not pass the age gate");
+
+            // A runner (no age gate) takes it immediately
+            Assert.IsTrue(_coordinator.TryClaimBusJob(out var fresh));
+            Assert.AreEqual(990f, fresh.EnqueuedTime);
         }
     }
 }

--- a/PitHero.Tests/KitchenServiceLoopTests.cs
+++ b/PitHero.Tests/KitchenServiceLoopTests.cs
@@ -514,6 +514,149 @@ namespace PitHero.Tests
             Assert.IsFalse(_coordinator.HasPendingBusJob);
         }
 
+        // ── Runner fetch route (issue #327 follow-up: visit the storages that hold the crops) ──
+
+        /// <summary>Adds a second Crop Storage further from the kitchen than the default one.</summary>
+        private const int FarStorageBuildingId = 3;
+
+        private void AddFarStorage()
+        {
+            _buildings.AddBuilding(new PlacedBuilding
+            {
+                Type = BuildingType.CropStorage,
+                TileX = GameConfig.NewGameCropStorageAnchorTileX + 20,
+                TileY = GameConfig.NewGameCropStorageAnchorTileY,
+                UniqueId = FarStorageBuildingId
+            });
+        }
+
+        private static Point DoorOf(int anchorX, int anchorY)
+            => Util.BuildingConfig.GetDoorTile(BuildingType.CropStorage, new Point(anchorX, anchorY));
+
+        private static Point NearStorageDoor => DoorOf(
+            GameConfig.NewGameCropStorageAnchorTileX, GameConfig.NewGameCropStorageAnchorTileY);
+
+        private static Point FarStorageDoor => DoorOf(
+            GameConfig.NewGameCropStorageAnchorTileX + 20, GameConfig.NewGameCropStorageAnchorTileY);
+
+        private System.Collections.Generic.List<KitchenTaskCoordinator.FetchStop> PlanRoute(KitchenTicket t)
+        {
+            var route = new System.Collections.Generic.List<KitchenTaskCoordinator.FetchStop>();
+            _coordinator.PlanFetchRoute(t, KitchenTaskCoordinator.FridgeTile, route);
+            return route;
+        }
+
+        [TestMethod]
+        public void FetchRoute_SkipsTheNearStorageWhenOnlyTheFarOneHoldsTheCrops()
+        {
+            AddFarStorage();
+            // Everything the recipe needs sits in the FAR storage; the near one is empty
+            var def = DishConfig.GetDefinition(Dish);
+            for (int i = 0; i < def.Recipe.Length; i++)
+                Assert.IsTrue(_storage.TryDeposit(FarStorageBuildingId, def.Recipe[i].Crop, def.Recipe[i].Qty));
+
+            var ticket = _coordinator.CreateTicket(Dish, false, -1, null, PatronSeat);
+            Assert.IsNotNull(ticket);
+            CollectionAssert.AreEqual(new[] { FarStorageBuildingId }, ticket.SourceBuildingIds,
+                "the shortfall came from the far storage, so that's what the ticket must remember");
+
+            var route = PlanRoute(ticket);
+            Assert.AreEqual(1, route.Count, "the empty near storage is not worth a stop");
+            Assert.AreEqual(FarStorageBuildingId, route[0].BuildingId);
+            Assert.AreEqual(FarStorageDoor, route[0].DoorTile);
+        }
+
+        [TestMethod]
+        public void FetchRoute_VisitsBothStoragesWhenTheRecipeIsSplitAcrossThem()
+        {
+            AddFarStorage();
+            // TurnipOnionStew is turnip + onion — one crop per storage
+            var splitDish = DishType.TurnipOnionStew;
+            var def = DishConfig.GetDefinition(splitDish);
+            Assert.IsTrue(def.Recipe.Length >= 2, "this test needs a multi-crop recipe");
+
+            // First crop only in the near storage, the rest only in the far one
+            Assert.IsTrue(_storage.TryDeposit(StorageBuildingId, def.Recipe[0].Crop, def.Recipe[0].Qty));
+            for (int i = 1; i < def.Recipe.Length; i++)
+                Assert.IsTrue(_storage.TryDeposit(FarStorageBuildingId, def.Recipe[i].Crop, def.Recipe[i].Qty));
+
+            var ticket = _coordinator.CreateTicket(splitDish, false, -1, null, PatronSeat);
+            Assert.IsNotNull(ticket);
+            CollectionAssert.AreEquivalent(new[] { StorageBuildingId, FarStorageBuildingId },
+                ticket.SourceBuildingIds);
+
+            var route = PlanRoute(ticket);
+            Assert.AreEqual(2, route.Count, "a recipe split across two storages must tour both");
+            Assert.AreEqual(StorageBuildingId, route[0].BuildingId, "nearest storage first");
+            Assert.AreEqual(NearStorageDoor, route[0].DoorTile);
+            Assert.AreEqual(FarStorageBuildingId, route[1].BuildingId);
+        }
+
+        [TestMethod]
+        public void FetchRoute_NeverExceedsTheStopCap()
+        {
+            for (int extra = 0; extra < GameConfig.RunnerMaxStorageStops + 3; extra++)
+            {
+                _buildings.AddBuilding(new PlacedBuilding
+                {
+                    Type = BuildingType.CropStorage,
+                    TileX = GameConfig.NewGameCropStorageAnchorTileX + 4 * (extra + 1),
+                    TileY = GameConfig.NewGameCropStorageAnchorTileY,
+                    UniqueId = 10 + extra
+                });
+            }
+
+            // Spread one recipe crop across every storage so they all look worth visiting
+            var def = DishConfig.GetDefinition(Dish);
+            for (int extra = 0; extra < GameConfig.RunnerMaxStorageStops + 3; extra++)
+                Assert.IsTrue(_storage.TryDeposit(10 + extra, def.Recipe[0].Crop, 1));
+            for (int i = 0; i < def.Recipe.Length; i++)
+                Assert.IsTrue(_storage.TryDeposit(StorageBuildingId, def.Recipe[i].Crop, def.Recipe[i].Qty));
+
+            var ticket = _coordinator.CreateTicket(Dish, false, -1, null, PatronSeat);
+            Assert.IsNotNull(ticket);
+            Assert.IsTrue(PlanRoute(ticket).Count <= GameConfig.RunnerMaxStorageStops,
+                "a runner must not tour every storage on the farm");
+        }
+
+        [TestMethod]
+        public void RunnerCollect_AtOneStorageOnlyDrawsOnThatBuilding()
+        {
+            AddFarStorage();
+            var crop = DishConfig.GetDefinition(Dish).Recipe[0].Crop;
+            Assert.IsTrue(_storage.TryDeposit(StorageBuildingId, crop, 2));
+            Assert.IsTrue(_storage.TryDeposit(FarStorageBuildingId, crop, 5));
+
+            StockRecipe();
+            var ticket = _coordinator.CreateTicket(Dish, false, -1, null, PatronSeat);
+            int nearBefore = _storage.CountIn(StorageBuildingId, crop);
+            int farBefore = _storage.CountIn(FarStorageBuildingId, crop);
+
+            _coordinator.RunnerCollectAtStorage(ticket, FarStorageBuildingId);
+
+            Assert.AreEqual(nearBefore, _storage.CountIn(StorageBuildingId, crop),
+                "collecting at the far storage must not teleport crops out of the near one");
+            Assert.IsTrue(_storage.CountIn(FarStorageBuildingId, crop) < farBefore,
+                "the far storage should have supplied the fridge top-up");
+        }
+
+        [TestMethod]
+        public void HasReadableTicket_MirrorsWhatACookCanClaim()
+        {
+            StockRecipe();
+            Assert.IsFalse(_coordinator.HasReadableTicket(), "no orders yet");
+
+            var ticket = _coordinator.CreateTicket(Dish, false, -1, null, PatronSeat);
+            Assert.IsFalse(_coordinator.HasReadableTicket(),
+                "an unposted ticket is invisible to cooks, so a wandering cook must stay put");
+
+            _coordinator.PostTicket(ticket);
+            Assert.IsTrue(_coordinator.HasReadableTicket(), "a posted ticket must call the cook back");
+
+            Assert.AreSame(ticket, _coordinator.TryReadNextTicket());
+            Assert.IsFalse(_coordinator.HasReadableTicket(), "a claimed ticket must not call a second cook back");
+        }
+
         [TestMethod]
         public void BusJob_AgeGateClaimsTheOldestWaitingPlateFirst()
         {

--- a/PitHero/Dining/KitchenMonsterState.cs
+++ b/PitHero/Dining/KitchenMonsterState.cs
@@ -55,6 +55,10 @@ namespace PitHero.Dining
         RunnerCollect,
         /// <summary>Runner carrying ingredients back to the fridge.</summary>
         RunnerWalkToFridge,
+        /// <summary>Runner sprinting to a finished plate to pick it up (batches up to 3).</summary>
+        RunnerBusPlate,
+        /// <summary>Runner sprinting its stack of empty plates to the sink.</summary>
+        RunnerWalkToSink,
     }
 
     /// <summary>Role assigned to a kitchen worker.</summary>

--- a/PitHero/Dining/KitchenMonsterState.cs
+++ b/PitHero/Dining/KitchenMonsterState.cs
@@ -45,6 +45,8 @@ namespace PitHero.Dining
         CookWalkToServing,
         /// <summary>All serving tables are full — cook holds the dish until a slot frees.</summary>
         CookWaitServingSlot,
+        /// <summary>Cook pottering around the board and stoves while no ticket is posted.</summary>
+        CookWander,
 
         // ── Runner ──────────────────────────────────────────────────────────────
         /// <summary>Runner idling at its post waiting for a fetch job.</summary>

--- a/PitHero/Dining/KitchenTicket.cs
+++ b/PitHero/Dining/KitchenTicket.cs
@@ -69,6 +69,14 @@ namespace PitHero.Dining
         /// <summary>Units withdrawn from Crop Storage at creation, parallel to the recipe entries (for refunds).</summary>
         public int[] StorageTakenQty;
 
+        /// <summary>
+        /// Crop Storage buildings the shortfall was actually withdrawn from, in withdraw order.
+        /// Drives the runner's fetch route so it is seen visiting the storages this order really
+        /// drew on rather than whichever one happens to be closest. Null when nothing came from
+        /// storage. Refunds don't use this — they go through DepositAcrossBuildings.
+        /// </summary>
+        public System.Collections.Generic.List<int> SourceBuildingIds;
+
         /// <summary>Cooking station index (0-2) claimed by a cook; -1 until claimed.</summary>
         public int StationIndex = -1;
 

--- a/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
+++ b/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
@@ -80,6 +80,9 @@ namespace PitHero.ECS.Components
         private KitchenTicket _fetchTicket;
         private float _runnerWanderPause;
         private int _platesCarried; // empty plates in hand on the current sink run
+        private readonly System.Collections.Generic.List<KitchenTaskCoordinator.FetchStop> _fetchRoute =
+            new System.Collections.Generic.List<KitchenTaskCoordinator.FetchStop>(GameConfig.RunnerMaxStorageStops);
+        private int _fetchStopIndex; // which stop of _fetchRoute the runner is headed to
 
         public bool ShouldPause => true;
 
@@ -147,6 +150,7 @@ namespace PitHero.ECS.Components
 
             _coordinator.ReleaseFetchJob(_fetchTicket);
             _fetchTicket = null;
+            EndFetchTrip();
 
             // A plate we were walking to is still on its table — put the job back. Plates already
             // in hand had their entities destroyed at pickup, so they're simply gone (same as a
@@ -687,6 +691,9 @@ namespace PitHero.ECS.Components
                     return;
                 _cookTicket = _coordinator.TryReadNextTicket();
                 _cookReadElapsed = 0f;
+                // Nothing posted — potter around the kitchen instead of standing at the board
+                if (_cookTicket == null)
+                    CurrentState = KitchenMonsterState.CookWander;
                 return;
             }
 
@@ -707,6 +714,47 @@ namespace PitHero.ECS.Components
                 CurrentState = KitchenMonsterState.CookWalkToFridge;
             }
             // else: all stations busy (more cooks than stations shouldn't happen) — keep waiting
+        }
+
+        /// <summary>
+        /// Idle loop between tickets. Standing frozen at the board looked wrong, so the cook
+        /// potters around the board and the first two stoves; a posted ticket pulls it straight
+        /// back. Claiming still happens at the board (with the read pause), never out here.
+        /// </summary>
+        private void CookWander_Enter() => PickCookWanderTarget();
+
+        private void CookWander_Tick()
+        {
+            if (_goHome)
+            {
+                _mover.Stop();
+                CurrentState = KitchenMonsterState.ReturnHome;
+                return;
+            }
+            if (_coordinator.HasReadableTicket())
+            {
+                _mover.Stop();
+                CurrentState = KitchenMonsterState.CookWalkToBoard;
+                return;
+            }
+            if (_mover.IsMoving)
+                return;
+            if (elapsedTimeInState >= GameConfig.ServerWanderPauseSeconds)
+                PickCookWanderTarget();
+        }
+
+        private void PickCookWanderTarget()
+        {
+            elapsedTimeInState = 0f;
+            for (int attempt = 0; attempt < 8; attempt++)
+            {
+                var tile = new Point(
+                    Nez.Random.Range(GameConfig.KitchenCookWanderMinTileX, GameConfig.KitchenCookWanderMaxTileX + 1),
+                    Nez.Random.Range(GameConfig.KitchenCookWanderMinTileY, GameConfig.KitchenCookWanderMaxTileY + 1));
+                if (TrySetPathTo(tile))
+                    return;
+            }
+            // No walkable pick — idle in place this round
         }
 
         private void CookWalkToFridge_Enter()
@@ -922,14 +970,31 @@ namespace PitHero.ECS.Components
         {
             SetSprinting(true);
             Point myTile = WorldToTile(Entity.Transform.Position);
-            if (!_coordinator.TryFindNearestStorageDoor(myTile, out var door) || !TrySetPathTo(door))
+
+            // Plan the tour once, at the start of the trip: the storages this order's crops were
+            // actually withdrawn from, plus any that can still top the fridge up
+            if (_fetchStopIndex == 0)
+                _coordinator.PlanFetchRoute(_fetchTicket, myTile, _fetchRoute);
+
+            if (_fetchStopIndex < _fetchRoute.Count
+                && TrySetPathTo(_fetchRoute[_fetchStopIndex].DoorTile))
+                return;
+
+            // No route (every storage gone or none worth entering) — one trip to the nearest door
+            // still reads correctly, and the crops were reserved at order time either way
+            if (_fetchRoute.Count == 0
+                && _coordinator.TryFindNearestStorageDoor(myTile, out var door)
+                && TrySetPathTo(door))
             {
-                // Storage vanished mid-order — the crops were reserved at order time, so the
-                // ticket can proceed without the trip.
-                _coordinator.CompleteFetch(_fetchTicket);
-                _fetchTicket = null;
-                CurrentState = KitchenMonsterState.RunnerIdle;
+                _fetchRoute.Add(new KitchenTaskCoordinator.FetchStop { BuildingId = -1, DoorTile = door });
+                return;
             }
+
+            // Storage vanished mid-order — the crops were reserved at order time, so the
+            // ticket can proceed without the trip.
+            _coordinator.CompleteFetch(_fetchTicket);
+            EndFetchTrip();
+            CurrentState = KitchenMonsterState.RunnerIdle;
         }
 
         private void RunnerWalkToStorage_Tick()
@@ -937,6 +1002,7 @@ namespace PitHero.ECS.Components
             if (_fetchTicket == null || _fetchTicket.State == TicketState.Canceled)
             {
                 _fetchTicket = null;
+                EndFetchTrip();
                 CurrentState = KitchenMonsterState.RunnerIdle;
                 return;
             }
@@ -944,6 +1010,7 @@ namespace PitHero.ECS.Components
             {
                 _coordinator.ReleaseFetchJob(_fetchTicket);
                 _fetchTicket = null;
+                EndFetchTrip();
                 CurrentState = KitchenMonsterState.ReturnHome;
                 return;
             }
@@ -955,10 +1022,22 @@ namespace PitHero.ECS.Components
         {
             if (elapsedTimeInState < 1f)
                 return;
-            // Atomic top-up into the fridge happens here; the walk back is cosmetic
-            _coordinator.RunnerCollectAtStorage(_fetchTicket);
+
+            // The real top-up into the fridge happens here, drawing only on the storage we're
+            // standing at; the walk back is cosmetic
+            int buildingId = _fetchStopIndex < _fetchRoute.Count
+                ? _fetchRoute[_fetchStopIndex].BuildingId : -1;
+            _coordinator.RunnerCollectAtStorage(_fetchTicket, buildingId);
             if (_fetchTicket != null)
                 ShowCarryCrops(_fetchTicket.Dish);
+
+            _fetchStopIndex++;
+            if (!_goHome && _fetchStopIndex < _fetchRoute.Count)
+            {
+                // More of this order's ingredients sit in another storage — go there next
+                CurrentState = KitchenMonsterState.RunnerWalkToStorage;
+                return;
+            }
             CurrentState = KitchenMonsterState.RunnerWalkToFridge;
         }
 
@@ -975,7 +1054,15 @@ namespace PitHero.ECS.Components
             HideCarryDish();
             _coordinator.CompleteFetch(_fetchTicket);
             _fetchTicket = null;
+            EndFetchTrip();
             CurrentState = _goHome ? KitchenMonsterState.ReturnHome : KitchenMonsterState.RunnerIdle;
+        }
+
+        /// <summary>Clears the planned storage tour so the next fetch job plans a fresh one.</summary>
+        private void EndFetchTrip()
+        {
+            _fetchRoute.Clear();
+            _fetchStopIndex = 0;
         }
 
         // ── Runner bussing ──────────────────────────────────────────────────────

--- a/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
+++ b/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
@@ -14,13 +14,14 @@ namespace PitHero.ECS.Components
     /// Server: take up to 3 orders from patrons at its tables (1 server works all 4 tables;
     /// with 2 servers the first works the top pair, the second the bottom pair), post them at
     /// the ticket board, deliver up to 2 cooked dishes from the serving tables (only for its
-    /// own tables), bus finished plates (any table — bussing is zone-free), otherwise wander
-    /// its table area.
+    /// own tables), otherwise wander its table area. Bussing is the runners' job; a server only
+    /// falls back to it when no runner is on shift.
     /// Cook: read one ticket at the board, gather ingredients at the fridge (waiting for the
     /// runner if the fridge is short), cook at a free station, place the dish on a serving
     /// table — holding it if all three are full.
-    /// Runner: proactively haul each order's ingredient shortfall from Crop Storage to the
-    /// fridge, one claimed job at a time.
+    /// Runner: bus finished plates (any table — bussing is zone-free), sprinting out and back
+    /// with up to 3 plates per trip to the sink, and — once no plate is waiting — haul each
+    /// order's ingredient shortfall from Crop Storage to the fridge, one claimed job at a time.
     /// </summary>
     public class KitchenMonsterStateMachine : SimpleStateMachine<KitchenMonsterState>, IPausableComponent
     {
@@ -78,6 +79,7 @@ namespace PitHero.ECS.Components
         // ── Runner state ────────────────────────────────────────────────────────
         private KitchenTicket _fetchTicket;
         private float _runnerWanderPause;
+        private int _platesCarried; // empty plates in hand on the current sink run
 
         public bool ShouldPause => true;
 
@@ -145,6 +147,12 @@ namespace PitHero.ECS.Components
 
             _coordinator.ReleaseFetchJob(_fetchTicket);
             _fetchTicket = null;
+
+            // A plate we were walking to is still on its table — put the job back. Plates already
+            // in hand had their entities destroyed at pickup, so they're simply gone (same as a
+            // carried orphan dish); no work is stranded either way.
+            _coordinator.ReleaseBusJob(_busJob);
+            _busJob = default;
 
             base.OnRemovedFromEntity();
         }
@@ -240,10 +248,13 @@ namespace PitHero.ECS.Components
 
             var zone = Zone;
 
-            // 0) A plate that has waited too long (any table, any zone) — in a busy tavern
-            //    priorities 1-2 always have work, so without this age bump bussing starves
-            //    and plates pile up on tables
-            if (_coordinator.TryClaimBusJob(GameConfig.ServerBusPlateMaxWaitSeconds, out _busJob))
+            // 0) Fallback bussing only: with a runner on shift the plates are theirs, and taking
+            //    them off the server was the whole point (bussing was the server bottleneck).
+            //    Without one, a plate that has waited too long still bumps ahead of everything —
+            //    in a busy tavern priorities 1-2 always have work, so plates would otherwise pile
+            //    up and block arriving patrons at the door forever.
+            if (!_coordinator.HasActiveRunner
+                && _coordinator.TryClaimBusJob(GameConfig.ServerBusPlateMaxWaitSeconds, out _busJob))
             {
                 _busPickedUp = false;
                 CurrentState = KitchenMonsterState.ServerBusPlate;
@@ -261,8 +272,8 @@ namespace PitHero.ECS.Components
                 CurrentState = KitchenMonsterState.ServerWalkToPatron;
                 return;
             }
-            // 3) Dirty plates — any table, any zone (only orders/deliveries are zone-bound)
-            if (_coordinator.TryClaimBusJob(out _busJob))
+            // 3) Dirty plates — fallback only (see 0); any table, any zone
+            if (!_coordinator.HasActiveRunner && _coordinator.TryClaimBusJob(out _busJob))
             {
                 _busPickedUp = false;
                 CurrentState = KitchenMonsterState.ServerBusPlate;
@@ -532,6 +543,9 @@ namespace PitHero.ECS.Components
                 // First arrival trigger: walk to the plate
                 if (!TrySetPathToTileOrNeighbor(WorldToTile(_busJob.WorldPos)))
                 {
+                    // Unreachable plate (broken map geometry). The job has already left the queue,
+                    // so leaving the entity behind would block that seat forever — clear it here.
+                    ClearUnreachablePlate();
                     CurrentState = KitchenMonsterState.ServerDecide;
                     return;
                 }
@@ -863,6 +877,16 @@ namespace PitHero.ECS.Components
                 return;
             }
 
+            // Dirty plates come first: an un-bussed plate keeps a seat out of service and parks
+            // arriving patrons at the door, which costs the tavern more than a slow order does.
+            if (_coordinator.TryClaimBusJob(out _busJob))
+            {
+                _mover.Stop();
+                _platesCarried = 0;
+                CurrentState = KitchenMonsterState.RunnerBusPlate;
+                return;
+            }
+
             // A fetch job interrupts the wander immediately
             _fetchTicket = _coordinator.TryClaimFetchJob();
             if (_fetchTicket != null)
@@ -954,6 +978,79 @@ namespace PitHero.ECS.Components
             CurrentState = _goHome ? KitchenMonsterState.ReturnHome : KitchenMonsterState.RunnerIdle;
         }
 
+        // ── Runner bussing ──────────────────────────────────────────────────────
+
+        private void RunnerBusPlate_Enter()
+        {
+            SetSprinting(true);
+            if (TrySetPathToTileOrNeighbor(WorldToTile(_busJob.WorldPos)))
+                return;
+            // Unreachable plate (broken map geometry). The job has already left the queue, so
+            // leaving the entity behind would block that seat forever — clear it in place and
+            // let the tick below move on to the next plate.
+            ClearUnreachablePlate();
+            _mover.Stop();
+        }
+
+        private void RunnerBusPlate_Tick()
+        {
+            if (_mover.IsMoving)
+                return;
+
+            // Arrived: take the plate in hand
+            if (_busJob.DishEntity != null && !_busJob.DishEntity.IsDestroyed)
+            {
+                _busJob.DishEntity.Destroy();
+                _platesCarried++;
+            }
+            _busJob = default;
+            ShowCarryPlates(_platesCarried);
+
+            // Grab another plate on the same trip while there's a free hand
+            if (!_goHome && _platesCarried < GameConfig.RunnerCarryPlateLimit
+                && _coordinator.TryClaimBusJob(out _busJob))
+            {
+                RunnerBusPlate_Enter(); // same-state re-entry doesn't re-run Enter
+                return;
+            }
+
+            if (_platesCarried == 0)
+            {
+                CurrentState = _goHome ? KitchenMonsterState.ReturnHome : KitchenMonsterState.RunnerIdle;
+                return;
+            }
+            CurrentState = KitchenMonsterState.RunnerWalkToSink;
+        }
+
+        private void RunnerWalkToSink_Enter()
+        {
+            SetSprinting(true);
+            TrySetPathToTileOrNeighbor(KitchenTaskCoordinator.SinkTile);
+        }
+
+        private void RunnerWalkToSink_Tick()
+        {
+            if (_mover.IsMoving)
+                return;
+            // Plates go in the sink; if the sink was unreachable they're washed where we stand —
+            // either way the tables are clear, which is what the seat gate cares about.
+            HideCarryDish();
+            _platesCarried = 0;
+            CurrentState = _goHome ? KitchenMonsterState.ReturnHome : KitchenMonsterState.RunnerIdle;
+        }
+
+        /// <summary>
+        /// Destroys the plate of the current bus job in place. Used when the plate can't be walked
+        /// to — the job is already off the queue, so the alternative is a seat blocked forever.
+        /// </summary>
+        private void ClearUnreachablePlate()
+        {
+            Debug.Warn($"[KitchenMonster] Plate at {_busJob.WorldPos} is unreachable — clearing it in place");
+            if (_busJob.DishEntity != null && !_busJob.DishEntity.IsDestroyed)
+                _busJob.DishEntity.Destroy();
+            _busJob = default;
+        }
+
         // ─────────────────────────────────── ReturnHome
 
         private void ReturnHome_Enter()
@@ -1020,11 +1117,29 @@ namespace PitHero.ECS.Components
         private void ShowCarryCropAt(Nez.Sprites.SpriteRenderer renderer, Nez.Sprites.SpriteAtlas atlas,
             RecipeEntry[] recipe, int recipeIndex, float offsetX)
         {
-            if (renderer == null)
-                return;
             var sprite = recipeIndex < recipe.Length
                 ? atlas?.GetSprite(Util.CropConfig.GetHarvestSpriteName(recipe[recipeIndex].Crop))
                 : null;
+            ShowCarrySpriteAt(renderer, sprite, offsetX);
+        }
+
+        /// <summary>
+        /// Runner bus visual: one empty plate per free hand — first centered, second offset left,
+        /// third offset right (the same three-item look as a crop haul).
+        /// </summary>
+        private void ShowCarryPlates(int count)
+        {
+            var plate = count > 0 ? GetPlateSprite() : null;
+            ShowCarrySpriteAt(CarryRenderer, count >= 1 ? plate : null, 0f);
+            ShowCarrySpriteAt(CarryLeftRenderer, count >= 2 ? plate : null, -CarrySideOffsetX);
+            ShowCarrySpriteAt(CarryRightRenderer, count >= 3 ? plate : null, CarrySideOffsetX);
+        }
+
+        private void ShowCarrySpriteAt(Nez.Sprites.SpriteRenderer renderer,
+            Nez.Textures.Sprite sprite, float offsetX)
+        {
+            if (renderer == null)
+                return;
             if (sprite == null)
             {
                 renderer.SetEnabled(false);

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -180,6 +180,12 @@ namespace PitHero
         public const int KitchenRunnerWanderMinTileY = 6;
         public const int KitchenRunnerWanderMaxTileX = 88;
         public const int KitchenRunnerWanderMaxTileY = 8;
+        // Cooks wander this area (around the ticket board and the first two stoves) between tickets
+        public const int KitchenCookWanderMinTileX = 82;
+        public const int KitchenCookWanderMinTileY = 2;
+        public const int KitchenCookWanderMaxTileX = 84;
+        public const int KitchenCookWanderMaxTileY = 3;
+        public const int RunnerMaxStorageStops = 3;             // storages a runner tours in one ingredient trip
         public const int ServerOrderMemoryLimit = 3;            // orders a server can hold before posting at the board
         public const int ServerCarryDishLimit = 2;              // cooked dishes a server can carry at once
         public const float ServerBusPlateMaxWaitSeconds = 90f;  // fallback bussing only (no runner on shift): a plate waiting this long jumps ahead of deliveries/orders

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -165,7 +165,7 @@ namespace PitHero
         public const int KitchenSinkTileY = 2;
         public const int MaxKitchenCooks = 3;
         public const int MaxKitchenServers = 2;
-        public const int MaxKitchenRunners = 2;
+        public const int MaxKitchenRunners = 3;         // runners also bus plates, so peak hours want a third
         public const float KitchenHatOverlapPixels = 6f;        // how far the job hat's brim overlaps the head top
         public const float KitchenHatCheckIntervalSeconds = 5f; // how often the coordinator re-checks that workers wear hats
         public const int KitchenTicketBoardTileX = 82;          // servers post orders / cooks read them here
@@ -182,7 +182,8 @@ namespace PitHero
         public const int KitchenRunnerWanderMaxTileY = 8;
         public const int ServerOrderMemoryLimit = 3;            // orders a server can hold before posting at the board
         public const int ServerCarryDishLimit = 2;              // cooked dishes a server can carry at once
-        public const float ServerBusPlateMaxWaitSeconds = 90f;  // a plate waiting this long jumps ahead of deliveries/orders
+        public const float ServerBusPlateMaxWaitSeconds = 90f;  // fallback bussing only (no runner on shift): a plate waiting this long jumps ahead of deliveries/orders
+        public const int RunnerCarryPlateLimit = 3;             // empty plates a runner carries to the sink in one trip
         public const float TicketBoardPauseSeconds = 1f;        // pause at the board to post/read a ticket
         public const int KitchenFridgeParPerCrop = 4;           // runner tops the fridge up to this many of each fetched crop
         public const float KitchenRunnerSprintMultiplier = 3f;  // runner speed multiplier while fetching ingredients
@@ -230,7 +231,7 @@ namespace PitHero
         public const int AutoJobFarmCropsPerWorkerBaseline = 12;   // quiet-period demand: crops + plans each farmer can tend
         public const int AutoJobKitchenBaseStaff = 3;              // cook + server + runner minimum (no runner -> fridge runs dry)
         public const int AutoJobKitchenBacklogPerExtraWorker = 3;  // tickets/patrons per extra kitchen worker beyond base staff
-        public const int AutoJobKitchenMaxWorkers = 7;             // mirrors KitchenTaskCoordinator role-post cap
+        public const int AutoJobKitchenMaxWorkers = 8;             // mirrors KitchenTaskCoordinator.MaxWorkerPosts (3 cooks + 2 servers + 3 runners)
 
         // Camera Configuration
         public const float CameraDefaultZoom = 1f; // default zoom level

--- a/PitHero/Services/CropStorageInventoryService.cs
+++ b/PitHero/Services/CropStorageInventoryService.cs
@@ -257,11 +257,52 @@ namespace PitHero.Services
             return total;
         }
 
+        /// <summary>Units of <paramref name="crop"/> stored in one specific Crop Storage building.</summary>
+        public int CountIn(int buildingId, Farming.CropType crop)
+        {
+            var slots = GetOrCreate(buildingId);
+            int total = 0;
+            for (int s = 0; s < slots.Length; s++)
+            {
+                if (!slots[s].IsEmpty && slots[s].Type == crop)
+                    total += slots[s].Count;
+            }
+            return total;
+        }
+
+        /// <summary>
+        /// Best-effort withdrawal of up to <paramref name="max"/> units of <paramref name="crop"/>
+        /// from one specific building. Returns how many were actually taken (0 if it holds none).
+        /// Used by the kitchen runner, which collects at the storage it is standing in front of.
+        /// </summary>
+        public int WithdrawUpTo(int buildingId, Farming.CropType crop, int max)
+        {
+            if (max <= 0)
+                return 0;
+
+            var slots = GetOrCreate(buildingId);
+            int remaining = max;
+            for (int s = 0; s < slots.Length && remaining > 0; s++)
+            {
+                if (slots[s].IsEmpty || slots[s].Type != crop)
+                    continue;
+                int take = slots[s].Count < remaining ? slots[s].Count : remaining;
+                slots[s].Count -= take;
+                if (slots[s].Count <= 0)
+                    slots[s] = default;
+                remaining -= take;
+            }
+            return max - remaining;
+        }
+
         /// <summary>
         /// All-or-nothing withdrawal of <paramref name="amount"/> units of <paramref name="crop"/>
         /// across all Crop Storage buildings. Returns false without mutating if storage is insufficient.
+        /// When <paramref name="sourceBuildingIds"/> is given, each building actually drawn from is
+        /// appended to it (no duplicates) so callers can retrace where the crops came from.
         /// </summary>
-        public bool TryWithdrawAcrossBuildings(Farming.CropType crop, int amount)
+        public bool TryWithdrawAcrossBuildings(Farming.CropType crop, int amount,
+            List<int> sourceBuildingIds = null)
         {
             if (amount <= 0)
                 return true;
@@ -277,17 +318,12 @@ namespace PitHero.Services
             {
                 if (all[b].Type != BuildingType.CropStorage)
                     continue;
-                var slots = GetOrCreate(all[b].UniqueId);
-                for (int s = 0; s < slots.Length && remaining > 0; s++)
-                {
-                    if (slots[s].IsEmpty || slots[s].Type != crop)
-                        continue;
-                    int take = slots[s].Count < remaining ? slots[s].Count : remaining;
-                    slots[s].Count -= take;
-                    if (slots[s].Count <= 0)
-                        slots[s] = default;
-                    remaining -= take;
-                }
+                int took = WithdrawUpTo(all[b].UniqueId, crop, remaining);
+                if (took <= 0)
+                    continue;
+                remaining -= took;
+                if (sourceBuildingIds != null && !sourceBuildingIds.Contains(all[b].UniqueId))
+                    sourceBuildingIds.Add(all[b].UniqueId);
             }
             return true;
         }

--- a/PitHero/Services/KitchenTaskCoordinator.cs
+++ b/PitHero/Services/KitchenTaskCoordinator.cs
@@ -500,6 +500,7 @@ namespace PitHero.Services
             var fridgeTaken = new int[def.Recipe.Length];
             var storageTaken = new int[def.Recipe.Length];
             int storageTotal = 0;
+            List<int> sourceBuildings = null;
 
             for (int i = 0; i < def.Recipe.Length; i++)
             {
@@ -509,7 +510,9 @@ namespace PitHero.Services
                 int shortfall = need - fridgeTaken[i];
                 if (shortfall > 0)
                 {
-                    if (!(_cropStorage?.TryWithdrawAcrossBuildings(crop, shortfall) ?? false))
+                    if (sourceBuildings == null)
+                        sourceBuildings = new List<int>(2);
+                    if (!(_cropStorage?.TryWithdrawAcrossBuildings(crop, shortfall, sourceBuildings) ?? false))
                     {
                         // Availability changed mid-withdraw — roll everything back
                         for (int r = 0; r <= i; r++)
@@ -536,6 +539,7 @@ namespace PitHero.Services
                 TableTile = TavernSeatConfig.GetTableTile(seatTile),
                 FridgeTakenQty = fridgeTaken,
                 StorageTakenQty = storageTaken,
+                SourceBuildingIds = sourceBuildings,
                 IngredientsFetched = storageTotal == 0,
             };
             ticket.State = ticket.IngredientsFetched
@@ -758,6 +762,24 @@ namespace PitHero.Services
         /// Cook reads the next unclaimed posted ticket from the board (party tickets first, then
         /// FIFO). Only one cook holds any given ticket. Returns null when the board is empty.
         /// </summary>
+        /// <summary>
+        /// True when a posted, unclaimed ticket is waiting at the board. Non-claiming peek — a
+        /// cook wandering between tickets uses it to decide when to walk back and read one, so it
+        /// must mirror TryReadNextTicket's filter exactly.
+        /// </summary>
+        public bool HasReadableTicket()
+        {
+            for (int i = 0; i < _tickets.Count; i++)
+            {
+                var t = _tickets[i];
+                if (!t.PostedToBoard || t.CookClaimed || t.State == TicketState.Canceled)
+                    continue;
+                if (t.State == TicketState.AwaitingIngredients || t.State == TicketState.ReadyToCook)
+                    return true;
+            }
+            return false;
+        }
+
         public KitchenTicket TryReadNextTicket()
         {
             for (int pass = 0; pass < 2; pass++)
@@ -1083,12 +1105,127 @@ namespace PitHero.Services
                 _fetchQueue.Add(t);
         }
 
+        /// <summary>One leg of a runner's ingredient trip: the storage building and its door tile.</summary>
+        public struct FetchStop
+        {
+            public int BuildingId;
+            public Point DoorTile;
+        }
+
+        // Scratch for route planning (allocation-free; the planner runs once per fetch trip)
+        private readonly Dictionary<CropType, int> _routeNeed = new Dictionary<CropType, int>(16);
+        private readonly List<PlacedBuilding> _routeCandidates = new List<PlacedBuilding>(8);
+
         /// <summary>
-        /// Runner is at the storage door: opportunistically tops the fridge up to par for each
-        /// crop in the ticket's recipe (withdrawn atomically into the fridge — the walk back is
-        /// cosmetic, so a crash never loses crops).
+        /// Plans the runner's tour of Crop Storage buildings for a fetch job, nearest-first from
+        /// <paramref name="fromTile"/>, capped at <see cref="GameConfig.RunnerMaxStorageStops"/>.
+        ///
+        /// A building earns a stop when it either supplied this ticket's shortfall
+        /// (<see cref="KitchenTicket.SourceBuildingIds"/> — the crops are already withdrawn, so
+        /// this is the only record of where they came from) or still holds a crop the fridge needs
+        /// to reach par. Stops that no longer contribute once nearer ones are visited are dropped,
+        /// so a multi-crop recipe visits several storages but never one it has no reason to enter.
+        ///
+        /// Best-effort by design: stock can change between planning and arrival, and the ticket's
+        /// own ingredients were reserved at order time, so a short route never blocks a cook.
         /// </summary>
-        public void RunnerCollectAtStorage(KitchenTicket t)
+        public void PlanFetchRoute(KitchenTicket t, Point fromTile, List<FetchStop> route)
+        {
+            route.Clear();
+            if (t == null || _buildingService == null)
+                return;
+            EnsureServices();
+            if (_cropStorage == null)
+                return;
+
+            // Remaining fridge top-up per recipe crop
+            _routeNeed.Clear();
+            var def = DishConfig.GetDefinition(t.Dish);
+            for (int i = 0; i < def.Recipe.Length; i++)
+            {
+                var crop = def.Recipe[i].Crop;
+                if (_routeNeed.ContainsKey(crop))
+                    continue;
+                int want = GameConfig.KitchenFridgeParPerCrop - FridgeCount(crop);
+                if (want > 0)
+                    _routeNeed[crop] = want;
+            }
+
+            _routeCandidates.Clear();
+            var all = _buildingService.GetAll();
+            for (int i = 0; i < all.Count; i++)
+            {
+                if (all[i].Type == BuildingType.CropStorage)
+                    _routeCandidates.Add(all[i]);
+            }
+
+            var cursor = fromTile;
+            while (_routeCandidates.Count > 0 && route.Count < GameConfig.RunnerMaxStorageStops)
+            {
+                int nearest = -1;
+                long best = long.MaxValue;
+                Point bestDoor = default;
+                for (int i = 0; i < _routeCandidates.Count; i++)
+                {
+                    var door = Util.BuildingConfig.GetDoorTile(_routeCandidates[i].Type,
+                        new Point(_routeCandidates[i].TileX, _routeCandidates[i].TileY));
+                    long dx = door.X - cursor.X;
+                    long dy = door.Y - cursor.Y;
+                    long distSq = dx * dx + dy * dy;
+                    if (distSq < best)
+                    {
+                        best = distSq;
+                        nearest = i;
+                        bestDoor = door;
+                    }
+                }
+
+                var building = _routeCandidates[nearest];
+                _routeCandidates.RemoveAt(nearest);
+
+                bool worthStopping = t.SourceBuildingIds != null
+                    && t.SourceBuildingIds.Contains(building.UniqueId);
+                if (!worthStopping)
+                {
+                    foreach (var kvp in _routeNeed)
+                    {
+                        if (kvp.Value > 0 && _cropStorage.CountIn(building.UniqueId, kvp.Key) > 0)
+                        {
+                            worthStopping = true;
+                            break;
+                        }
+                    }
+                }
+                if (!worthStopping)
+                    continue;
+
+                route.Add(new FetchStop { BuildingId = building.UniqueId, DoorTile = bestDoor });
+                cursor = bestDoor;
+
+                // Simulate this stop's supply so a later storage isn't toured for a crop
+                // this one already covers
+                _routeScratchCrops.Clear();
+                foreach (var kvp in _routeNeed)
+                    _routeScratchCrops.Add(kvp.Key);
+                for (int i = 0; i < _routeScratchCrops.Count; i++)
+                {
+                    var crop = _routeScratchCrops[i];
+                    int have = _cropStorage.CountIn(building.UniqueId, crop);
+                    int left = _routeNeed[crop] - have;
+                    _routeNeed[crop] = left > 0 ? left : 0;
+                }
+            }
+        }
+
+        private readonly List<CropType> _routeScratchCrops = new List<CropType>(16);
+
+        /// <summary>
+        /// Runner is at a storage door: opportunistically tops the fridge up to par for each crop
+        /// in the ticket's recipe, drawing only on the building it is standing in front of (the
+        /// walk back is cosmetic, so a crash never loses crops). Pass a negative id to draw from
+        /// every storage at once — the fallback when no route could be planned.
+        /// </summary>
+        public void RunnerCollectAtStorage(KitchenTicket t, int buildingId = -1)
         {
             if (t == null) return;
             EnsureServices();
@@ -1101,6 +1238,13 @@ namespace PitHero.Services
                 int want = GameConfig.KitchenFridgeParPerCrop - FridgeCount(crop);
                 if (want <= 0)
                     continue;
+
+                if (buildingId >= 0)
+                {
+                    FridgeAdd(crop, _cropStorage.WithdrawUpTo(buildingId, crop, want));
+                    continue;
+                }
+
                 int available = _cropStorage.CountTotal(crop);
                 int take = want < available ? want : available;
                 if (take > 0 && _cropStorage.TryWithdrawAcrossBuildings(crop, take))

--- a/PitHero/Services/KitchenTaskCoordinator.cs
+++ b/PitHero/Services/KitchenTaskCoordinator.cs
@@ -96,9 +96,56 @@ namespace PitHero.Services
         // ── Kitchen open/closed ─────────────────────────────────────────────────
         private int _cook1WorkerIdx = -1;
         private int _server1WorkerIdx = -1;
+        private int _runner1WorkerIdx = -1;
 
         /// <summary>True when ≥1 cook and ≥1 server are assigned and awake.</summary>
         public bool IsKitchenOpen => _cook1WorkerIdx >= 0 && _server1WorkerIdx >= 0;
+
+        /// <summary>
+        /// True when ≥1 runner is on shift. Runners own plate bussing; servers only fall back to
+        /// it while this is false, so a cook+server-only kitchen still clears its tables.
+        /// </summary>
+        public bool HasActiveRunner => _runner1WorkerIdx >= 0;
+
+        /// <summary>Total kitchen role posts — the cap on simultaneous kitchen workers.</summary>
+        public static int MaxWorkerPosts =>
+            GameConfig.MaxKitchenCooks + GameConfig.MaxKitchenServers + GameConfig.MaxKitchenRunners;
+
+        /// <summary>
+        /// Fills <paramref name="into"/> with the role for each of the first postCount posts by
+        /// cycling Cook → Server → Runner and skipping roles that are already full, which yields
+        /// cook1, server1, runner1, cook2, server2, runner2, cook3, runner3. Ordering is what
+        /// makes the crew grow sensibly: a two-monster kitchen is a cook and a server (the pair
+        /// that opens it), the third is the runner that keeps the fridge stocked and the tables
+        /// clear. Stations and zones are then claimed dynamically by the FSMs.
+        /// </summary>
+        public static void FillRoleMix(int postCount, List<KitchenRole> into)
+        {
+            if (postCount > MaxWorkerPosts)
+                postCount = MaxWorkerPosts;
+            int cooks = 0, servers = 0, runners = 0, cursor = 0;
+            for (int i = 0; i < postCount; i++)
+            {
+                // postCount never exceeds the sum of the per-role caps, so this always resolves
+                while (true)
+                {
+                    int slot = cursor % 3;
+                    cursor++;
+                    if (slot == 0 && cooks < GameConfig.MaxKitchenCooks)
+                    {
+                        cooks++; into.Add(KitchenRole.Cook); break;
+                    }
+                    if (slot == 1 && servers < GameConfig.MaxKitchenServers)
+                    {
+                        servers++; into.Add(KitchenRole.Server); break;
+                    }
+                    if (slot == 2 && runners < GameConfig.MaxKitchenRunners)
+                    {
+                        runners++; into.Add(KitchenRole.Runner); break;
+                    }
+                }
+            }
+        }
 
         /// <summary>Number of open kitchen tickets (any state) — the order backlog.</summary>
         public int ActiveTicketCount => _tickets.Count;
@@ -190,25 +237,9 @@ namespace PitHero.Services
                 _wantedAssignments.Insert(insertPos, m);
             }
 
-            // Assign roles in order: cook1, server1, runner1, cook2, server2, runner2, cook3.
-            // Stations and zones are claimed dynamically by the FSMs.
-            int postCount = _wantedAssignments.Count < GameConfig.AutoJobKitchenMaxWorkers
-                ? _wantedAssignments.Count : GameConfig.AutoJobKitchenMaxWorkers;
-            for (int i = 0; i < postCount; i++)
-            {
-                KitchenRole role;
-                switch (i)
-                {
-                    case 0: role = KitchenRole.Cook;   break;
-                    case 1: role = KitchenRole.Server; break;
-                    case 2: role = KitchenRole.Runner; break;
-                    case 3: role = KitchenRole.Cook;   break;
-                    case 4: role = KitchenRole.Server; break;
-                    case 5: role = KitchenRole.Runner; break;
-                    default: role = KitchenRole.Cook;  break;
-                }
-                _wantedRoles.Add(role);
-            }
+            int postCount = _wantedAssignments.Count < MaxWorkerPosts
+                ? _wantedAssignments.Count : MaxWorkerPosts;
+            FillRoleMix(postCount, _wantedRoles);
 
             // Track which pre-existing workers keep their assignment. SpawnWorker appends to
             // _workers mid-pass, so snapshot the count and never index past it.
@@ -269,15 +300,20 @@ namespace PitHero.Services
                     _workers.RemoveAt(wi);
             }
 
-            // Update kitchen-open post indices (first cook, first server)
+            // Update kitchen-open post indices (first cook, first server, first runner)
             _cook1WorkerIdx = -1;
             _server1WorkerIdx = -1;
+            _runner1WorkerIdx = -1;
             for (int wi = 0; wi < _workers.Count; wi++)
             {
-                if (_cook1WorkerIdx < 0 && _workers[wi].Role == KitchenRole.Cook && !_workers[wi].Fsm.IsReturningHome)
+                if (_workers[wi].Fsm.IsReturningHome)
+                    continue;
+                if (_cook1WorkerIdx < 0 && _workers[wi].Role == KitchenRole.Cook)
                     _cook1WorkerIdx = wi;
-                if (_server1WorkerIdx < 0 && _workers[wi].Role == KitchenRole.Server && !_workers[wi].Fsm.IsReturningHome)
+                if (_server1WorkerIdx < 0 && _workers[wi].Role == KitchenRole.Server)
                     _server1WorkerIdx = wi;
+                if (_runner1WorkerIdx < 0 && _workers[wi].Role == KitchenRole.Runner)
+                    _runner1WorkerIdx = wi;
             }
 
             // Periodic hat sweep: shift overlaps can leave a worker hatless at spawn
@@ -960,6 +996,27 @@ namespace PitHero.Services
             _busJobs.RemoveAt(oldest);
             return true;
         }
+
+        /// <summary>
+        /// Returns a claimed bus job to the queue — the worker was sent home (or died) before it
+        /// picked the plate up. Keeps the original enqueue time so the plate stays at the head of
+        /// the queue. No-ops for a plate that was already picked up (its entity is gone) or one
+        /// that is somehow queued twice, so calling this defensively is always safe.
+        /// </summary>
+        public void ReleaseBusJob(BusJob job)
+        {
+            if (job.DishEntity == null || job.DishEntity.IsDestroyed)
+                return;
+            for (int i = 0; i < _busJobs.Count; i++)
+            {
+                if (ReferenceEquals(_busJobs[i].DishEntity, job.DishEntity))
+                    return;
+            }
+            _busJobs.Add(job);
+        }
+
+        /// <summary>True while any plate is waiting to be bussed.</summary>
+        public bool HasPendingBusJob => _busJobs.Count > 0;
 
         /// <summary>
         /// True while a pending (unclaimed) bus job's plate sits at the given world position

--- a/PitHero/Services/MercenaryManager.cs
+++ b/PitHero/Services/MercenaryManager.cs
@@ -311,9 +311,16 @@ namespace PitHero.Services
             if (mercComponent.IsBeingRemoved)
                 yield break;
 
-            // The assigned seat's table still has an un-bussed plate: wait at the tavern door
-            // until a server clears it. A server only takes orders from seated patrons, so a
-            // patron waiting at the door adds no ordering pressure while the backlog drains.
+            // The assigned seat's table still has an un-bussed plate. Prefer any other free seat
+            // that is already cleared; only when every free seat is dirty (or there is none) do we
+            // wait at the tavern door until a plate is cleared. A server only takes orders from
+            // seated patrons, so a patron waiting at the door adds no ordering pressure meanwhile.
+            if (HasUnbussedPlateAtSeat(tavernPosition))
+            {
+                var cleared = TryReseatToClearedSeat(mercComponent, tavernPosition);
+                if (cleared.HasValue)
+                    tavernPosition = cleared.Value;
+            }
             if (HasUnbussedPlateAtSeat(tavernPosition))
             {
                 var doorTile = new Point(GameConfig.TavernDoorWaitTileX, GameConfig.TavernDoorWaitTileY);
@@ -327,6 +334,13 @@ namespace PitHero.Services
                 {
                     if (mercComponent.IsHired || mercComponent.IsBeingRemoved)
                         yield break;
+                    // A seat elsewhere may free up (or get bussed) while we wait — take it
+                    var freed = TryReseatToClearedSeat(mercComponent, tavernPosition);
+                    if (freed.HasValue)
+                    {
+                        tavernPosition = freed.Value;
+                        break;
+                    }
                     yield return Coroutine.WaitForSeconds(0.25f);
                 }
             }
@@ -737,13 +751,45 @@ namespace PitHero.Services
             return count;
         }
 
-        /// <summary>Gets an available tavern position</summary>
+        /// <summary>
+        /// Gets an available tavern position, preferring one whose table is already cleared —
+        /// a seat with an un-bussed plate would park the arriving patron at the door.
+        /// </summary>
         private Point? GetAvailableTavernPosition()
+        {
+            Point? dirtyFallback = null;
+            for (int i = 0; i < TavernPositions.Length; i++)
+            {
+                if (_occupiedTavernPositions.Contains(TavernPositions[i]))
+                    continue;
+                if (!HasUnbussedPlateAtSeat(TavernPositions[i]))
+                    return TavernPositions[i];
+                if (!dirtyFallback.HasValue)
+                    dirtyFallback = TavernPositions[i];
+            }
+            return dirtyFallback;
+        }
+
+        /// <summary>
+        /// Moves the mercenary's seat reservation to a free, already-cleared seat when its current
+        /// one still has an un-bussed plate. Returns the new seat, or null when every other free
+        /// seat is dirty too (or there is none) — only then is waiting at the door the right call.
+        /// </summary>
+        private Point? TryReseatToClearedSeat(MercenaryComponent mercComponent, Point currentSeat)
         {
             for (int i = 0; i < TavernPositions.Length; i++)
             {
-                if (!_occupiedTavernPositions.Contains(TavernPositions[i]))
-                    return TavernPositions[i];
+                var seat = TavernPositions[i];
+                if (seat == currentSeat || _occupiedTavernPositions.Contains(seat))
+                    continue;
+                if (HasUnbussedPlateAtSeat(seat))
+                    continue;
+
+                _occupiedTavernPositions.Remove(currentSeat);
+                _occupiedTavernPositions.Add(seat);
+                mercComponent.TavernPosition = seat;
+                Debug.Log($"[MercenaryManager] Mercenary {mercComponent.LinkedMercenary.Name} switched from dirty seat ({currentSeat.X},{currentSeat.Y}) to cleared seat ({seat.X},{seat.Y})");
+                return seat;
             }
             return null;
         }

--- a/PitHero/docs/AutoJobAssignmentSystem.md
+++ b/PitHero/docs/AutoJobAssignmentSystem.md
@@ -63,10 +63,15 @@ evaluator exists just returns to the pool).
 
 - **Kitchen** (`Sticky = true`, listed first so its small crew staffs before farming absorbs the
   rest): base crew `AutoJobKitchenBaseStaff` = 3 — **cook + server + runner; never less, a
-  runner-less kitchen runs the fridge dry** — plus one worker per
-  `AutoJobKitchenBacklogPerExtraWorker` backlog items (open tickets + seated patrons + pending
-  party diners), capped at `AutoJobKitchenMaxWorkers` (mirrors the coordinator's role-post cap).
+  runner-less kitchen runs the fridge dry and leaves dirty plates on the tables** — plus one
+  worker per `AutoJobKitchenBacklogPerExtraWorker` backlog items (open tickets + seated patrons +
+  pending party diners), capped at `AutoJobKitchenMaxWorkers` (must mirror
+  `KitchenTaskCoordinator.MaxWorkerPosts` = 3 cooks + 2 servers + 3 runners = 8; asserted by
+  `KitchenServiceLoopTests.RoleMix_RespectsPerRoleCapsAndNeverExceedsMaxPosts`).
   `MinWorkers` = base crew only when backlog > 0.
+
+  The demand model's granularity is `MonsterJob`, not `KitchenRole` — it asks for *N kitchen
+  workers* and the coordinator decides the cook/server/runner split (`FillRoleMix`).
 - **Farming** (`Sticky = false`): `max(burst, baseline)` where burst =
   `FarmTaskCoordinator.OutstandingTaskCount / AutoJobFarmTasksPerWorker` (catches watering/harvest
   waves) and baseline = `(CropCount + PlanCount) / AutoJobFarmCropsPerWorkerBaseline` (quiet

--- a/PitHero/docs/TavernDiningSystem.md
+++ b/PitHero/docs/TavernDiningSystem.md
@@ -116,9 +116,11 @@ the sink by the carrier's FSM when it sees `Canceled`.
 
 **Staffing** (coordinator `Update`, per frame): candidates = allied monsters with
 `Job == Cooking` that are awake per `MonsterScheduleConfig.IsAsleep` (in-game time = the shift
-system), sorted by `CookingProficiency` descending. Roles fill in fixed order
-**cook1, server1, runner1, cook2, server2, runner2, cook3** (max 7 = 3 cooks + 2 servers +
-2 runners). Workers whose role/slot disappears get `RequestReturnHome()` (finish current task,
+system), sorted by `CookingProficiency` descending. `FillRoleMix` cycles Cook → Server → Runner
+skipping full roles, giving **cook1, server1, runner1, cook2, server2, runner2, cook3, runner3**
+(`MaxWorkerPosts` = 8 = 3 cooks + 2 servers + 3 runners). Change a `GameConfig.MaxKitchen*`
+constant and the order re-derives — but keep `AutoJobKitchenMaxWorkers` in sync (a test asserts
+it). Workers whose role/slot disappears get `RequestReturnHome()` (finish current task,
 walk into the house, despawn); a restored assignment calls `CancelReturnHome()`. Spawn is at
 their Monster House door (anchor +2 south); no collider/TAG_MONSTER, so workers never trigger
 battles. A 5s sweep calls `EnsureHat()` — `KitchenHatService` pools 7 hat entities
@@ -127,8 +129,12 @@ overlap exhausts it.
 
 **Server loop** (`ServerDecide`): priority is (1) deliver plated dishes for its zone,
 (2) take orders — party members first, then nearest waiting patron, batching up to
-`ServerOrderMemoryLimit = 3` before a single trip to the board, (3) bus dirty plates,
-(4) wander its table area (interruptible). Pickup: walks to the middle serving approach tile,
+`ServerOrderMemoryLimit = 3` before a single trip to the board, (3) wander its table area
+(interruptible). **Bussing belongs to the runners** — it was the server bottleneck (issue #327).
+A server only falls back to bussing while `HasActiveRunner` is false, so a cook+server-only
+kitchen still clears its tables; in that mode the old two-tier priority applies (a plate older
+than `ServerBusPlateMaxWaitSeconds = 90` bumps ahead of deliveries and orders, otherwise plates
+come after orders). Pickup: walks to the middle serving approach tile,
 grabs up to `ServerCarryDishLimit = 2` dishes for its zone, delivers each to the seat's plate
 position. One server on shift = `ServerZone.AllTables`; two = first works `TopTables`, second
 `BottomTables` (recomputed live, so zones re-shard when staffing changes).
@@ -141,14 +147,32 @@ full the cook holds the dish (`CookWaitServingSlot`); at shift end `ForceReserve
 overflows onto slot 0 rather than stranding the dish (pickup scans tickets, not slots, so this
 self-heals). Deluxe roll happens at cook start: `proficiency × 5%` capped 45%.
 
-**Runner loop**: wander the south corridor → claim fetch job → sprint (3×) to nearest
-CropStorage door → 1s collect (the real fridge top-up) → carry crop sprites back to the fridge
-→ `CompleteFetch`.
+**Runner loop** (`RunnerIdle`): **dirty plates first**, then ingredients — a plate left on a
+table keeps that seat out of service and parks arriving patrons at the door, which costs more
+than a slow order. Backing orders up a little is the accepted trade.
+
+- *Bus* (`RunnerBusPlate` → `RunnerWalkToSink`): claim a bus job (zone-free, oldest first) →
+  sprint to the plate → pick it up → keep claiming and collecting while under
+  `RunnerCarryPlateLimit = 3` → sprint the stack to the sink. The plates show on the runner's
+  three carry renderers (center / left / right), the same rig as a crop haul.
+- *Fetch*: sprint (3×) to nearest CropStorage door → 1s collect (the real fridge top-up) →
+  carry crop sprites back to the fridge → `CompleteFetch`. Never interrupted mid-trip by a
+  plate; prioritization happens at claim time only.
+
+A claimed-but-not-yet-picked-up plate goes back to the queue via `ReleaseBusJob` when the runner
+despawns (it keeps its original `EnqueuedTime`, so it stays at the head of the line). Plates
+already in hand had their entities destroyed at pickup, so they're simply gone — the tables are
+clear either way, which is all the seat gate cares about.
 
 ## Walk-in patrons
 
 `MercenaryManager` spawns unhired mercs on a 60–120s rolled interval (5s when the tavern is
-empty) into 9 fixed seats; at the seat a `TavernPatronComponent` is added. When full, the
+empty) into 9 fixed seats; at the seat a `TavernPatronComponent` is added. **A patron never sits
+down at a table that still has an un-bussed plate.** `GetAvailableTavernPosition` prefers a free
+seat that is already cleared, and `TryReseatToClearedSeat` re-checks (plates appear and get
+bussed during the walk in) — only when *every* free seat is dirty does the patron wait at the
+tavern door (100,6), retrying the reseat every 0.25s until a plate is cleared. Waiting patrons
+are unseated, so they add no ordering pressure while the backlog drains. When full, the
 oldest patron in `FinishedEating` is walked off to free a seat — never one still waiting or
 eating. `PatronState`: `WaitingToOrder → Ordered → FoodDelivered → Eating → FinishedEating`.
 Patience: 10 min pre-order and post-order (expiry cancels the ticket and leaves immediately);
@@ -226,15 +250,19 @@ entities, patron state. All of that is transient and reconciled live after load.
   dishes (force-reserving a slot if needed), releases cook tickets and fetch jobs.
 - Reservations are physical-at-creation, so crashes/despawns never lose crops; runner and
   server walks are presentation only.
-- `PostTicket`, `ReleaseFetchJob`, `ForceReserveServingSlot` are idempotent / self-healing —
-  a canceled or stale ticket is skipped everywhere.
+- `PostTicket`, `ReleaseFetchJob`, `ReleaseBusJob`, `ForceReserveServingSlot` are idempotent /
+  self-healing — a canceled or stale ticket is skipped everywhere.
+- A bus job that leaves the queue must end with its plate entity destroyed. A claimed job whose
+  plate is unreachable is cleared in place (`ClearUnreachablePlate`) rather than dropped: the
+  alternative is a seat that blocks arriving patrons forever.
 - Kitchen workers must not carry colliders or `TAG_MONSTER`.
 - Meal-buff injection must stay RNG-free.
 
 ## Tests & analytics
 
 - `KitchenServiceLoopTests` — headless end-to-end ticket logic (order → fetch → cook → plate →
-  deliver → eat), cancellation/orphans, slot exhaustion. No tiles or FSM.
+  deliver → eat), cancellation/orphans, slot exhaustion, role mix, bus queue. No tiles or FSM.
+  Note `Entity.Destroy()` no-ops without a scene, so headless tests can't fake a picked-up plate.
 - `KitchenFlowPathTests` — parses the real TMX collision layer and asserts every walk leg
   (house exit → posts, station → serving approach, pickup → all 12 seat tables → sink,
   storage door ↔ fridge) is passable. Update this when moving any kitchen/tavern tile.

--- a/PitHero/docs/TavernDiningSystem.md
+++ b/PitHero/docs/TavernDiningSystem.md
@@ -52,6 +52,7 @@ All coordinates are tiles on the surface map (`PitHero.tmx`). Static helpers liv
 | Serving tables (dish sits here) | (87,3) (87,4) (87,5) | `GetServingTile(slot)` |
 | Serving **approach** (worker stands here) | (86,3) (86,4) (86,5) | `GetServingApproachTile(slot)` |
 | Runner wander box | x 83–88, y 6–8 | `RunnerWanderAnchorTile` |
+| Cook wander box | x 82–84, y 2–3 | `GameConfig.KitchenCookWander*` |
 
 Workers never stand on a serving table: cooks/servers path to the approach tile (one tile left)
 and the dish entity spawns on the table tile.
@@ -98,11 +99,13 @@ if a mid-loop withdraw fails). `FridgeTakenQty[]` / `StorageTakenQty[]` remember
 refunds.
 
 - If everything came from the fridge → `IngredientsFetched = true`, ticket starts `ReadyToCook`.
-- Any storage shortfall → ticket starts `AwaitingIngredients` and is enqueued as a **fetch job**.
-  The runner's trip is **cosmetic** — the crops are already committed. At the storage door,
-  `RunnerCollectAtStorage` additionally tops the fridge up to par (`KitchenFridgeParPerCrop = 4`
-  per recipe crop) with an atomic withdraw+add; at the fridge, `CompleteFetch` flips
-  `IngredientsFetched`. If storage vanishes mid-run the ticket still proceeds.
+- Any storage shortfall → ticket starts `AwaitingIngredients` and is enqueued as a **fetch job**,
+  and the buildings drawn from are recorded in `SourceBuildingIds` so the runner can retrace the
+  route. The runner's trip is **cosmetic for this ticket** — the crops are already committed. At
+  each storage door, `RunnerCollectAtStorage` additionally tops the fridge up to par
+  (`KitchenFridgeParPerCrop = 4` per recipe crop) with a withdraw+add against that one building;
+  at the fridge, `CompleteFetch` flips `IngredientsFetched`. If storage vanishes mid-run the
+  ticket still proceeds.
 - Milk/cheese (`UsesMilk`/`UsesCheese`) are display-only — never in recipes, prices, or checks.
 
 **Cancellation refund rules** (`CancelTicket`): while `CropsRefundable` (pre-cooking) both
@@ -147,6 +150,12 @@ full the cook holds the dish (`CookWaitServingSlot`); at shift end `ForceReserve
 overflows onto slot 0 rather than stranding the dish (pickup scans tickets, not slots, so this
 self-heals). Deluxe roll happens at cook start: `proficiency × 5%` capped 45%.
 
+Between tickets the cook potters around the board and the first two stoves (`CookWander`,
+x 82–84 / y 2–3) instead of standing frozen at the board. `HasReadableTicket()` — a non-claiming
+peek that must mirror `TryReadNextTicket`'s filter — pulls it straight back. Claiming still
+happens only at the board, with the read pause. A cook holding a ticket while every station is
+busy waits at the board rather than wandering.
+
 **Runner loop** (`RunnerIdle`): **dirty plates first**, then ingredients — a plate left on a
 table keeps that seat out of service and parks arriving patrons at the door, which costs more
 than a slow order. Backing orders up a little is the accepted trade.
@@ -155,9 +164,20 @@ than a slow order. Backing orders up a little is the accepted trade.
   sprint to the plate → pick it up → keep claiming and collecting while under
   `RunnerCarryPlateLimit = 3` → sprint the stack to the sink. The plates show on the runner's
   three carry renderers (center / left / right), the same rig as a crop haul.
-- *Fetch*: sprint (3×) to nearest CropStorage door → 1s collect (the real fridge top-up) →
-  carry crop sprites back to the fridge → `CompleteFetch`. Never interrupted mid-trip by a
-  plate; prioritization happens at claim time only.
+- *Fetch*: `PlanFetchRoute` builds a tour of the storages that **actually hold the crops** —
+  the buildings this ticket's shortfall was withdrawn from (`KitchenTicket.SourceBuildingIds`,
+  the only record of that, since the crops left storage at order time) plus any that can still
+  top the fridge up to par. Nearest-first, dropping stops that later become redundant, capped at
+  `RunnerMaxStorageStops = 3`. Then: sprint (3×) to each door → 1s collect (`RunnerCollectAtStorage`
+  draws **only on that building** via `WithdrawUpTo`) → next stop → carry crop sprites back to
+  the fridge → `CompleteFetch`. A multi-crop recipe spread over two storages visits both; the
+  longer trip is the point. Never interrupted mid-trip by a plate; prioritization happens at
+  claim time only.
+
+  Route planning is best-effort: stock can shift between planning and arrival, and the ticket's
+  own ingredients were already reserved at order time, so a short or stale route never blocks a
+  cook. With no storage left standing the runner completes the fetch on the spot; with none
+  worth entering it still makes one trip to the nearest door (`BuildingId = -1` = draw from all).
 
 A claimed-but-not-yet-picked-up plate goes back to the queue via `ReleaseBusJob` when the runner
 despawns (it keeps its original `EnqueuedTime`, so it stays at the head of the line). Plates
@@ -265,7 +285,8 @@ entities, patron state. All of that is transient and reconciled live after load.
   Note `Entity.Destroy()` no-ops without a scene, so headless tests can't fake a picked-up plate.
 - `KitchenFlowPathTests` — parses the real TMX collision layer and asserts every walk leg
   (house exit → posts, station → serving approach, pickup → all 12 seat tables → sink,
-  storage door ↔ fridge) is passable. Update this when moving any kitchen/tavern tile.
+  storage door ↔ fridge) is passable, and that every tile in the cook wander box is walkable.
+  Update this when moving any kitchen/tavern tile.
 - `DishPricingTests` — pricing formula and monotonicity.
 - Analytics (see `AnalyticsSchema.md`): `dish_served` (price, tip, party, deluxe),
   `party_dine_skipped` (reason).


### PR DESCRIPTION
Closes #327.

## Runners own plate clearing

Bussing was the server bottleneck: a server in a busy tavern spent its time walking plates to the sink instead of taking orders and delivering food, and a plate left on a table parks the next arriving patron at the door.

- New `RunnerBusPlate` → `RunnerWalkToSink` states. A runner sprints to a plate, picks up as many as three per trip (`RunnerCarryPlateLimit`), and sprints the stack to the sink. The plates render on the three carry renderers already used for crop hauls — no new art rig.
- Plates are claimed **before** ingredient fetches. Backing orders up a little beats keeping a seat out of service, as the issue calls for. An in-flight fetch is never interrupted; prioritization happens at claim time only.
- Servers only bus when `!HasActiveRunner`. Without that gate a cook+server-only kitchen (which the player can create by hand-assigning 2 monsters) would never clear a table and every seat would eventually block at the door. In that fallback the old two-tier priority still applies. The delivery-time swap (`TryClaimBusJobAtPosition`) is untouched — a server still never stacks a meal on a dirty plate.

## Max runners 2 → 3

The role mix was a hardcoded `switch` where the per-role caps were implicit in the ordering plus a `7` cap. It's now `KitchenTaskCoordinator.FillRoleMix`, cycling Cook → Server → Runner and skipping full roles: cook1, server1, runner1, cook2, server2, runner2, cook3, runner3. Changing a `GameConfig.MaxKitchen*` constant re-derives the order. `AutoJobKitchenMaxWorkers` → 8, with a test asserting it mirrors `MaxWorkerPosts`.

## Patrons prefer a cleared seat

`GetAvailableTavernPosition` now picks a clean free seat first, and `TryReseatToClearedSeat` re-checks before the door wait **and** on each 0.25s poll while waiting (a seat can be bussed or freed mid-wait). The door wait is now genuinely last-resort.

## Cooks wander between tickets

Cooks stood frozen at the ticket board whenever nothing was posted. New `CookWander` state over (82,2)–(84,3), with `HasReadableTicket()` — a non-claiming peek that mirrors `TryReadNextTicket`'s filter — pulling them straight back. Claiming still happens only at the board with its read pause. A cook holding a ticket while every station is busy still waits there rather than wandering off with an unstarted order.

## Runners tour the storages that actually hold the crops

Runners always ran to the nearest Crop Storage, which often didn't hold what the order needed. The complication: crops are physically withdrawn at `CreateTicket`, so by the time the runner sets off the ingredients are already out of storage and there was no record of which building supplied them.

- `TryWithdrawAcrossBuildings` takes an optional out-list of source buildings; `CreateTicket` stores it on `KitchenTicket.SourceBuildingIds`.
- `PlanFetchRoute` builds a nearest-first tour of those buildings plus any that still hold a crop the fridge needs to reach par, dropping stops that become redundant once nearer ones are visited.
- `RunnerCollectAtStorage(ticket, buildingId)` draws only on the building the runner is standing at (new `CropStorageInventoryService.WithdrawUpTo` / `CountIn`) instead of teleporting crops out of every storage at once, as it did before.
- The FSM loops `RunnerWalkToStorage → RunnerCollect` per stop before heading to the fridge, so a recipe split over two storages visits both.

Trips are capped at `RunnerMaxStorageStops = 3`: without a cap an 11-crop recipe like `HarvestFeastPlatter` on a farm with many storages could send one runner on a grand tour. Since the ticket's own ingredients are already reserved, a short route never blocks a cook — the leftover top-up happens on the next run. Fallbacks preserved: no storage standing → fetch completes on the spot; none worth entering → one trip to the nearest door.

## Incidental fix

A claimed bus job whose plate couldn't be pathed to was dropped silently — the job was already off the queue, so that seat blocked patrons forever. It's now cleared in place (`ClearUnreachablePlate`), and a worker sent home before pickup returns the job via `ReleaseBusJob` with its original `EnqueuedTime` so the plate keeps its place in line. This predates the issue; it just became much more visible once patrons started gating on dirty plates.

## Testing

Build clean. **1571 pass / 0 fail** (5 new tests, plus a new assertion in `KitchenFlowPathTests`).

- `KitchenServiceLoopTests` — role mix (growth order, per-role caps, auto-job cap parity), bus queue (release/reclaim, idempotence, age gate), fetch routing (skips an empty near storage, tours both when a recipe is split, respects the stop cap, per-building collect doesn't touch other storages), `HasReadableTicket` parity with `TryReadNextTicket`.
- `KitchenFlowPathTests` — asserts every tile in the cook wander box is walkable against the real TMX collision layer.

No save-format change.

## Not verified in-game

- Three plates at ±10px on the carry renderers, and runner pathing into the tavern (runners previously only walked the kitchen/storage corridor). `KitchenFlowPathTests` covers server pickup → all 12 seat tables → sink, which is the same geometry, so the routes are known passable; the sprite spacing and hat overlap while carrying are worth a look.
- Runner trip length in practice. Two stops at 3× sprint across the farm is noticeably longer than the old single hop. The `KitchenFridgeParPerCrop = 4` buffer should absorb it, but it's the thing to watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)