### PR TITLE
Gray out deactivated Automation tab controls instead of hiding them

### DIFF
--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -300,14 +300,14 @@ AddMonsterDaytimeLabel,Daytime
 AddMonsterNocturnalLabel,Nocturnal
 TabAutomation,Automation
 SettingsAutomateMonsterJobs,Automate monster jobs
-SettingsAutomateMonsterJobsTooltip,System will handle monster job assignments. Player can not assign monster jobs with this enabled
+SettingsAutomateMonsterJobsTooltip,Monster job assignments are handled automatically.  Player can't assign monster jobs when this is enabled
 SettingsAutomateSeedPurchases,Auto-Purchase Seeds
 SettingsAutoShopGoldBuffer,Gold Buffer: {0}
 SettingsAutomateSeedPurchasesTooltip,Buy seeds for planned crops as soon as gold is available
 SettingsAutoShopGoldBufferTooltip,No auto purchases will be made when gold is below this value
 SettingsAutoSellCrops,Auto-Sell Crops
 SettingsAutoSellCropsTooltip,When a crop reaches max stack quantity, sell it automatically
-ButtonDesignateCrops,Designate Crops
+ButtonDesignateCrops,Choose Crops to Sell
 WindowAutoSellCropTypes,Auto-Sell Crop Types
 ButtonSelectAll,Select All
 ButtonDeselectAll,Deselect All

--- a/PitHero/UI/HoverableLabel.cs
+++ b/PitHero/UI/HoverableLabel.cs
@@ -25,6 +25,20 @@ namespace PitHero.UI
                 BuildTooltipWindow(skin);
         }
 
