### PR TITLE
Location-based sound effects with distance attenuation and pan (#331)

### DIFF
--- a/PitHero.Tests/PositionalAudioTests.cs
+++ b/PitHero.Tests/PositionalAudioTests.cs
@@ -1,0 +1,132 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Util;
+
+namespace PitHero.Tests
+{
+    [TestClass]
+    public class PositionalAudioTests
+    {
+        // Fixture: camera spans world X [100, 500]; max audible distance = 10 tiles * 32px = 320px
+        private const float Left = 100f;
+        private const float Right = 500f;
+        private const float MaxPx = 320f;
+        private const float Delta = 0.0001f;
+
+        #region CalculateVolumeScale Tests
+
+        [TestMethod]
+        public void VolumeScale_SourceAtCameraCenter_ReturnsFullVolume()
+        {
+            Assert.AreEqual(1f, PositionalAudio.CalculateVolumeScale(300f, Left, Right, MaxPx), Delta);
+        }
+
+        [TestMethod]
+        public void VolumeScale_SourceExactlyAtEdges_ReturnsFullVolume()
+        {
+            Assert.AreEqual(1f, PositionalAudio.CalculateVolumeScale(Left, Left, Right, MaxPx), Delta);
+            Assert.AreEqual(1f, PositionalAudio.CalculateVolumeScale(Right, Left, Right, MaxPx), Delta);
+        }
+
+        [TestMethod]
+        public void VolumeScale_SourceJustInsideEdges_ReturnsFullVolume()
+        {
+            Assert.AreEqual(1f, PositionalAudio.CalculateVolumeScale(Left + 1f, Left, Right, MaxPx), Delta);
+            Assert.AreEqual(1f, PositionalAudio.CalculateVolumeScale(Right - 1f, Left, Right, MaxPx), Delta);
+        }
+
+        [TestMethod]
+        public void VolumeScale_SourceHalfMaxDistancePastLeftEdge_ReturnsHalfVolume()
+        {
+            Assert.AreEqual(0.5f, PositionalAudio.CalculateVolumeScale(Left - 160f, Left, Right, MaxPx), Delta);
+        }
+
+        [TestMethod]
+        public void VolumeScale_SourceHalfMaxDistancePastRightEdge_ReturnsHalfVolume()
+        {
+            Assert.AreEqual(0.5f, PositionalAudio.CalculateVolumeScale(Right + 160f, Left, Right, MaxPx), Delta);
+        }
+
+        [TestMethod]
+        public void VolumeScale_FalloffIsLinear()
+        {
+            Assert.AreEqual(0.75f, PositionalAudio.CalculateVolumeScale(Left - 80f, Left, Right, MaxPx), Delta);
+            Assert.AreEqual(0.25f, PositionalAudio.CalculateVolumeScale(Right + 240f, Left, Right, MaxPx), Delta);
+        }
+
+        [TestMethod]
+        public void VolumeScale_SourceExactlyAtMaxDistance_ReturnsZero()
+        {
+            Assert.AreEqual(0f, PositionalAudio.CalculateVolumeScale(Left - MaxPx, Left, Right, MaxPx), Delta);
+            Assert.AreEqual(0f, PositionalAudio.CalculateVolumeScale(Right + MaxPx, Left, Right, MaxPx), Delta);
+        }
+
+        [TestMethod]
+        public void VolumeScale_SourceBeyondMaxDistance_ReturnsZero()
+        {
+            Assert.AreEqual(0f, PositionalAudio.CalculateVolumeScale(Left - 1000f, Left, Right, MaxPx), Delta);
+            Assert.AreEqual(0f, PositionalAudio.CalculateVolumeScale(Right + 1000f, Left, Right, MaxPx), Delta);
+        }
+
+        [TestMethod]
+        public void VolumeScale_SourceJustInsideMaxDistance_ReturnsSmallPositive()
+        {
+            float scale = PositionalAudio.CalculateVolumeScale(Left - 319f, Left, Right, MaxPx);
+            Assert.IsTrue(scale > 0f && scale < 0.01f, $"Expected small positive scale, got {scale}");
+        }
+
+        [TestMethod]
+        public void VolumeScale_ZeroMaxDistance_FullInsideZeroOutside()
+        {
+            Assert.AreEqual(1f, PositionalAudio.CalculateVolumeScale(300f, Left, Right, 0f), Delta);
+            Assert.AreEqual(0f, PositionalAudio.CalculateVolumeScale(Left - 1f, Left, Right, 0f), Delta);
+        }
+
+        #endregion
+
+        #region CalculatePan Tests
+
+        [TestMethod]
+        public void Pan_SourceOnScreen_ReturnsCenter()
+        {
+            Assert.AreEqual(0f, PositionalAudio.CalculatePan(300f, Left, Right, MaxPx), Delta);
+            Assert.AreEqual(0f, PositionalAudio.CalculatePan(Left, Left, Right, MaxPx), Delta);
+            Assert.AreEqual(0f, PositionalAudio.CalculatePan(Right, Left, Right, MaxPx), Delta);
+        }
+
+        [TestMethod]
+        public void Pan_SourceHalfMaxDistancePastLeftEdge_ReturnsHalfLeft()
+        {
+            Assert.AreEqual(-0.5f, PositionalAudio.CalculatePan(Left - 160f, Left, Right, MaxPx), Delta);
+        }
+
+        [TestMethod]
+        public void Pan_SourceHalfMaxDistancePastRightEdge_ReturnsHalfRight()
+        {
+            Assert.AreEqual(0.5f, PositionalAudio.CalculatePan(Right + 160f, Left, Right, MaxPx), Delta);
+        }
+
+        [TestMethod]
+        public void Pan_SourceAtOrBeyondMaxDistance_ClampsToFullPan()
+        {
+            Assert.AreEqual(-1f, PositionalAudio.CalculatePan(Left - MaxPx, Left, Right, MaxPx), Delta);
+            Assert.AreEqual(1f, PositionalAudio.CalculatePan(Right + MaxPx, Left, Right, MaxPx), Delta);
+            Assert.AreEqual(-1f, PositionalAudio.CalculatePan(Left - 1000f, Left, Right, MaxPx), Delta);
+            Assert.AreEqual(1f, PositionalAudio.CalculatePan(Right + 1000f, Left, Right, MaxPx), Delta);
+        }
+
+        [TestMethod]
+        public void Pan_ZeroMaxDistance_FullPanOutside()
+        {
+            Assert.AreEqual(-1f, PositionalAudio.CalculatePan(Left - 1f, Left, Right, 0f), Delta);
+            Assert.AreEqual(1f, PositionalAudio.CalculatePan(Right + 1f, Left, Right, 0f), Delta);
+        }
+
+        #endregion
+
+        [TestMethod]
+        public void ConfiguredMaxAudibleDistance_Is10Tiles320Pixels()
+        {
+            Assert.AreEqual(320, GameConfig.MaxAudibleDistanceTiles * GameConfig.TileSize);
+        }
+    }
+}

--- a/PitHero/AI/JumpIntoPitAction.cs
+++ b/PitHero/AI/JumpIntoPitAction.cs
@@ -136,7 +136,7 @@ namespace PitHero.AI
 
             // Play jump sound effect
             SoundEffectManager soundEffectManager = Core.GetGlobalManager<SoundEffectManager>();
-            soundEffectManager.PlaySound(SoundEffectType.Jump);
+            soundEffectManager.PlaySoundAt(SoundEffectType.Jump, entity.Transform.Position);
 
             // Start the movement coroutine
             Core.StartCoroutine(JumpMovementCoroutine(entity, targetPosition, GameConfig.HeroJumpSpeed));
@@ -213,7 +213,7 @@ namespace PitHero.AI
 
             // Play land sound effect
             SoundEffectManager soundEffectManager = Core.GetGlobalManager<SoundEffectManager>();
-            soundEffectManager.PlaySound(SoundEffectType.Land);
+            soundEffectManager.PlaySoundAt(SoundEffectType.Land, entity.Transform.Position);
         }
 
         /// <summary>

