### PR TITLE
Make stronger versions of gear more practical (#341)

### DIFF
--- a/PitHero.Tests/GearTierScalingTests.cs
+++ b/PitHero.Tests/GearTierScalingTests.cs
@@ -177,6 +177,124 @@ namespace PitHero.Tests
                 "Stat delta for depthDelta=25, Normal rarity should be 5 (25/5 = 5)");
         }
 
+        // ── Issue #341: only base stats scale, plus one minimal kind-based bonus ──────
+
+        private static Gear MakeKindGear(ItemKind kind, int atk = 0, int def = 0)
+        {
+            var stats = new StatBlock(0, 0, 0, 0);
+            return new Gear("TestGear", kind, ItemRarity.Normal, "TestDesc", 100, in stats, atk: atk, def: def);
+        }
+
+        [TestMethod]
+        public void CreateTierScaledCopy_AttackOnlyWeapon_ZeroStatsStayZero()
+        {
+            // A plain atk-only sword must not gain defense or across-the-board stats.
+            var gear = MakeKindGear(ItemKind.WeaponSword, atk: 10);
+            var scaled = Gear.CreateTierScaledCopy(gear, 2, 25);
+
+            Assert.AreEqual(22, scaled.AttackBonus, "atk 10 + delta 12 = 22");
+            Assert.AreEqual(0, scaled.DefenseBonus, "Zero base defense must stay zero");
+            Assert.AreEqual(0, scaled.StatBonus.Agility, "Zero base AGI must stay zero");
+            Assert.AreEqual(0, scaled.StatBonus.Vitality, "Zero base VIT must stay zero");
+            Assert.AreEqual(0, scaled.StatBonus.Magic, "Zero base MAG must stay zero");
+            Assert.AreEqual(0, scaled.HPBonus, "Zero base HP must stay zero");
+            Assert.AreEqual(0, scaled.MPBonus, "Zero base MP must stay zero");
+        }
+
+        [TestMethod]
+        public void CreateTierScaledCopy_DefenseOnlyArmor_NoAttackCreated()
+        {
+            var gear = MakeKindGear(ItemKind.ArmorMail, def: 5);
+            var scaled = Gear.CreateTierScaledCopy(gear, 2, 25);
+
+            Assert.AreEqual(0, scaled.AttackBonus, "Zero base attack must stay zero");
+            Assert.AreEqual(13, scaled.DefenseBonus, "def 5 + delta 8 = 13");
+        }
+
+        [TestMethod]
+        public void CreateTierScaledCopy_NonzeroStatsScale()
+        {
+            // MakeBaseGear: sword with STR 2, AGI 1, VIT 1, MAG 0. statDelta = 5, sword bonus stat = STR (+1).
+            var gear = MakeBaseGear();
+            var scaled = Gear.CreateTierScaledCopy(gear, 2, 25);
+
+            Assert.AreEqual(8, scaled.StatBonus.Strength, "STR 2 + statDelta 5 + kind bonus 1 = 8");
+            Assert.AreEqual(6, scaled.StatBonus.Agility, "AGI 1 + statDelta 5 = 6");
+            Assert.AreEqual(6, scaled.StatBonus.Vitality, "VIT 1 + statDelta 5 = 6");
+            Assert.AreEqual(0, scaled.StatBonus.Magic, "Zero base MAG must stay zero");
+        }
+
+        [TestMethod]
+        public void CreateTierScaledCopy_KindBonusStat_Sword_IsStrength()
+        {
+            var scaled = Gear.CreateTierScaledCopy(MakeKindGear(ItemKind.WeaponSword, atk: 10), 2, 25);
+            Assert.AreEqual(1, scaled.StatBonus.Strength, "Sword bonus stat is STR: max(1, 5/5) = 1");
+        }
+
+        [TestMethod]
+        public void CreateTierScaledCopy_KindBonusStat_Rod_IsMagic()
+        {
+            var scaled = Gear.CreateTierScaledCopy(MakeKindGear(ItemKind.WeaponRod, atk: 10), 2, 25);
+            Assert.AreEqual(1, scaled.StatBonus.Magic);
+            Assert.AreEqual(0, scaled.StatBonus.Strength);
+        }
+
+        [TestMethod]
+        public void CreateTierScaledCopy_KindBonusStat_Bow_IsAgility()
+        {
+            var scaled = Gear.CreateTierScaledCopy(MakeKindGear(ItemKind.WeaponBow, atk: 10), 2, 25);
+            Assert.AreEqual(1, scaled.StatBonus.Agility);
+        }
+
+        [TestMethod]
+        public void CreateTierScaledCopy_KindBonusStat_Mail_IsVitality()
+        {
+            var scaled = Gear.CreateTierScaledCopy(MakeKindGear(ItemKind.ArmorMail, def: 5), 2, 25);
+            Assert.AreEqual(1, scaled.StatBonus.Vitality);
+        }
+
+        [TestMethod]
+        public void CreateTierScaledCopy_KindBonusStat_Accessory_IsAgility()
+        {
+            var scaled = Gear.CreateTierScaledCopy(MakeKindGear(ItemKind.Accessory), 2, 25);
+            Assert.AreEqual(1, scaled.StatBonus.Agility);
+        }
+
+        [TestMethod]
+        public void CreateTierScaledCopy_HigherRarity_BonusStatScalesMinimally()
+        {
+            // Legendary statDelta @ 25 = (25/5)*3.5 = 17 → bonus = max(1, 17/5) = 3.
+            var stats = new StatBlock(0, 0, 0, 0);
+            var gear = new Gear("TestGear", ItemKind.WeaponSword, ItemRarity.Legendary, "TestDesc", 100, in stats, atk: 10);
+            var scaled = Gear.CreateTierScaledCopy(gear, 2, 25);
+            Assert.AreEqual(3, scaled.StatBonus.Strength);
+        }
+
+        [TestMethod]
+        public void CreateTierScaledCopy_SaveLoadRoundTrip_ProducesIdenticalStats()
+        {
+            // Save serializes only "BaseName+N"; load rebuilds via ItemRegistry. Stats must match
+            // what the chest originally produced, so scaling must be deterministic.
+            Assert.IsTrue(ItemRegistry.TryCreateItem("Inv_RustyBlade_Name", out var baseItem));
+            var baseGear = (Gear)baseItem;
+
+            ItemRegistry.TierDepthStride = BiomeProgressionConfig.MaxBiomeLevel;
+            int depthDelta = 1 * ItemRegistry.TierDepthStride;
+            var direct = Gear.CreateTierScaledCopy(baseGear, 2, depthDelta);
+
+            Assert.IsTrue(ItemRegistry.TryCreateItem(baseGear.Name + "+2", out var loadedItem));
+            var loaded = (Gear)loadedItem;
+
+            Assert.AreEqual(direct.AttackBonus, loaded.AttackBonus);
+            Assert.AreEqual(direct.DefenseBonus, loaded.DefenseBonus);
+            Assert.AreEqual(direct.StatBonus.Strength, loaded.StatBonus.Strength);
+            Assert.AreEqual(direct.StatBonus.Agility, loaded.StatBonus.Agility);
+            Assert.AreEqual(direct.StatBonus.Vitality, loaded.StatBonus.Vitality);
+            Assert.AreEqual(direct.StatBonus.Magic, loaded.StatBonus.Magic);
+            Assert.AreEqual(direct.HPBonus, loaded.HPBonus);
+            Assert.AreEqual(direct.MPBonus, loaded.MPBonus);
+        }
+
         // ── ItemRegistry "+N" round-trip ─────────────────────────────────────────────
 
         [TestMethod]

