### PR TITLE
Render party above fog of war and match chest colors to contents (#337)

### DIFF
--- a/PitHero.Tests/RenderLayerConfigTests.cs
+++ b/PitHero.Tests/RenderLayerConfigTests.cs
@@ -1,0 +1,26 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PitHero.Tests
+{
+    [TestClass]
+    public class RenderLayerConfigTests
+    {
+        /// <summary>
+        /// #337: fog of war must render BEHIND actors, single-tile objects, and dropped items
+        /// (higher layer value = drawn further back) so the party is never partially covered by
+        /// adjacent fog. Entities under covered fog are hidden via FogHideableComponent instead.
+        /// </summary>
+        [TestMethod]
+        public void FogOfWar_RendersBehindActorsAndPitObjects()
+        {
+            Assert.IsTrue(GameConfig.RenderLayerFogOfWar > GameConfig.RenderLayerActors,
+                "Fog of war must draw behind actors (heroes, mercenaries, monsters)");
+            Assert.IsTrue(GameConfig.RenderLayerFogOfWar > GameConfig.RenderLayerSingleTileObject,
+                "Fog of war must draw behind single-tile objects (chests, walls)");
+            Assert.IsTrue(GameConfig.RenderLayerFogOfWar > GameConfig.RenderLayerDroppedItems,
+                "Fog of war must draw behind dropped items");
+            Assert.IsTrue(GameConfig.RenderLayerFogOfWar < GameConfig.RenderLayerDetail,
+                "Fog of war must still draw in front of the detail/base tilemap layers");
+        }
+    }
+}

--- a/PitHero.Tests/TreasureComponentTests.cs
+++ b/PitHero.Tests/TreasureComponentTests.cs
@@ -442,5 +442,74 @@ namespace PitHero.Tests
             Assert.AreEqual(1, BalanceConfig.LootWeightNoPartyJob);
             Assert.AreEqual(2, BalanceConfig.LootWeightAllJobs);
         }
+
+        // #337: chest color must match contents — consumables/seeds are always brown (level 1),
+        // gear chests match the gear's rarity.
+
+        [TestMethod]
+        public void InitializeForPitLevel_ConsumableAlwaysBrownChest()
+        {
+            int[] pitLevels = { 1, 3, 11, 22, 25 };
+            foreach (var pitLevel in pitLevels)
+            {
+                for (int i = 0; i < 300; i++)
+                {
+                    var component = new TreasureComponent();
+                    component.InitializeForPitLevel(pitLevel);
+                    if (component.ContainedItem is Consumable)
+                        Assert.AreEqual(1, component.Level,
+                            $"Consumable ({component.ContainedItem.Name}) at pit level {pitLevel} must be in a brown (level 1) chest but chest level was {component.Level}");
+                }
+            }
+        }
+
+        [TestMethod]
+        public void InitializeForPitLevel_GearChestColorMatchesRarity()
+        {
+            int[] pitLevels = { 1, 11, 22, 25 };
+            foreach (var pitLevel in pitLevels)
+            {
+                for (int i = 0; i < 300; i++)
+                {
+                    var component = new TreasureComponent();
+                    component.InitializeForPitLevel(pitLevel);
+                    if (component.ContainedItem is Gear gear)
+                        Assert.AreEqual(RarityUtils.GetTreasureLevelForRarity(gear.Rarity), component.Level,
+                            $"Gear ({gear.Name}, {gear.Rarity}) at pit level {pitLevel} must be in a chest matching its rarity but chest level was {component.Level}");
+                }
+            }
+        }
+
+        [TestMethod]
+        public void InitializeForPitLevel_Tier2GearChestColorMatchesScaledRarity()
+        {
+            for (int i = 0; i < 300; i++)
+            {
+                var component = new TreasureComponent();
+                component.InitializeForPitLevel(22, default, pitTier: 2);
+                if (component.ContainedItem is Gear gear)
+                    Assert.AreEqual(RarityUtils.GetTreasureLevelForRarity(gear.Rarity), component.Level,
+                        $"Tier-2 gear ({gear.Name}, {gear.Rarity}) must be in a chest matching its rarity but chest level was {component.Level}");
+            }
+        }
+
+        [TestMethod]
+        public void InitializeForPitLevel_SeedChestIsBrown()
+        {
+            int seedChestsFound = 0;
+            for (int i = 0; i < 5000 && seedChestsFound < 10; i++)
+            {
+                var component = new TreasureComponent();
+                component.InitializeForPitLevel(22);
+                if (component.ContainedSeedType != null)
+                {
+                    seedChestsFound++;
+                    Assert.AreEqual(1, component.Level,
+                        $"Seed chest ({component.ContainedSeedType}) must be brown (level 1) but chest level was {component.Level}");
+                    Assert.IsNull(component.ContainedItem, "Seed chest must not also contain an item");
+                }
+            }
+            Assert.IsTrue(seedChestsFound > 0, "Expected at least one seed chest in 5000 rolls at pit level 22");
+        }
     }
 }

