### PR TITLE
Auto-Sell Excess Items: free bag space on full-bag chest pickup

### DIFF
--- a/PitHero.Tests/AutoSellExcessItemsTests.cs
+++ b/PitHero.Tests/AutoSellExcessItemsTests.cs
@@ -90,6 +90,43 @@ namespace PitHero.Tests
         }
 
         [TestMethod]
+        public void Selector_GearFirst_SellsGearBeforeConsumable()
+        {
+            var bag = new ItemBag("Test", 2);
+            bag.SetSlotItem(0, new TestPotion("WeakPotion", 5, 10));
+            bag.SetSlotItem(1, MakeGear("Shield", ItemKind.Shield, 10));
+
+            var selection = ExcessItemSellSelector.Select(bag, MakeGear("NewSword", ItemKind.WeaponSword, 20), null, null, consumablesFirst: false);
+
+            Assert.AreEqual(1, selection.BagIndex, "With gear priority the weakest gear sells even when a weaker consumable exists");
+        }
+
+        [TestMethod]
+        public void Selector_GearFirst_FallsBackToConsumableWhenNoSellableGear()
+        {
+            var bag = new ItemBag("Test", 2);
+            bag.SetSlotItem(0, new TestPotion("Potion", 20, 30));
+            bag.SetSlotItem(1, MakeGear("Legendary", ItemKind.WeaponSword, 5, ItemRarity.Legendary));
+
+            var selection = ExcessItemSellSelector.Select(bag, new TestPotion("StrongPotion", 30, 250),
+                null, r => r != ItemRarity.Legendary, consumablesFirst: false);
+
+            Assert.AreEqual(0, selection.BagIndex, "With no sellable gear the weakest consumable is the fallback");
+        }
+
+        [TestMethod]
+        public void Selector_GearFirst_IncomingWeakestGear_SellsIncoming()
+        {
+            var bag = new ItemBag("Test", 2);
+            bag.SetSlotItem(0, new TestPotion("Potion", 20, 30));
+            bag.SetSlotItem(1, MakeGear("GoodSword", ItemKind.WeaponSword, 30));
+
+            var selection = ExcessItemSellSelector.Select(bag, MakeGear("Junk", ItemKind.Shield, 1), null, null, consumablesFirst: false);
+
+            Assert.IsTrue(selection.SellIncoming, "Incoming junk gear is the weakest gear and sells directly");
+        }
+
+        [TestMethod]
         public void Selector_RarityFilterExcludesGear()
         {
             var bag = new ItemBag("Test", 2);
@@ -224,6 +261,7 @@ namespace PitHero.Tests
         {
             Assert.IsTrue(new AutoSellExcessItemsService().Enabled);
             var svc = new AutoSellExcessItemsService();
+            Assert.IsTrue(svc.ConsumablesFirst, "Sell priority should default to consumables-first");
             for (int i = 0; i < svc.RarityAllowed.Length; i++)
                 Assert.IsTrue(svc.RarityAllowed[i], $"Rarity {i} should be allowed by default");
         }
@@ -266,6 +304,22 @@ namespace PitHero.Tests
             Assert.AreEqual(AutoSellOutcome.SoldBagItem, outcome);
             Assert.IsNull(bag.GetSlotItem(1), "The weakest gear should have been sold");
             Assert.IsTrue(bag.TryAdd(incoming), "A slot must now be free for the incoming item");
+        }
+
+        [TestMethod]
+        public void Service_GearFirst_SellsWeakestGearOverConsumable()
+        {
+            var svc = new AutoSellExcessItemsService { ConsumablesFirst = false };
+            var bag = new ItemBag("Test", 2);
+            bag.SetSlotItem(0, new TestPotion("WeakPotion", 5, 10));
+            bag.SetSlotItem(1, MakeGear("JunkShield", ItemKind.Shield, 2));
+            var incoming = MakeGear("NewArmor", ItemKind.ArmorMail, 20);
+
+            var outcome = svc.TryMakeRoom(bag, incoming);
+
+            Assert.AreEqual(AutoSellOutcome.SoldBagItem, outcome);
+            Assert.IsNull(bag.GetSlotItem(1), "With gear priority the junk shield sells, not the potion");
+            Assert.IsNotNull(bag.GetSlotItem(0), "The consumable must be untouched");
         }
 
         [TestMethod]
@@ -323,6 +377,24 @@ namespace PitHero.Tests
 
             Assert.AreEqual(1, runner.ItemsAutoSold);
             Assert.IsTrue(runner.AutoSellGold > 0, "Gold from the sold junk shield should be credited");
+            Assert.AreEqual(2, bag.Count, "Junk shield sold, new armor collected");
+        }
+
+        [TestMethod]
+        public void VirtualRunner_GearFirst_SellsGearBeforeConsumable()
+        {
+            var (runner, bag) = CreateVirtualRunner(2);
+            runner.AutoSellExcessItems = true;
+            runner.AutoSellConsumablesFirst = false;
+            runner.AutoEquipHero = false;
+            runner.AutoEquipMercenaries = false;
+            bag.SetSlotItem(0, new TestPotion("WeakPotion", 5, 10));
+            bag.SetSlotItem(1, MakeGear("JunkShield", ItemKind.Shield, 2));
+
+            runner.CollectChestItem(MakeGear("NewArmor", ItemKind.ArmorMail, 20));
+
+            Assert.AreEqual(1, runner.ItemsAutoSold);
+            Assert.IsNotNull(bag.GetSlotItem(0), "The consumable must survive under gear-first priority");
             Assert.AreEqual(2, bag.Count, "Junk shield sold, new armor collected");
         }
 