--- a/PitHero/RolePlayingFramework/Equipment/Gear.cs
+++ b/PitHero/RolePlayingFramework/Equipment/Gear.cs
@@ -160,11 +160,25 @@ namespace RolePlayingFramework.Equipment
             int defDelta  = BalanceConfig.CalculateEquipmentDefenseBonusDelta(depthDelta, source.Rarity);
             int statDelta = BalanceConfig.CalculateEquipmentStatBonusDelta(depthDelta, source.Rarity);
 
-            var scaledStats = new StatBlock(
-                source.StatBonus.Strength  + statDelta,
-                source.StatBonus.Agility   + statDelta,
-                source.StatBonus.Vitality  + statDelta,
-                source.StatBonus.Magic     + statDelta);
+            // Only stats the base item actually has get scaled (issue #341) — a +N copy is a
+            // stronger version of the same item, not an everything-boosted one. Save/load
+            // reconstructs +N gear from its name alone, so this must stay deterministic.
+            int str = source.StatBonus.Strength > 0 ? source.StatBonus.Strength + statDelta : 0;
+            int agi = source.StatBonus.Agility  > 0 ? source.StatBonus.Agility  + statDelta : 0;
+            int vit = source.StatBonus.Vitality > 0 ? source.StatBonus.Vitality + statDelta : 0;
+            int mag = source.StatBonus.Magic    > 0 ? source.StatBonus.Magic    + statDelta : 0;
+
+            // One small kind-based bonus stat; everything-boosting is reserved for special gear.
+            int bonus = System.Math.Max(1, statDelta / 5);
+            switch (GetTierBonusStat(source.Kind))
+            {
+                case BalanceConfig.StatType.Strength: str += bonus; break;
+                case BalanceConfig.StatType.Agility:  agi += bonus; break;
+                case BalanceConfig.StatType.Vitality: vit += bonus; break;
+                case BalanceConfig.StatType.Magic:    mag += bonus; break;
+            }
+
+            var scaledStats = new StatBlock(str, agi, vit, mag);
 
             // HP/MP: no dedicated delta formula — scale linearly with tier.
             return new Gear(
@@ -174,13 +188,38 @@ namespace RolePlayingFramework.Equipment
                 source._descKey,
                 source.Price * tier,
                 in scaledStats,
-                atk:          source.AttackBonus  + atkDelta,
-                def:          source.DefenseBonus + defDelta,
+                atk:          source.AttackBonus  > 0 ? source.AttackBonus  + atkDelta : 0,
+                def:          source.DefenseBonus > 0 ? source.DefenseBonus + defDelta : 0,
                 hp:           source.HPBonus  * tier,
                 mp:           source.MPBonus  * tier,
                 elementalProps: source.ElementalProps,
                 allowedJobs:  source.AllowedJobs,
                 tier:         tier);