--- a/PitHero/ECS/Components/FogHideableComponent.cs
+++ b/PitHero/ECS/Components/FogHideableComponent.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Nez;
+using PitHero.Util;
+
+namespace PitHero.ECS.Components
+{
+    /// <summary>
+    /// Hides a renderable while the fog-of-war tile over its entity is covered and reveals it when
+    /// that tile is uncovered. Attach to static pit entities (treasure chests, walls, wizard orb)
+    /// so they don't show through fog now that actors render above the FogOfWar layer.
+    /// Reveal is driven by <see cref="TiledMapService.RefreshFogHiddenEntities"/> after any fog clear.
+    /// </summary>
+    public class FogHideableComponent : Component
+    {
+        // Static registry maintained by OnAddedToEntity/OnRemovedFromEntity so the fog-clear path can
+        // iterate without calling FindEntitiesWithTag (which allocates a new list every invocation).
+
+        /// <summary>All live FogHideableComponent instances in the current scene.</summary>
+        public static readonly List<FogHideableComponent> Active = new List<FogHideableComponent>(64);
+
+        private readonly RenderableComponent _target;
+        private Point _tile; // cached — targets are static entities that never change tiles
+        private bool _hiddenByFog;
+
+        /// <summary>Creates the component for the renderable that should be fog-gated.</summary>
+        public FogHideableComponent(RenderableComponent target)
+        {
+            _target = target;
+        }
+
+        /// <summary>Registers in the static registry and hides the target if its tile is fogged.</summary>
+        public override void OnAddedToEntity()
+        {
+            Active.Add(this);
+
+            var pos = Entity.Transform.Position;
+            _tile = new Point(
+                (int)System.Math.Floor(pos.X / GameConfig.TileSize),
+                (int)System.Math.Floor(pos.Y / GameConfig.TileSize));
+
+            var tms = Core.Services?.GetService<TiledMapService>();
+            if (tms != null && tms.IsFogOfWarTile(_tile.X, _tile.Y))
+            {
+                _target?.SetEnabled(false);
+                _hiddenByFog = true;
+            }
+        }
+
+        /// <summary>Removes this component from the static registry.</summary>
+        public override void OnRemovedFromEntity()
+        {
+            // Backward search so the common case (last added = first removed) is O(1)
+            for (int i = Active.Count - 1; i >= 0; i--)
+            {
+                if (Active[i] == this)
+                {
+                    Active.RemoveAt(i);
+                    break;
+                }
+            }
+        }
+
+        /// <summary>Re-enables all fog-hidden targets whose tile is no longer fogged.</summary>
+        public static void RevealUnfogged(TiledMapService tms)
+        {
+            for (int i = 0; i < Active.Count; i++)
+            {
+                var hideable = Active[i];
+                if (!hideable._hiddenByFog)
+                    continue;
+                if (!tms.IsFogOfWarTile(hideable._tile.X, hideable._tile.Y))
+                {
+                    hideable._target?.SetEnabled(true);
+                    hideable._hiddenByFog = false;
+                }
+            }
+        }
+    }
+}

--- a/PitHero/ECS/Components/TileByTileMover.cs
+++ b/PitHero/ECS/Components/TileByTileMover.cs
@@ -160,13 +160,12 @@ namespace PitHero.ECS.Components
             var heroComponent = Entity.GetComponent<HeroComponent>();
             if (tms != null && heroComponent != null)
             {
-                // Hero: clear fog and refresh visibility of any monsters now in revealed tiles
+                // Hero: clear fog. TiledMapService refreshes fog-hidden entity visibility itself.
                 var tile = GetCurrentTileCoordinates();
                 bool fogCleared = tms.ClearFogOfWarAroundTile(tile.X, tile.Y, heroComponent);
                 if (fogCleared)
                 {
                     heroComponent.TriggerFogCooldown();
-                    RefreshMonsterFogVisibility(tms);
                     CheckTrapSenseDisarm(heroComponent, tms);
                 }
             }