--- a/PitHero.Tests/AutoSellExcessItemsTests.cs
+++ b/PitHero.Tests/AutoSellExcessItemsTests.cs
@@ -1,0 +1,342 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Services;
+using PitHero.VirtualGame;
+using RolePlayingFramework.Equipment;
+using RolePlayingFramework.Heroes;
+using RolePlayingFramework.Inventory;
+using RolePlayingFramework.Jobs.Primary;
+using RolePlayingFramework.Mercenaries;
+using RolePlayingFramework.Stats;
+using System.Collections.Generic;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Tests for auto-selling excess items on full-bag chest pickup:
+    /// ExcessItemSellSelector selection rules, the ItemBag full-bag stacking fix,
+    /// and AutoSellExcessItemsService behavior.
+    /// </summary>
+    [TestClass]
+    public class AutoSellExcessItemsTests
+    {
+        private sealed class TestPotion : Consumable
+        {
+            private readonly int _hp;
+            private readonly int _mp;
+            public TestPotion(string name, int price, int hp, int mp = 0, ItemRarity rarity = ItemRarity.Normal)
+                : base(name, rarity, "desc", price, hp, mp)
+            {
+                _hp = hp;
+                _mp = mp;
+            }
+            public override Consumable CreateFreshInstance() => new TestPotion(Name, Price, _hp, _mp, Rarity);
+        }
+
+        private static Gear MakeGear(string name, ItemKind kind, int score, ItemRarity rarity = ItemRarity.Normal, int price = 100)
+            => new Gear(name, kind, rarity, "desc", price, new StatBlock(0, 0, 0, 0), atk: score);
+
+        // ── ExcessItemSellSelector ────────────────────────────────────────────────
+
+        [TestMethod]
+        public void Selector_ConsumableSoldBeforeGear()
+        {
+            var bag = new ItemBag("Test", 2);
+            bag.SetSlotItem(0, MakeGear("JunkShield", ItemKind.Shield, 1));
+            bag.SetSlotItem(1, new TestPotion("Potion", 20, 30));
+
+            var selection = ExcessItemSellSelector.Select(bag, MakeGear("NewSword", ItemKind.WeaponSword, 10), null, null);
+
+            Assert.IsTrue(selection.HasSelection);
+            Assert.IsFalse(selection.SellIncoming);
+            Assert.AreEqual(1, selection.BagIndex, "The consumable should sell before even weaker gear");
+        }
+
+        [TestMethod]
+        public void Selector_WeakestConsumableByRestoreEffect()
+        {
+            var bag = new ItemBag("Test", 3);
+            bag.SetSlotItem(0, new TestPotion("MidPotion", 10, 100));
+            bag.SetSlotItem(1, new TestPotion("WeakPotion", 50, 30));   // pricier but weakest effect
+            bag.SetSlotItem(2, new TestPotion("StrongPotion", 5, 250));
+
+            var selection = ExcessItemSellSelector.Select(bag, MakeGear("New", ItemKind.WeaponSword, 10), null, null);
+
+            Assert.AreEqual(1, selection.BagIndex, "Weakest restore effect wins regardless of price");
+        }
+
+        [TestMethod]
+        public void Selector_ZeroEffectConsumableSortsFirst()
+        {
+            var bag = new ItemBag("Test", 2);
+            bag.SetSlotItem(0, new TestPotion("Potion", 20, 30));
+            bag.SetSlotItem(1, new TestPotion("BattleBuff", 100, 0, 0));
+
+            var selection = ExcessItemSellSelector.Select(bag, MakeGear("New", ItemKind.WeaponSword, 10), null, null);
+
+            Assert.AreEqual(1, selection.BagIndex);
+        }
+
+        [TestMethod]
+        public void Selector_GearComparedAcrossAllTypes()
+        {
+            // A lone strong sword must not sell before a junk shield of a different type.
+            var bag = new ItemBag("Test", 2);
+            bag.SetSlotItem(0, MakeGear("LegendarySword", ItemKind.WeaponSword, 50, ItemRarity.Legendary));
+            bag.SetSlotItem(1, MakeGear("JunkShield", ItemKind.Shield, 2));
+
+            var selection = ExcessItemSellSelector.Select(bag, MakeGear("NewArmor", ItemKind.ArmorMail, 20), null, null);
+
+            Assert.AreEqual(1, selection.BagIndex, "Weakest gear across ALL types should be chosen");
+        }
+
+        [TestMethod]
+        public void Selector_RarityFilterExcludesGear()
+        {
+            var bag = new ItemBag("Test", 2);
+            bag.SetSlotItem(0, MakeGear("LegendaryDagger", ItemKind.WeaponKnife, 1, ItemRarity.Legendary));
+            bag.SetSlotItem(1, MakeGear("NormalHelm", ItemKind.HatHelm, 5, ItemRarity.Normal));
+
+            var selection = ExcessItemSellSelector.Select(bag, MakeGear("New", ItemKind.WeaponSword, 10, ItemRarity.Normal),
+                null, r => r != ItemRarity.Legendary);
+
+            Assert.AreEqual(1, selection.BagIndex, "Legendary gear is filtered out even when weakest");
+        }
+
+        [TestMethod]
+        public void Selector_RarityFilterNeverAppliesToConsumables()
+        {
+            var bag = new ItemBag("Test", 1);
+            bag.SetSlotItem(0, new TestPotion("RarePotion", 20, 30, 0, ItemRarity.Rare));
+
+            var selection = ExcessItemSellSelector.Select(bag, MakeGear("New", ItemKind.WeaponSword, 10),
+                null, r => r == ItemRarity.Normal);
+
+            Assert.AreEqual(0, selection.BagIndex, "Consumables are never rarity-filtered");
+        }
+
+        [TestMethod]
+        public void Selector_ProtectedItemsAreSkipped()
+        {
+            var bag = new ItemBag("Test", 2);
+            bag.SetSlotItem(0, MakeGear("WeakButProtected", ItemKind.Shield, 1));
+            bag.SetSlotItem(1, MakeGear("Stronger", ItemKind.WeaponSword, 10));
+
+            var selection = ExcessItemSellSelector.Select(bag, MakeGear("New", ItemKind.WeaponSword, 20),
+                idx => idx == 0, null);
+
+            Assert.AreEqual(1, selection.BagIndex, "Synergy/stencil-protected items must never be selected");
+        }
+
+        [TestMethod]
+        public void Selector_AllProtected_SellsIncomingWhenAllowed()
+        {
+            var bag = new ItemBag("Test", 2);
+            bag.SetSlotItem(0, MakeGear("A", ItemKind.Shield, 1));
+            bag.SetSlotItem(1, MakeGear("B", ItemKind.WeaponSword, 10));
+
+            var selection = ExcessItemSellSelector.Select(bag, MakeGear("New", ItemKind.WeaponSword, 20),
+                idx => true, null);
+
+            Assert.IsTrue(selection.SellIncoming, "With every bag item protected, the incoming item is the only candidate");
+        }
+
+        [TestMethod]
+        public void Selector_AllProtectedAndIncomingDisallowed_ReturnsNone()
+        {
+            var bag = new ItemBag("Test", 1);
+            bag.SetSlotItem(0, MakeGear("A", ItemKind.Shield, 1));
+
+            var selection = ExcessItemSellSelector.Select(bag, MakeGear("New", ItemKind.WeaponSword, 20, ItemRarity.Legendary),
+                idx => true, r => r != ItemRarity.Legendary);
+
+            Assert.IsFalse(selection.HasSelection);
+        }
+
+        [TestMethod]
+        public void Selector_IncomingWeakestGear_SellsIncoming()
+        {
+            var bag = new ItemBag("Test", 2);
+            bag.SetSlotItem(0, MakeGear("GoodSword", ItemKind.WeaponSword, 30));
+            bag.SetSlotItem(1, MakeGear("GoodShield", ItemKind.Shield, 20));
+
+            var selection = ExcessItemSellSelector.Select(bag, MakeGear("JunkSword", ItemKind.WeaponSword, 2), null, null);
+
+            Assert.IsTrue(selection.SellIncoming, "Junk loot must not displace better gear");
+        }
+
+        [TestMethod]
+        public void Selector_IncomingWeakestConsumable_SellsIncoming()
+        {
+            var bag = new ItemBag("Test", 1);
+            bag.SetSlotItem(0, new TestPotion("StrongPotion", 50, 200));
+
+            var selection = ExcessItemSellSelector.Select(bag, new TestPotion("WeakPotion", 10, 20), null, null);
+
+            Assert.IsTrue(selection.SellIncoming);
+        }
+
+        [TestMethod]
+        public void Selector_Tie_PrefersBagItemOverIncoming()
+        {
+            var bag = new ItemBag("Test", 1);
+            bag.SetSlotItem(0, MakeGear("Sword", ItemKind.WeaponSword, 5));
+
+            var selection = ExcessItemSellSelector.Select(bag, MakeGear("Sword", ItemKind.WeaponSword, 5), null, null);
+
+            Assert.IsFalse(selection.SellIncoming, "On an exact tie the bag item sells and the new item is kept");
+            Assert.AreEqual(0, selection.BagIndex);
+        }
+
+        // ── ItemBag full-bag stacking fix ─────────────────────────────────────────
+
+        [TestMethod]
+        public void ItemBag_TryAdd_StacksIntoPartialStackWhenFull()
+        {
+            var bag = new ItemBag("Test", 2);
+            var stack = new TestPotion("Potion", 20, 30);
+            stack.StackCount = 3;
+            bag.SetSlotItem(0, stack);
+            bag.SetSlotItem(1, MakeGear("Sword", ItemKind.WeaponSword, 5));
+            Assert.IsTrue(bag.IsFull);
+
+            bool added = bag.TryAdd(new TestPotion("Potion", 20, 30));
+
+            Assert.IsTrue(added, "A stackable consumable needs no empty slot and must be accepted on a full bag");
+            Assert.AreEqual(4, stack.StackCount);
+            Assert.AreEqual(2, bag.Count);
+        }
+
+        // ── AutoSellExcessItemsService (headless: no grid, no vault/funds) ────────
+
+        [TestMethod]
+        public void Service_Disabled_ReturnsNone()
+        {
+            var svc = new AutoSellExcessItemsService { Enabled = false };
+            var bag = new ItemBag("Test", 1);
+            bag.SetSlotItem(0, MakeGear("Sword", ItemKind.WeaponSword, 5));
+
+            Assert.AreEqual(AutoSellOutcome.None, svc.TryMakeRoom(bag, MakeGear("New", ItemKind.Shield, 1)));
+            Assert.IsNotNull(bag.GetSlotItem(0), "Nothing may be sold while disabled");
+        }
+
+        [TestMethod]
+        public void Service_EnabledByDefault()
+        {
+            Assert.IsTrue(new AutoSellExcessItemsService().Enabled);
+            var svc = new AutoSellExcessItemsService();
+            for (int i = 0; i < svc.RarityAllowed.Length; i++)
+                Assert.IsTrue(svc.RarityAllowed[i], $"Rarity {i} should be allowed by default");
+        }
+
+        [TestMethod]
+        public void Service_BagNotFull_ReturnsNone()
+        {
+            var svc = new AutoSellExcessItemsService();
+            var bag = new ItemBag("Test", 2);
+            bag.SetSlotItem(0, MakeGear("Sword", ItemKind.WeaponSword, 5));
+
+            Assert.AreEqual(AutoSellOutcome.None, svc.TryMakeRoom(bag, MakeGear("New", ItemKind.Shield, 1)));
+        }
+
+        [TestMethod]
+        public void Service_StackablePickup_ReturnsNoneWithoutSelling()
+        {
+            var svc = new AutoSellExcessItemsService();
+            var bag = new ItemBag("Test", 2);
+            var stack = new TestPotion("Potion", 20, 30);
+            stack.StackCount = 2;
+            bag.SetSlotItem(0, stack);
+            bag.SetSlotItem(1, MakeGear("Sword", ItemKind.WeaponSword, 5));
+
+            Assert.AreEqual(AutoSellOutcome.None, svc.TryMakeRoom(bag, new TestPotion("Potion", 20, 30)));
+            Assert.AreEqual(2, bag.Count, "No sale should happen for a stackable pickup");
+        }
+
+        [TestMethod]
+        public void Service_SellsWeakestBagItemAndFreesSlot()
+        {
+            var svc = new AutoSellExcessItemsService();
+            var bag = new ItemBag("Test", 2);
+            bag.SetSlotItem(0, MakeGear("GoodSword", ItemKind.WeaponSword, 30));
+            bag.SetSlotItem(1, MakeGear("JunkShield", ItemKind.Shield, 2));
+            var incoming = MakeGear("NewArmor", ItemKind.ArmorMail, 20);
+
+            var outcome = svc.TryMakeRoom(bag, incoming);
+
+            Assert.AreEqual(AutoSellOutcome.SoldBagItem, outcome);
+            Assert.IsNull(bag.GetSlotItem(1), "The weakest gear should have been sold");
+            Assert.IsTrue(bag.TryAdd(incoming), "A slot must now be free for the incoming item");
+        }
+
+        [TestMethod]
+        public void Service_IncomingWeakest_SoldIncoming()
+        {
+            var svc = new AutoSellExcessItemsService();
+            var bag = new ItemBag("Test", 1);
+            bag.SetSlotItem(0, MakeGear("GoodSword", ItemKind.WeaponSword, 30));
+
+            var outcome = svc.TryMakeRoom(bag, MakeGear("Junk", ItemKind.WeaponSword, 1));
+
+            Assert.AreEqual(AutoSellOutcome.SoldIncoming, outcome);
+            Assert.IsNotNull(bag.GetSlotItem(0), "The bag item must be untouched when the incoming item sells");
+        }
+
+        // ── Virtual layer (VirtualBattleRunner.CollectChestItem) ──────────────────
+
+        private static (VirtualBattleRunner runner, ItemBag bag) CreateVirtualRunner(int bagCapacity)
+        {
+            var world = new VirtualWorldState();
+            world.RegeneratePit(1);
+            var hero = new Hero("TestHero", new Knight(), 10, new StatBlock(12, 10, 12, 5));
+            var bag = new ItemBag("Test", bagCapacity);
+            var runner = new VirtualBattleRunner(world, new VirtualBattlePartyView(hero, bag));
+            runner.SetHeroAlly(hero);
+            runner.SetMercenaries(new List<Mercenary>(0));
+            return (runner, bag);
+        }
+
+        [TestMethod]
+        public void VirtualRunner_AutoSellOff_PreservesBaselineFullBagBehavior()
+        {
+            var (runner, bag) = CreateVirtualRunner(1);
+            bag.SetSlotItem(0, MakeGear("Sword", ItemKind.WeaponSword, 30));
+
+            runner.CollectChestItem(MakeGear("NewShield", ItemKind.Shield, 1));
+
+            Assert.AreEqual(0, runner.ItemsAutoSold, "Auto-sell must stay inert while off (balance baseline)");
+            Assert.AreEqual(0, runner.AutoSellGold);
+            Assert.AreEqual(1, bag.Count, "Item is dropped on a full bag, as before");
+        }
+
+        [TestMethod]
+        public void VirtualRunner_AutoSellOn_SellsWeakestAndCollects()
+        {
+            var (runner, bag) = CreateVirtualRunner(2);
+            runner.AutoSellExcessItems = true;
+            runner.AutoEquipHero = false;        // keep the collected item in the bag so the count is observable
+            runner.AutoEquipMercenaries = false;
+            bag.SetSlotItem(0, MakeGear("GoodSword", ItemKind.WeaponSword, 30));
+            bag.SetSlotItem(1, MakeGear("JunkShield", ItemKind.Shield, 2));
+            var incoming = MakeGear("NewArmor", ItemKind.ArmorMail, 20);
+
+            runner.CollectChestItem(incoming);
+
+            Assert.AreEqual(1, runner.ItemsAutoSold);
+            Assert.IsTrue(runner.AutoSellGold > 0, "Gold from the sold junk shield should be credited");
+            Assert.AreEqual(2, bag.Count, "Junk shield sold, new armor collected");
+        }
+
+        [TestMethod]
+        public void Service_RarityDisallowed_ProtectsGear()
+        {
+            var svc = new AutoSellExcessItemsService();
+            svc.RarityAllowed[(int)ItemRarity.Legendary] = false;
+            var bag = new ItemBag("Test", 1);
+            bag.SetSlotItem(0, MakeGear("Legendary", ItemKind.WeaponSword, 1, ItemRarity.Legendary));
+
+            var outcome = svc.TryMakeRoom(bag, MakeGear("New", ItemKind.Shield, 50, ItemRarity.Legendary));
+
+            Assert.AreEqual(AutoSellOutcome.None, outcome, "Disallowed rarities may never be auto-sold, incoming included");
+        }
+    }
+}

--- a/PitHero.Tests/SaveLoadTests.cs
+++ b/PitHero.Tests/SaveLoadTests.cs
@@ -630,6 +630,80 @@ namespace PitHero.Tests
         }
 
         /// <summary>