+        }
+
+        /// <summary>The single stat a +N tier-scaled copy receives a minimal bonus to, chosen by gear kind.</summary>
+        public static BalanceConfig.StatType? GetTierBonusStat(ItemKind kind)
+        {
+            switch (kind)
+            {
+                case ItemKind.WeaponSword:
+                case ItemKind.WeaponKnuckle:
+                case ItemKind.WeaponHammer: return BalanceConfig.StatType.Strength;
+                case ItemKind.WeaponKnife:
+                case ItemKind.WeaponBow:
+                case ItemKind.Accessory: return BalanceConfig.StatType.Agility;
+                case ItemKind.WeaponStaff:
+                case ItemKind.WeaponRod: return BalanceConfig.StatType.Magic;
+                case ItemKind.ArmorMail:
+                case ItemKind.ArmorGi:
+                case ItemKind.ArmorRobe:
+                case ItemKind.HatHelm:
+                case ItemKind.HatHeadband:
+                case ItemKind.HatWizard:
+                case ItemKind.HatPriest:
+                case ItemKind.Shield: return BalanceConfig.StatType.Vitality;
+                default: return null;
+            }
         }
 
         /// <summary>Returns the default allowed jobs for a given ItemKind.</summary>

--- a/PitHero/docs/EquipmentLibrary.md
+++ b/PitHero/docs/EquipmentLibrary.md
@@ -36,6 +36,26 @@ Equipment Name
 - Epic: 2.5x
 - Legendary: 3.5x
 