@@ -228,27 +227,6 @@ namespace PitHero.ECS.Components
                 {
                     trapComp.Disarm();
                 }
-            }
-        }
-
-        /// <summary>
-        /// Scans all monster entities and re-enables their animator if their tile is no longer fogged.
-        /// Called after the hero clears fog.
-        /// </summary>
-        private static void RefreshMonsterFogVisibility(TiledMapService tms)
-        {
-            var monsters = Core.Scene?.FindEntitiesWithTag(GameConfig.TAG_MONSTER);
-            if (monsters == null)
-                return;
-            for (int i = 0; i < monsters.Count; i++)
-            {
-                var mover = monsters[i].GetComponent<TileByTileMover>();
-                var anim = monsters[i].GetComponent<EnemyAnimationComponent>();
-                if (mover == null || anim == null || anim.Enabled)
-                    continue;
-                var tile = mover.GetCurrentTileCoordinates();
-                if (!tms.IsFogOfWarTile(tile.X, tile.Y))
-                    anim.SetEnabled(true);
             }
         }
 

--- a/PitHero/ECS/Components/TreasureComponent.cs
+++ b/PitHero/ECS/Components/TreasureComponent.cs
@@ -38,6 +38,7 @@ namespace PitHero.ECS.Components
         private int _level = 1;
         private SpriteRenderer _baseRenderer;
         private SpriteRenderer _woodRenderer;
+        private StaticSpriteCompositor _compositor;
         private SpriteAtlas _actorsAtlas;
         private IItem _containedItem;
 
@@ -130,12 +131,15 @@ namespace PitHero.ECS.Components
             // Composite both layers into a single 32×32 render target so the chest
             // always occupies exactly one render layer with no z-order inconsistency.
             // Treasure sprites are 32×32 with center origin — pivot maps entity pos to RT center.
-            var compositor = Entity.AddComponent(new StaticSpriteCompositor(
+            _compositor = Entity.AddComponent(new StaticSpriteCompositor(
                 new Nez.Sprites.SpriteRenderer[] { _baseRenderer, _woodRenderer },
                 GameConfig.TileSize,
                 GameConfig.TileSize,
                 new Microsoft.Xna.Framework.Vector2(GameConfig.TileSize / 2f, GameConfig.TileSize / 2f)));
-            compositor.SetRenderLayer(GameConfig.RenderLayerSingleTileObject);
+            _compositor.SetRenderLayer(GameConfig.RenderLayerSingleTileObject);
+
+            // Chests render above the FogOfWar layer, so hide the composite while their tile is fogged.
+            Entity.AddComponent(new FogHideableComponent(_compositor));
         }
 
         private void UpdateSprites()
@@ -857,13 +861,14 @@ namespace PitHero.ECS.Components
         {
             Level = DetermineTreasureLevel(pitLevel);
 
-            // Seed drop: any uncommon (level-2) chest has a chance to yield seeds instead of normal loot.
+            // Seed drop: any uncommon (level-2) roll has a chance to yield seeds instead of normal loot.
             // Seeds are not tier-scaled (they are consumables, not gear).
             if (Level == 2 && Nez.Random.NextFloat() < BalanceConfig.SeedChestDropRate)
             {
                 ContainedSeedType  = (CropType)Nez.Random.NextInt(CropTypeInfo.Count);
                 ContainedSeedCount = Nez.Random.NextInt(3) + 1; // 1..3
                 ContainedItem = null;
+                Level = 1; // seeds are consumables — always a brown chest (#337)
                 return;
             }
 
@@ -882,6 +887,12 @@ namespace PitHero.ECS.Components
                 int depthDelta = (pitTier - 1) * BiomeProgressionConfig.MaxBiomeLevel;
                 ContainedItem = RolePlayingFramework.Equipment.Gear.CreateTierScaledCopy(g, pitTier, depthDelta);
             }
+
+            // Chest color must match contents (#337): gear rarity drives color; consumables are always brown.
+            if (ContainedItem is RolePlayingFramework.Equipment.Gear finalGear)
+                Level = RarityUtils.GetTreasureLevelForRarity(finalGear.Rarity);
+            else if (ContainedItem != null)
+                Level = 1;
         }
     }
 }

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -348,12 +348,14 @@ namespace PitHero
         public const int RenderLayerPickupItem = 1; // Pickup items layer
         public const int RenderLayerTop = 2;
 
