### PR TITLE
Show equip Changes tooltip only when dragging gear to a valid equip slot

### DIFF
--- a/PitHero/UI/EquipPreviewTooltip.cs
+++ b/PitHero/UI/EquipPreviewTooltip.cs
@@ -4,6 +4,7 @@ using Nez.BitmapFonts;
 using Nez.UI;
 using PitHero.Services;
 using RolePlayingFramework.Equipment;
+using RolePlayingFramework.Stats;
 
 namespace PitHero.UI
 {
@@ -42,13 +43,13 @@ namespace PitHero.UI
             _container.SetTouchable(Touchable.Disabled);
         }
 
-        /// <summary>Shows the tooltip comparing new gear with currently equipped gear.</summary>
+        /// <summary>Shows the tooltip comparing new gear with currently equipped gear (null = empty slot, zero baseline).</summary>
         public void ShowComparison(IGear newGear, IGear equippedGear)
         {
             _newGear = newGear;
             _equippedGear = equippedGear;
 
-            if (_newGear == null || _equippedGear == null)
+            if (_newGear == null)
             {
                 return;
             }
@@ -62,7 +63,7 @@ namespace PitHero.UI
         {
             _contentTable.Clear();
 
-            if (_newGear == null || _equippedGear == null) return;
+            if (_newGear == null) return;
 
             var font = Graphics.Instance.BitmapFont;
             float maxLineWidth = 0f;
@@ -75,9 +76,13 @@ namespace PitHero.UI
             _contentTable.Row();
             maxLineWidth = Max(maxLineWidth, Measure(font, titleText));
 
-            // Compare StatBlock bonuses
+            // Compare StatBlock bonuses (null equipped gear = empty slot, all zeros)
             var newStats = _newGear.StatBonus;
-            var equippedStats = _equippedGear.StatBonus;
+            var equippedStats = _equippedGear != null ? _equippedGear.StatBonus : default(StatBlock);
+            int eqAttack = _equippedGear != null ? _equippedGear.AttackBonus : 0;
+            int eqDefense = _equippedGear != null ? _equippedGear.DefenseBonus : 0;
+            int eqHp = _equippedGear != null ? _equippedGear.HPBonus : 0;
+            int eqMp = _equippedGear != null ? _equippedGear.MPBonus : 0;
 
             // Strength
             int strengthDiff = newStats.Strength - equippedStats.Strength;
@@ -133,7 +138,7 @@ namespace PitHero.UI
 
             // Compare flat bonuses
             // Attack
-            int attackDiff = _newGear.AttackBonus - _equippedGear.AttackBonus;
+            int attackDiff = _newGear.AttackBonus - eqAttack;
             if (attackDiff != 0)
             {
                 hasAnyChanges = true;
@@ -146,7 +151,7 @@ namespace PitHero.UI
             }
 
             // Defense
-            int defenseDiff = _newGear.DefenseBonus - _equippedGear.DefenseBonus;
+            int defenseDiff = _newGear.DefenseBonus - eqDefense;
             if (defenseDiff != 0)
             {
                 hasAnyChanges = true;
@@ -159,7 +164,7 @@ namespace PitHero.UI
             }
 
             // HP
-            int hpDiff = _newGear.HPBonus - _equippedGear.HPBonus;
+            int hpDiff = _newGear.HPBonus - eqHp;
             if (hpDiff != 0)
             {
                 hasAnyChanges = true;
@@ -172,7 +177,7 @@ namespace PitHero.UI
             }
 
             // AP (MP)
-            int apDiff = _newGear.MPBonus - _equippedGear.MPBonus;
+            int apDiff = _newGear.MPBonus - eqMp;
             if (apDiff != 0)
             {
                 hasAnyChanges = true;
@@ -205,22 +210,22 @@ namespace PitHero.UI
             return font.MeasureString(text).X;
         }
 
-        /// <summary>Checks if there are any changes to display.</summary>
+        /// <summary>Checks if there are any changes to display (null equipped gear = empty slot, zero baseline).</summary>
         public bool HasChanges()
         {
-            if (_newGear == null || _equippedGear == null) return false;
+            if (_newGear == null) return false;
 
             var newStats = _newGear.StatBonus;
-            var equippedStats = _equippedGear.StatBonus;
+            var equippedStats = _equippedGear != null ? _equippedGear.StatBonus : default(StatBlock);
 
             return newStats.Strength != equippedStats.Strength ||
                    newStats.Agility != equippedStats.Agility ||
                    newStats.Vitality != equippedStats.Vitality ||
                    newStats.Magic != equippedStats.Magic ||
-                   _newGear.AttackBonus != _equippedGear.AttackBonus ||
-                   _newGear.DefenseBonus != _equippedGear.DefenseBonus ||
-                   _newGear.HPBonus != _equippedGear.HPBonus ||
-                   _newGear.MPBonus != _equippedGear.MPBonus;
+                   _newGear.AttackBonus != (_equippedGear?.AttackBonus ?? 0) ||
+                   _newGear.DefenseBonus != (_equippedGear?.DefenseBonus ?? 0) ||
+                   _newGear.HPBonus != (_equippedGear?.HPBonus ?? 0) ||
+                   _newGear.MPBonus != (_equippedGear?.MPBonus ?? 0);
         }
     }
 }