+        /// <summary>
+        /// Enables or disables the hover tooltip. Used when the label is shown in a deactivated
+        /// (grayed) state, where hovering must give no feedback.
+        /// </summary>
+        public void SetTooltipEnabled(bool enabled)
+        {
+            SetTouchable(enabled ? Touchable.Enabled : Touchable.Disabled);
+            if (enabled) return;
+
+            // OnMouseExit will not fire once the label stops accepting input, so drop the tooltip here
+            _hovered = false;
+            _tooltipWindow?.SetVisible(false);
+        }
+
         private void BuildTooltipWindow(Skin skin)
         {
             _tooltipWindow = new Window("", skin);

--- a/PitHero/UI/PitHeroSkin.cs
+++ b/PitHero/UI/PitHeroSkin.cs
@@ -13,6 +13,12 @@ namespace PitHero.UI
     {
         private static Skin _cachedSkin;
 
+        /// <summary>Multiplied into drawables of the "ph-grayed" styles to fade deactivated controls.</summary>
+        private static readonly Color GrayedTint = new Color(180, 180, 180, 180);
+
+        /// <summary>Washed-out version of the brown font color used by the "ph-grayed" styles.</summary>
+        private static readonly Color GrayedFontColor = new Color(146, 128, 111);
+
         /// <summary>
         /// Creates or returns the cached PitHero skin with custom window background.
         /// </summary>
@@ -48,6 +54,9 @@ namespace PitHero.UI
             // does not affect any other text.
             skin.Add("ph-sleeping", new LabelStyle(defaultFont, Color.Red));
 
+            // Washed-out label style for controls that are visible but deactivated
+            skin.Add("ph-grayed", new LabelStyle(defaultFont, GrayedFontColor));
+
             // Create custom text button style to use brown color
             var textButtonStyle = new TextButtonStyle
             {
@@ -78,7 +87,24 @@ namespace PitHero.UI
             };
             phTextButtonStyle.Up.SetPadding(0, 0, 25, 25); //Force centered text
             skin.Add("ph-default", phTextButtonStyle);
-            
+
+            // Grayed ("deactivated") button variant: same nine patch faded out, with every state
+            // drawn identically so hover/press give no feedback. Created after SetPadding above so
+            // the tinted copy inherits the centering padding.
+            var ninePatchGrayed = ninePatchUp.NewTintedDrawable(GrayedTint);
+            var phGrayedTextButtonStyle = new TextButtonStyle
+            {
+                Up = ninePatchGrayed,
+                Down = ninePatchGrayed,
+                Over = ninePatchGrayed,
+                Disabled = ninePatchGrayed,
+                FontColor = GrayedFontColor,
+                DownFontColor = GrayedFontColor,
+                OverFontColor = GrayedFontColor,
+                DisabledFontColor = GrayedFontColor
+            };
+            skin.Add("ph-grayed", phGrayedTextButtonStyle);
+
             // Window background
             var ninepatchSprite = uiAtlas.GetSprite("NinepatchWindowBackground");
             var ninePatch = new NinePatchSprite(ninepatchSprite, 24, 24, 24, 24);
@@ -103,10 +129,13 @@ namespace PitHero.UI
             else
                 checkboxUncheckedHover = checkboxChecked; // Fallback to checked sprite for hover feedback
 
+            var checkboxOffDrawable = new SpriteDrawable(checkboxUnchecked);
+            var checkboxOnDrawable = new SpriteDrawable(checkboxChecked);
+
             var checkboxStyle = new CheckBoxStyle
             {
-                CheckboxOff = new SpriteDrawable(checkboxUnchecked),
-                CheckboxOn = new SpriteDrawable(checkboxChecked),
+                CheckboxOff = checkboxOffDrawable,
+                CheckboxOn = checkboxOnDrawable,
                 CheckboxOver = new SpriteDrawable(checkboxUncheckedHover), // Hover when unchecked only
                 Font = labelStyle.Font,
                 FontColor = brownFontColor,
@@ -115,6 +144,24 @@ namespace PitHero.UI
             };
 
             skin.Add("ph-default", checkboxStyle);
+
+            // Grayed ("deactivated") checkbox variant. Over reuses the faded off/on sprites so
+            // hovering gives no feedback while the control is deactivated.
+            var checkboxOffGrayed = checkboxOffDrawable.NewTintedDrawable(GrayedTint);
+            var checkboxOnGrayed = checkboxOnDrawable.NewTintedDrawable(GrayedTint);
+            skin.Add("ph-grayed", new CheckBoxStyle
+            {
+                CheckboxOff = checkboxOffGrayed,
+                CheckboxOn = checkboxOnGrayed,
+                CheckboxOver = checkboxOffGrayed,
+                CheckboxOffDisabled = checkboxOffGrayed,
+                CheckboxOnDisabled = checkboxOnGrayed,
+                Font = labelStyle.Font,
+                FontColor = GrayedFontColor,
+                DisabledFontColor = GrayedFontColor,
+                FontScaleX = 1f,
+                FontScaleY = 1f
+            });
 
             // Radio button style (for mutually exclusive options)
             var radioButtonUnselected = uiAtlas.GetSprite("UIRadioButton_Unselected");

--- a/PitHero/UI/ReorderableTableList.cs
+++ b/PitHero/UI/ReorderableTableList.cs
@@ -11,6 +11,7 @@ namespace PitHero.UI
     {
         private readonly List<T> _items;
         private readonly Skin _skin;
+        private bool _grayed;
 
         public Action<int, int, T> OnReordered;
 
@@ -29,6 +30,19 @@ namespace PitHero.UI
             Build();
         }
 
+        /// <summary>
+        /// Draws the list faded out with the reorder buttons deactivated. Used when the owning
+        /// feature is switched off but the list stays on screen.
+        /// </summary>
+        public void SetGrayed(bool grayed)
+        {
+            if (_grayed == grayed)
+                return;
+
+            _grayed = grayed;
+            Rebuild();
+        }
+
         private void Build()
         {
             // All rows share this table's columns so the Up/Down buttons align across rows
@@ -43,20 +57,22 @@ namespace PitHero.UI
 
         private void AddRowCells(int index, T item)
         {
-            // Priority number label - use ph-default style
-            var num = new Label((index + 1).ToString(), _skin, "ph-default");
+            var styleName = _grayed ? "ph-grayed" : "ph-default";
 
-            // Item text - use ph-default style
-            var txt = new Label(item?.ToString() ?? string.Empty, _skin, "ph-default");
+            // Priority number label
+            var num = new Label((index + 1).ToString(), _skin, styleName);
+
+            // Item text
+            var txt = new Label(item?.ToString() ?? string.Empty, _skin, styleName);
 
             // Up button
-            var upButton = new TextButton("Up", _skin, "ph-default");
-            upButton.SetDisabled(index == 0); // Disable if first item
+            var upButton = new TextButton("Up", _skin, styleName);
+            upButton.SetDisabled(_grayed || index == 0); // Disable if first item
             upButton.OnClicked += (btn) => MoveItemUp(index);
 
             // Down button
-            var downButton = new TextButton("Down", _skin, "ph-default");
-            downButton.SetDisabled(index == _items.Count - 1); // Disable if last item
+            var downButton = new TextButton("Down", _skin, styleName);
+            downButton.SetDisabled(_grayed || index == _items.Count - 1); // Disable if last item
             downButton.OnClicked += (btn) => MoveItemDown(index);
 
             Add(num).SetMinWidth(30f).SetPadRight(5f).SetPadBottom(2f);

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -926,7 +926,7 @@ namespace PitHero.UI
             {
                 var svc = Core.Services?.GetService<AutoCropSellService>();
                 if (svc != null) svc.Enabled = isChecked;
-                _designateCropsButton?.SetVisible(isChecked);
+                SetDesignateCropsActive(isChecked);
                 if (!isChecked)
                     _autoSellCropTypesDialog?.Hide();
             };
@@ -940,9 +940,9 @@ namespace PitHero.UI
                     _autoSellCropTypesDialog = new AutoSellCropTypesDialog(_stage);
                 _autoSellCropTypesDialog.Show();
             };
-            _designateCropsButton.SetVisible(false);
-            autoShopTable.Add(_designateCropsButton).Left().Width(140f);
+            autoShopTable.Add(_designateCropsButton).Left().SetMinWidth(140f).SetMinHeight(16f);
             autoShopTable.Row();
+            SetDesignateCropsActive(false);
 
             string excessTooltip = GetText(TextType.UI, UITextKey.SettingsAutoSellExcessItemsTooltip);
             _autoSellExcessCheckBox = new HoverableCheckBox(
@@ -955,10 +955,7 @@ namespace PitHero.UI
             {
                 var svc = Core.Services?.GetService<AutoSellExcessItemsService>();
                 if (svc != null) svc.Enabled = isChecked;
-                _sellPriorityLabel?.SetVisible(isChecked);
-                _sellPriorityList?.SetVisible(isChecked);
-                _sellRaritiesLabel?.SetVisible(isChecked);
-                _sellRaritiesTable?.SetVisible(isChecked);
+                SetExcessItemControlsActive(isChecked);
             };
             autoShopTable.Add(_autoSellExcessCheckBox).Left().SetPadTop(15f).SetPadBottom(8f);
             autoShopTable.Row();
@@ -1011,8 +1008,65 @@ namespace PitHero.UI
                     _sellRaritiesTable.Row();
             }
             autoShopTable.Add(_sellRaritiesTable).Left();
+            SetExcessItemControlsActive(_autoSellExcessCheckBox.IsChecked);
 
             automationTab.Add(autoShopTable).Expand().Top().Left();
+        }
+
+        /// <summary>
+        /// Activates or deactivates the crop designation button. When deactivated it stays on
+        /// screen but is drawn grayed out with hover and click disabled.
+        /// </summary>
+        private void SetDesignateCropsActive(bool active)
+        {
+            if (_designateCropsButton == null)
+                return;
+
+            var skin = PitHeroSkin.CreateSkin();
+            _designateCropsButton.SetDisabled(!active);
+            _designateCropsButton.SetStyle(skin.Get<TextButtonStyle>(active ? "ph-default" : "ph-grayed"));
+            _designateCropsButton.SetTouchable(active ? Touchable.Enabled : Touchable.Disabled);
+        }
+
+        /// <summary>
+        /// Activates or deactivates the auto-sell-excess sub-controls (sell priority list and gear
+        /// rarity checkboxes). When deactivated they stay on screen but are drawn grayed out with
+        /// tooltips, hover and click disabled.
+        /// </summary>
+        private void SetExcessItemControlsActive(bool active)
+        {
+            var skin = PitHeroSkin.CreateSkin();
+            var labelStyle = skin.Get<LabelStyle>(active ? "ph-default" : "ph-grayed");
+            var checkBoxStyle = skin.Get<CheckBoxStyle>(active ? "ph-default" : "ph-grayed");
+            var touchable = active ? Touchable.Enabled : Touchable.Disabled;
+
+            if (_sellPriorityLabel != null)
+            {
+                _sellPriorityLabel.SetStyle(labelStyle);
+                _sellPriorityLabel.SetTooltipEnabled(active);
+            }
+
+            _sellPriorityList?.SetGrayed(!active);
+
+            if (_sellRaritiesLabel != null)
+            {
+                _sellRaritiesLabel.SetStyle(labelStyle);
+                _sellRaritiesLabel.SetTooltipEnabled(active);
+            }
+
+            if (_sellRarityCheckBoxes == null)
+                return;
+
+            for (int i = 0; i < _sellRarityCheckBoxes.Length; i++)
+            {
+                var rarityCheckBox = _sellRarityCheckBoxes[i];
+                if (rarityCheckBox == null)
+                    continue;
+
+                rarityCheckBox.SetDisabled(!active);
+                rarityCheckBox.SetStyle(checkBoxStyle);
+                rarityCheckBox.SetTouchable(touchable);
+            }
         }
 
         /// <summary>Writes the reordered sell priority (top entry sells first) to the service.</summary>
@@ -1050,7 +1104,7 @@ namespace PitHero.UI
             {
                 if (_autoSellCropsCheckBox != null)
                     _autoSellCropsCheckBox.IsChecked = cropSellSvc.Enabled;
-                _designateCropsButton?.SetVisible(cropSellSvc.Enabled);
+                SetDesignateCropsActive(cropSellSvc.Enabled);
                 _autoSellCropTypesDialog?.SyncFromService();
             }
 
@@ -1073,10 +1127,7 @@ namespace PitHero.UI
                     for (int i = 0; i < _sellRarityCheckBoxes.Length && i < excessSvc.RarityAllowed.Length; i++)
                         _sellRarityCheckBoxes[i].IsChecked = excessSvc.RarityAllowed[i];
                 }
-                _sellPriorityLabel?.SetVisible(excessSvc.Enabled);
-                _sellPriorityList?.SetVisible(excessSvc.Enabled);
-                _sellRaritiesLabel?.SetVisible(excessSvc.Enabled);
-                _sellRaritiesTable?.SetVisible(excessSvc.Enabled);
+                SetExcessItemControlsActive(excessSvc.Enabled);
             }
         }
 