-        public const int RenderLayerFogOfWar = 40;   // Fog of war layer above most things, except hero
-        public const int RenderLayerActorPropOverlay = 41; // Actor prop overlay layer (above actors, below fog of war).  Useful for things like watering can, water, harvested crops that display over monster workers.
+        public const int RenderLayerActorPropOverlay = 41; // Actor prop overlay layer (above actors).  Useful for things like watering can, water, harvested crops that display over monster workers.
         // Actors layer — heroes, mercenaries, monsters, and treasures. Y-sorted within layer via LayerDepth.
         public const int RenderLayerActors = 60;
         public const int RenderLayerSingleTileObject = 61; // Single tile object layer (below actors, so single tile objects render below monsters/heroes)
         public const int RenderLayerDroppedItems = 65; // Dropped items layer
+        // Fog of war renders BEHIND actors so the party is never partially hidden by adjacent fog (#337).
+        // Pit statics/monsters under covered fog are hidden via FogHideableComponent / EnemyAnimationComponent instead.
+        public const int RenderLayerFogOfWar = 70;
         // NOTE: Placed buildings (Monster House / Crop Storage) render at RenderLayerActors and are
         // Y-sorted with monsters via YSortSpriteRenderer.YSortOffset (see IYSortOffset / YSortManager).
         public const int RenderLayerDetail = 90; // Detail tilemap layer (tilled soil, etc.) — above base, below actors

--- a/PitHero/PitGenerator.cs
+++ b/PitHero/PitGenerator.cs
@@ -728,6 +728,8 @@ namespace PitHero
                             var colorGrading = Core.Services.GetService<Rendering.ColorGradingController>();
                             if (colorGrading?.Material != null)
                                 renderer.SetMaterial(colorGrading.Material);
+                            // Walls render above the FogOfWar layer, so hide them while their tile is fogged.
+                            entity.AddComponent(new FogHideableComponent(renderer));
                         }
                         else
                         {
@@ -827,6 +829,8 @@ namespace PitHero
                             var renderer = entity.AddComponent(new YSortSpriteRenderer(wizardOrbSprite));
                             renderer.Color = color;
                             renderer.SetRenderLayer(GameConfig.RenderLayerActors);
+                            // The orb only counts as "found" once its tile is unfogged — keep it hidden until then.
+                            entity.AddComponent(new FogHideableComponent(renderer));
                         }
                         else
                         {

--- a/PitHero/Util/TiledMapService.cs
+++ b/PitHero/Util/TiledMapService.cs
@@ -154,6 +154,9 @@ namespace PitHero.Util
                 }
             }
 
+            if (anyFogCleared)
+                RefreshFogHiddenEntities();
+
             return anyFogCleared;
         }
 
@@ -197,7 +200,34 @@ namespace PitHero.Util
                 }
             }
 
+            if (anyFogCleared)
+                RefreshFogHiddenEntities();
+
             return anyFogCleared;
+        }
+
+        /// <summary>
+        /// Re-enables monsters and fog-hidden statics (chests, walls, wizard orb) whose tiles are no
+        /// longer fogged. Called automatically after any fog clear so every uncover path (hero step,
+        /// warp, wander, orb activation, pit jumps) reveals entities consistently.
+        /// </summary>
+        public void RefreshFogHiddenEntities()
+        {
+            FogHideableComponent.RevealUnfogged(this);
+
+            var monsters = Core.Scene?.FindEntitiesWithTag(GameConfig.TAG_MONSTER);
+            if (monsters == null)
+                return;
+            for (int i = 0; i < monsters.Count; i++)
+            {
+                var mover = monsters[i].GetComponent<TileByTileMover>();
+                var anim = monsters[i].GetComponent<EnemyAnimationComponent>();
+                if (mover == null || anim == null || anim.Enabled)
+                    continue;
+                var tile = mover.GetCurrentTileCoordinates();
+                if (!IsFogOfWarTile(tile.X, tile.Y))
+                    anim.SetEnabled(true);
+            }
         }
 
         /// <summary>