+### Tier Scaling (+N Gear)
+
+Gear found in subsequent dungeon cycles (pit tier 2+) is a scaled copy of a base item with a "+N" name suffix, produced by `Gear.CreateTierScaledCopy` with `depthDelta = (tier - 1) × MaxBiomeLevel`. A +N item is a stronger version of the *same* item — only stats the base item actually has are scaled (issue #341):
+
+- **Attack / Defense:** if nonzero on the base, add `CalculateEquipmentAttackBonusDelta` / `CalculateEquipmentDefenseBonusDelta` (same depth formulas as above, using depthDelta). Zero stays zero.
+- **STR/AGI/VIT/MAG:** per-stat — nonzero base stats gain `CalculateEquipmentStatBonusDelta`; zero stats stay zero.
+- **HP/MP:** multiplied by tier (zero stays zero).
+- **Price:** multiplied by tier. Rarity, element, allowed jobs, and sprite are unchanged.
+
+**Kind-based bonus stat:** each +N copy additionally gains `max(1, statDelta / 5)` (e.g., +1 at tier 2 Normal, +3 at tier 2 Legendary) in exactly one stat chosen by gear kind:
+
+| Gear kind | Bonus stat |
+|---|---|
+| Sword, Knuckle, Hammer | Strength |
+| Knife, Bow, Accessory | Agility |
+| Staff, Rod | Magic |
+| Mail, Gi, Robe, Helm, Headband, Wizard Hat, Priest Hat, Shield | Vitality |
+
+Scaling is fully deterministic — saves store only the "+N" name and `ItemRegistry` reconstructs identical stats on load. Gear that boosts all stats across the board is reserved for future special items.
+
 ### Spawn Window System
 
 Equipment spawns using a sliding window system:


### PR DESCRIPTION
Fixes #341.

## Problem

"+N" tier-scaled gear (subsequent dungeon cycles) gained attack, defense, and all four stats (STR/AGI/VIT/MAG) unconditionally in `Gear.CreateTierScaledCopy`. A `RustyBlade` (atk 1, everything else 0) became `RustyBlade+2` with atk 13, def 8, and 5 in every stat — a strictly-better-at-everything item, which is not intended. Only future special gear should boost all stats.

## Fix

`CreateTierScaledCopy` now:

- **Gates each delta on the base item having that stat** — attack/defense/per-stat deltas apply only where the base value is nonzero; zero stays zero. HP/MP already behaved this way (`* tier`) and are unchanged.
- **Adds one minimal kind-based bonus stat**: `max(1, statDelta / 5)` (+1 at tier 2 Normal, +3 at tier 2 Legendary) to a single stat chosen deterministically by `ItemKind` — Sword/Knuckle/Hammer → STR, Knife/Bow/Accessory → AGI, Staff/Rod → MAG, all armor/hats/shields → VIT.

Scaling stays fully deterministic, so `ItemRegistry`'s "+N" name reconstruction on save/load produces identical stats. `RustyBlade+2` (Normal) is now atk 13, STR +1, everything else 0.

Also added a "Tier Scaling (+N Gear)" section to `PitHero/docs/EquipmentLibrary.md`.

## Tests

New tests in `GearTierScalingTests.cs`: zero-stats-stay-zero (weapon and armor), nonzero-stat scaling, kind-based bonus mapping (sword/rod/bow/mail/accessory), Legendary bonus magnitude, and a save/load round-trip determinism guard. Full suite: **1607 passed, 0 failed** (baseline is 0 pre-existing failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)