--- a/PitHero/AI/JumpOutOfPitForInnAction.cs
+++ b/PitHero/AI/JumpOutOfPitForInnAction.cs
@@ -211,7 +211,7 @@ namespace PitHero.AI
 
             // Play jump sound effect
             SoundEffectManager soundEffectManager = Core.GetGlobalManager<SoundEffectManager>();
-            soundEffectManager.PlaySound(SoundEffectType.Jump);
+            soundEffectManager.PlaySoundAt(SoundEffectType.Jump, entity.Transform.Position);
 
             // Start the movement coroutine
             Core.StartCoroutine(JumpOutMovementCoroutine(entity, targetPosition, GameConfig.HeroJumpSpeed));

--- a/PitHero/AI/JumpOutOfPitForStopAction.cs
+++ b/PitHero/AI/JumpOutOfPitForStopAction.cs
@@ -130,7 +130,7 @@ namespace PitHero.AI
 
             // Play jump sound effect
             SoundEffectManager soundEffectManager = Core.GetGlobalManager<SoundEffectManager>();
-            soundEffectManager.PlaySound(SoundEffectType.Jump);
+            soundEffectManager.PlaySoundAt(SoundEffectType.Jump, entity.Transform.Position);
 
             // Start the movement coroutine
             Core.StartCoroutine(JumpOutMovementCoroutine(entity, targetPosition, GameConfig.HeroJumpSpeed));

