### PR TITLE
Make hidden top bar buttons unclickable above the window (#335)

### DIFF
--- a/PitHero/UI/FarmUI.cs
+++ b/PitHero/UI/FarmUI.cs
@@ -363,6 +363,17 @@ namespace PitHero.UI
             }
         }
 
+        /// <summary>Enables/disables hit-testing; disabled while the top UI bar is hidden off-screen.</summary>
+        public void SetTouchable(Touchable touchable)
+        {
+            _farmButton?.SetTouchable(touchable);
+            if (_subButtons != null)
+            {
+                for (int i = 0; i < _subButtons.Length; i++)
+                    _subButtons[i].SetTouchable(touchable);
+            }
+        }
+
         public float GetWidth()  => _farmButton?.GetWidth()  ?? 0f;
         public float GetHeight() => _farmButton?.GetHeight() ?? 0f;
 

--- a/PitHero/UI/FastFUI.cs
+++ b/PitHero/UI/FastFUI.cs
@@ -186,6 +186,12 @@ namespace PitHero.UI
             _fastFButton?.SetPosition(x, y);
         }
 
+        /// <summary>Enables/disables hit-testing; disabled while the top UI bar is hidden off-screen.</summary>
+        public void SetTouchable(Touchable touchable)
+        {
+            _fastFButton?.SetTouchable(touchable);
+        }
+
         /// <summary>
         /// Get the button width
         /// </summary>

--- a/PitHero/UI/HeroUI.cs
+++ b/PitHero/UI/HeroUI.cs
@@ -1139,6 +1139,9 @@ namespace PitHero.UI
         }
 
         public void SetPosition(float x, float y) => _heroButton?.SetPosition(x, y);
+
+        /// <summary>Enables/disables hit-testing; disabled while the top UI bar is hidden off-screen.</summary>
+        public void SetTouchable(Touchable touchable) => _heroButton?.SetTouchable(touchable);
         public float GetX() => _heroButton?.GetX() ?? 0f;
         public float GetY() => _heroButton?.GetY() ?? 0f;
         public float GetWidth() => _heroButton?.GetWidth() ?? 0f;

--- a/PitHero/UI/MonsterUI.cs
+++ b/PitHero/UI/MonsterUI.cs
@@ -503,6 +503,9 @@ namespace PitHero.UI
             if (_windowVisible) PositionWindow();
         }
 
+        /// <summary>Enables/disables hit-testing; disabled while the top UI bar is hidden off-screen.</summary>
+        public void SetTouchable(Touchable touchable) => _monsterButton?.SetTouchable(touchable);
+
         /// <summary>Returns the width of the monster icon button.</summary>
         public float GetWidth() => _monsterButton?.GetWidth() ?? 0f;
 

--- a/PitHero/UI/ReplenishUI.cs
+++ b/PitHero/UI/ReplenishUI.cs
@@ -138,6 +138,12 @@ namespace PitHero.UI
             _button?.SetPosition(x, y);
         }
 
+        /// <summary>Enables/disables hit-testing; disabled while the top UI bar is hidden off-screen.</summary>
+        public void SetTouchable(Touchable touchable)
+        {
+            _button?.SetTouchable(touchable);
+        }
+
         /// <summary>
         /// Get the button width
         /// </summary>

--- a/PitHero/UI/SecondChanceShopUI.cs
+++ b/PitHero/UI/SecondChanceShopUI.cs
@@ -39,6 +39,7 @@ namespace PitHero.UI
         private ImageButtonStyle _shopHalfStyle;
         private bool _styleChanged = false;
         private bool _isHiddenForPromotion = false;
+        private bool _barTouchDisabled = false;   // true while the top UI bar is hidden off-screen (issue #335)
         private SettingsUI _settingsUI;
         private HeroUI _heroUI;
         private MonsterUI _monsterUI;
@@ -634,14 +635,31 @@ namespace PitHero.UI
                     ForceCloseWindow();
 
                 _shopButton.SetVisible(false);
-                _shopButton.SetTouchable(Touchable.Disabled);
             }
             else
             {
                 _shopButton.SetVisible(true);
-                _shopButton.SetTouchable(Touchable.Enabled);
             }
+            ApplyEffectiveTouchable();
             _styleChanged = true; // Triggers SettingsUI layout reflow
+        }
+
+        /// <summary>Enables/disables hit-testing; disabled while the top UI bar is hidden off-screen.</summary>
+        public void SetTouchable(Touchable touchable)
+        {
+            _barTouchDisabled = touchable == Touchable.Disabled;
+            ApplyEffectiveTouchable();
+        }
+
+        /// <summary>
+        /// The button is touchable only when neither the bar-hide nor the promotion hide wants it disabled.
+        /// </summary>
+        private void ApplyEffectiveTouchable()
+        {
+            if (_shopButton == null)
+                return;
+            bool enabled = !_barTouchDisabled && !_isHiddenForPromotion;
+            _shopButton.SetTouchable(enabled ? Touchable.Enabled : Touchable.Disabled);
         }
 
         // ──────────────────────────────────────────────────────────────────────────

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -1737,6 +1737,7 @@ namespace PitHero.UI
             _uiBarHidden = false;
             _uiBarIdleTimer = 0f;
             _uiBarAnimating = true;
+            SetTopBarButtonsTouchable(true);
         }
 
         /// <summary>Slides the UI bar up off the top of the screen.</summary>
@@ -1745,6 +1746,25 @@ namespace PitHero.UI
             _uiBarHidden = true;
             _uiBarAnimating = true;
             _farmUI?.DismissSubButtons();