--- a/PitHero/docs/RenderingSystem.md
+++ b/PitHero/docs/RenderingSystem.md
@@ -15,11 +15,20 @@ Higher number = drawn first = further back.  Lower number = drawn later = in fro
 | Constant | Value | What lives here |
 |---|---|---|
 | `RenderLayerTop` | 2 | Tilemap "Top" layer (tree-tops, overhangs) — covers everything |
-| `RenderLayerFogOfWar` | 40 | Tilemap fog-of-war overlay — covers actors but not the top layer |
 | `RenderLayerActors` | 60 | Heroes, mercenaries, monsters, **placed buildings** (all Y-sorted via `LayerDepth`) |
 | `RenderLayerSingleTileObject` | 61 | Static 32×32 world objects: treasure chests, walls/obstacles (Y-sorted) |
 | `RenderLayerDroppedItems` | 65 | Dropped loot items |
+| `RenderLayerFogOfWar` | 70 | Tilemap fog-of-war overlay — renders **behind** actors/objects (#337) |
 | `RenderLayerBase` | 100 | Tilemap base layer |
+
+Fog of war renders behind actors so the party is never partially covered when walking next
+to fogged tiles. Pit entities that spawn under covered fog are instead hidden per-entity:
+`FogHideableComponent` (treasure chests, walls/obstacles, wizard orb) disables its target
+renderable while the entity's tile is fogged, and `TiledMapService.RefreshFogHiddenEntities`
+— called automatically after any fog clear — re-enables revealed statics and monster
+animators. Monsters additionally self-hide/self-reveal when they move between fogged and
+clear tiles (`EnemyAnimationComponent.CheckFogVisibility` / `TileByTileMover.CompleteMove`).
+Heroes and mercenaries are never fog-hidden.
 
 UI / HUD layers (screen-space, unaffected by camera): `RenderLayerActionQueue` (996),
 `RenderLayerGraphicalHUD` (997), `RenderLayerUI` (998), `TransparentPauseOverlay` (999).


### PR DESCRIPTION
Fixes #337 — two cosmetic bugs.

## 1. Party rendered below fog of war

- `RenderLayerFogOfWar` moved from 40 to **70** (behind actors 60 / single-tile objects 61 / dropped items 65, still in front of detail/base). Heroes and mercenaries now always render above fog with no per-entity work.
- New `FogHideableComponent` (static registry pattern, like `TrapComponent.ActiveTraps`) hides a target renderable while its entity's tile is fogged. Attached to **treasure chests** (the `StaticSpriteCompositor`), **pit walls/obstacles**, and the **wizard orb** — the orb hide also matches gameplay, which only counts the orb as "found" once its tile is unfogged.
- Reveal is centralized in `TiledMapService.RefreshFogHiddenEntities()`, called automatically whenever any fog is cleared. Previously only the hero-step path refreshed monster visibility; now warp, wander, orb-activation, and pit-jump uncover paths all reveal correctly. The monster refresh loop moved there from `TileByTileMover.RefreshMonsterFogVisibility` (deleted); monster self-hide/self-reveal while moving is unchanged.
- Spawn-time hiding covers all entry paths (new game, load, orb advance, pit expansion) because fog is always regenerated before pit entities spawn.

**Known cosmetic edge:** large monster sprites on an unfogged tile adjacent to fog now overhang above the fog edge — same as heroes, consistent with "actors above fog."

## 2. Potions in colored chests

Chest color was rolled first and contents generated to match, so level 3–5 rolls yielded Mid/Full potions (all `ItemRarity.Normal`) in blue/purple/gold chests. Now `InitializeForPitLevel` reassigns `Level` from the final (tier-scaled) item:

- Gear → `RarityUtils.GetTreasureLevelForRarity(rarity)` (previously unused helper; no-op for cave gear)
- Consumables **and seed chests** → level 1 (brown)

Loot distribution is unchanged — only the chest cosmetics. This also restores live/virtual parity: `VirtualWorldState` already infers chest level from item rarity.

## Tests

- `InitializeForPitLevel_ConsumableAlwaysBrownChest`, `_GearChestColorMatchesRarity`, `_Tier2GearChestColorMatchesScaledRarity`, `_SeedChestIsBrown`
- `RenderLayerConfigTests.FogOfWar_RendersBehindActorsAndPitObjects` pins the layer ordering
- Full suite: **1597 passed, 0 failed** (baseline 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)