+        /// Verifies that AutoSellExcessItems and AutoSellRarityAllowed (v21) round-trip through
+        /// Persist/Recover with non-default values.
+        /// </summary>
+        [TestMethod]
+        public void SaveData_V21_AutoSellExcessItems_RoundTrip()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "pithero_v21_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var dataStore = new FileDataStore(tempDir);
+
+                var original = new SaveData();
+                original.AutoSellExcessItems = false;               // non-default (defaults to true)
+                original.AutoSellRarityAllowed = new bool[] { true, true, true, false, false };
+
+                dataStore.Save("v21_autosellexcess.bin", original);
+
+                var loaded = new SaveData();
+                dataStore.Load("v21_autosellexcess.bin", loaded);
+
+                Assert.AreEqual(false, loaded.AutoSellExcessItems, "AutoSellExcessItems=false should round-trip");
+                Assert.IsNotNull(loaded.AutoSellRarityAllowed, "RarityAllowed should be recovered");
+                Assert.AreEqual(5, loaded.AutoSellRarityAllowed.Length);
+                Assert.AreEqual(true, loaded.AutoSellRarityAllowed[(int)ItemRarity.Normal]);
+                Assert.AreEqual(false, loaded.AutoSellRarityAllowed[(int)ItemRarity.Epic], "Unchecked Epic should round-trip");
+                Assert.AreEqual(false, loaded.AutoSellRarityAllowed[(int)ItemRarity.Legendary], "Unchecked Legendary should round-trip");
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
+            }
+        }
+
+        /// <summary>
+        /// Verifies the v21 defaults: auto-sell excess items is ON with all rarities allowed,
+        /// including when the saved rarity array is absent (older files / null array writes count 0).
+        /// </summary>
+        [TestMethod]
+        public void SaveData_V21_AutoSellExcessItems_Defaults()
+        {
+            Assert.AreEqual(true, new SaveData().AutoSellExcessItems, "Auto-sell excess items defaults to ON");
+
+            var tempDir = Path.Combine(Path.GetTempPath(), "pithero_v21d_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var dataStore = new FileDataStore(tempDir);
+
+                // Null rarity array persists a zero count; Recover must normalize to all-true.
+                var original = new SaveData();
+                original.AutoSellRarityAllowed = null;
+
+                dataStore.Save("v21_defaults.bin", original);
+
+                var loaded = new SaveData();
+                dataStore.Load("v21_defaults.bin", loaded);
+
+                Assert.AreEqual(true, loaded.AutoSellExcessItems);
+                Assert.IsNotNull(loaded.AutoSellRarityAllowed);
+                for (int i = 0; i < loaded.AutoSellRarityAllowed.Length; i++)
+                    Assert.AreEqual(true, loaded.AutoSellRarityAllowed[i], $"Rarity {i} should default to allowed");
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
+            }
+        }
+
+        /// <summary>
         /// Verifies that AutoSellKeepStacks round-trips through Persist/Recover.
         /// </summary>
         [TestMethod]

--- a/PitHero.Tests/SaveLoadTests.cs
+++ b/PitHero.Tests/SaveLoadTests.cs
@@ -645,6 +645,7 @@ namespace PitHero.Tests
 
                 var original = new SaveData();
                 original.AutoSellExcessItems = false;               // non-default (defaults to true)
+                original.AutoSellConsumablesFirst = false;          // non-default (defaults to true, v22)
                 original.AutoSellRarityAllowed = new bool[] { true, true, true, false, false };
 
                 dataStore.Save("v21_autosellexcess.bin", original);
@@ -653,6 +654,7 @@ namespace PitHero.Tests
                 dataStore.Load("v21_autosellexcess.bin", loaded);
 
                 Assert.AreEqual(false, loaded.AutoSellExcessItems, "AutoSellExcessItems=false should round-trip");
+                Assert.AreEqual(false, loaded.AutoSellConsumablesFirst, "AutoSellConsumablesFirst=false should round-trip");
                 Assert.IsNotNull(loaded.AutoSellRarityAllowed, "RarityAllowed should be recovered");
                 Assert.AreEqual(5, loaded.AutoSellRarityAllowed.Length);
                 Assert.AreEqual(true, loaded.AutoSellRarityAllowed[(int)ItemRarity.Normal]);
@@ -674,6 +676,7 @@ namespace PitHero.Tests
         public void SaveData_V21_AutoSellExcessItems_Defaults()
         {
             Assert.AreEqual(true, new SaveData().AutoSellExcessItems, "Auto-sell excess items defaults to ON");
+            Assert.AreEqual(true, new SaveData().AutoSellConsumablesFirst, "Sell priority defaults to consumables-first");
 
             var tempDir = Path.Combine(Path.GetTempPath(), "pithero_v21d_" + Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(tempDir);
@@ -692,6 +695,7 @@ namespace PitHero.Tests
                 dataStore.Load("v21_defaults.bin", loaded);
 
                 Assert.AreEqual(true, loaded.AutoSellExcessItems);
+                Assert.AreEqual(true, loaded.AutoSellConsumablesFirst, "Sell priority should recover as consumables-first by default");
                 Assert.IsNotNull(loaded.AutoSellRarityAllowed);
                 for (int i = 0; i < loaded.AutoSellRarityAllowed.Length; i++)
                     Assert.AreEqual(true, loaded.AutoSellRarityAllowed[i], $"Rarity {i} should default to allowed");

--- a/PitHero/AI/OpenChestAction.cs
+++ b/PitHero/AI/OpenChestAction.cs
@@ -295,6 +295,18 @@ namespace PitHero.AI
                 Debug.Log($"[OpenChest] Created pickup animation for {containedItem.Name} at position X: {_chestEntity.Transform.Position.X}, Y: {_chestEntity.Transform.Position.Y}");
             }
 
+            // When the bag is full, auto-sell the weakest excess item to make room (if enabled).
+            // SoldIncoming means the new item itself was the weakest and was sold directly.
+            if (hero.Bag != null && hero.Bag.IsFull)
+            {
+                var autoSellSvc = Core.Services.GetService<Services.AutoSellExcessItemsService>();
+                if (autoSellSvc?.TryMakeRoom(hero.Bag, containedItem) == Services.AutoSellOutcome.SoldIncoming)
+                {
+                    treasureComponent.ContainedItem = null;
+                    return;
+                }
+            }
+
             // Try to add item using hero's TryAddItem method (handles consumable priority logic)
             if (hero.TryAddItem(containedItem))
             {
@@ -323,7 +335,13 @@ namespace PitHero.AI
             }
             else
             {
-                Debug.Warn($"[OpenChest] Hero's bags are full! Could not add {containedItem.Name}");
+                // Bag is full and nothing could be sold. The chest is already OPEN and is never
+                // re-targeted, so send the item to the Second Chance vault instead of losing it.
+                Debug.Warn($"[OpenChest] Hero's bags are full! Sending {containedItem.Name} to the Second Chance vault");
+                Core.Services.GetService<PitHero.Services.SecondChanceMerchantVault>()?.AddItem(containedItem);
+                Core.Services.GetService<GameEventService>()?.EmitLocalized(UITextKey.ConsoleItemSentToVault,
+                    (containedItem.Name, RarityUtils.GetRarityColor(containedItem.Rarity)));
+                treasureComponent.ContainedItem = null;
             }
         }
 

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -353,3 +353,14 @@ DishApplePie,Apple Pie
 DishPumpkinCreamSoup,Pumpkin Cream Soup
 DishChilledWatermelonSorbet,Chilled Watermelon Sorbet
 DishHarvestFeastPlatter,Harvest Feast Platter
+SettingsAutoSellExcessItems,Auto-Sell Excess Items
+SettingsAutoSellExcessItemsTooltip,Auto-Sell items to make room for new loot
+SettingsSellRarities,Gear Rarities to Sell
+SettingsSellRaritiesTooltip,Gear of unchecked rarities will never be auto-sold
+RarityNormal,Normal
+RarityUncommon,Uncommon
+RarityRare,Rare
+RarityEpic,Epic
+RarityLegendary,Legendary
+ConsoleAutoSoldItem,Auto-sold {0} for {1}G to make room.
+ConsoleItemSentToVault,Bag full! {0} was sent to the Second Chance shop.

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -355,6 +355,10 @@ DishChilledWatermelonSorbet,Chilled Watermelon Sorbet
 DishHarvestFeastPlatter,Harvest Feast Platter
 SettingsAutoSellExcessItems,Auto-Sell Excess Items
 SettingsAutoSellExcessItemsTooltip,Auto-Sell items to make room for new loot