### PR DESCRIPTION
## Summary

Cosmetic pass on the Automation tab in Settings. Controls that are switched off now stay on screen in a visibly deactivated state instead of disappearing, so the tab layout no longer shifts as options are toggled.

## Changes

**New `"ph-grayed"` skin family** (`PitHeroSkin.cs`) — `LabelStyle`, `TextButtonStyle`, and `CheckBoxStyle` variants for controls that are visible but not usable: tinted/faded drawables and a washed-out brown font, with up/down/over/disabled all drawn identically so hovering gives no feedback. The tinted nine-patch is created after `SetPadding`, so it inherits the text-centering padding.

**Automation tab** (`SettingsUI.cs`)
- Reworded the "Automate monster jobs" tooltip.
- Renamed "Designate Crops" to "Choose Crops to Sell"; the cell now uses a 16px minimum height, and a minimum width instead of a fixed 140 so the longer label is not clipped.
- The crop button always shows now — when Auto-Sell Crops is off it grays out with hover and click disabled.
- The Item Sell Priority and Gear Rarities labels and controls gray out instead of hiding when Auto-Sell Excess Items is off, with tooltips and hover/click suppressed.
- Two helpers (`SetDesignateCropsActive`, `SetExcessItemControlsActive`) replace the old show/hide calls and are also invoked from `SyncAutomationControlsFromService`, so a loaded save lands in the correct visual state.

**Supporting API**
- `HoverableLabel.SetTooltipEnabled(bool)` — flips touchability and force-hides the tooltip window, since `OnMouseExit` will not fire once the label stops accepting input.
- `ReorderableTableList.SetGrayed(bool)` — rebuilds rows with the grayed styles and both reorder buttons disabled.

## Testing

- `dotnet build PitHero.sln` — 0 errors.
- `dotnet test` — 1636 passed, 0 failed, 6 skipped (matches the 0-failure baseline).
- Visual states still want a playtest pass in Settings > Automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)