--- a/PitHero/AI/LiveBattleAdapter.cs
+++ b/PitHero/AI/LiveBattleAdapter.cs
@@ -731,25 +731,35 @@ namespace PitHero.AI
         // ── IBattleEventSink — audio ─────────────────────────────────────────────────
 
         /// <inheritdoc/>
-        public void PlaySound(BattleSound sound)
+        public void PlaySound(BattleSound sound, ICombatant source)
         {
             var sfx = Core.GetGlobalManager<SoundEffectManager>();
             if (sfx == null) return;
+
+            SoundEffectType sfxType;
             switch (sound)
             {
                 case BattleSound.Punch:
-                    sfx.PlaySound(SoundEffectType.Punch);
+                    sfxType = SoundEffectType.Punch;
                     break;
                 case BattleSound.TakeDamage:
-                    sfx.PlaySound(SoundEffectType.TakeDamage);
+                    sfxType = SoundEffectType.TakeDamage;
                     break;
                 case BattleSound.Restorative:
-                    sfx.PlaySound(SoundEffectType.Restorative);
+                    sfxType = SoundEffectType.Restorative;
                     break;
                 case BattleSound.EnemyDefeat:
-                    sfx.PlaySound(SoundEffectType.EnemyDefeat);
+                    sfxType = SoundEffectType.EnemyDefeat;
                     break;
+                default:
+                    return;
             }
+
+            var sourceEntity = source != null ? GetEntityForCombatant(source) : null;
+            if (sourceEntity != null)
+                sfx.PlaySoundAt(sfxType, sourceEntity.Transform.Position);
+            else
+                sfx.PlaySound(sfxType);
         }
 
         // ── Post-battle cleanup ──────────────────────────────────────────────────────
@@ -875,7 +885,7 @@ namespace PitHero.AI
             if (protoRenderer != null) origColorProto = protoRenderer.Color;
 #endif
 
-            PlaySound(BattleSound.EnemyDefeat);
+            Core.GetGlobalManager<SoundEffectManager>()?.PlaySoundAt(SoundEffectType.EnemyDefeat, monsterEntity.Transform.Position);
 
             const float fadeDuration = 0.5f;
             float elapsed = 0f;

--- a/PitHero/AI/MercenaryJumpIntoPitAction.cs
+++ b/PitHero/AI/MercenaryJumpIntoPitAction.cs
@@ -113,7 +113,7 @@ namespace PitHero.AI
 
             // Play jump sound effect
             SoundEffectManager soundEffectManager = Core.GetGlobalManager<SoundEffectManager>();
-            soundEffectManager.PlaySound(SoundEffectType.Jump);
+            soundEffectManager.PlaySoundAt(SoundEffectType.Jump, entity.Transform.Position);
 
             Core.StartCoroutine(JumpMovementCoroutine(entity, targetPosition, GameConfig.HeroJumpSpeed));
         }
@@ -195,7 +195,7 @@ namespace PitHero.AI
 
             // Play land sound effect
             SoundEffectManager soundEffectManager = Core.GetGlobalManager<SoundEffectManager>();
-            soundEffectManager.PlaySound(SoundEffectType.Land);
+            soundEffectManager.PlaySoundAt(SoundEffectType.Land, entity.Transform.Position);
         }
     }
 }

--- a/PitHero/AI/MercenaryJumpOutOfPitAction.cs
+++ b/PitHero/AI/MercenaryJumpOutOfPitAction.cs
@@ -241,7 +241,7 @@ namespace PitHero.AI
 
             // Play jump sound effect
             SoundEffectManager soundEffectManager = Core.GetGlobalManager<SoundEffectManager>();