+SettingsSellPriority,Item Sell Priority
+SettingsSellPriorityTooltip,Items of the top category are sold first to make room
+SellPriorityConsumables,Consumables
+SellPriorityGear,Gear
 SettingsSellRarities,Gear Rarities to Sell
 SettingsSellRaritiesTooltip,Gear of unchecked rarities will never be auto-sold
 RarityNormal,Normal

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -535,6 +535,7 @@ namespace PitHero.ECS.Scenes
             if (autoSellExcessSvc != null)
             {
                 autoSellExcessSvc.Enabled = pendingData.AutoSellExcessItems;
+                autoSellExcessSvc.ConsumablesFirst = pendingData.AutoSellConsumablesFirst;
                 if (pendingData.AutoSellRarityAllowed != null)
                 {
                     int count = pendingData.AutoSellRarityAllowed.Length < autoSellExcessSvc.RarityAllowed.Length

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -211,6 +211,7 @@ namespace PitHero.ECS.Scenes
             Core.Services.RemoveService(typeof(Services.CropGrowthService));
             Core.Services.RemoveService(typeof(Services.AutoSeedPurchaseService));
             Core.Services.RemoveService(typeof(Services.AutoCropSellService));
+            Core.Services.RemoveService(typeof(Services.AutoSellExcessItemsService));
             Core.Services.GetService<Services.FarmTaskCoordinator>()?.Detach();
             Core.Services.RemoveService(typeof(Services.FarmTaskCoordinator));
             Core.Services.RemoveService(typeof(Services.MealBuffService));
@@ -293,6 +294,9 @@ namespace PitHero.ECS.Scenes
                 Core.Services.GetService<Services.CropStorageInventoryService>(),
                 Core.Services.GetService<Services.GameStateService>());
             Core.Services.AddService(autoCropSellService);
+
+            // Auto-sell excess items service frees a bag slot when a chest item arrives and the bag is full
+            Core.Services.AddService(new Services.AutoSellExcessItemsService());
 
             // Meal buff service holds each party member's day-long food buffs (issue #319)
             Core.Services.AddService(new Services.MealBuffService());
@@ -527,6 +531,19 @@ namespace PitHero.ECS.Scenes
             var autoJobSvc = Core.Services.GetService<Services.AutoJobAssignmentService>();
             if (autoJobSvc != null)
                 autoJobSvc.Enabled = pendingData.AutomateMonsterJobs;
+            var autoSellExcessSvc = Core.Services.GetService<Services.AutoSellExcessItemsService>();
+            if (autoSellExcessSvc != null)
+            {
+                autoSellExcessSvc.Enabled = pendingData.AutoSellExcessItems;
+                if (pendingData.AutoSellRarityAllowed != null)
+                {
+                    int count = pendingData.AutoSellRarityAllowed.Length < autoSellExcessSvc.RarityAllowed.Length
+                        ? pendingData.AutoSellRarityAllowed.Length
+                        : autoSellExcessSvc.RarityAllowed.Length;
+                    for (int i = 0; i < count; i++)
+                        autoSellExcessSvc.RarityAllowed[i] = pendingData.AutoSellRarityAllowed[i];
+                }
+            }
             _settingsUI?.SyncAutomationControlsFromService();
 
             // Rebuild the plant queue now that both tile states and crop plans are restored

--- a/PitHero/RolePlayingFramework/Equipment/ExcessItemSellSelector.cs
+++ b/PitHero/RolePlayingFramework/Equipment/ExcessItemSellSelector.cs
@@ -1,0 +1,111 @@
+using System;
+using RolePlayingFramework.Inventory;
+
+namespace RolePlayingFramework.Equipment
+{
+    /// <summary>Result of an excess-item sell selection.</summary>
+    public struct SellSelection
+    {
+        /// <summary>Bag slot index of the item to sell, or -1 when nothing (or the incoming item) was chosen.</summary>
+        public int BagIndex;
+        /// <summary>True when the incoming item itself is the weakest candidate and should be sold directly.</summary>
+        public bool SellIncoming;
+        /// <summary>True when either a bag item or the incoming item was selected.</summary>
+        public bool HasSelection => SellIncoming || BagIndex >= 0;
+
+        public static SellSelection None => new SellSelection { BagIndex = -1 };
+        public static SellSelection Incoming => new SellSelection { BagIndex = -1, SellIncoming = true };
+        public static SellSelection AtIndex(int bagIndex) => new SellSelection { BagIndex = bagIndex };
+    }
+
+    /// <summary>
+    /// Pure selection logic for auto-selling excess items when the bag is full (issue: auto-sell excess items).
+    /// Consumables are always sold before gear; among gear, weakness is compared across ALL gear types at once
+    /// so a lone strong item of one type never sells before a weak item of another. The incoming item participates
+    /// in the comparison so junk loot never displaces better items.
+    /// </summary>
+    public static class ExcessItemSellSelector
+    {
+        /// <summary>Sentinel index representing the incoming (not yet in bag) item.</summary>
+        private const int IncomingIndex = int.MaxValue;
+
+        /// <summary>
+        /// Selects the item to sell to free a bag slot for <paramref name="incoming"/>.
+        /// Step 1: weakest-effect unprotected consumable stack (HP+MP restore, then sell price, then stack count).
+        /// Step 2 (only if no sellable consumable): weakest unprotected gear across all types by gear score
+        /// (then rarity, then sell price), filtered by <paramref name="rarityAllowed"/> (gear only).
+        /// Bag items win ties against the incoming item.
+        /// </summary>
+        public static SellSelection Select(ItemBag bag, IItem incoming, Func<int, bool> isProtectedBagIndex, Func<ItemRarity, bool> rarityAllowed)
+        {
+            if (bag == null)
+                return SellSelection.None;
+
+            // Step 1: consumables
+            int bestIndex = -1;
+            long bestKeyA = 0, bestKeyB = 0, bestKeyC = 0;
+            for (int i = 0; i < bag.Capacity; i++)
+            {
+                if (bag.GetSlotItem(i) is Consumable c && !IsProtected(isProtectedBagIndex, i))
+                    ConsiderConsumable(c, i, ref bestIndex, ref bestKeyA, ref bestKeyB, ref bestKeyC);
+            }
+            if (incoming is Consumable incomingConsumable)
+                ConsiderConsumable(incomingConsumable, IncomingIndex, ref bestIndex, ref bestKeyA, ref bestKeyB, ref bestKeyC);
+
+            if (bestIndex >= 0)
+                return bestIndex == IncomingIndex ? SellSelection.Incoming : SellSelection.AtIndex(bestIndex);
+
+            // Step 2: gear across all types
+            for (int i = 0; i < bag.Capacity; i++)
+            {
+                if (bag.GetSlotItem(i) is IGear g && RarityOk(rarityAllowed, g.Rarity) && !IsProtected(isProtectedBagIndex, i))
+                    ConsiderGear(g, i, ref bestIndex, ref bestKeyA, ref bestKeyB, ref bestKeyC);
+            }
+            if (incoming is IGear incomingGear && RarityOk(rarityAllowed, incomingGear.Rarity))
+                ConsiderGear(incomingGear, IncomingIndex, ref bestIndex, ref bestKeyA, ref bestKeyB, ref bestKeyC);
+
+            if (bestIndex >= 0)
+                return bestIndex == IncomingIndex ? SellSelection.Incoming : SellSelection.AtIndex(bestIndex);
+
+            return SellSelection.None;
+        }
+
+        private static bool IsProtected(Func<int, bool> isProtectedBagIndex, int bagIndex)
+            => isProtectedBagIndex != null && isProtectedBagIndex(bagIndex);
+
+        private static bool RarityOk(Func<ItemRarity, bool> rarityAllowed, ItemRarity rarity)
+            => rarityAllowed == null || rarityAllowed(rarity);
+
+        /// <summary>Weakness key: restore effect, then sell price, then stack count. Lower wins; bag index breaks final ties.</summary>
+        private static void ConsiderConsumable(Consumable c, int index, ref int bestIndex, ref long keyA, ref long keyB, ref long keyC)
+        {
+            long a = c.HPRestoreAmount + c.MPRestoreAmount;
+            long b = ((IItem)c).GetSellPrice();
+            long k = c.StackCount;
+            if (bestIndex < 0 || IsWeaker(a, b, k, index, keyA, keyB, keyC, bestIndex))
+            {
+                bestIndex = index; keyA = a; keyB = b; keyC = k;
+            }
+        }
+
+        /// <summary>Weakness key: gear score, then rarity, then sell price. Lower wins; bag index breaks final ties.</summary>
+        private static void ConsiderGear(IGear g, int index, ref int bestIndex, ref long keyA, ref long keyB, ref long keyC)
+        {
+            long a = GearAutoEquipService.GetGearScore(g);
+            long b = (long)g.Rarity;
+            long c = ((IItem)g).GetSellPrice();
+            if (bestIndex < 0 || IsWeaker(a, b, c, index, keyA, keyB, keyC, bestIndex))
+            {
+                bestIndex = index; keyA = a; keyB = b; keyC = c;
+            }
+        }
+
+        private static bool IsWeaker(long a, long b, long c, int index, long bestA, long bestB, long bestC, int bestIndex)
+        {
+            if (a != bestA) return a < bestA;
+            if (b != bestB) return b < bestB;
+            if (c != bestC) return c < bestC;
+            return index < bestIndex;
+        }
+    }
+}

--- a/PitHero/RolePlayingFramework/Equipment/ExcessItemSellSelector.cs
+++ b/PitHero/RolePlayingFramework/Equipment/ExcessItemSellSelector.cs
@@ -20,9 +20,10 @@ namespace RolePlayingFramework.Equipment
 
     /// <summary>
     /// Pure selection logic for auto-selling excess items when the bag is full (issue: auto-sell excess items).
-    /// Consumables are always sold before gear; among gear, weakness is compared across ALL gear types at once
-    /// so a lone strong item of one type never sells before a weak item of another. The incoming item participates
-    /// in the comparison so junk loot never displaces better items.
+    /// The player chooses whether consumables or gear sell first; within the second category items are only
+    /// considered when the first category has no sellable candidate. Among gear, weakness is compared across
+    /// ALL gear types at once so a lone strong item of one type never sells before a weak item of another.
+    /// The incoming item participates in the comparison so junk loot never displaces better items.
     /// </summary>
     public static class ExcessItemSellSelector
     {
@@ -31,17 +32,31 @@ namespace RolePlayingFramework.Equipment
 
         /// <summary>
         /// Selects the item to sell to free a bag slot for <paramref name="incoming"/>.
-        /// Step 1: weakest-effect unprotected consumable stack (HP+MP restore, then sell price, then stack count).
-        /// Step 2 (only if no sellable consumable): weakest unprotected gear across all types by gear score
-        /// (then rarity, then sell price), filtered by <paramref name="rarityAllowed"/> (gear only).
+        /// Consumable pass: weakest-effect unprotected consumable stack (HP+MP restore, then sell price, then stack count).
+        /// Gear pass: weakest unprotected gear across all types by gear score (then rarity, then sell price),
+        /// filtered by <paramref name="rarityAllowed"/> (gear only). <paramref name="consumablesFirst"/> picks
+        /// which pass runs first; the other pass only runs when the first finds no candidate.
         /// Bag items win ties against the incoming item.
         /// </summary>
-        public static SellSelection Select(ItemBag bag, IItem incoming, Func<int, bool> isProtectedBagIndex, Func<ItemRarity, bool> rarityAllowed)
+        public static SellSelection Select(ItemBag bag, IItem incoming, Func<int, bool> isProtectedBagIndex, Func<ItemRarity, bool> rarityAllowed, bool consumablesFirst = true)
         {
             if (bag == null)
                 return SellSelection.None;
 
-            // Step 1: consumables
+            var first = consumablesFirst
+                ? SelectConsumable(bag, incoming, isProtectedBagIndex)
+                : SelectGear(bag, incoming, isProtectedBagIndex, rarityAllowed);
+            if (first.HasSelection)
+                return first;
+
+            return consumablesFirst
+                ? SelectGear(bag, incoming, isProtectedBagIndex, rarityAllowed)
+                : SelectConsumable(bag, incoming, isProtectedBagIndex);
+        }
+
+        /// <summary>Picks the weakest-effect unprotected consumable stack, or none.</summary>
+        private static SellSelection SelectConsumable(ItemBag bag, IItem incoming, Func<int, bool> isProtectedBagIndex)
+        {
             int bestIndex = -1;
             long bestKeyA = 0, bestKeyB = 0, bestKeyC = 0;
             for (int i = 0; i < bag.Capacity; i++)
@@ -52,10 +67,14 @@ namespace RolePlayingFramework.Equipment
             if (incoming is Consumable incomingConsumable)
                 ConsiderConsumable(incomingConsumable, IncomingIndex, ref bestIndex, ref bestKeyA, ref bestKeyB, ref bestKeyC);
 
-            if (bestIndex >= 0)
-                return bestIndex == IncomingIndex ? SellSelection.Incoming : SellSelection.AtIndex(bestIndex);
+            return ToSelection(bestIndex);
+        }
 
-            // Step 2: gear across all types
+        /// <summary>Picks the weakest unprotected gear across all gear types (rarity-filtered), or none.</summary>
+        private static SellSelection SelectGear(ItemBag bag, IItem incoming, Func<int, bool> isProtectedBagIndex, Func<ItemRarity, bool> rarityAllowed)
+        {
+            int bestIndex = -1;
+            long bestKeyA = 0, bestKeyB = 0, bestKeyC = 0;
             for (int i = 0; i < bag.Capacity; i++)
             {
                 if (bag.GetSlotItem(i) is IGear g && RarityOk(rarityAllowed, g.Rarity) && !IsProtected(isProtectedBagIndex, i))
@@ -64,10 +83,14 @@ namespace RolePlayingFramework.Equipment
             if (incoming is IGear incomingGear && RarityOk(rarityAllowed, incomingGear.Rarity))
                 ConsiderGear(incomingGear, IncomingIndex, ref bestIndex, ref bestKeyA, ref bestKeyB, ref bestKeyC);
 
-            if (bestIndex >= 0)
-                return bestIndex == IncomingIndex ? SellSelection.Incoming : SellSelection.AtIndex(bestIndex);
+            return ToSelection(bestIndex);
+        }
 
-            return SellSelection.None;
+        private static SellSelection ToSelection(int bestIndex)
+        {
+            if (bestIndex < 0)
+                return SellSelection.None;
+            return bestIndex == IncomingIndex ? SellSelection.Incoming : SellSelection.AtIndex(bestIndex);
         }
 
         private static bool IsProtected(Func<int, bool> isProtectedBagIndex, int bagIndex)

--- a/PitHero/RolePlayingFramework/Inventory/ItemBag.cs
+++ b/PitHero/RolePlayingFramework/Inventory/ItemBag.cs
@@ -35,9 +35,10 @@ namespace RolePlayingFramework.Inventory
         /// <summary>Adds an item to first empty slot.</summary>
         public bool TryAdd(IItem item)
         {
-            if (item == null || IsFull) return false;
+            if (item == null) return false;
 
-            // If it's a consumable, try to stack it first
+            // If it's a consumable, try to stack it first — absorbing into an existing
+            // stack needs no empty slot, so this must run even when the bag is full
             if (item is Consumable consumable)
             {
                 // Look for an existing stack of the same item that isn't maxed out
@@ -53,6 +54,8 @@ namespace RolePlayingFramework.Inventory
                     }
                 }
             }
+
+            if (IsFull) return false;
 
             // If not stackable or no existing stack found, add to first empty slot
             for (int i = 0; i < _slots.Length; i++)

--- a/PitHero/Services/Analytics/AnalyticsService.cs
+++ b/PitHero/Services/Analytics/AnalyticsService.cs
@@ -371,6 +371,25 @@ namespace PitHero.Services.Analytics
 #endif
         }
 
+        /// <summary>Logs an item sold to the Second Chance vault (manually or by auto-sell).</summary>
+        [Conditional("DEBUG")]
+        public static void LogItemSold(IItem item, int qty, int gold, string source)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("item_sold"))
+                return;
+            _json.Field("item", item.Name);
+            _json.Field("kind", item.Kind.ToString());
+            _json.Field("rarity", item.Rarity.ToString());
+            _json.Field("qty", qty);
+            _json.Field("gold", gold);
+            _json.Field("source", source);
+            EndEvent();
+#endif
+        }
+
         /// <summary>Logs gear equipped on the hero along with the hero's resulting stats.</summary>
         [Conditional("DEBUG")]
         public static void LogGearEquipped(Hero hero, EquipmentSlot slot, IItem item)