--- a/PitHero/UI/HeroUI.cs
+++ b/PitHero/UI/HeroUI.cs
@@ -365,6 +365,7 @@ namespace PitHero.UI
             _inventoryGrid = new InventoryGrid();
             _inventoryGrid.OnItemHovered += HandleItemHovered;
             _inventoryGrid.OnItemUnhovered += HandleItemUnhovered;
+            _inventoryGrid.OnDragEquipTargetChanged += HandleDragEquipTargetChanged;
             _inventoryGrid.OnItemSelected += HandleItemSelected;
             _inventoryGrid.OnItemDeselected += HandleItemDeselected;
             _inventoryGrid.OnStencilRemovalRequested += HandleStencilRemovalRequested;
@@ -1155,6 +1156,11 @@ namespace PitHero.UI
 
             // Note: Keyboard shortcuts are now handled by ShortcutBar in MainGameScene
 
+            // Safety net: the equip preview only exists while dragging (covers cancel paths and force-close)
+            if (_equipPreviewTooltip != null && !InventoryDragManager.IsDragging
+                && _equipPreviewTooltip.GetContainer().HasParent())
+                _equipPreviewTooltip.GetContainer().Remove();
+
             if (_windowVisible && _inventoryGrid != null)
             {
 
@@ -1174,15 +1180,6 @@ namespace PitHero.UI
                     tooltipY = Mathf.Clamp(tooltipY, 0, stageHeight - tooltipHeight);
                     
                     tooltipContainer.SetPosition(tooltipX, tooltipY);
-
-                    // Update equip preview tooltip position if visible
-                    if (_equipPreviewTooltip != null && _equipPreviewTooltip.GetContainer().HasParent())
-                    {
-                        var itemTooltipContainer = _itemTooltip.GetContainer();
-                        float previewX = itemTooltipContainer.GetX() + itemTooltipContainer.GetWidth() + 5;
-                        float previewY = itemTooltipContainer.GetY();
-                        _equipPreviewTooltip.GetContainer().SetPosition(previewX, previewY);
-                    }
                 }
 
                 // Update hero crystal tab tooltip
@@ -1231,7 +1228,8 @@ namespace PitHero.UI
 
         private void HandleItemHovered(IItem item, InventorySlot slot)
         {
-            if (item == null) return;
+            // Suppress hover tooltips during drags (PerformPeriodicHoverCheck bypasses hover events)
+            if (item == null || InventoryDragManager.IsDragging) return;
 
             // Get synergies for the hovered slot (passed directly, no search needed)
             var synergies = slot != null ? _inventoryGrid?.GetSynergiesForSlot(slot) : null;
@@ -1262,39 +1260,6 @@ namespace PitHero.UI
             
             tooltipContainer.SetPosition(tooltipX, tooltipY);
             tooltipContainer.ToFront();
-
-            // Show equip preview tooltip if item is qualifying gear
-            if (item is IGear hoveredGear)
-            {
-                // Do not show preview for accessories
-                if (hoveredGear.Kind == ItemKind.Accessory)
-                {
-                    // ensure any previous preview is removed
-                    if (_equipPreviewTooltip != null)
-                        _equipPreviewTooltip.GetContainer().Remove();
-                    return;
-                }
-                var heroComponent = GetHeroComponent();
-                if (heroComponent != null && heroComponent.LinkedHero != null)
-                {
-                    var equippedGear = GetCurrentlyEquippedGear(hoveredGear, heroComponent.LinkedHero);
-                    if (equippedGear != null)
-                    {
-                        _equipPreviewTooltip.ShowComparison(hoveredGear, equippedGear);
-                        if (_equipPreviewTooltip.GetContainer().GetParent() == null)
-                        {
-                            _stage.AddElement(_equipPreviewTooltip.GetContainer());
-                        }
-
-                        // Position equip preview tooltip to the right of item tooltip (using item tooltip's clamped Y)
-                        var itemTooltipContainer = _itemTooltip.GetContainer();
-                        float previewX = itemTooltipContainer.GetX() + itemTooltipContainer.GetWidth() + 5;
-                        float previewY = itemTooltipContainer.GetY();
-                        _equipPreviewTooltip.GetContainer().SetPosition(previewX, previewY);
-                        _equipPreviewTooltip.GetContainer().ToFront();
-                    }
-                }
-            }
         }
 
         private void HandleItemUnhovered()
