### PR TITLE
Cosmetic updates: Y-sort buildings, anchor large sprites, per-monster hat height (#329)

### DIFF
--- a/PitHero/ECS/Components/EnemyAnimationComponent.cs
+++ b/PitHero/ECS/Components/EnemyAnimationComponent.cs
@@ -31,6 +31,8 @@ namespace PitHero.ECS.Components
         /// <summary>Attack animation name, or null if none exists for this enemy.</summary>
         protected virtual string AnimAttack => null;
 
+        private bool _tileAnchorApplied;
+
         private Color _componentColor = Color.White;
         /// <summary>Gets the tint color for this component (default: White)</summary>
         public Color ComponentColor
@@ -76,6 +78,29 @@ namespace PitHero.ECS.Components
             }
 
             this.SetColor(ComponentColor);
+
+            ApplyTileAnchorOffset();
+        }
+
+        /// <summary>
+        /// Shifts the sprite up so its lower 32px (one tile) aligns with the entity's tile, making
+        /// medium/large monsters visually "stand" on their tile instead of floating centred on it
+        /// (their upper body then reads correctly behind top-layer overhangs like the tavern wall).
+        /// Pathfinding/collision are unaffected — they already use the entity-centred 32×32 tile.
+        /// A no-op for 32px sprites. Y-only, so it survives the FlipX offset flip; the attack
+        /// placeholder saves/restores LocalOffset.Y relative to this resting value.
+        /// </summary>
+        protected void ApplyTileAnchorOffset()
+        {
+            if (_tileAnchorApplied)
+                return;
+            var sprite = this.Sprite;
+            if (sprite == null)
+                return;
+            float dy = (GameConfig.TileSize - sprite.SourceRect.Height) / 2f;
+            if (dy != 0f)
+                LocalOffset = new Vector2(LocalOffset.X, LocalOffset.Y + dy);
+            _tileAnchorApplied = true;
         }
 
         public new void Update()

--- a/PitHero/ECS/Components/IYSortOffset.cs
+++ b/PitHero/ECS/Components/IYSortOffset.cs
@@ -1,0 +1,14 @@
+namespace PitHero.ECS.Components
+{
+    /// <summary>
+    /// Implemented by a Y-sorted RenderableComponent whose depth-sort point is not its entity
+    /// position Y but an offset below it — e.g. a tall building whose ground / front-face line
+    /// sits below its sprite centre. <see cref="YSortManager"/> adds <see cref="YSortOffset"/> to
+    /// the entity's Y before computing the pixel-granular layer depth.
+    /// </summary>
+    public interface IYSortOffset
+    {
+        /// <summary>Pixels added to entity.Y before Y-sort depth is computed. Positive = sort lower.</summary>
+        float YSortOffset { get; }
+    }
+}

--- a/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
+++ b/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
@@ -109,7 +109,7 @@ namespace PitHero.ECS.Components
             _hatService = Core.Services.GetService<KitchenHatService>();
             // Wear the job hat while doing kitchen work (BodyAnimator's sprite is set by now —
             // it was added before this component, so its OnAddedToEntity already ran)
-            _hat = _hatService?.AttachHat(_role, Entity, BodyAnimator);
+            _hat = _hatService?.AttachHat(_role, Entity, BodyAnimator, _monster.MonsterTypeName);
             InitialState = KitchenMonsterState.EmergeFromHouse;
         }
 
@@ -179,7 +179,7 @@ namespace PitHero.ECS.Components
         {
             if (HasHat || Entity == null || Entity.IsDestroyed)
                 return;
-            _hat = _hatService?.AttachHat(_role, Entity, BodyAnimator);
+            _hat = _hatService?.AttachHat(_role, Entity, BodyAnimator, _monster.MonsterTypeName);
         }
 
         /// <summary>Asks the monster to finish what it's doing, walk back into its house, and despawn.</summary>

--- a/PitHero/ECS/Components/PlaceholderMonsterAnimationComponent.cs
+++ b/PitHero/ECS/Components/PlaceholderMonsterAnimationComponent.cs
@@ -33,6 +33,7 @@ namespace PitHero.ECS.Components
                     {
                         this.Sprite = sprite;
                         this.SetColor(ComponentColor);
+                        ApplyTileAnchorOffset();
                         Debug.Log("[PlaceholderMonsterAnimationComponent] Loaded static sprite PlaceholderMonster");
                     }
                     else