--- a/PitHero/Services/AutoSellExcessItemsService.cs
+++ b/PitHero/Services/AutoSellExcessItemsService.cs
@@ -21,8 +21,8 @@ namespace PitHero.Services
     /// Auto-sells the weakest excess item when the bag is full and a new chest item arrives.
     /// Call-driven (no update loop): OpenChestAction invokes TryMakeRoom before adding the item.
     /// Items in an active synergy or under a placed stencil are never sold; gear rarities can be
-    /// excluded via RarityAllowed. Consumables always sell before gear; gear weakness is compared
-    /// across all gear types at once.
+    /// excluded via RarityAllowed. ConsumablesFirst picks whether the weakest consumable or the
+    /// weakest gear (compared across all gear types at once) sells first.
     /// </summary>
     public class AutoSellExcessItemsService
     {
@@ -30,6 +30,9 @@ namespace PitHero.Services
 
         /// <summary>Master toggle. On by default (unlike other automation toggles) — this guards against loot loss.</summary>
         public bool Enabled { get; set; } = true;
+
+        /// <summary>Sell priority: true sells consumables before gear (default), false sells gear before consumables.</summary>
+        public bool ConsumablesFirst { get; set; } = true;
 
         /// <summary>Whether gear of each rarity may be auto-sold, indexed by ItemRarity. All true by default.</summary>
         public bool[] RarityAllowed { get; } = new bool[5];
@@ -65,7 +68,7 @@ namespace PitHero.Services
             grid?.UpdateItemsFromBag();
             System.Func<int, bool> isProtected = grid != null ? grid.IsBagIndexProtected : (System.Func<int, bool>)null;
 
-            var selection = ExcessItemSellSelector.Select(bag, incoming, isProtected, IsRarityAllowed);
+            var selection = ExcessItemSellSelector.Select(bag, incoming, isProtected, IsRarityAllowed, ConsumablesFirst);
             if (!selection.HasSelection)
                 return AutoSellOutcome.None;
 

--- a/PitHero/Services/AutoSellExcessItemsService.cs
+++ b/PitHero/Services/AutoSellExcessItemsService.cs
@@ -1,0 +1,115 @@
+using Microsoft.Xna.Framework;
+using Nez;
+using PitHero.UI;
+using RolePlayingFramework.Equipment;
+using RolePlayingFramework.Inventory;
+
+namespace PitHero.Services
+{
+    /// <summary>Outcome of an auto-sell attempt when the bag is full.</summary>
+    public enum AutoSellOutcome
+    {
+        /// <summary>Nothing was sold (disabled, bag not full, stackable pickup, or everything protected).</summary>
+        None,
+        /// <summary>A bag item was sold, freeing a slot for the incoming item.</summary>
+        SoldBagItem,
+        /// <summary>The incoming item was the weakest candidate and was sold directly.</summary>
+        SoldIncoming
+    }
+
+    /// <summary>
+    /// Auto-sells the weakest excess item when the bag is full and a new chest item arrives.
+    /// Call-driven (no update loop): OpenChestAction invokes TryMakeRoom before adding the item.
+    /// Items in an active synergy or under a placed stencil are never sold; gear rarities can be
+    /// excluded via RarityAllowed. Consumables always sell before gear; gear weakness is compared
+    /// across all gear types at once.
+    /// </summary>
+    public class AutoSellExcessItemsService
+    {
+        private const string SellSource = "auto_excess";
+
+        /// <summary>Master toggle. On by default (unlike other automation toggles) — this guards against loot loss.</summary>
+        public bool Enabled { get; set; } = true;
+
+        /// <summary>Whether gear of each rarity may be auto-sold, indexed by ItemRarity. All true by default.</summary>
+        public bool[] RarityAllowed { get; } = new bool[5];
+
+        public AutoSellExcessItemsService()
+        {
+            for (int i = 0; i < RarityAllowed.Length; i++)
+                RarityAllowed[i] = true;
+        }
+
+        /// <summary>True when gear of the given rarity may be auto-sold. Consumables are never rarity-filtered.</summary>
+        public bool IsRarityAllowed(ItemRarity rarity)
+        {
+            int i = (int)rarity;
+            return i < 0 || i >= RarityAllowed.Length || RarityAllowed[i];
+        }
+
+        /// <summary>
+        /// Attempts to free a bag slot for the incoming item by selling the weakest sellable item.
+        /// Returns SoldIncoming when the incoming item itself was sold (caller must not add it to the bag).
+        /// </summary>
+        public AutoSellOutcome TryMakeRoom(ItemBag bag, IItem incoming)
+        {
+            if (!Enabled || bag == null || incoming == null || !bag.IsFull)
+                return AutoSellOutcome.None;
+
+            // A consumable that can absorb into an existing non-full stack needs no empty slot
+            if (incoming is Consumable consumable && CanStackInto(bag, consumable))
+                return AutoSellOutcome.None;
+
+            // Refresh the grid from the bag so the synergy cache matches current contents before protection checks
+            var grid = GetHeroInventoryGrid();
+            grid?.UpdateItemsFromBag();
+            System.Func<int, bool> isProtected = grid != null ? grid.IsBagIndexProtected : (System.Func<int, bool>)null;
+
+            var selection = ExcessItemSellSelector.Select(bag, incoming, isProtected, IsRarityAllowed);
+            if (!selection.HasSelection)
+                return AutoSellOutcome.None;
+
+            if (selection.SellIncoming)
+            {
+                int gold = ItemSellHelper.SellItemDirect(incoming, SellSource);
+                EmitConsole(incoming, gold);
+                return AutoSellOutcome.SoldIncoming;
+            }
+
+            var soldItem = bag.GetSlotItem(selection.BagIndex);
+            int earned = ItemSellHelper.SellBagItem(bag, selection.BagIndex, SellSource);
+            grid?.UpdateItemsFromBag();
+            InventorySelectionManager.OnInventoryChanged?.Invoke();
+            EmitConsole(soldItem, earned);
+            return AutoSellOutcome.SoldBagItem;
+        }
+
+        private static bool CanStackInto(ItemBag bag, Consumable incoming)
+        {
+            for (int i = 0; i < bag.Capacity; i++)
+            {
+                if (bag.GetSlotItem(i) is Consumable existing &&
+                    existing.Name == incoming.Name &&
+                    existing.StackCount < existing.StackSize)
+                    return true;
+            }
+            return false;
+        }
+
+        private static InventoryGrid GetHeroInventoryGrid()
+        {
+            if (Core.Instance == null)
+                return null;
+            return Core.Services?.GetService<SettingsUI>()?.HeroUI?.GetInventoryGrid();
+        }
+
+        private static void EmitConsole(IItem item, int gold)
+        {
+            if (Core.Instance == null || item == null)
+                return;
+            Core.Services?.GetService<GameEventService>()?.EmitLocalized(UITextKey.ConsoleAutoSoldItem,
+                (item.Name, RarityUtils.GetRarityColor(item.Rarity)),
+                (gold.ToString(), Color.White));
+        }
+    }
+}

--- a/PitHero/Services/ItemSellHelper.cs
+++ b/PitHero/Services/ItemSellHelper.cs
@@ -1,0 +1,47 @@
+using Nez;
+using RolePlayingFramework.Equipment;
+using RolePlayingFramework.Inventory;
+
+namespace PitHero.Services
+{
+    /// <summary>
+    /// Shared sell-to-vault logic used by manual selling (InventoryGrid.DiscardItem) and
+    /// auto-sell of excess items. Sold items go to the Second Chance vault for buyback and
+    /// gold is credited via GameStateService with the "sell_item" source.
+    /// </summary>
+    public static class ItemSellHelper
+    {
+        /// <summary>Sells the item at the given bag slot (whole stack for consumables) and clears the slot. Returns gold earned (0 if slot empty).</summary>
+        public static int SellBagItem(ItemBag bag, int bagIndex, string source)
+        {
+            var item = bag?.GetSlotItem(bagIndex);
+            if (item == null)
+                return 0;
+
+            int gold = SellItemDirect(item, source);
+            bag.SetSlotItem(bagIndex, null);
+            return gold;
+        }
+
+        /// <summary>Sells an item that is not in a bag (e.g. an incoming chest item). Returns gold earned.</summary>
+        public static int SellItemDirect(IItem item, string source)
+        {
+            if (item == null)
+                return 0;
+
+            int qty = (item is Consumable c) ? c.StackCount : 1;
+            int gold = item.GetSellPrice() * qty;
+
+            // Core.Instance is null in headless hosts (unit tests, virtual balance runs); Core.Services would throw there.
+            if (Core.Instance != null)
+            {
+                Core.Services?.GetService<SecondChanceMerchantVault>()?.AddItem(item);
+                Core.Services?.GetService<GameStateService>()?.AddFunds(gold, "sell_item");
+            }
+
+            Analytics.AnalyticsService.LogItemSold(item, qty, gold, source);
+            Debug.Log($"Sold {item.Name} x{qty} for {gold}G ({source})");
+            return gold;
+        }
+    }
+}

--- a/PitHero/Services/SaveData.cs
+++ b/PitHero/Services/SaveData.cs
@@ -255,12 +255,13 @@ namespace PitHero.Services
     public class SaveData : IPersistable
     {
         /// <summary>Current save file version.</summary>
-        public const int CurrentVersion = 20;
+        public const int CurrentVersion = 21;
 
         /// <summary>
-        /// Oldest save file version this build can still load. v17–v19 files are byte-exact
-        /// prefixes of v20 (sections 33 dining, 34 automation, and 35 auto-dine resume were
-        /// appended at the end), so they load with default state for the missing sections.
+        /// Oldest save file version this build can still load. v17–v20 files are byte-exact
+        /// prefixes of v21 (sections 33 dining, 34 automation, 35 auto-dine resume, and
+        /// 36 auto-sell excess items were appended at the end), so they load with default
+        /// state for the missing sections.
         /// </summary>
         public const int MinSupportedVersion = 17;
 
@@ -507,6 +508,13 @@ namespace PitHero.Services
         // Auto-dine resume (v20)
         /// <summary>Whether a breakfast trip in progress should auto-resume adventuring when done.</summary>
         public bool PartyAutoDineResume = false;
+
+        // Auto-sell excess items (v21)
+        /// <summary>Whether auto-selling the weakest excess item on full-bag chest pickup is enabled. On by default.</summary>
+        public bool AutoSellExcessItems = true;
+
+        /// <summary>Which gear rarities may be auto-sold, indexed by ItemRarity. Null until Recover normalizes it.</summary>
+        public bool[] AutoSellRarityAllowed;
 
         /// <summary>Initializes a new SaveData with default empty collections.</summary>
         public SaveData()
@@ -913,6 +921,13 @@ namespace PitHero.Services
 
             // 35. Auto-dine resume (v20)
             writer.Write(PartyAutoDineResume);
+
+            // 36. Auto-sell excess items (v21)
+            writer.Write(AutoSellExcessItems);
+            int rarityCount = AutoSellRarityAllowed != null ? AutoSellRarityAllowed.Length : 0;
+            writer.Write(rarityCount);
+            for (int i = 0; i < rarityCount; i++)
+                writer.Write(AutoSellRarityAllowed[i]);
         }
 
         /// <summary>Reads all game state from the persistence reader.</summary>
@@ -1324,6 +1339,24 @@ namespace PitHero.Services
                         PartyAutoDineResume = true;
                         break;
                     }