@@ -1303,41 +1268,41 @@ namespace PitHero.UI
             if (!(_inventoryGrid != null && _inventoryGrid.HasAnyHoveredSlot()))
             {
                 _itemTooltip.GetContainer().Remove();
-                _equipPreviewTooltip.GetContainer().Remove();
             }
         }
 
-        /// <summary>Gets the currently equipped gear for the same slot as the hovered gear.</summary>
-        private IGear GetCurrentlyEquippedGear(IGear hoveredGear, RolePlayingFramework.Heroes.Hero hero)
+        /// <summary>Shows/hides the equip preview beside the drag's current valid equip target slot.</summary>
+        private void HandleDragEquipTargetChanged(InventorySlot targetSlot, IGear draggedGear)
         {
-            if (hoveredGear == null || hero == null) return null;
-
-            // Determine which slot this gear would equip to
-            var kind = hoveredGear.Kind;
-
-            if (kind == ItemKind.HatHelm || kind == ItemKind.HatHeadband || kind == ItemKind.HatWizard || kind == ItemKind.HatPriest)
+            if (targetSlot == null || draggedGear == null)
             {
-                return hero.Hat as IGear;
-            }
-            else if (kind == ItemKind.ArmorMail || kind == ItemKind.ArmorRobe || kind == ItemKind.ArmorGi)
-            {
-                return hero.Armor as IGear;
-            }
-            else if (kind == ItemKind.WeaponSword || kind == ItemKind.WeaponKnife || kind == ItemKind.WeaponKnuckle || kind == ItemKind.WeaponStaff || kind == ItemKind.WeaponRod || kind == ItemKind.WeaponHammer)
-            {
-                return hero.WeaponShield1 as IGear;
-            }
-            else if (kind == ItemKind.Shield)
-            {
-                return hero.WeaponShield2 as IGear;
-            }
-            else if (kind == ItemKind.Accessory)
-            {
-                // For accessories do not show preview
-                return null;
+                _equipPreviewTooltip?.GetContainer().Remove();
+                return;
             }
 
-            return null;
+            var equippedGear = targetSlot.SlotData.Item as IGear; // null = empty slot, all bonuses show as gains
+            _equipPreviewTooltip.ShowComparison(draggedGear, equippedGear);
+
+            if (!_equipPreviewTooltip.HasChanges())
+            {
+                _equipPreviewTooltip.GetContainer().Remove();
+                return;
+            }
+
+            var container = _equipPreviewTooltip.GetContainer();
+            if (container.GetParent() == null)
+                _stage.AddElement(container);
+            container.Validate();
+
+            // Anchor beside the target slot; flip to the left side if overflowing the right edge, clamp Y
+            var slotTopLeft = targetSlot.LocalToStageCoordinates(Vector2.Zero);
+            const float pad = 4f;
+            float x = slotTopLeft.X + targetSlot.GetWidth() + pad;
+            if (x + container.GetWidth() > _stage.GetWidth())
+                x = slotTopLeft.X - container.GetWidth() - pad;
+            float y = Mathf.Clamp(slotTopLeft.Y, 0f, _stage.GetHeight() - container.GetHeight());
+            container.SetPosition(x, y);
+            container.ToFront();
         }
 
         private void HandleItemSelected(IItem item)

--- a/PitHero/UI/InventoryGrid.cs
+++ b/PitHero/UI/InventoryGrid.cs
@@ -36,6 +36,8 @@ namespace PitHero.UI
         private HeroComponent _heroComponent;
         /// <summary>Slot currently showing the hover-during-drag visual effect.</summary>
         private InventorySlot _dragHoveredSlot;