-            soundEffectManager.PlaySound(SoundEffectType.Jump);
+            soundEffectManager.PlaySoundAt(SoundEffectType.Jump, entity.Transform.Position);
 
             Core.StartCoroutine(JumpOutMovementCoroutine(entity, targetPosition, GameConfig.HeroJumpSpeed));
         }

--- a/PitHero/AI/OpenChestAction.cs
+++ b/PitHero/AI/OpenChestAction.cs
@@ -69,7 +69,7 @@ namespace PitHero.AI
                         if (_treasureComponent != null && _treasureComponent.State == TreasureComponent.TreasureState.CLOSED)
                         {
                             SoundEffectManager soundEffectManager = Core.GetGlobalManager<SoundEffectManager>();
-                            soundEffectManager?.PlaySound(SoundEffectType.ChestOpen);
+                            soundEffectManager?.PlaySoundAt(SoundEffectType.ChestOpen, _chestEntity.Transform.Position);
 
                             _treasureComponent.State = TreasureComponent.TreasureState.OPEN;
                             Debug.Log("[OpenChest] Chest state changed to OPEN");

--- a/PitHero/AI/SleepInBedAction.cs
+++ b/PitHero/AI/SleepInBedAction.cs
@@ -258,7 +258,7 @@ namespace PitHero.AI
                 {
                     gameState.Funds -= innCost;
                     _hasPaidInnkeeper = true;
-                    soundEffectManager.PlaySound(SoundEffectType.PayGold);
+                    soundEffectManager.PlaySoundAt(SoundEffectType.PayGold, heroEntity.Transform.Position);
                     Debug.Log($"[SleepInBedAction] Paid {innCost} gold to innkeeper. Remaining funds: {gameState.Funds}");
 
                     Services.Analytics.AnalyticsService.LogInnSleep(innCost, gameState.Funds);
@@ -461,7 +461,7 @@ namespace PitHero.AI
             }
 
             Debug.Log("[SleepInBedAction] Sleep complete, restoring HP and MP to full for hero and mercenaries");
-            soundEffectManager.PlaySound(SoundEffectType.Restorative);
+            soundEffectManager.PlaySoundAt(SoundEffectType.Restorative, heroEntity.Transform.Position);
 
             // Heal hero to full HP and MP
             if (hero.LinkedHero != null)

--- a/PitHero/AI/UseHealingItemAction.cs
+++ b/PitHero/AI/UseHealingItemAction.cs
@@ -209,7 +209,7 @@ namespace PitHero.AI
 
                 // Play restorative sound effect
                 SoundEffectManager soundEffectManager = Core.GetGlobalManager<SoundEffectManager>();
-                soundEffectManager.PlaySound(SoundEffectType.Restorative);
+                soundEffectManager.PlaySoundAt(SoundEffectType.Restorative, heroComponent.Entity.Transform.Position);
 
                 int currentHP = isHero
                     ? ((RolePlayingFramework.Heroes.Hero)target).CurrentHP

--- a/PitHero/Combat/BattleEngine.cs
+++ b/PitHero/Combat/BattleEngine.cs
@@ -578,7 +578,7 @@ namespace PitHero.Combat
             battleContext.MarkActed(hero);
 
             if (queuedAction.WeaponItem == null)
-                _sink.PlaySound(BattleSound.Punch);
+                _sink.PlaySound(BattleSound.Punch, hero);
 
             if (heroAttackResult.Hit)
             {
@@ -789,7 +789,7 @@ namespace PitHero.Combat
                 Random.NextFloat());
             battleContext.MarkActed(mercenary);
 
-            _sink.PlaySound(BattleSound.Punch);
+            _sink.PlaySound(BattleSound.Punch, mercenary);
 
             if (mercAttackResult.Hit)
             {
@@ -1042,7 +1042,7 @@ namespace PitHero.Combat
 
             if (enemyAttackResult.Hit)
             {
-                _sink.PlaySound(BattleSound.TakeDamage);
+                _sink.PlaySound(BattleSound.TakeDamage, target);
 
                 int actualDamage = enemyAttackResult.Damage * DEBUG_DAMAGE_MULT;
                 int targetHpBefore = target.CurrentHP;
@@ -1157,7 +1157,7 @@ namespace PitHero.Combat
 
                 if (healed)
                 {
-                    _sink.PlaySound(BattleSound.Restorative);
+                    _sink.PlaySound(BattleSound.Restorative, healTarget as ICombatant);
                     if (targetAlly != null)
                     {
                         var rh = _sink.ShowHealOnAlly(targetAlly, healAmount);
@@ -1252,7 +1252,7 @@ namespace PitHero.Combat
                     var evt = new BattleHealEvent(itemUserName, consumable.Name, targetName, healAmount, hpAfter);
                     _sink.OnConsumableHealApplied(consumable, in evt);
 
-                    _sink.PlaySound(BattleSound.Restorative);
+                    _sink.PlaySound(BattleSound.Restorative, target as ICombatant);
                     var targetAlly = FindAllyForTarget(target, targetsHero);
                     if (targetAlly != null)
                     {

--- a/PitHero/Combat/BattleEventSinkBase.cs
+++ b/PitHero/Combat/BattleEventSinkBase.cs
@@ -106,6 +106,6 @@ namespace PitHero.Combat
         public virtual void OnAllyKilled(IBattleAlly ally, IEnemy killer) { }
 
         /// <inheritdoc/>
-        public virtual void PlaySound(BattleSound sound) { }
+        public virtual void PlaySound(BattleSound sound, RolePlayingFramework.Combat.ICombatant source) { }
     }
 }

--- a/PitHero/Combat/IBattleEventSink.cs
+++ b/PitHero/Combat/IBattleEventSink.cs
@@ -163,7 +163,8 @@ namespace PitHero.Combat
 
         // ── Audio ─────────────────────────────────────────────────────────────────
 
-        /// <summary>Requests a sound effect to be played.</summary>
-        void PlaySound(BattleSound sound);
+        /// <summary>Requests a sound effect to be played. The source combatant's entity position
+        /// attenuates the sound by distance from the camera view; null plays at full volume.</summary>
+        void PlaySound(BattleSound sound, RolePlayingFramework.Combat.ICombatant source);
     }
 }

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -67,6 +67,9 @@ namespace PitHero
         // Sound configuration (can be updated in UI)
         public static float MasterVolume = 0.5f;
 
+        /// <summary>World sounds farther than this many tiles past the nearest horizontal camera edge are inaudible and skipped</summary>
+        public const int MaxAudibleDistanceTiles = 10;
+
         // Hero movement speed
         public const float HeroMovementSpeed = 64f;  //Move speed in pixels per second (64 pixels = 2 tiles)
         public const float HeroPitMovementSpeed = 32f; //Move speed in pixels per second when in pit (32 pixels = 1 tile)

--- a/PitHero/Util/PositionalAudio.cs
+++ b/PitHero/Util/PositionalAudio.cs
@@ -1,0 +1,42 @@
+namespace PitHero.Util
+{
+    /// <summary>Pure, camera-free math for horizontal distance-based sound attenuation and panning.</summary>
+    public static class PositionalAudio
+    {
+        /// <summary>Returns a volume scale in [0,1]: 1 when sourceX is within [cameraLeft, cameraRight],
+        /// linearly falling to 0 at maxAudibleDistancePx beyond the nearest horizontal edge.</summary>
+        public static float CalculateVolumeScale(float sourceX, float cameraLeft, float cameraRight, float maxAudibleDistancePx)
+        {
+            if (sourceX >= cameraLeft && sourceX <= cameraRight)
+                return 1f;
+
+            float distance = sourceX < cameraLeft ? cameraLeft - sourceX : sourceX - cameraRight;
+            if (maxAudibleDistancePx <= 0f || distance >= maxAudibleDistancePx)
+                return 0f;
+
+            return 1f - distance / maxAudibleDistancePx;
+        }
+
+        /// <summary>Returns a stereo pan in [-1,1]: 0 when sourceX is within [cameraLeft, cameraRight],
+        /// growing toward -1 (left of camera) or +1 (right of camera) proportional to distance past the edge.</summary>
+        public static float CalculatePan(float sourceX, float cameraLeft, float cameraRight, float maxAudibleDistancePx)
+        {
+            if (sourceX >= cameraLeft && sourceX <= cameraRight)
+                return 0f;
+
+            if (maxAudibleDistancePx <= 0f)
+                return sourceX < cameraLeft ? -1f : 1f;
+
+            if (sourceX < cameraLeft)
+            {
+                float pan = -(cameraLeft - sourceX) / maxAudibleDistancePx;
+                return pan < -1f ? -1f : pan;
+            }
+            else
+            {
+                float pan = (sourceX - cameraRight) / maxAudibleDistancePx;
+                return pan > 1f ? 1f : pan;
+            }
+        }
+    }
+}

--- a/PitHero/Util/SoundEffectManager.cs
+++ b/PitHero/Util/SoundEffectManager.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework.Audio;
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Audio;
 using Nez;
 using Nez.Systems;
 using PitHero.Util.SoundEffectTypes;
@@ -71,6 +72,27 @@ namespace PitHero.Util
         public void PlaySound(SoundEffectType soundEffectType, float volume, float pitch, float pan)
         {
             soundEffectDict[soundEffectType].Play(volume, pitch, pan);
+        }
+
+        /// <summary>Plays a world-positioned sound attenuated and panned by horizontal distance from the camera view;
+        /// skipped entirely beyond GameConfig.MaxAudibleDistanceTiles past the nearest edge. Position is sampled at play time.</summary>
+        public void PlaySoundAt(SoundEffectType soundEffectType, Vector2 sourceWorldPosition)
+        {
+            float scale = 1f;
+            float pan = 0f;
+            var camera = Core.Scene?.Camera;
+            if (camera != null)
+            {
+                var bounds = camera.Bounds;
+                float maxAudiblePx = GameConfig.MaxAudibleDistanceTiles * GameConfig.TileSize;
+                scale = PositionalAudio.CalculateVolumeScale(sourceWorldPosition.X, bounds.Left, bounds.Right, maxAudiblePx);
+                pan = PositionalAudio.CalculatePan(sourceWorldPosition.X, bounds.Left, bounds.Right, maxAudiblePx);
+            }
+
+            if (scale <= 0f)
+                return;
+
+            soundEffectDict[soundEffectType].Play(SoundVolume * scale, 0f, pan);
         }
 
         public void StopSound(SoundEffectType soundEffectType)


### PR DESCRIPTION
Closes #331.

Every in-game sound effect is now linked to a source entity and attenuated by horizontal distance from the camera view:

- **Full volume** while the source X is between the camera's left and right edges (zoom-aware `Camera.Bounds`).
- **Linear falloff** past the nearest edge, reaching silence at `GameConfig.MaxAudibleDistanceTiles` (new constant, default 10 tiles) — sounds beyond that are skipped entirely.
- **Stereo pan**: off-screen sounds pan toward the side of the camera they're on, growing with distance (0 while on screen, so there's no discontinuity at the edge).

## Implementation

- **`PitHero/Util/PositionalAudio.cs`** (new) — pure static math (`CalculateVolumeScale`, `CalculatePan`), camera-free so it unit-tests directly. No LINQ/reflection/allocations.
- **`SoundEffectManager.PlaySoundAt(type, worldPosition)`** — samples the camera bounds at play time, scales `SoundVolume` and computes pan, and routes through the existing `Play(volume, pitch, pan)` path. The existing `PlaySound(type)` overload remains untouched as the full-volume path for future UI sounds.
- **Battle sounds** — `IBattleEventSink.PlaySound` now carries the source `ICombatant`. `BattleEngine` stays headless (passes `hero`/`mercenary`/heal target); `LiveBattleAdapter` resolves the entity via its existing `GetEntityForCombatant` and falls back to full volume when unresolvable. Headless/virtual sinks inherit the no-op from `BattleEventSinkBase`, so **no RNG calls were added or removed** — battle RNG parity is preserved. The monster-defeat sound in the fade-out coroutine uses `monsterEntity`'s position directly.
- **AI actions** — all jump/land, chest-open, inn (pay gold + rest), and healing-item call sites now pass their source entity position.

Position is sampled at play time; since all world SFX are short one-shots, this also covers moving sources (each play uses the entity's current position).

## Testing

- New `PitHero.Tests/PositionalAudioTests.cs`: 16 tests covering on-screen full volume, edge cases at/inside the edges, linear falloff (¼/½/¾ points), cutoff at/beyond max distance, pan direction/clamping, and degenerate zero-distance config.
- `dotnet test`: **1587 passed, 0 failed** (baseline preserved), 6 pre-existing skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)