+                }
+            }
+
+            // 36. Auto-sell excess items (v21+). Older files end at section 35 — defaults apply
+            // (enabled, all rarities allowed). Rarities default to all-true so rarities added
+            // after the save was written behave like a fresh enable.
+            AutoSellRarityAllowed = new bool[5];
+            for (int i = 0; i < AutoSellRarityAllowed.Length; i++)
+                AutoSellRarityAllowed[i] = true;
+            if (fileVersion >= 21)
+            {
+                AutoSellExcessItems = reader.ReadBool();
+                int rarityCount = reader.ReadInt();
+                for (int i = 0; i < rarityCount; i++)
+                {
+                    bool allowed = reader.ReadBool();
+                    if (i < AutoSellRarityAllowed.Length)
+                        AutoSellRarityAllowed[i] = allowed;
                 }
             }
         }

--- a/PitHero/Services/SaveData.cs
+++ b/PitHero/Services/SaveData.cs
@@ -255,13 +255,13 @@ namespace PitHero.Services
     public class SaveData : IPersistable
     {
         /// <summary>Current save file version.</summary>
-        public const int CurrentVersion = 21;
+        public const int CurrentVersion = 22;
 
         /// <summary>
-        /// Oldest save file version this build can still load. v17–v20 files are byte-exact
-        /// prefixes of v21 (sections 33 dining, 34 automation, 35 auto-dine resume, and
-        /// 36 auto-sell excess items were appended at the end), so they load with default
-        /// state for the missing sections.
+        /// Oldest save file version this build can still load. v17–v21 files are byte-exact
+        /// prefixes of v22 (sections 33 dining, 34 automation, 35 auto-dine resume,
+        /// 36 auto-sell excess items, and 37 auto-sell priority were appended at the end),
+        /// so they load with default state for the missing sections.
         /// </summary>
         public const int MinSupportedVersion = 17;
 
@@ -515,6 +515,10 @@ namespace PitHero.Services
 
         /// <summary>Which gear rarities may be auto-sold, indexed by ItemRarity. Null until Recover normalizes it.</summary>
         public bool[] AutoSellRarityAllowed;
+
+        // Auto-sell priority (v22)
+        /// <summary>Sell priority for auto-selling excess items: true sells consumables before gear (default).</summary>
+        public bool AutoSellConsumablesFirst = true;
 
         /// <summary>Initializes a new SaveData with default empty collections.</summary>
         public SaveData()
@@ -928,6 +932,9 @@ namespace PitHero.Services
             writer.Write(rarityCount);
             for (int i = 0; i < rarityCount; i++)
                 writer.Write(AutoSellRarityAllowed[i]);
+
+            // 37. Auto-sell priority (v22)
+            writer.Write(AutoSellConsumablesFirst);
         }
 
         /// <summary>Reads all game state from the persistence reader.</summary>
@@ -1359,6 +1366,11 @@ namespace PitHero.Services
                         AutoSellRarityAllowed[i] = allowed;
                 }
             }
+
+            // 37. Auto-sell priority (v22+). Older files default to consumables-first.
+            AutoSellConsumablesFirst = true;
+            if (fileVersion >= 22)
+                AutoSellConsumablesFirst = reader.ReadBool();
         }
 
         /// <summary>Writes a Color as four individual int components (R, G, B, A).</summary>

--- a/PitHero/Services/SaveLoadService.cs
+++ b/PitHero/Services/SaveLoadService.cs
@@ -803,6 +803,16 @@ namespace PitHero.Services
             if (partyDiningService != null)
                 data.PartyAutoDineResume = partyDiningService.AutoResumeWhenDone;
 
+            // Auto-sell excess items (v21+)
+            var autoSellExcessService = Core.Services.GetService<AutoSellExcessItemsService>();
+            if (autoSellExcessService != null)
+            {
+                data.AutoSellExcessItems = autoSellExcessService.Enabled;
+                data.AutoSellRarityAllowed = new bool[autoSellExcessService.RarityAllowed.Length];
+                for (int i = 0; i < data.AutoSellRarityAllowed.Length; i++)
+                    data.AutoSellRarityAllowed[i] = autoSellExcessService.RarityAllowed[i];
+            }
+
             return data;
         }
 

--- a/PitHero/Services/SaveLoadService.cs
+++ b/PitHero/Services/SaveLoadService.cs
@@ -808,6 +808,7 @@ namespace PitHero.Services
             if (autoSellExcessService != null)
             {
                 data.AutoSellExcessItems = autoSellExcessService.Enabled;
+                data.AutoSellConsumablesFirst = autoSellExcessService.ConsumablesFirst;
                 data.AutoSellRarityAllowed = new bool[autoSellExcessService.RarityAllowed.Length];
                 for (int i = 0; i < data.AutoSellRarityAllowed.Length; i++)
                     data.AutoSellRarityAllowed[i] = autoSellExcessService.RarityAllowed[i];

--- a/PitHero/UI/InventoryGrid.cs
+++ b/PitHero/UI/InventoryGrid.cs
@@ -854,23 +854,32 @@ namespace PitHero.UI
             if (_heroComponent?.Bag == null)
                 return;
 
-            var item = _heroComponent.Bag.GetSlotItem(bagIndex);
-            if (item != null)
+            if (PitHero.Services.ItemSellHelper.SellBagItem(_heroComponent.Bag, bagIndex, "manual") > 0)
             {
-                int qty = (item is RolePlayingFramework.Equipment.Consumable c) ? c.StackCount : 1;
-                int gold = item.GetSellPrice() * qty;
-
-                var vault = Core.Services?.GetService<PitHero.Services.SecondChanceMerchantVault>();
-                vault?.AddItem(item);
-
-                var gameState = Core.Services?.GetService<PitHero.Services.GameStateService>();
-                gameState?.AddFunds(gold, "sell_item");
-
-                _heroComponent.Bag.SetSlotItem(bagIndex, null);
-                Debug.Log($"Sold {item.Name} x{qty} for {gold}G");
                 UpdateItemsFromBag();
                 OnItemSoldToVault?.Invoke();
             }
+        }
+
+        /// <summary>
+        /// True when the bag slot's item must never be auto-sold: it participates in an active synergy
+        /// or sits under a placed stencil on the grid. Callers must refresh the grid from the bag first
+        /// (UpdateItemsFromBag) so the synergy cache reflects the current bag contents.
+        /// </summary>
+        public bool IsBagIndexProtected(int bagIndex)
+        {
+            for (int i = 0; i < _slots.Length; i++)
+            {
+                var slot = _slots.Buffer[i];
+                if (slot == null || slot.SlotData.SlotType != InventorySlotType.Inventory || slot.SlotData.BagIndex != bagIndex)
+                    continue;
+
+                var gridPos = new Point(slot.SlotData.X, slot.SlotData.Y);
+                if (GetSynergiesForSlot(gridPos).Count > 0)
+                    return true;
+                return _stencilManager.FindStencilAtPosition(gridPos) != null;
+            }
+            return false;
         }
 
         /// <summary>Swaps two slot items (if legal) and persists bag ordering.</summary>

--- a/PitHero/UI/ReorderableTableList.cs
+++ b/PitHero/UI/ReorderableTableList.cs
@@ -31,20 +31,18 @@ namespace PitHero.UI
 
         private void Build()
         {
+            // All rows share this table's columns so the Up/Down buttons align across rows
+            // regardless of each item's text width.
             for (int i = 0; i < _items.Count; i++)
             {
-                var row = MakeRow(i, _items[i]);
-                Add(row).SetFillX().SetPadBottom(2f);
+                AddRowCells(i, _items[i]);
                 Row();
             }
             Pack();
         }
 
-        private Table MakeRow(int index, T item)
+        private void AddRowCells(int index, T item)
         {
-            var row = new Table();
-            row.SetTouchable(Touchable.Enabled);
-
             // Priority number label - use ph-default style
             var num = new Label((index + 1).ToString(), _skin, "ph-default");
 
@@ -52,21 +50,20 @@ namespace PitHero.UI
             var txt = new Label(item?.ToString() ?? string.Empty, _skin, "ph-default");
 
             // Up button
-            var upButton = new TextButton("Up", _skin, "ph-default");           
+            var upButton = new TextButton("Up", _skin, "ph-default");
             upButton.SetDisabled(index == 0); // Disable if first item
             upButton.OnClicked += (btn) => MoveItemUp(index);
 
-            // Down button  
+            // Down button
             var downButton = new TextButton("Down", _skin, "ph-default");
             downButton.SetDisabled(index == _items.Count - 1); // Disable if last item
             downButton.OnClicked += (btn) => MoveItemDown(index);
 
-            row.Add(num).SetMinWidth(30f).SetPadRight(5f);
-            row.Add(txt).SetExpandX().Left().SetPadRight(5f);
-            row.Add(upButton).SetMinWidth(30f).SetMinHeight(16f).SetPadRight(2f);
-            row.Add(downButton).SetMinWidth(30f).SetMinHeight(16f);
-
-            return row;
+            Add(num).SetMinWidth(30f).SetPadRight(5f).SetPadBottom(2f);
+            Add(txt).Left().SetPadRight(5f).SetPadBottom(2f);
+            Add(upButton).SetMinWidth(30f).SetMinHeight(16f).SetPadRight(2f).SetPadBottom(2f);
+            Add(downButton).SetMinWidth(30f).SetMinHeight(16f).SetPadBottom(2f);
+            Add().SetExpandX(); // spacer soaks leftover width so the buttons stay next to the text
         }
 
         private void MoveItemUp(int index)

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -6,6 +6,7 @@ using PitHero.ECS.Components;
 using PitHero.ECS.Scenes;
 using PitHero.Services;
 using System;
+using System.Collections.Generic;
 
 namespace PitHero.UI
 {
@@ -68,6 +69,9 @@ namespace PitHero.UI
         private TextButton _designateCropsButton;
         private AutoSellCropTypesDialog _autoSellCropTypesDialog;
         private HoverableCheckBox _autoSellExcessCheckBox;
+        private HoverableLabel _sellPriorityLabel;
+        private ReorderableTableList<string> _sellPriorityList;
+        private List<string> _sellPriorityItems;
         private HoverableLabel _sellRaritiesLabel;
         private CheckBox[] _sellRarityCheckBoxes;
         private Table _sellRaritiesTable;
@@ -951,10 +955,28 @@ namespace PitHero.UI
             {
                 var svc = Core.Services?.GetService<AutoSellExcessItemsService>();
                 if (svc != null) svc.Enabled = isChecked;
+                _sellPriorityLabel?.SetVisible(isChecked);
+                _sellPriorityList?.SetVisible(isChecked);
                 _sellRaritiesLabel?.SetVisible(isChecked);
                 _sellRaritiesTable?.SetVisible(isChecked);
             };
             autoShopTable.Add(_autoSellExcessCheckBox).Left().SetPadTop(15f).SetPadBottom(8f);
+            autoShopTable.Row();
+
+            string sellPriorityTooltip = GetText(TextType.UI, UITextKey.SettingsSellPriorityTooltip);
+            _sellPriorityLabel = new HoverableLabel(
+                GetText(TextType.UI, UITextKey.SettingsSellPriority),
+                skin, "ph-default", sellPriorityTooltip, _stage);
+            autoShopTable.Add(_sellPriorityLabel).Left().SetPadBottom(4f);
+            autoShopTable.Row();
+
+            _sellPriorityItems = new List<string>(2)
+            {
+                GetText(TextType.UI, UITextKey.SellPriorityConsumables),
+                GetText(TextType.UI, UITextKey.SellPriorityGear)
+            };
+            _sellPriorityList = new ReorderableTableList<string>(skin, _sellPriorityItems, OnSellPriorityReordered);
+            autoShopTable.Add(_sellPriorityList).Left().Width(240f).SetPadBottom(8f);
             autoShopTable.Row();
 
             string raritiesTooltip = GetText(TextType.UI, UITextKey.SettingsSellRaritiesTooltip);
@@ -993,6 +1015,14 @@ namespace PitHero.UI
             automationTab.Add(autoShopTable).Expand().Top().Left();
         }
 