+        /// <summary>Valid equip target the drag is currently over (equip preview tooltip anchor).</summary>
+        private InventorySlot _lastEquipPreviewTarget;
         private InventoryContextMenu _contextMenu;
         private Stage _stage; // Reference to stage for tooltip management
 
@@ -69,6 +71,9 @@ namespace PitHero.UI
 
         // Fired after an item is sold to the Second Chance vault
         public event System.Action OnItemSoldToVault;
+
+        /// <summary>Fired while dragging gear when the valid equip-target slot changes. Null slot = no valid target.</summary>
+        public event System.Action<InventorySlot, IGear> OnDragEquipTargetChanged;
 
         /// <summary>Fired when an item drag is released outside the grid, passing the source slot and stage drop position.</summary>
         public event System.Action<InventorySlot, Vector2> OnHeroItemDroppedOutside;
@@ -713,6 +718,22 @@ namespace PitHero.UI
                 target.SetItemSpriteOffsetY(HOVER_OFFSET_Y);
                 _dragHoveredSlot = target;
             }
+
+            // Equip-preview target detection (also fires for empty valid equip slots)
+            InventorySlot previewTarget = null;
+            var dragItem = InventoryDragManager.DragItem;
+            if (target != null && target != source && dragItem is IGear draggedGear
+                && (target.SlotData.SlotType == InventorySlotType.Equipment ||
+                    target.SlotData.SlotType == InventorySlotType.MercenaryEquipment)
+                && CanPlaceItemInSlot(draggedGear, target.SlotData))
+            {
+                previewTarget = target;
+            }
+            if (previewTarget != _lastEquipPreviewTarget)
+            {
+                _lastEquipPreviewTarget = previewTarget;
+                OnDragEquipTargetChanged?.Invoke(previewTarget, previewTarget != null ? (IGear)dragItem : null);
+            }
         }
 
         /// <summary>Handles the drop event, swapping items or cancelling if no valid target.</summary>
@@ -722,6 +743,12 @@ namespace PitHero.UI
             {
                 _dragHoveredSlot.SetItemSpriteOffsetY(0f);
                 _dragHoveredSlot = null;
+            }
+
+            if (_lastEquipPreviewTarget != null)
+            {
+                _lastEquipPreviewTarget = null;
+                OnDragEquipTargetChanged?.Invoke(null, null);
             }
 
             // Handle vault item drop specially - route to purchase flow


### PR DESCRIPTION
Fixes #339

## What changed

The "Changes" equip preview tooltip no longer shows on hover. It now appears only while **dragging** a piece of gear over a valid target equipment slot, and it compares against the gear currently in **that slot** — so mercenary equip slots diff against the mercenary's gear, not the hero's.

- **`InventoryGrid`**: new `OnDragEquipTargetChanged` event fired from `HandleSlotDragMoved` when the drag's valid equip target changes (validated via the existing `CanPlaceItemInSlot`, which covers hero/merc `CanEquipItem` and kind-vs-slot rules). Cleared at the top of `HandleSlotDragDropped`, which every grid drag-end path funnels through.
- **`HeroUI`**: hover-time preview block and the hero-hardcoded `GetCurrentlyEquippedGear` removed; new `HandleDragEquipTargetChanged` anchors the tooltip beside the target slot (flips left near the screen edge, clamps Y). Hover tooltips are suppressed while dragging, and an `Update()` safety net removes the preview whenever no drag is active.
- **`EquipPreviewTooltip`**: accepts a null equipped gear (empty slot) as a zero baseline, so first-time equips show all bonuses as green gains. `HasChanges()` now gates display, so identical gear shows nothing instead of an empty box.

Side improvements that fall out of comparing against the actual target slot:
- Accessories now get a Changes preview (dragging onto Accessory1 vs Accessory2 is unambiguous).
- Weapons dragged onto WeaponShield2 compare against slot 2's item instead of always slot 1.

## Testing

- `dotnet build` clean, `dotnet test`: 1597 passed / 0 failed (baseline holds).
- Vault/shortcut/crystal drags are structurally unaffected (they never route through `InventoryGrid.HandleSlotDragMoved`); `SecondChanceShopUI`'s grid has no subscriber to the new event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)