### PR TITLE
Fix pit-shrink stale wall column and statue jump deadlock after crystal ceremony (#333)

### DIFF
--- a/PitHero.Tests/PitShrinkStaleCollisionTests.cs
+++ b/PitHero.Tests/PitShrinkStaleCollisionTests.cs
@@ -1,0 +1,153 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Config;
+using PitHero.VirtualGame;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Regression tests for the hero-stuck-after-promotion deadlock: when the pit shrinks on a
+    /// death reset (SetPitLevel to a lower width), the old pit's inner-wall collision column must
+    /// be cleared. Previously SetPitLevel overestimated the new right edge (+2), skipped the
+    /// shrink cleanup, and the stranded wall column sealed the pit mouth so the hero and
+    /// mercenaries could never path back to the pit edge.
+    /// </summary>
+    [TestClass]
+    public class PitShrinkStaleCollisionTests
+    {
+        private static (VirtualPitWidthManager manager, VirtualTiledMapService map) CreatePitManager()
+        {
+            var worldState = new VirtualWorldState();
+            var tiledMapService = new VirtualTiledMapService(worldState);
+            var manager = new VirtualPitWidthManager(tiledMapService);
+            manager.Initialize();
+            return (manager, tiledMapService);
+        }
+
+        private static bool HasCollision(VirtualTiledMapService map, int x, int y)
+        {
+            var tile = map.CurrentMap.GetLayer("Collision").GetTile(x, y);
+            return tile != null && tile.Gid != 0;
+        }
+
+        // ── Edge formula parity ───────────────────────────────────────────────────
+
+        [TestMethod]
+        public void CalculateRightEdgeForDepth_KnownValues()
+        {
+            int baseEdge = GameConfig.PitRectX + GameConfig.PitRectWidth; // 13
+
+            Assert.AreEqual(baseEdge, PitWidthManager.CalculateRightEdgeForDepth(1), "Depth 1-9 has no extension");
+            Assert.AreEqual(baseEdge, PitWidthManager.CalculateRightEdgeForDepth(9), "Depth 1-9 has no extension");
+            Assert.AreEqual(baseEdge + 2, PitWidthManager.CalculateRightEdgeForDepth(10), "Depth 10 extends 2 tiles");
+            Assert.AreEqual(baseEdge + 4, PitWidthManager.CalculateRightEdgeForDepth(26), "Depth 26 (tier 2 level 1) extends 4 tiles");
+            Assert.AreEqual(baseEdge + 6, PitWidthManager.CalculateRightEdgeForDepth(32), "Depth 32 (tier 2 level 7) extends 6 tiles");
+            Assert.AreEqual(baseEdge + 20, PitWidthManager.CalculateRightEdgeForDepth(100), "Depth 100 extends 20 tiles");
+            Assert.AreEqual(baseEdge + 20, PitWidthManager.CalculateRightEdgeForDepth(150), "Expansion caps at depth 100");
+        }
+
+        [TestMethod]
+        public void CalculateRightEdgeForDepth_MatchesRegeneratedEdge()
+        {
+            // The shrink cleanup in SetPitLevel relies on this prediction matching what
+            // RegeneratePitWidth actually produces — verify across levels and tiers.
+            int[] levels = { 1, 5, 7, 10, 15, 25 };
+            int[] tiers = { 1, 2, 3 };
+
+            for (int t = 0; t < tiers.Length; t++)
+            {
+                for (int l = 0; l < levels.Length; l++)
+                {
+                    var (manager, _) = CreatePitManager();
+                    manager.SetPitTier(tiers[t]);
+                    manager.SetPitLevel(levels[l]);
+
+                    int predicted = PitWidthManager.CalculateRightEdgeForDepth(
+                        BiomeProgressionConfig.GetEffectiveDepth(levels[l], tiers[t]));
+                    Assert.AreEqual(predicted, manager.CurrentPitRightEdge,
+                        $"Predicted edge must match regenerated edge for level {levels[l]} tier {tiers[t]}");
+                }
+            }
+        }
+
+        // ── Regression: tier-2 death reset (the exact stuck-hero scenario) ────────
+
+        [TestMethod]
+        public void TierTwoDeathReset_ClearsStaleInnerWallColumn()
+        {
+            // Reproduces the logged deadlock: tier 2 pit at level 7 (edge 19), hero dies,
+            // pit resets to level 1 (still extended in tier 2 → edge 17).
+            var (manager, map) = CreatePitManager();
+            manager.SetPitTier(2);
+
+            manager.SetPitLevel(7);
+            Assert.AreEqual(19, manager.CurrentPitRightEdge, "Tier 2 level 7 pit right edge");
+            Assert.IsTrue(HasCollision(map, 18, 5), "Level 7 pit should have its inner wall at x=18");
+
+            manager.SetPitLevel(1);
+            Assert.AreEqual(17, manager.CurrentPitRightEdge, "Tier 2 level 1 pit right edge");
+
+            // The old inner-wall column at x=18 must be gone — this stranded column previously
+            // sealed the pit mouth and deadlocked the hero after the crystal ceremony.
+            for (int y = 1; y <= 11; y++)
+            {
+                Assert.IsFalse(HasCollision(map, 18, y), $"Stale inner wall collision must be cleared at (18,{y})");
+                Assert.IsFalse(HasCollision(map, 19, y), $"Stale outer floor collision must be cleared at (19,{y})");
+            }
+
+            // Sanity: the shrunken pit's own inner wall exists at x=16
+            Assert.IsTrue(HasCollision(map, 16, 5), "Level 1 tier 2 pit should have its inner wall at x=16");
+        }
+
+        [TestMethod]
+        public void TierOneDeathReset_ClearsExtensionEntirely()
+        {
+            // Tier 1: level 35 pit (edge 19) resets to level 1 (no extension, edge 13).
+            var (manager, map) = CreatePitManager();
+
+            manager.SetPitLevel(35);
+            Assert.AreEqual(19, manager.CurrentPitRightEdge, "Tier 1 level 35 pit right edge");
+            Assert.IsTrue(HasCollision(map, 18, 5), "Level 35 pit should have its inner wall at x=18");
+
+            manager.SetPitLevel(1);
+            Assert.AreEqual(GameConfig.PitRectX + GameConfig.PitRectWidth, manager.CurrentPitRightEdge,
+                "Tier 1 level 1 pit right edge is the base pit boundary");
+
+            // Entire extension region must be free of collision
+            for (int x = 14; x <= 19; x++)
+            {
+                for (int y = 1; y <= 11; y++)
+                {
+                    Assert.IsFalse(HasCollision(map, x, y), $"Stale extension collision must be cleared at ({x},{y})");
+                }
+            }
+
+            // Sanity: the base pit's own inner wall at x=12 survives the restore
+            Assert.IsTrue(HasCollision(map, 12, 5), "Base pit inner wall at x=12 must survive the reset");
+        }
+
+        [TestMethod]
+        public void RepeatedGrowAndShrink_NeverLeavesStaleCollision()
+        {
+            // Cycle the pit through several grow/shrink transitions and verify no stale
+            // collision ever survives past the current right edge.
+            var (manager, map) = CreatePitManager();
+            manager.SetPitTier(2);
+
+            int[] levelSequence = { 7, 1, 15, 1, 25, 7, 1 };
+            for (int i = 0; i < levelSequence.Length; i++)
+            {
+                manager.SetPitLevel(levelSequence[i]);
+                int edge = manager.CurrentPitRightEdge;
+
+                for (int x = edge + 1; x <= 33; x++)
+                {
+                    for (int y = 1; y <= 11; y++)
+                    {
+                        Assert.IsFalse(HasCollision(map, x, y),
+                            $"Stale collision at ({x},{y}) after SetPitLevel({levelSequence[i]}) with edge {edge}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PitHero/AI/HeroStateMachine.cs
+++ b/PitHero/AI/HeroStateMachine.cs
@@ -340,6 +340,15 @@ namespace PitHero.AI
                     return;
                 }
 
+                // JumpIntoPitAction must execute at the pit edge — executing it in place after a
+                // pathfinding failure makes the hero jump wherever it stands and corrupts InsidePit.
+                if (_actionPlan.Count > 0 && _actionPlan.Peek().Name == GoapConstants.JumpIntoPitAction)
+                {
+                    Debug.Warn($"[HeroStateMachine] GoTo_Enter: No path to pit edge ({_targetTile.X},{_targetTile.Y}) for JumpIntoPitAction, restarting planning");
+                    CurrentState = ActorState.Idle; // Restart planning
+                    return;
+                }
+
                 CurrentState = ActorState.PerformAction;
                 return;
             }

--- a/PitHero/AI/JumpIntoPitAction.cs
+++ b/PitHero/AI/JumpIntoPitAction.cs
@@ -97,6 +97,16 @@ namespace PitHero.AI
                 return true; // Action failed, but complete
             }
 
+            // The state machine can fall through to executing this action in place when no path
+            // to the pit edge exists. Never jump (or claim InsidePit) unless the landing tile is
+            // actually inside the pit — otherwise the hero leaps 2 tiles through open town and
+            // corrupts the InsidePit world state, deadlocking GOAP on unreachable pit goals.
+            if (!hero.CheckInsidePit(TileToWorldPosition(targetTile.Value)))
+            {
+                Debug.Warn($"[JumpIntoPit] Landing tile ({targetTile.Value.X},{targetTile.Value.Y}) is not inside the pit - aborting jump from ({currentStartTile.X},{currentStartTile.Y})");
+                return true; // Action failed, but complete — InsidePit stays untouched
+            }
+
             _plannedTargetTile = targetTile.Value;
 
             // Start the coroutine-based movement to avoid TileMap collider issues

--- a/PitHero/PitWidthManager.cs
+++ b/PitHero/PitWidthManager.cs
@@ -275,13 +275,11 @@ namespace PitHero
             Debug.Log($"[PitWidthManager] Setting pit level from {_currentPitLevel} to {newLevel}");
             _currentPitLevel = newLevel;
 
-            // Calculate new right edge
-            int initialRightEdge = GameConfig.PitRectX + GameConfig.PitRectWidth;
-            // Cap expansion at effective depth 100 - pit stops expanding beyond effective depth 100.
-            // Tier 1 behaviour is identical to before (effectiveDepth == pitLevel).
-            int expansionLevel = Math.Min(BiomeProgressionConfig.GetEffectiveDepth(_currentPitLevel, _currentPitTier), 100);
-            int innerFloorTilesToExtend = ((int)(expansionLevel / 10)) * 2;
-            int newRightEdge = initialRightEdge + innerFloorTilesToExtend + (innerFloorTilesToExtend > 0 ? 2 : 0); // +2 for inner wall and outer floor
+            // Calculate the right edge RegeneratePitWidth will actually produce for the new level.
+            // Must match its output exactly: an overestimate here skips the shrink cleanup and
+            // strands the old pit's inner-wall collision column in the map, sealing off the pit
+            // mouth (hero/mercenaries can never path back to the pit edge after a death reset).
+            int newRightEdge = CalculateRightEdgeForDepth(BiomeProgressionConfig.GetEffectiveDepth(_currentPitLevel, _currentPitTier));
 
             // If sizing down, clear tiles first
             if (newRightEdge < previousRightEdge)
@@ -290,6 +288,19 @@ namespace PitHero
             }
 
             RegeneratePitWidth();
+        }
+
+        /// <summary>
+        /// Calculates the pit right edge X that RegeneratePitWidth produces for the given effective
+        /// depth. The extension rewrites the base pit's inner-wall (x=12) and outer-floor (x=13)
+        /// columns as inner floor, so the edge grows by exactly the inner floor tile count:
+        /// edge = PitRectX + PitRectWidth + tiles. Expansion is capped at effective depth 100.
+        /// </summary>
+        public static int CalculateRightEdgeForDepth(int effectiveDepth)
+        {
+            int expansionLevel = Math.Min(effectiveDepth, 100);
+            int innerFloorTilesToExtend = (expansionLevel / 10) * 2;
+            return GameConfig.PitRectX + GameConfig.PitRectWidth + innerFloorTilesToExtend;
         }
 
         /// <summary>

--- a/PitHero/VirtualGame/VirtualPitWidthManager.cs
+++ b/PitHero/VirtualGame/VirtualPitWidthManager.cs
@@ -186,7 +186,57 @@ namespace PitHero.VirtualGame
             Console.WriteLine($"[VirtualPitWidthManager] Setting pit level from {_currentPitLevel} to {newLevel}");
             _currentPitLevel = newLevel;
 
+            // Mirror the real PitWidthManager: when sizing down, restore the old extension
+            // region first so no stale inner-wall collision column survives the shrink.
+            int newRightEdge = PitWidthManager.CalculateRightEdgeForDepth(BiomeProgressionConfig.GetEffectiveDepth(_currentPitLevel, _currentPitTier));
+            if (newRightEdge < previousRightEdge)
+            {
+                ClearTilesFromXToEnd(newRightEdge);
+            }
+
             RegeneratePitWidth();
+        }
+
+        /// <summary>
+        /// Clear tiles from a given x coordinate to x=33 to clean up when sizing down.
+        /// Mirrors the real PitWidthManager: the base pit's inner-wall (x=12) and outer-floor (x=13)
+        /// columns are restored from their recorded patterns; everything further right becomes
+        /// plain ground with no collision or fog.
+        /// </summary>
+        private void ClearTilesFromXToEnd(int startX)
+        {
+            Console.WriteLine($"[VirtualPitWidthManager] Clearing tiles from x={startX} to x=33, y=1 to y=11");
+
+            for (int x = startX - 1; x <= 33; x++)
+            {
+                for (int y = 1; y <= 11; y++)
+                {
+                    if (x == 12 || x == 13)
+                    {
+                        // Restore the base pit's own columns from their recorded patterns
+                        var basePattern = x == 12 ? _baseInnerWall : _baseOuterFloor;
+                        var collisionPattern = x == 12 ? _collisionInnerWall : _collisionOuterFloor;
+
+                        if (basePattern.TryGetValue(y, out int baseGid) && baseGid != 0)
+                            _tiledMapService.SetTile("Base", x, y, baseGid);
+
+                        if (collisionPattern.TryGetValue(y, out int colGid) && colGid != 0)
+                            _tiledMapService.SetTile("Collision", x, y, colGid);
+                        else
+                            _tiledMapService.RemoveTile("Collision", x, y);
+                    }
+                    else
+                    {
+                        if (_groundTileIndex != 0)
+                            _tiledMapService.SetTile("Base", x, y, _groundTileIndex);
+                        _tiledMapService.RemoveTile("Collision", x, y);
+                    }
+
+                    _tiledMapService.RemoveTile("FogOfWar", x, y);
+                }
+            }
+
+            Console.WriteLine($"[VirtualPitWidthManager] Cleared tiles from x={startX} to x=33");
         }
 
         public void RegeneratePitWidth()
@@ -206,7 +256,9 @@ namespace PitHero.VirtualGame
 
             if (innerFloorTilesToExtend <= 0)
             {
-                Console.WriteLine("[VirtualPitWidthManager] No extension needed for current level");
+                // No extension tiles — reset right edge to the base pit boundary (mirrors real manager)
+                _currentPitRightEdge = GameConfig.PitRectX + GameConfig.PitRectWidth;
+                Console.WriteLine($"[VirtualPitWidthManager] No extension needed for current level. Reset right edge to {_currentPitRightEdge}");
                 return;
             }
 


### PR DESCRIPTION
Closes #333.

Fixes the hero-stuck-after-promotion deadlock diagnosed from the debug logs: after a tier-2 death reset the hero completed the crystal ceremony, jumped in place at the statue, and then looped forever on `WanderPitAction` while mercenaries spammed `cannot find path to pit edge`.

## Root cause

`PitWidthManager.SetPitLevel` predicted the post-regeneration right edge as `base + tiles + 2`, but `RegeneratePitWidth` actually produces `base + tiles` (the extension overwrites the base pit's inner-wall/outer-floor columns at x=12/13). On the tier-2 reset (level 7 → 1, edge 19 → 17) the overestimate (19) wasn't less than the previous edge (19), so `ClearTilesFromXToEnd` was skipped and the old inner-wall collision column at x=18 was stranded — observable in the logs as the pathfinding graph growing 534 → 541 walls while the pit *shrank*. That column seals the pit mouth, making the pit edge unreachable from town. Two missing guards then converted "no path" into corrupted state: `GoTo_Enter` fell through to executing `JumpIntoPitAction` in place, and the action blindly jumped `X-2` and set `InsidePit = true` at the statue.

## Changes

- **`PitWidthManager`** — new shared `CalculateRightEdgeForDepth(effectiveDepth)` used by `SetPitLevel`'s shrink check, so the prediction exactly matches what `RegeneratePitWidth` produces and the cleanup runs whenever the pit narrows.
- **`VirtualPitWidthManager`** — mirrors the shrink cleanup (`ClearTilesFromXToEnd`, restoring the base pit's x=12/13 pattern columns) and resets the right edge to the base boundary when no extension is needed, keeping virtual-layer parity.
- **`JumpIntoPitAction`** — aborts (without touching `InsidePit`) unless the computed landing tile is actually inside the pit, so a fall-through execution can never corrupt world state.
- **`HeroStateMachine.GoTo_Enter`** — when no path to the pit edge exists for `JumpIntoPitAction`, restarts planning instead of executing the jump in place (same pattern as the existing `WanderPitAction` guard).

## Testing

- New `PitShrinkStaleCollisionTests` (5 tests): edge-formula known values, prediction-vs-regeneration parity across levels and tiers, the exact logged scenario (tier 2, level 7 → 1: stale x=18 wall must be cleared, new x=16 wall must exist), tier-1 full reset restoring the base pit, and repeated grow/shrink cycles never leaving stale collision past the current edge.
- Full suite: **1576 passed, 0 failed** (baseline preserved), 6 pre-existing skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)