+        /// <summary>Writes the reordered sell priority (top entry sells first) to the service.</summary>
+        private void OnSellPriorityReordered(int from, int to, string item)
+        {
+            var svc = Core.Services?.GetService<AutoSellExcessItemsService>();
+            if (svc != null && _sellPriorityItems != null && _sellPriorityItems.Count > 0)
+                svc.ConsumablesFirst = _sellPriorityItems[0] == GetText(TextType.UI, UITextKey.SellPriorityConsumables);
+        }
+
         /// <summary>
         /// Reads the automation services' state and syncs the Automation tab controls.
         /// Called after load to reflect persisted settings.
@@ -1029,11 +1059,22 @@ namespace PitHero.UI
             {
                 if (_autoSellExcessCheckBox != null)
                     _autoSellExcessCheckBox.IsChecked = excessSvc.Enabled;
+                if (_sellPriorityItems != null)
+                {
+                    _sellPriorityItems.Clear();
+                    var consumablesText = GetText(TextType.UI, UITextKey.SellPriorityConsumables);
+                    var gearText = GetText(TextType.UI, UITextKey.SellPriorityGear);
+                    _sellPriorityItems.Add(excessSvc.ConsumablesFirst ? consumablesText : gearText);
+                    _sellPriorityItems.Add(excessSvc.ConsumablesFirst ? gearText : consumablesText);
+                    _sellPriorityList?.Rebuild();
+                }
                 if (_sellRarityCheckBoxes != null)
                 {
                     for (int i = 0; i < _sellRarityCheckBoxes.Length && i < excessSvc.RarityAllowed.Length; i++)
                         _sellRarityCheckBoxes[i].IsChecked = excessSvc.RarityAllowed[i];
                 }
+                _sellPriorityLabel?.SetVisible(excessSvc.Enabled);
+                _sellPriorityList?.SetVisible(excessSvc.Enabled);
                 _sellRaritiesLabel?.SetVisible(excessSvc.Enabled);
                 _sellRaritiesTable?.SetVisible(excessSvc.Enabled);
             }

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -67,6 +67,10 @@ namespace PitHero.UI
         private HoverableCheckBox _autoSellCropsCheckBox;
         private TextButton _designateCropsButton;
         private AutoSellCropTypesDialog _autoSellCropTypesDialog;
+        private HoverableCheckBox _autoSellExcessCheckBox;
+        private HoverableLabel _sellRaritiesLabel;
+        private CheckBox[] _sellRarityCheckBoxes;
+        private Table _sellRaritiesTable;
 
         // Confirmation dialogs
         private Window _exitConfirmationDialog;
@@ -934,6 +938,57 @@ namespace PitHero.UI
             };
             _designateCropsButton.SetVisible(false);
             autoShopTable.Add(_designateCropsButton).Left().Width(140f);
+            autoShopTable.Row();
+
+            string excessTooltip = GetText(TextType.UI, UITextKey.SettingsAutoSellExcessItemsTooltip);
+            _autoSellExcessCheckBox = new HoverableCheckBox(
+                GetText(TextType.UI, UITextKey.SettingsAutoSellExcessItems),
+                skin,
+                excessTooltip,
+                _stage);
+            _autoSellExcessCheckBox.IsChecked = true;
+            _autoSellExcessCheckBox.OnChanged += (isChecked) =>
+            {
+                var svc = Core.Services?.GetService<AutoSellExcessItemsService>();
+                if (svc != null) svc.Enabled = isChecked;
+                _sellRaritiesLabel?.SetVisible(isChecked);
+                _sellRaritiesTable?.SetVisible(isChecked);
+            };
+            autoShopTable.Add(_autoSellExcessCheckBox).Left().SetPadTop(15f).SetPadBottom(8f);
+            autoShopTable.Row();
+
+            string raritiesTooltip = GetText(TextType.UI, UITextKey.SettingsSellRaritiesTooltip);
+            _sellRaritiesLabel = new HoverableLabel(
+                GetText(TextType.UI, UITextKey.SettingsSellRarities),
+                skin, "ph-default", raritiesTooltip, _stage);
+            autoShopTable.Add(_sellRaritiesLabel).Left().SetPadBottom(4f);
+            autoShopTable.Row();
+
+            _sellRaritiesTable = new Table();
+            var rarityKeys = new[]
+            {
+                UITextKey.RarityNormal, UITextKey.RarityUncommon, UITextKey.RarityRare,
+                UITextKey.RarityEpic, UITextKey.RarityLegendary
+            };
+            _sellRarityCheckBoxes = new CheckBox[rarityKeys.Length];
+            for (int i = 0; i < rarityKeys.Length; i++)
+            {
+                int rarityIndex = i;
+                var rarityCheckBox = new CheckBox(GetText(TextType.UI, rarityKeys[i]), skin, "ph-default");
+                rarityCheckBox.IsChecked = true;
+                rarityCheckBox.OnChanged += (isChecked) =>
+                {
+                    var svc = Core.Services?.GetService<AutoSellExcessItemsService>();
+                    if (svc != null) svc.RarityAllowed[rarityIndex] = isChecked;
+                };
+                _sellRarityCheckBoxes[i] = rarityCheckBox;
+                _sellRaritiesTable.Add(rarityCheckBox).Left().SetPadRight(12f).SetPadBottom(4f);
+
+                // Two rows (Normal/Uncommon/Rare, then Epic/Legendary) so the tab isn't widened
+                if (i == 2)
+                    _sellRaritiesTable.Row();
+            }
+            autoShopTable.Add(_sellRaritiesTable).Left();
 
             automationTab.Add(autoShopTable).Expand().Top().Left();
         }
@@ -967,6 +1022,20 @@ namespace PitHero.UI
                     _autoSellCropsCheckBox.IsChecked = cropSellSvc.Enabled;
                 _designateCropsButton?.SetVisible(cropSellSvc.Enabled);
                 _autoSellCropTypesDialog?.SyncFromService();
+            }
+
+            var excessSvc = Core.Services?.GetService<AutoSellExcessItemsService>();
+            if (excessSvc != null)
+            {
+                if (_autoSellExcessCheckBox != null)
+                    _autoSellExcessCheckBox.IsChecked = excessSvc.Enabled;
+                if (_sellRarityCheckBoxes != null)
+                {
+                    for (int i = 0; i < _sellRarityCheckBoxes.Length && i < excessSvc.RarityAllowed.Length; i++)
+                        _sellRarityCheckBoxes[i].IsChecked = excessSvc.RarityAllowed[i];
+                }
+                _sellRaritiesLabel?.SetVisible(excessSvc.Enabled);
+                _sellRaritiesTable?.SetVisible(excessSvc.Enabled);
             }
         }
 

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -350,5 +350,16 @@ namespace PitHero
         public const string DishPumpkinCreamSoup = "DishPumpkinCreamSoup";
         public const string DishChilledWatermelonSorbet = "DishChilledWatermelonSorbet";
         public const string DishHarvestFeastPlatter = "DishHarvestFeastPlatter";
+        public const string SettingsAutoSellExcessItems = "SettingsAutoSellExcessItems";
+        public const string SettingsAutoSellExcessItemsTooltip = "SettingsAutoSellExcessItemsTooltip";
+        public const string SettingsSellRarities = "SettingsSellRarities";
+        public const string SettingsSellRaritiesTooltip = "SettingsSellRaritiesTooltip";
+        public const string RarityNormal = "RarityNormal";
+        public const string RarityUncommon = "RarityUncommon";
+        public const string RarityRare = "RarityRare";
+        public const string RarityEpic = "RarityEpic";
+        public const string RarityLegendary = "RarityLegendary";
+        public const string ConsoleAutoSoldItem = "ConsoleAutoSoldItem";
+        public const string ConsoleItemSentToVault = "ConsoleItemSentToVault";
     }
 }

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -352,6 +352,10 @@ namespace PitHero
         public const string DishHarvestFeastPlatter = "DishHarvestFeastPlatter";
         public const string SettingsAutoSellExcessItems = "SettingsAutoSellExcessItems";
         public const string SettingsAutoSellExcessItemsTooltip = "SettingsAutoSellExcessItemsTooltip";
+        public const string SettingsSellPriority = "SettingsSellPriority";
+        public const string SettingsSellPriorityTooltip = "SettingsSellPriorityTooltip";
+        public const string SellPriorityConsumables = "SellPriorityConsumables";
+        public const string SellPriorityGear = "SellPriorityGear";
         public const string SettingsSellRarities = "SettingsSellRarities";
         public const string SettingsSellRaritiesTooltip = "SettingsSellRaritiesTooltip";
         public const string RarityNormal = "RarityNormal";

--- a/PitHero/VirtualGame/VirtualBattleRunner.cs
+++ b/PitHero/VirtualGame/VirtualBattleRunner.cs
@@ -104,6 +104,23 @@ namespace PitHero.VirtualGame
         /// <summary>Number of gear pieces successfully auto-equipped (hero or mercenary) since this runner was created.</summary>
         public int GearEquipped { get; private set; }
 
+        // ── Configuration: auto-sell excess items ────────────────────────────────
+
+        /// <summary>
+        /// When true, <see cref="CollectChestItem"/> mirrors <c>AutoSellExcessItemsService</c>:
+        /// on a full bag the weakest item (consumables first, then gear across all types) is
+        /// sold to make room. Off by default to preserve existing balance baselines.
+        /// The virtual layer has no synergy/stencil model, so nothing is protected and all
+        /// rarities are sellable (documented Delta-Plan gap).
+        /// </summary>
+        public bool AutoSellExcessItems { get; set; } = false;
+
+        /// <summary>Number of items auto-sold to make room since this runner was created.</summary>
+        public int ItemsAutoSold { get; private set; }
+
+        /// <summary>Gold earned from auto-selling excess items since this runner was created.</summary>
+        public int AutoSellGold { get; private set; }
+
         // ── Bag access ───────────────────────────────────────────────────────────
 
         /// <summary>
@@ -218,8 +235,29 @@ namespace PitHero.VirtualGame
             // Mirrors hero.TryAddItem (which is just Bag.TryAdd with consumable stacking).
             if (!bag.TryAdd(item))
             {
-                System.Console.WriteLine($"[VirtualBattleRunner] Bag full — could not collect {item.Name}");
-                return;
+                bool added = false;
+                if (AutoSellExcessItems)
+                {
+                    var selection = ExcessItemSellSelector.Select(bag, item, null, null);
+                    if (selection.SellIncoming)
+                    {
+                        ItemsAutoSold++;
+                        AutoSellGold += SellValue(item);
+                        return; // the incoming item was the weakest and was sold directly
+                    }
+                    if (selection.BagIndex >= 0)
+                    {
+                        ItemsAutoSold++;
+                        AutoSellGold += SellValue(bag.GetSlotItem(selection.BagIndex));
+                        bag.SetSlotItem(selection.BagIndex, null);
+                        added = bag.TryAdd(item);
+                    }
+                }
+                if (!added)
+                {
+                    System.Console.WriteLine($"[VirtualBattleRunner] Bag full — could not collect {item.Name}");
+                    return;
+                }
             }
 
             // Reset HealingItemExhausted when a healing consumable arrives (mirrors live).
@@ -259,6 +297,10 @@ namespace PitHero.VirtualGame
                 }
             }
         }