--- a/PitHero/ECS/Components/YSortManager.cs
+++ b/PitHero/ECS/Components/YSortManager.cs
@@ -23,8 +23,11 @@ namespace PitHero.ECS.Components
                     if (renderable == null || !renderable.Enabled) continue;
                     if (!camera.Bounds.Intersects(renderable.Bounds)) continue;
 
-                    var depth = Mathf.Clamp01(1f - renderable.Entity.Transform.Position.Y
-                                                   * GameConfig.YSortDepthScale);
+                    var sortY = renderable.Entity.Transform.Position.Y;
+                    if (renderable is IYSortOffset ySortOffset)
+                        sortY += ySortOffset.YSortOffset;
+
+                    var depth = Mathf.Clamp01(1f - sortY * GameConfig.YSortDepthScale);
                     renderable.SetLayerDepth(depth);
                 }
             }

--- a/PitHero/ECS/Components/YSortSpriteRenderer.cs
+++ b/PitHero/ECS/Components/YSortSpriteRenderer.cs
@@ -5,8 +5,15 @@ using Nez.Textures;
 
 namespace PitHero.ECS.Components
 {
-    public class YSortSpriteRenderer : SpriteRenderer
+    public class YSortSpriteRenderer : SpriteRenderer, IYSortOffset
     {
+        /// <summary>
+        /// Pixels added to the entity's Y before Y-sort depth is computed, so the sort point can be
+        /// placed at the sprite's ground / front-face line instead of its centre. Default 0 (sort by
+        /// entity position, matching pit walls and the hero statue).
+        /// </summary>
+        public float YSortOffset { get; set; }
+
         public YSortSpriteRenderer() : base() { }
         public YSortSpriteRenderer(Sprite sprite) : base(sprite) { }
         public YSortSpriteRenderer(Texture2D texture) : base(texture) { }

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -351,8 +351,9 @@ namespace PitHero
         public const int RenderLayerActors = 60;
         public const int RenderLayerSingleTileObject = 61; // Single tile object layer (below actors, so single tile objects render below monsters/heroes)
         public const int RenderLayerDroppedItems = 65; // Dropped items layer
-        public const int RenderLayerBuilding = 80; // Placed buildings — above map base, below fog of war
-        public const int RenderLayerDetail = 90; // Detail tilemap layer (tilled soil, etc.) — above base, below buildings
+        // NOTE: Placed buildings (Monster House / Crop Storage) render at RenderLayerActors and are
+        // Y-sorted with monsters via YSortSpriteRenderer.YSortOffset (see IYSortOffset / YSortManager).
+        public const int RenderLayerDetail = 90; // Detail tilemap layer (tilled soil, etc.) — above base, below actors
         public const int RenderLayerBase = 100; // Background layer
 
         public const int RenderLayerActionQueue = 996; // Action queue layer (screen space, not affected by scene scaling)

--- a/PitHero/RolePlayingFramework/Enemies/IEnemy.cs
+++ b/PitHero/RolePlayingFramework/Enemies/IEnemy.cs
@@ -55,6 +55,13 @@ namespace RolePlayingFramework.Enemies
         /// <summary>True if this enemy type can be recruited as an allied monster.</summary>
         bool IsRecruitable { get; }
 
+        /// <summary>
+        /// Vertical nudge (pixels, negative = raise) applied to a worn job prop (e.g. a kitchen hat)
+        /// when this monster works a job. Defaults to 0 for sprites whose head sits at the top of the
+        /// frame; types that seat the head lower override this so the prop doesn't cover the face.
+        /// </summary>
+        float HatYOffset => 0f;
+
         /// <summary>Inflicts damage, returns true if died.</summary>
         bool TakeDamage(int amount);
     }

--- a/PitHero/RolePlayingFramework/Enemies/Orc.cs
+++ b/PitHero/RolePlayingFramework/Enemies/Orc.cs
@@ -26,6 +26,7 @@ namespace RolePlayingFramework.Enemies
         public float JoinPercentageModifier => 0.6f;
         public bool IsBoss => false;
         public bool IsRecruitable => true;
+        public float HatYOffset => -8f; // Orc's head seats low in-frame — raise worn hats 8px
 
         public Orc(int level = 6)
         {

--- a/PitHero/Services/KitchenHatService.cs
+++ b/PitHero/Services/KitchenHatService.cs
@@ -44,6 +44,33 @@ namespace PitHero.Services
         private SpriteAtlas CropsAtlas
             => _cropsAtlas ??= Core.Content.LoadSpriteAtlas("Content/Atlases/CropsProps.atlas");
 
+        // Cached per-type hat offset so the monster definition isn't re-created on every attach.
+        private static readonly Dictionary<RolePlayingFramework.Enemies.EnemyId, float> _hatYOffsetCache
+            = new Dictionary<RolePlayingFramework.Enemies.EnemyId, float>();
+
+        /// <summary>
+        /// Per-monster-type vertical nudge (px, negative = raise) layered on the generic head-top hat
+        /// placement, read from the monster's own definition (<see cref="RolePlayingFramework.Enemies.IEnemy.HatYOffset"/>).
+        /// Most monsters use the default (0); a type that seats its head lower (e.g. Orc) overrides
+        /// HatYOffset in its own class, so no central table is needed here.
+        /// </summary>
+        private static float HatYOffsetFor(string monsterTypeName)
+        {
+            if (string.IsNullOrEmpty(monsterTypeName))
+                return 0f;
+            var bare = monsterTypeName.StartsWith("Monster_")
+                ? monsterTypeName.Substring("Monster_".Length)
+                : monsterTypeName;
+            if (!System.Enum.TryParse(bare, out RolePlayingFramework.Enemies.EnemyId id))
+                return 0f;
+            if (!_hatYOffsetCache.TryGetValue(id, out var offset))
+            {
+                offset = RolePlayingFramework.Enemies.EnemyFactory.Create(id).HatYOffset;
+                _hatYOffsetCache[id] = offset;
+            }
+            return offset;
+        }
+
         private static string SpriteNameFor(KitchenRole role)
         {
             switch (role)
@@ -58,7 +85,7 @@ namespace PitHero.Services
         /// Puts a role hat on the worker: parents a pooled hat entity to the worker's transform,
         /// top-center where the head is. Returns null when no scene/sprite is available.
         /// </summary>
-        public Entity AttachHat(KitchenRole role, Entity worker, SpriteRenderer bodyRenderer)
+        public Entity AttachHat(KitchenRole role, Entity worker, SpriteRenderer bodyRenderer, string monsterTypeName)
         {
             if (_scene == null || worker == null)
                 return null;
@@ -90,7 +117,8 @@ namespace PitHero.Services
                 ? bodyRenderer.Sprite.SourceRect.Height
                 : GameConfig.TileSize;
             float hatHeight = sprite.SourceRect.Height;
-            float localY = -bodyHeight / 2f - hatHeight / 2f + GameConfig.KitchenHatOverlapPixels;
+            float localY = -bodyHeight / 2f - hatHeight / 2f + GameConfig.KitchenHatOverlapPixels
+                           + HatYOffsetFor(monsterTypeName);
 
             // Draw just above the body (same convention as the carry sprite)
             if (bodyRenderer != null)

--- a/PitHero/UI/BuildingModeOverlay.cs
+++ b/PitHero/UI/BuildingModeOverlay.cs
@@ -437,8 +437,9 @@ namespace PitHero.UI
                 "building-" + type.ToString().ToLower() + "-" + tileX + "-" + tileY);
             entity.SetPosition(finalPos.X, finalPos.Y);
 
-            var renderer = entity.AddComponent(new SpriteRenderer(sprite));
-            renderer.SetRenderLayer(GameConfig.RenderLayerBuilding);
+            var renderer = entity.AddComponent(new YSortSpriteRenderer(sprite));
+            renderer.SetRenderLayer(GameConfig.RenderLayerActors);
+            renderer.YSortOffset = sprite.SourceRect.Height / 2f; // sort at the sprite's bottom (walled 64px band)
             ApplyDayNightGrading(renderer);
 
             Core.Services.GetService<BuildingService>()?.AddBuilding(new PlacedBuilding
@@ -516,8 +517,9 @@ namespace PitHero.UI
                 "building-" + type.ToString().ToLower() + "-" + tileX + "-" + tileY);
             entity.SetPosition(finalPos.X, finalPos.Y + FallStartOffset);
 
-            var renderer = entity.AddComponent(new SpriteRenderer(sprite));
-            renderer.SetRenderLayer(GameConfig.RenderLayerBuilding);
+            var renderer = entity.AddComponent(new YSortSpriteRenderer(sprite));
+            renderer.SetRenderLayer(GameConfig.RenderLayerActors);
+            renderer.YSortOffset = sprite.SourceRect.Height / 2f; // sort at the sprite's bottom (walled 64px band)
             ApplyDayNightGrading(renderer);
 
             entity.AddComponent(new BuildingFallAnimator(finalPos.Y));

--- a/PitHero/docs/RenderingSystem.md
+++ b/PitHero/docs/RenderingSystem.md
@@ -16,7 +16,7 @@ Higher number = drawn first = further back.  Lower number = drawn later = in fro
 |---|---|---|
 | `RenderLayerTop` | 2 | Tilemap "Top" layer (tree-tops, overhangs) — covers everything |
 | `RenderLayerFogOfWar` | 40 | Tilemap fog-of-war overlay — covers actors but not the top layer |
-| `RenderLayerActors` | 60 | Heroes, mercenaries, monsters (all Y-sorted via `LayerDepth`) |
+| `RenderLayerActors` | 60 | Heroes, mercenaries, monsters, **placed buildings** (all Y-sorted via `LayerDepth`) |
 | `RenderLayerSingleTileObject` | 61 | Static 32×32 world objects: treasure chests, walls/obstacles (Y-sorted) |
 | `RenderLayerDroppedItems` | 65 | Dropped loot items |
 | `RenderLayerBase` | 100 | Tilemap base layer |
@@ -40,6 +40,30 @@ Using pixel-granular Y (not tile rows) ensures a unique depth per pixel row, eli
 the flickering that tile-row snapping caused between adjacent entities.
 
 `GameConfig.YSortDepthScale = 1f / 100000f` supports pits up to ~3 000 tiles deep.
+
+### Per-entity sort offset (`IYSortOffset`)
+
+A renderable may implement `IYSortOffset { float YSortOffset { get; } }`; `YSortManager` adds
+that offset to `entity.Y` before computing depth, moving the sort point off the entity centre.
+`YSortSpriteRenderer` exposes a settable `YSortOffset` (default 0).
+
+Used by **placed buildings** (Monster House / Crop Storage). A building's entity sits at its
+sprite centre, but its "ground / front-face" line is the bottom of its footprint — the lower
+64 px (2 tiles) that `FarmPathfinder` walls off. Setting `YSortOffset = spriteHeight / 2` puts
+the sort point at the sprite's bottom edge, so a monster walking in the walkable top rows
+*behind* the building sorts behind it (the building draws over it), while a monster standing in
+front draws over the building. Buildings therefore render at `RenderLayerActors`, not a fixed
+layer.
+
+### Monster sprite tile-anchor (large sprites)
+
+Monsters occupy a single entity-centred 32×32 tile for pathfinding/collision regardless of art
+size, but sprites use a centre origin, so a 64×64 sprite hangs 16 px below its tile. To make
+medium/large monsters visually "stand" on their tile (and sit correctly behind top-layer
+overhangs such as the tavern wall), `EnemyAnimationComponent.ApplyTileAnchorOffset` adds
+`LocalOffset.Y += (TileSize − spriteHeight) / 2` after the first sprite is assigned, aligning the
+sprite's **lower 32 px** with the tile. It is a no-op for 32×32 monsters and never touches the
+entity position, so tile logic is unchanged.
 
 ---
 


### PR DESCRIPTION
Closes #329.

Two cosmetic rendering fixes plus a follow-up.

## 1. Buildings Y-sort with monsters
Monster House / Crop Storage rendered at a fixed layer behind actors, so monsters always painted over them. They now render at `RenderLayerActors` via `YSortSpriteRenderer` and Y-sort together with monsters. A new `IYSortOffset` interface lets `YSortManager` place a renderable's sort point below its entity center; buildings set it to the sprite's bottom edge — the walled lower-64px band that `FarmPathfinder` already blocks — so a monster in the walkable top rows sorts **behind** the building and one in front sorts over it.

## 2. Large monster sprites anchor to their tile
Monsters sat centered on their tile, so tall sprites hung below it and poked under the tavern's top-layer wall. `EnemyAnimationComponent` now shifts each sprite up by `(TileSize - spriteHeight)/2` so the lower 32px aligns to the tile. No-op for 32px monsters; tile position and collision are unchanged (purely visual).

## 3. Follow-up: per-monster job-hat height
The sprite shift moved medium/large worker heads up, so kitchen job hats covered the face (worst on Orc). The nudge is defined on the monster's own definition rather than a central switch: `IEnemy.HatYOffset` defaults to 0 and `Orc` overrides it. The hat service resolves the worker's type name to its `EnemyId`, reads `HatYOffset`, and caches it per type.

## Testing
- `dotnet build` clean (0 errors).
- Full suite: 1571 passed, 0 failed, 6 skipped.
- Rendering/hat placement are visual — validated in-game (buildings occlude correctly; large monsters stand on their tile; Orc hat clears the face).

🤖 Generated with [Claude Code](https://claude.com/claude-code)