+            SetTopBarButtonsTouchable(false);
+        }
+
+        /// <summary>
+        /// Enables/disables hit-testing on every top bar button. While the bar is hidden it sits above
+        /// the window top, but raw mouse clicks above the client area still hit-test at negative stage Y,
+        /// so hidden buttons must be made untouchable (issue #335).
+        /// </summary>
+        private void SetTopBarButtonsTouchable(bool touchable)
+        {
+            var t = touchable ? Touchable.Enabled : Touchable.Disabled;
+            _gearButton?.SetTouchable(t);
+            _replenishUI?.SetTouchable(t);
+            _stopAdventuringUI?.SetTouchable(t);
+            _fastFUI?.SetTouchable(t);
+            _heroUI?.SetTouchable(t);
+            _monsterUI?.SetTouchable(t);
+            _secondChanceShopUI?.SetTouchable(t);
+            _farmUI?.SetTouchable(t);
         }
 
         /// <summary>

--- a/PitHero/UI/StopAdventuringUI.cs
+++ b/PitHero/UI/StopAdventuringUI.cs
@@ -29,6 +29,7 @@ namespace PitHero.UI
         private bool _isStoppedAdventuring = false;
         private bool _styleChanged = false;
         private bool _isHiddenForPromotion = false;
+        private bool _barTouchDisabled = false;   // true while the top UI bar is hidden off-screen (issue #335)
         private bool _isHiddenForSleep = false;
 
         public StopAdventuringUI()
@@ -278,37 +279,39 @@ namespace PitHero.UI
             return false;
         }
 
+        /// <summary>Enables/disables hit-testing; disabled while the top UI bar is hidden off-screen.</summary>
+        public void SetTouchable(Touchable touchable)
+        {
+            _barTouchDisabled = touchable == Touchable.Disabled;
+            ApplyEffectiveTouchable();
+        }
+
+        /// <summary>
+        /// The button is touchable only when neither the bar-hide nor the promotion/sleep hides want it disabled.
+        /// </summary>
+        private void ApplyEffectiveTouchable()
+        {
+            if (_button == null)
+                return;
+            bool enabled = !_barTouchDisabled && !_isHiddenForPromotion && !_isHiddenForSleep;
+            _button.SetTouchable(enabled ? Touchable.Enabled : Touchable.Disabled);
+        }
+
         /// <summary>
         /// Applies button visibility based on whether the hero promotion is in progress.
         /// Also sets _styleChanged so SettingsUI triggers a layout reflow (GetWidth/GetHeight return 0 while hidden).
         /// </summary>
         private void ApplyPromotionVisibility(bool hidden)
         {
-            if (hidden)
-            {
-                _button.SetVisible(false);
-                _button.SetTouchable(Touchable.Disabled);
-            }
-            else
-            {
-                _button.SetVisible(true);
-                _button.SetTouchable(Touchable.Enabled);
-            }
+            _button.SetVisible(!hidden);
+            ApplyEffectiveTouchable();
             _styleChanged = true; // Triggers SettingsUI layout reflow via ConsumeStyleChangedFlag
         }
 
         private void ApplySleepVisibility(bool hidden)
         {
-            if (hidden)
-            {
-                _button.SetVisible(false);
-                _button.SetTouchable(Touchable.Disabled);
-            }
-            else
-            {
-                _button.SetVisible(true);
-                _button.SetTouchable(Touchable.Enabled);
-            }
+            _button.SetVisible(!hidden);
+            ApplyEffectiveTouchable();
             _styleChanged = true;
         }
 


### PR DESCRIPTION
Fixes #335

## Problem
When the top UI bar auto-hides, it slides above the window top edge (negative stage Y). FNA on Windows reads the mouse via `SDL_GetGlobalMouseState` minus the window position, so clicks outside the client area are still reported while the game has focus, and Nez `Stage` hit-testing happily resolves those negative-Y positions to the off-screen buttons — so the player could click hidden buttons by clicking above the game window.

## Fix
Touchability now follows the bar's hide state:
- `SettingsUI.HideUIBar()` sets all eight top bar buttons (gear, replenish, stop, fast-forward, hero, monster, second-chance shop, farm + farm sub-buttons) to `Touchable.Disabled`; `ShowUIBar()` restores `Touchable.Enabled`.
- Each button wrapper gains a `SetTouchable` passthrough.
- `StopAdventuringUI` and `SecondChanceShopUI` already toggle touchability for promotion/sleep hiding, so they track the bar-hide request in a `_barTouchDisabled` flag and compute the effective touchability from all flags — neither path can re-enable a button the other wants disabled (e.g. promotion ending while the bar is hidden no longer re-enables the off-screen button).

Bar reveal is unaffected: the hover marker uses raw mouse coordinates, not stage hit-testing.

The shortcut bar and event console (which slide off the *bottom* edge) are left unchanged. Off-screen clicks reach them the same way, but neither has any click behavior to trigger: `ShortcutSlotVisual` only reacts to hover and drag (activation is via hotkeys, and a click that never crosses the drag threshold is a no-op), and `EventConsolePanel` has no input listeners at all. Verified by testing clicks below the hidden bars in top/middle window anchoring — nothing happens.

## Testing
- `dotnet build` clean (0 errors)
- `dotnet test`: 1592 passed, 0 failed, 6 skipped
- Manual: clicks above the window with the bar hidden no longer trigger buttons; clicks below hidden shortcut bar/console confirmed inert

🤖 Generated with [Claude Code](https://claude.com/claude-code)