+
+        /// <summary>Sell value of an item: sell price times stack count for consumables (mirrors ItemSellHelper).</summary>
+        private static int SellValue(IItem item)
+            => item.GetSellPrice() * ((item is Consumable c) ? c.StackCount : 1);
 
         /// <summary>
         /// Offers displaced gear to mercenaries starting at <paramref name="startIndex"/>.

--- a/PitHero/VirtualGame/VirtualBattleRunner.cs
+++ b/PitHero/VirtualGame/VirtualBattleRunner.cs
@@ -108,12 +108,15 @@ namespace PitHero.VirtualGame
 
         /// <summary>
         /// When true, <see cref="CollectChestItem"/> mirrors <c>AutoSellExcessItemsService</c>:
-        /// on a full bag the weakest item (consumables first, then gear across all types) is
-        /// sold to make room. Off by default to preserve existing balance baselines.
-        /// The virtual layer has no synergy/stencil model, so nothing is protected and all
-        /// rarities are sellable (documented Delta-Plan gap).
+        /// on a full bag the weakest item is sold to make room, ordered by
+        /// <see cref="AutoSellConsumablesFirst"/>. Off by default to preserve existing balance
+        /// baselines. The virtual layer has no synergy/stencil model, so nothing is protected
+        /// and all rarities are sellable (documented Delta-Plan gap).
         /// </summary>
         public bool AutoSellExcessItems { get; set; } = false;
+
+        /// <summary>Sell priority mirror of <c>AutoSellExcessItemsService.ConsumablesFirst</c>: true sells consumables before gear.</summary>
+        public bool AutoSellConsumablesFirst { get; set; } = true;
 
         /// <summary>Number of items auto-sold to make room since this runner was created.</summary>
         public int ItemsAutoSold { get; private set; }
@@ -238,7 +241,7 @@ namespace PitHero.VirtualGame
                 bool added = false;
                 if (AutoSellExcessItems)
                 {
-                    var selection = ExcessItemSellSelector.Select(bag, item, null, null);
+                    var selection = ExcessItemSellSelector.Select(bag, item, null, null, AutoSellConsumablesFirst);
                     if (selection.SellIncoming)
                     {
                         ItemsAutoSold++;

--- a/PitHero/VirtualGame/VirtualGameSimulation.cs
+++ b/PitHero/VirtualGame/VirtualGameSimulation.cs
@@ -488,12 +488,14 @@ namespace PitHero.VirtualGame
             _runMetrics.Wiped           = !_battleRunner.HeroAlive;
             _runMetrics.TreasuresOpened = _battleRunner.TreasuresOpened;
             _runMetrics.GearEquipped    = _battleRunner.GearEquipped;
+            _runMetrics.ItemsAutoSold   = _battleRunner.ItemsAutoSold;
+            _runMetrics.AutoSellGold    = _battleRunner.AutoSellGold;
             if (partyMaxHPPool > 0)
                 _runMetrics.HpLossPercent = (float)_runMetrics.DamageTaken / partyMaxHPPool;
 
             // Credit the wallet with gold earned this level and snapshot the balance.
             // InnRested / MercsHired are 0/false here; RunLevelRange stamps them after.
-            Gold                  += _runMetrics.GoldEarned;
+            Gold                  += _runMetrics.GoldEarned + _runMetrics.AutoSellGold;
             _runMetrics.Wallet     = Gold;
             _runMetrics.HeroLevel  = _hero.LinkedHero.Level;
 

--- a/PitHero/VirtualGame/VirtualRunMetrics.cs
+++ b/PitHero/VirtualGame/VirtualRunMetrics.cs
@@ -51,6 +51,12 @@ namespace PitHero.VirtualGame
         /// <summary>Total gold earned from defeated monsters on this pit level.</summary>
         public int GoldEarned;
 
+        /// <summary>Total items auto-sold to make bag room on this pit level.</summary>
+        public int ItemsAutoSold;
+
+        /// <summary>Total gold earned from auto-selling excess items on this pit level.</summary>
+        public int AutoSellGold;
+
         /// <summary>
         /// Gold wallet balance at the end of this pit level, after crediting <see cref="GoldEarned"/>.
         /// In a <see cref="VirtualGameSimulation.RunLevelRange"/> run, between-level spending
@@ -130,7 +136,7 @@ namespace PitHero.VirtualGame
         /// </summary>
         public static void WriteCsvHeader(TextWriter writer)
         {
-            writer.WriteLine("pitLevel,battles,rounds,dmgDealt,dmgTaken,hpLossPct,healing,deaths,wiped,treasures,gearEquipped,goldEarned,wallet,innRested,mercsHired,pitTier,displayedLevel,heroLevel");
+            writer.WriteLine("pitLevel,battles,rounds,dmgDealt,dmgTaken,hpLossPct,healing,deaths,wiped,treasures,gearEquipped,goldEarned,itemsAutoSold,autoSellGold,wallet,innRested,mercsHired,pitTier,displayedLevel,heroLevel");
         }
 
         /// <summary>
@@ -141,7 +147,7 @@ namespace PitHero.VirtualGame
             writer.WriteLine(
                 $"{PitLevel},{BattleCount},{TotalRounds},{DamageDealt},{DamageTaken}," +
                 $"{HpLossPercent:F4},{HealingConsumed},{PartyDeaths},{(Wiped ? 1 : 0)}," +
-                $"{TreasuresOpened},{GearEquipped},{GoldEarned},{Wallet},{(InnRested ? 1 : 0)},{MercsHired}," +
+                $"{TreasuresOpened},{GearEquipped},{GoldEarned},{ItemsAutoSold},{AutoSellGold},{Wallet},{(InnRested ? 1 : 0)},{MercsHired}," +
                 $"{PitTier},{DisplayedLevel},{HeroLevel}");
         }
 

--- a/PitHero/docs/AnalyticsSchema.md
+++ b/PitHero/docs/AnalyticsSchema.md
@@ -66,6 +66,7 @@ interpretation caveats that are not obvious from the raw data.
 |---|---|---|
 | `item_acquired` | `item`, `kind`, `rarity`, `pitLevel`, `chestLevel` | Item actually collected from a chest. Pair with `chest_spawned` (availability) — they answer different questions. |
 | `gear_equipped` | `character`, `charType`, `slot`, `item`, `rarity`, `str/agi/vit/mag`, `maxHP`, `maxMP` | Stats are the character's **resulting totals after** the equip. Save-restore re-equips are deliberately not logged. |
+| `item_sold` | `item`, `kind`, `rarity`, `qty`, `gold`, `source` | Item sold to the Second Chance vault. `qty` is the stack count for consumables, else 1. `source`: `"manual"` (player sell) or `"auto_excess"` (AutoSellExcessItemsService making bag room). Gold arrives via the paired `gold_gained (source:"sell_item")`. |
 | `gold_gained` | `amount`, `source`, `sessionTotal`, `currentGold` | `source`: `"battle"`, `"sell_item"`, `"sell_building"`, `"sell_crops"`, `"refund"`. `sessionTotal` resets each `session_start`. Spends are mostly not logged; infer from `currentGold` deltas (e.g. `inn_sleep.goldAfter`). Exceptions: `seed_purchased` and `building_created` (below) record their own spends. `source:"sell_crops"` lines pair with per-stack `crop_sold` detail lines. |
 
 ### Battle

--- a/PitHero/docs/VirtualGameLogicLayer.md
+++ b/PitHero/docs/VirtualGameLogicLayer.md
@@ -153,6 +153,12 @@ same-seed ⇒ identical-event-stream determinism test that catches accidental dr
   consumable stacking, `HealingItemExhausted` reset on healing pickups, auto-equip hero
   first then mercenaries (`GearAutoEquipService`), with the recursive hand-me-down cascade
   for displaced gear. Toggles: `AutoEquipHero` / `AutoEquipMercenaries` (default true).
+- **Auto-sell excess items**: `AutoSellExcessItems` (default **false** to preserve balance
+  baselines) mirrors the live `AutoSellExcessItemsService` — on a full bag the weakest item
+  (consumables by restore effect first, then gear across all types by gear score, via the
+  shared `ExcessItemSellSelector`) is sold and the gold lands in `AutoSellGold`/the wallet.
+  Delta-Plan gap: the virtual layer has no synergy/stencil model, so nothing is protected
+  and all rarities are sellable; selling consumes no RNG, so parity is unaffected either way.
 
 ## Metrics & CSV Reference
 
@@ -170,6 +176,7 @@ same-seed ⇒ identical-event-stream determinism test that catches accidental dr
 | `wiped` | 1 when the hero died before completing the level |
 | `treasures` / `gearEquipped` | Chests opened / gear pieces auto-equipped |
 | `goldEarned` / `wallet` | Gold from kills this level / balance after crediting |
+| `itemsAutoSold` / `autoSellGold` | Items auto-sold to make bag room / gold they earned (0 unless `AutoSellExcessItems` is on) |
 | `innRested` / `mercsHired` | Between-level actions taken **before** this level (`RunLevelRange` only) |
 
 Run-level fields: `RngSeed`, `JobName`, `LevelRangeMin/Max`.


### PR DESCRIPTION
## Summary

Adds an **Auto-Sell Excess Items** automation (Settings &gt; Automation, **on by default**): when the hero picks up a chest item with a full bag, the weakest sellable item is auto-sold to the Second Chance vault to make room.

### Selection rules
- **Item Sell Priority** (reorderable two-entry list, Behavior-tab style): **Consumables** or **Gear** on top decides which category sells first; the other is only a fallback when the first has no sellable candidate. Consumables-first by default.
- **Consumables**: the weakest-effect stack (HP+MP restore, then sell price, then stack count) sells whole, mirroring manual sell semantics. A pickup that can merge into an existing stack never triggers a sale.
- **Gear, compared across ALL gear types** by `GetGearScore` (then rarity, then sell price) — a lone Legendary sword never sells before a junk shield.
- **The incoming item participates**: if the new loot is the weakest candidate, it is sold directly instead of displacing better gear; exact ties keep the new item out.
- **Never sold**: items in an active synergy or under a placed stencil (`InventoryGrid.IsBagIndexProtected`, grid refreshed from the bag before checking), and gear of rarities unchecked in the new **Gear Rarities to Sell** checkboxes (two rows to preserve the Settings window width).

### Bug fixes folded in
- **Silent loot loss**: a full-bag chest pickup previously stranded the item forever (chest already OPEN, never re-targeted). Unplaceable items now always fall back to the Second Chance vault — even with auto-sell off.
- **`ItemBag.TryAdd` stacking**: the `IsFull` early-out ran before the consumable-stacking loop, so a full bag rejected potions that needed no slot.
- **`ReorderableTableList` alignment**: rows now share table columns so the Up/Down buttons align vertically, with a trailing spacer column keeping them next to the labels instead of the far right edge (also improves the Party UI Behavior tab lists).

### Plumbing
- Shared sell path extracted to `ItemSellHelper` (vault + `AddFunds("sell_item")` + new `item_sold` analytics event); `InventoryGrid.DiscardItem` now delegates to it.
- Save **v22**: enabled flag + rarity bools (section 36, v21) and consumables-first priority (section 37, v22); older saves load with the feature ON, all rarities allowed, and consumables-first.
- Virtual layer: `VirtualBattleRunner.AutoSellExcessItems` (default **off** — balance baselines untouched; selling consumes no RNG) with `AutoSellConsumablesFirst` mirror and `itemsAutoSold`/`autoSellGold` metrics columns; no-synergy-model gap documented in `VirtualGameLogicLayer.md`.

### Known limitation
Placed stencils are session-only (only discovery persists), so stencil protection resets on load — follow-up filed as #343.

## Testing
- 27 new tests: selector rules (priority order + fallback, cross-type gear, rarity filter, protection, incoming-participates, tie-breaks), ItemBag stacking fix, service outcomes, save v21/v22 round-trip + defaults, virtual runner on/off/gear-first.
- Full suite: **0 failed** (baseline maintained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)