### PR TITLE
Add tree bands at the top and bottom of the map (#348)

### DIFF
--- a/PitHero/ECS/Components/TreeBandComponent.cs
+++ b/PitHero/ECS/Components/TreeBandComponent.cs
@@ -1,0 +1,194 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Nez;
+using Nez.Textures;
+
+namespace PitHero.ECS.Components
+{
+    /// <summary>
+    /// A decorative band of deterministic random trees filling the empty space north or south of the
+    /// map (#348). The whole band is painted once into its own RenderTexture — trees are drawn
+    /// top-to-bottom like a painter, so lower trees overdraw higher ones — and every frame after that
+    /// only blits that single texture, instead of redrawing ~1900 sprites.
+    ///
+    /// The render texture covers the band rect plus TreeBandMapOverlapPx on the map-facing side, so
+    /// trees may spill slightly over the map edge for an organic seam while anything beyond that is
+    /// clipped for free by the texture bounds.
+    /// </summary>
+    public class TreeBandComponent : RenderableComponent
+    {
+        private readonly Sprite _tree;
+        private readonly Sprite _tree2;
+        private readonly int _startTileY;
+        private readonly int _endTileY;
+        private readonly int _seed;
+        private readonly int _rtWidth;
+        private readonly int _rtHeight;
+        private readonly float _rtWorldTop;
+
+        private RenderTexture _renderTexture;
+        private Sprite _bandSprite;
+        private bool _needsPaint = true;
+
+        /// <param name="tree">The shorter tree sprite (center origin).</param>
+        /// <param name="tree2">The taller tree sprite (center origin).</param>
+        /// <param name="mapWidthPx">Full map width in pixels — the band spans all of it.</param>
+        /// <param name="startTileY">First tile row of the band (inclusive, may be negative).</param>
+        /// <param name="endTileY">Last tile row of the band (inclusive).</param>
+        /// <param name="seed">Seed for this band's local deterministic RNG.</param>
+        /// <param name="overlapBelow">
+        ///   True for the top band (trees spill downward into the map), false for the bottom band
+        ///   (trees spill upward into the map).
+        /// </param>
+        public TreeBandComponent(Sprite tree, Sprite tree2, int mapWidthPx,
+                                 int startTileY, int endTileY, int seed, bool overlapBelow)
+        {
+            _tree = tree;
+            _tree2 = tree2;
+            _startTileY = startTileY;
+            _endTileY = endTileY;
+            _seed = seed;
+
+            var bandTop = startTileY * GameConfig.TileSize;
+            var rows = endTileY - startTileY + 1;
+
+            _rtWidth = mapWidthPx;
+            _rtHeight = rows * GameConfig.TileSize + GameConfig.TreeBandMapOverlapPx;
+            // The overlap is added on the map-facing side: below for the top band (texture keeps its
+            // top edge), above for the bottom band (texture top moves up into the map).
+            _rtWorldTop = overlapBelow ? bandTop : bandTop - GameConfig.TreeBandMapOverlapPx;
+        }
+
+        /// <summary>Band rect in world space. Overridden so camera culling uses the real extents.</summary>
+        public override RectangleF Bounds
+        {
+            get
+            {
+                if (_areBoundsDirty)
+                {
+                    _bounds.X = Entity.Transform.Position.X + _localOffset.X;
+                    _bounds.Y = Entity.Transform.Position.Y + _localOffset.Y;
+                    _bounds.Width = _rtWidth;
+                    _bounds.Height = _rtHeight;
+                    _areBoundsDirty = false;
+                }
+                return _bounds;
+            }
+        }
+
+        public override void OnAddedToEntity()
+        {
+            SetLocalOffset(new Vector2(0f, _rtWorldTop));
+
+            _renderTexture = new RenderTexture(_rtWidth, _rtHeight, SurfaceFormat.Color, DepthFormat.None);
+            _renderTexture.ResizeBehavior = RenderTexture.RenderTextureResizeBehavior.None;
+
+            _bandSprite = new Sprite(_renderTexture.RenderTarget);
+            _bandSprite.Origin = Vector2.Zero;
+        }
+
+        public override void OnRemovedFromEntity()
+        {
+            _renderTexture?.Dispose();
+            _renderTexture = null;
+            _bandSprite = null;
+        }
+
+        /// <summary>
+        /// Forces one Render call before the band has been painted. Both bands sit entirely outside
+        /// the viewport at the default 1x zoom, so the normal camera cull would defer the one-time
+        /// paint until the player first zooms out — a visible hitch. The extra off-screen quad drawn
+        /// on frame one is free (the GPU clips it).
+        /// </summary>
+        public override bool IsVisibleFromCamera(Camera camera)
+        {
+            if (_needsPaint)
+                return true;
+            return base.IsVisibleFromCamera(camera);
+        }
+
+        public override void Render(Batcher batcher, Camera camera)
+        {
+            if (_bandSprite == null)
+                return;
+
+            if (_needsPaint)
+            {
+                PaintBandOnce(batcher, camera);
+                _needsPaint = false;
+            }
+
+            batcher.Draw(_bandSprite, Entity.Transform.Position + _localOffset, Color,
+                0f, Vector2.Zero, Vector2.One, SpriteEffects.None, _layerDepth);
+        }
+
+        /// <summary>
+        /// Renders every tree into the band's RenderTexture a single time. Follows the render-target
+        /// save/restore sequence documented in docs/RenderingSystem.md: flush the outer batch, swap
+        /// render targets, paint, then restore the scene target and resume the outer batch.
+        /// </summary>
+        private void PaintBandOnce(Batcher batcher, Camera camera)
+        {
+            var prevRTs = Core.GraphicsDevice.GetRenderTargets();
+            batcher.End();
+
+            Core.GraphicsDevice.SetRenderTarget(_renderTexture);
+            Core.GraphicsDevice.Clear(Color.Transparent);
+
+            // World -> render-texture-local, so PaintTrees can work in plain world coordinates.
+            var rtTransform = Matrix.CreateTranslation(0f, -_rtWorldTop, 0f);
+            batcher.Begin(BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.None,
+                RasterizerState.CullCounterClockwise, null, rtTransform, false);
+            PaintTrees(batcher);
+            batcher.End();
+
+            Core.GraphicsDevice.SetRenderTargets(prevRTs.Length > 0 ? prevRTs : null);
+            // Resume with our own effect bound. The renderer still believes the grading material is
+            // active and so will not re-Begin for us; passing null here would drop grading from this
+            // band AND from the Base tilemap that shares the material later in the same batch.
+            batcher.Begin(BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.None,
+                RasterizerState.CullCounterClockwise, Material?.Effect, camera.TransformMatrix, false);
+
+            Debug.Log("[TreeBand] Painted band rows {0}..{1} into a {2}x{3} render texture",
+                _startTileY, _endTileY, _rtWidth, _rtHeight);
+        }
+
+        /// <summary>
+        /// Paints the band row by row, top to bottom. Uses a local System.Random seeded from a fixed
+        /// key so the layout is identical every run without touching the global Nez.Random stream
+        /// (whose call order is a combat save/replay contract).
+        /// </summary>
+        private void PaintTrees(Batcher batcher)
+        {
+            var rng = new System.Random(_seed);
+
+            for (int row = _startTileY; row <= _endTileY; row++)
+            {
+                // Trunks sit on the row's bottom edge, jittered per tree.
+                var rowBaseY = row * GameConfig.TileSize + GameConfig.TileSize;
+
+                // Start off the left edge by a random amount and stagger each row so rows never line up.
+                var x = -rng.Next(0, GameConfig.TreeBandBaseSpacingPx)
+                      + rng.Next(-GameConfig.TreeBandRowXOffsetPx, GameConfig.TreeBandRowXOffsetPx + 1);
+
+                while (x < _rtWidth + GameConfig.TreeBandBaseSpacingPx)
+                {
+                    var sprite = rng.NextDouble() < GameConfig.TreeBandTree2Chance ? _tree2 : _tree;
+                    var effects = rng.NextDouble() < GameConfig.TreeBandFlipChance
+                        ? SpriteEffects.FlipHorizontally
+                        : SpriteEffects.None;
+                    var baseY = rowBaseY + rng.Next(-GameConfig.TreeBandRowYJitterPx,
+                                                     GameConfig.TreeBandRowYJitterPx + 1);
+
+                    // Sprites are center-origin, so lift by half the height to put the trunk base on baseY.
+                    var pos = new Vector2(x, baseY - sprite.SourceRect.Height * 0.5f);
+                    batcher.Draw(sprite, pos, Color.White, 0f, sprite.Origin, Vector2.One, effects, 0f);
+
+                    x += GameConfig.TreeBandBaseSpacingPx
+                       + rng.Next(-GameConfig.TreeBandSpacingJitterPx,
+                                   GameConfig.TreeBandSpacingJitterPx + 1);
+                }
+            }
+        }
+    }
+}

--- a/PitHero/ECS/Components/TreeBandComponent.cs
+++ b/PitHero/ECS/Components/TreeBandComponent.cs
@@ -25,6 +25,9 @@ namespace PitHero.ECS.Components
         private readonly int _rtWidth;
         private readonly int _rtHeight;
         private readonly float _rtWorldTop;
+        private readonly int _rowCount;
+        private readonly float _firstRowAnchorY;
+        private readonly bool _anchorByTop;
 
         private RenderTexture _renderTexture;
         private Sprite _bandSprite;
@@ -50,13 +53,37 @@ namespace PitHero.ECS.Components
             _seed = seed;
 
             var bandTop = startTileY * GameConfig.TileSize;
-            var rows = endTileY - startTileY + 1;
+            var maxTreeHeight = tree.SourceRect.Height > tree2.SourceRect.Height
+                ? tree.SourceRect.Height
+                : tree2.SourceRect.Height;
 
+            _rowCount = endTileY - startTileY + 1;
             _rtWidth = mapWidthPx;
-            _rtHeight = rows * GameConfig.TileSize + GameConfig.TreeBandMapOverlapPx;
-            // The overlap is added on the map-facing side: below for the top band (texture keeps its
-            // top edge), above for the bottom band (texture top moves up into the map).
-            _rtWorldTop = overlapBelow ? bandTop : bandTop - GameConfig.TreeBandMapOverlapPx;
+
+            // Each band anchors its rows on the edge that faces the map, so the seam is governed by
+            // the part of the tree the player actually sees against the terrain.
+            if (overlapBelow)
+            {
+                // Top band: trees stand above the map, so anchor each row by its trunk base. Only
+                // trunk bottoms reach the map, and the texture clips them flush at the overlap line
+                // — a cut trunk simply reads as the tree standing on the ground there.
+                _anchorByTop = false;
+                _firstRowAnchorY = bandTop + GameConfig.TileSize;
+                _rtWorldTop = bandTop;
+                _rtHeight = _rowCount * GameConfig.TileSize + GameConfig.TreeBandMapOverlapPx;
+            }
+            else
+            {
+                // Bottom band: trees stand below the map and grow up toward it, so anchor each row by
+                // its canopy TOP. That keeps the first row's crowns just grazing the map's bottom tile
+                // row instead of burying it, and it holds regardless of which sprite is picked. The
+                // texture is sized to contain whole trees, so no canopy is ever cut.
+                _anchorByTop = true;
+                _firstRowAnchorY = bandTop - GameConfig.TreeBandCanopyPeekPx;
+                _rtWorldTop = _firstRowAnchorY - GameConfig.TreeBandRowYJitterPx;
+                var lastRowAnchorY = _firstRowAnchorY + (_rowCount - 1) * GameConfig.TileSize;
+                _rtHeight = (int)(lastRowAnchorY + GameConfig.TreeBandRowYJitterPx + maxTreeHeight - _rtWorldTop);
+            }
         }
 
         /// <summary>Band rect in world space. Overridden so camera culling uses the real extents.</summary>
@@ -162,10 +189,9 @@ namespace PitHero.ECS.Components
         {
             var rng = new System.Random(_seed);
 
-            for (int row = _startTileY; row <= _endTileY; row++)
+            for (int i = 0; i < _rowCount; i++)
             {
-                // Trunks sit on the row's bottom edge, jittered per tree.
-                var rowBaseY = row * GameConfig.TileSize + GameConfig.TileSize;
+                var rowAnchorY = _firstRowAnchorY + i * GameConfig.TileSize;
 
                 // Start off the left edge by a random amount and stagger each row so rows never line up.
                 var x = -rng.Next(0, GameConfig.TreeBandBaseSpacingPx)
@@ -177,11 +203,13 @@ namespace PitHero.ECS.Components
                     var effects = rng.NextDouble() < GameConfig.TreeBandFlipChance
                         ? SpriteEffects.FlipHorizontally
                         : SpriteEffects.None;
-                    var baseY = rowBaseY + rng.Next(-GameConfig.TreeBandRowYJitterPx,
-                                                     GameConfig.TreeBandRowYJitterPx + 1);
+                    var anchorY = rowAnchorY + rng.Next(-GameConfig.TreeBandRowYJitterPx,
+                                                         GameConfig.TreeBandRowYJitterPx + 1);
 
-                    // Sprites are center-origin, so lift by half the height to put the trunk base on baseY.
-                    var pos = new Vector2(x, baseY - sprite.SourceRect.Height * 0.5f);
+                    // Sprites are center-origin, so shift by half the height to put the anchored edge
+                    // (canopy top or trunk base, per the band) on anchorY.
+                    var halfHeight = sprite.SourceRect.Height * 0.5f;
+                    var pos = new Vector2(x, _anchorByTop ? anchorY + halfHeight : anchorY - halfHeight);
                     batcher.Draw(sprite, pos, Color.White, 0f, sprite.Origin, Vector2.One, effects, 0f);
 
                     x += GameConfig.TreeBandBaseSpacingPx

--- a/PitHero/ECS/Components/TreeBandComponent.cs
+++ b/PitHero/ECS/Components/TreeBandComponent.cs
@@ -19,6 +19,9 @@ namespace PitHero.ECS.Components
     {
         private readonly Sprite _tree;
         private readonly Sprite _tree2;
+        private readonly Sprite _grass;
+        private readonly float _grassTopY;
+        private readonly float _grassBottomY;
         private readonly int _startTileY;
         private readonly int _endTileY;
         private readonly int _seed;
@@ -35,7 +38,12 @@ namespace PitHero.ECS.Components
 
         /// <param name="tree">The shorter tree sprite (center origin).</param>
         /// <param name="tree2">The taller tree sprite (center origin).</param>
+        /// <param name="grass">
+        ///   Grass tile from the map tileset (top-left origin), tiled behind the trees so the band
+        ///   sits on graded grass instead of the ungraded window background.
+        /// </param>
         /// <param name="mapWidthPx">Full map width in pixels — the band spans all of it.</param>
+        /// <param name="mapHeightPx">Full map height in pixels — grass is only painted outside it.</param>
         /// <param name="startTileY">First tile row of the band (inclusive, may be negative).</param>
         /// <param name="endTileY">Last tile row of the band (inclusive).</param>
         /// <param name="seed">Seed for this band's local deterministic RNG.</param>
@@ -43,11 +51,12 @@ namespace PitHero.ECS.Components
         ///   True for the top band (trees spill downward into the map), false for the bottom band
         ///   (trees spill upward into the map).
         /// </param>
-        public TreeBandComponent(Sprite tree, Sprite tree2, int mapWidthPx,
+        public TreeBandComponent(Sprite tree, Sprite tree2, Sprite grass, int mapWidthPx, int mapHeightPx,
                                  int startTileY, int endTileY, int seed, bool overlapBelow)
         {
             _tree = tree;
             _tree2 = tree2;
+            _grass = grass;
             _startTileY = startTileY;
             _endTileY = endTileY;
             _seed = seed;
@@ -71,6 +80,10 @@ namespace PitHero.ECS.Components
                 _firstRowAnchorY = bandTop + GameConfig.TileSize;
                 _rtWorldTop = bandTop;
                 _rtHeight = _rowCount * GameConfig.TileSize + GameConfig.TreeBandMapOverlapPx;
+                // Grass stops at the map's top edge — the strip the trunks overhang must stay
+                // transparent so the real tilemap shows through it.
+                _grassTopY = _rtWorldTop;
+                _grassBottomY = 0f;
             }
             else
             {
@@ -83,6 +96,10 @@ namespace PitHero.ECS.Components
                 _rtWorldTop = _firstRowAnchorY - GameConfig.TreeBandRowYJitterPx;
                 var lastRowAnchorY = _firstRowAnchorY + (_rowCount - 1) * GameConfig.TileSize;
                 _rtHeight = (int)(lastRowAnchorY + GameConfig.TreeBandRowYJitterPx + maxTreeHeight - _rtWorldTop);
+                // Grass starts at the map's bottom edge — the strip the crowns poke into must stay
+                // transparent so the real tilemap (tilled soil included) shows through it.
+                _grassTopY = mapHeightPx;
+                _grassBottomY = _rtWorldTop + _rtHeight;
             }
         }
 
@@ -166,6 +183,7 @@ namespace PitHero.ECS.Components
             var rtTransform = Matrix.CreateTranslation(0f, -_rtWorldTop, 0f);
             batcher.Begin(BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.None,
                 RasterizerState.CullCounterClockwise, null, rtTransform, false);
+            PaintGrass(batcher);
             PaintTrees(batcher);
             batcher.End();
 
@@ -178,6 +196,27 @@ namespace PitHero.ECS.Components
 
             Debug.Log("[TreeBand] Painted band rows {0}..{1} into a {2}x{3} render texture",
                 _startTileY, _endTileY, _rtWidth, _rtHeight);
+        }
+
+        /// <summary>
+        /// Tiles the map tileset's grass tile across the part of the band that lies outside the map,
+        /// before any tree is drawn. Without it the gaps between trunks fall through to the window's
+        /// ungraded background colour, which matches grass by day but stands out badly once the
+        /// terrain is graded at night. Because the grass shares the band's render texture, it is
+        /// graded by the same material as the trees drawn on top of it.
+        /// </summary>
+        private void PaintGrass(Batcher batcher)
+        {
+            if (_grass == null || _grassBottomY <= _grassTopY)
+                return;
+
+            // Align to the world tile grid so the fill lines up seamlessly with the real tilemap.
+            for (var y = _grassTopY; y < _grassBottomY; y += GameConfig.TileSize)
+            {
+                for (var x = 0; x < _rtWidth; x += GameConfig.TileSize)
+                    batcher.Draw(_grass, new Vector2(x, y), Color.White, 0f, Vector2.Zero, Vector2.One,
+                        SpriteEffects.None, 0f);
+            }
         }
 
         /// <summary>

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -1164,23 +1164,46 @@ namespace PitHero.ECS.Scenes
                 return;
             }
 
+            var grass = GetMapTileSprite(GameConfig.TreeBandGrassTileGid);
             var mapWidthPx = _tmxMap.Width * _tmxMap.TileWidth;
+            var mapHeightPx = _tmxMap.Height * _tmxMap.TileHeight;
             var bandEntity = CreateEntity("tree-bands");
 
-            AddTreeBand(bandEntity, tree, tree2, mapWidthPx,
+            AddTreeBand(bandEntity, tree, tree2, grass, mapWidthPx, mapHeightPx,
                 GameConfig.TreeBandTopStartTileY, GameConfig.TreeBandTopEndTileY,
                 GameConfig.TreeBandSeed, true);
-            AddTreeBand(bandEntity, tree, tree2, mapWidthPx,
+            AddTreeBand(bandEntity, tree, tree2, grass, mapWidthPx, mapHeightPx,
                 GameConfig.TreeBandBottomStartTileY, GameConfig.TreeBandBottomEndTileY,
                 GameConfig.TreeBandSeed + 1, false);
         }
 
+        /// <summary>
+        /// Builds a top-left-origin sprite for a single tile of the map tileset, by global tile id
+        /// (the same 1-based numbering Tiled shows, since the tileset's firstgid is 1).
+        /// </summary>
+        private Sprite GetMapTileSprite(int gid)
+        {
+            var tileset = _tmxMap?.GetTilesetForTileGid(gid);
+            if (tileset?.Image?.Texture == null)
+                return null;
+            if (!tileset.TileRegions.TryGetValue(gid, out var region))
+            {
+                Debug.Warn("[MainGameScene] Map tileset has no region for gid {0}", gid);
+                return null;
+            }
+
+            var sprite = new Sprite(tileset.Image.Texture,
+                new Rectangle((int)region.X, (int)region.Y, (int)region.Width, (int)region.Height));
+            sprite.Origin = Vector2.Zero;
+            return sprite;
+        }
+
         /// <summary>Adds one tree band component to the shared band entity and grades it day/night.</summary>
-        private void AddTreeBand(Entity bandEntity, Sprite tree, Sprite tree2, int mapWidthPx,
-            int startTileY, int endTileY, int seed, bool overlapBelow)
+        private void AddTreeBand(Entity bandEntity, Sprite tree, Sprite tree2, Sprite grass,
+            int mapWidthPx, int mapHeightPx, int startTileY, int endTileY, int seed, bool overlapBelow)
         {
             var band = bandEntity.AddComponent(new TreeBandComponent(
-                tree, tree2, mapWidthPx, startTileY, endTileY, seed, overlapBelow));
+                tree, tree2, grass, mapWidthPx, mapHeightPx, startTileY, endTileY, seed, overlapBelow));
             band.SetRenderLayer(GameConfig.RenderLayerTreeBand);
             if (_colorGrading?.Material != null)
                 band.SetMaterial(_colorGrading.Material);

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework;
 using Nez;
 using Nez.BitmapFonts;
 using Nez.Sprites;
+using Nez.Textures;
 using Nez.Tiled;
 using Nez.UI; // Added for Label
 using PitHero.AI;
@@ -1063,6 +1064,8 @@ namespace PitHero.ECS.Scenes
             detailLayerRenderer.SetMaterial(_colorGrading.Material);
             topLayerRenderer.SetMaterial(_colorGrading.Material);
 
+            SpawnTreeBands();
+
             _cameraController?.ConfigureZoomForMap(_mapPath);
 
             // Initialize till mode overlay now that the map is loaded. SetupUIOverlay() runs
@@ -1141,6 +1144,46 @@ namespace PitHero.ECS.Scenes
 
             // Initialize pit width manager after map and services are set up
             SetupPitWidthManager();
+        }
+
+        /// <summary>
+        /// Creates the decorative tree bands north and south of the map (#348). Each band paints
+        /// itself once into its own RenderTexture on the first frame, then blits a single quad.
+        /// </summary>
+        private void SpawnTreeBands()
+        {
+            if (_tmxMap == null)
+                return;
+
+            var atlas = Core.Content.LoadSpriteAtlas("Content/Atlases/CropsProps.atlas");
+            var tree = atlas?.GetSprite("Tree");
+            var tree2 = atlas?.GetSprite("Tree2");
+            if (tree == null || tree2 == null)
+            {
+                Debug.Warn("[MainGameScene] Tree sprites missing from CropsProps atlas; skipping tree bands");
+                return;
+            }
+
+            var mapWidthPx = _tmxMap.Width * _tmxMap.TileWidth;
+            var bandEntity = CreateEntity("tree-bands");
+
+            AddTreeBand(bandEntity, tree, tree2, mapWidthPx,
+                GameConfig.TreeBandTopStartTileY, GameConfig.TreeBandTopEndTileY,
+                GameConfig.TreeBandSeed, true);
+            AddTreeBand(bandEntity, tree, tree2, mapWidthPx,
+                GameConfig.TreeBandBottomStartTileY, GameConfig.TreeBandBottomEndTileY,
+                GameConfig.TreeBandSeed + 1, false);
+        }
+
+        /// <summary>Adds one tree band component to the shared band entity and grades it day/night.</summary>
+        private void AddTreeBand(Entity bandEntity, Sprite tree, Sprite tree2, int mapWidthPx,
+            int startTileY, int endTileY, int seed, bool overlapBelow)
+        {
+            var band = bandEntity.AddComponent(new TreeBandComponent(
+                tree, tree2, mapWidthPx, startTileY, endTileY, seed, overlapBelow));
+            band.SetRenderLayer(GameConfig.RenderLayerTreeBand);
+            if (_colorGrading?.Material != null)
+                band.SetMaterial(_colorGrading.Material);
         }
 
         private void SetupPitWidthManager()

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -358,6 +358,10 @@ namespace PitHero
         public const int RenderLayerFogOfWar = 70;
         // NOTE: Placed buildings (Monster House / Crop Storage) render at RenderLayerActors and are
         // Y-sorted with monsters via YSortSpriteRenderer.YSortOffset (see IYSortOffset / YSortManager).
+        // Decorative tree bands north/south of the map (#348). Above the Base/Detail tilemap layers so the
+        // fringe that spills over the map edge covers terrain, but behind fog and actors. Deliberately not
+        // 60/61 so YSortManager ignores it — the bands are static and never sort.
+        public const int RenderLayerTreeBand = 80;
         public const int RenderLayerDetail = 90; // Detail tilemap layer (tilled soil, etc.) — above base, below actors
         public const int RenderLayerBase = 100; // Background layer
 
@@ -369,6 +373,21 @@ namespace PitHero
         // Y-sort: LayerDepth = Mathf.Clamp01(1f - entity.Y * YSortDepthScale)
         // Higher world-Y (closer to camera) → smaller depth → drawn in front.
         public const float YSortDepthScale = 1f / 100000f;
+
+        // Tree Bands (#348) — decorative deterministic tree fills above and below the map, painted
+        // once into a RenderTexture at map load so zooming out never exposes empty space north/south.
+        public const int TreeBandTopStartTileY = -10;   // first tile row of the top band (inclusive)
+        public const int TreeBandTopEndTileY = -1;      // last tile row of the top band (inclusive)
+        public const int TreeBandBottomStartTileY = 12; // first tile row of the bottom band (inclusive)
+        public const int TreeBandBottomEndTileY = 21;   // last tile row of the bottom band (inclusive)
+        public const int TreeBandSeed = 348;            // fixed seed — bands look identical every run
+        public const int TreeBandMapOverlapPx = 16;     // px a band may spill over the map edge for an organic seam
+        public const int TreeBandBaseSpacingPx = 40;    // nominal horizontal step between trunks
+        public const int TreeBandSpacingJitterPx = 18;  // +/- horizontal jitter added to the step
+        public const int TreeBandRowYJitterPx = 10;     // +/- vertical jitter applied per tree
+        public const int TreeBandRowXOffsetPx = 20;     // +/- per-row horizontal stagger so rows do not line up
+        public const float TreeBandTree2Chance = 0.45f; // probability a tree uses the taller Tree2 sprite
+        public const float TreeBandFlipChance = 0.5f;   // probability a tree is mirrored horizontally
 
         // Font paths
         public const string FontMainUI = "Content/Fonts/Express.fnt";

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -381,6 +381,7 @@ namespace PitHero
         public const int TreeBandBottomStartTileY = 12; // first tile row of the bottom band (inclusive)
         public const int TreeBandBottomEndTileY = 21;   // last tile row of the bottom band (inclusive)
         public const int TreeBandSeed = 348;            // fixed seed — bands look identical every run
+        public const int TreeBandGrassTileGid = 13;     // map tileset gid painted as the bands' grass backdrop
         public const int TreeBandMapOverlapPx = 16;     // px the top band's trunks may spill over the map edge
         public const int TreeBandCanopyPeekPx = 6;      // px the bottom band's canopy tops poke over the map's bottom edge
         public const int TreeBandBaseSpacingPx = 40;    // nominal horizontal step between trunks

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -381,7 +381,8 @@ namespace PitHero
         public const int TreeBandBottomStartTileY = 12; // first tile row of the bottom band (inclusive)
         public const int TreeBandBottomEndTileY = 21;   // last tile row of the bottom band (inclusive)
         public const int TreeBandSeed = 348;            // fixed seed — bands look identical every run
-        public const int TreeBandMapOverlapPx = 16;     // px a band may spill over the map edge for an organic seam
+        public const int TreeBandMapOverlapPx = 16;     // px the top band's trunks may spill over the map edge
+        public const int TreeBandCanopyPeekPx = 6;      // px the bottom band's canopy tops poke over the map's bottom edge
         public const int TreeBandBaseSpacingPx = 40;    // nominal horizontal step between trunks
         public const int TreeBandSpacingJitterPx = 18;  // +/- horizontal jitter added to the step
         public const int TreeBandRowYJitterPx = 10;     // +/- vertical jitter applied per tree

--- a/PitHero/docs/RenderingSystem.md
+++ b/PitHero/docs/RenderingSystem.md
@@ -38,6 +38,13 @@ cost nothing after the first frame. It sits in front of the Base/Detail tilemap 
 fringe that spills over the map edge covers terrain) but behind fog and actors, and it is
 deliberately not 60/61 so `YSortManager` ignores it — the bands are static and never sort.
 
+Each band anchors its rows on the edge that faces the map. The **top** band's trees stand above the
+map, so rows anchor by **trunk base** and the render texture clips those trunks flush at
+`TreeBandMapOverlapPx` — a cut trunk just reads as the tree standing on the ground. The **bottom**
+band's trees grow upward toward the map, so rows anchor by **canopy top**, holding the first row's
+crowns `TreeBandCanopyPeekPx` over the map's bottom tile row instead of burying it; that texture is
+sized to contain whole trees so no canopy is ever cut.
+
 UI / HUD layers (screen-space, unaffected by camera): `RenderLayerActionQueue` (996),
 `RenderLayerGraphicalHUD` (997), `RenderLayerUI` (998), `TransparentPauseOverlay` (999).
 

--- a/PitHero/docs/RenderingSystem.md
+++ b/PitHero/docs/RenderingSystem.md
@@ -38,6 +38,13 @@ cost nothing after the first frame. It sits in front of the Base/Detail tilemap 
 fringe that spills over the map edge covers terrain) but behind fog and actors, and it is
 deliberately not 60/61 so `YSortManager` ignores it — the bands are static and never sort.
 
+Each band first tiles the map tileset's grass tile (`GameConfig.TreeBandGrassTileGid`, resolved via
+`TmxMap.GetTilesetForTileGid` + `TmxTileset.TileRegions`) across the part of the band outside the
+map, then draws trees over it. Without that backdrop the gaps between trunks fall through to the
+window's ungraded background colour — which passes for grass by day but stands out badly once the
+terrain is graded at night. Grass stops at the map edge so the strip the trees overhang stays
+transparent and the real tilemap shows through.
+
 Each band anchors its rows on the edge that faces the map. The **top** band's trees stand above the
 map, so rows anchor by **trunk base** and the render texture clips those trunks flush at
 `TreeBandMapOverlapPx` — a cut trunk just reads as the tree standing on the ground. The **bottom**

--- a/PitHero/docs/RenderingSystem.md
+++ b/PitHero/docs/RenderingSystem.md
@@ -19,6 +19,7 @@ Higher number = drawn first = further back.  Lower number = drawn later = in fro
 | `RenderLayerSingleTileObject` | 61 | Static 32×32 world objects: treasure chests, walls/obstacles (Y-sorted) |
 | `RenderLayerDroppedItems` | 65 | Dropped loot items |
 | `RenderLayerFogOfWar` | 70 | Tilemap fog-of-war overlay — renders **behind** actors/objects (#337) |
+| `RenderLayerTreeBand` | 80 | Decorative tree bands north/south of the map (#348) |
 | `RenderLayerBase` | 100 | Tilemap base layer |
 
 Fog of war renders behind actors so the party is never partially covered when walking next
@@ -29,6 +30,13 @@ renderable while the entity's tile is fogged, and `TiledMapService.RefreshFogHid
 animators. Monsters additionally self-hide/self-reveal when they move between fogged and
 clear tiles (`EnemyAnimationComponent.CheckFogVisibility` / `TileByTileMover.CompleteMove`).
 Heroes and mercenaries are never fog-hidden.
+
+`RenderLayerTreeBand` holds the two decorative tree bands that fill the empty space above and
+below the map when the player zooms out (`TreeBandComponent`, #348). Each band is painted **once**
+into its own `RenderTexture` at map load and then blits a single quad per frame, so its ~1900 trees
+cost nothing after the first frame. It sits in front of the Base/Detail tilemap layers (so the
+fringe that spills over the map edge covers terrain) but behind fog and actors, and it is
+deliberately not 60/61 so `YSortManager` ignores it — the bands are static and never sort.
 
 UI / HUD layers (screen-space, unaffected by camera): `RenderLayerActionQueue` (996),
 `RenderLayerGraphicalHUD` (997), `RenderLayerUI` (998), `TransparentPauseOverlay` (999).


### PR DESCRIPTION
Closes #348.

Zooming out to 0.5x exposes ~168px of empty space north and south of the 7680x384 map. This fills both strips with a staggered field of deterministic random trees, using the `Tree` / `Tree2` art added in dfa5f97 (which was unwired until now).

Each band is painted **once** into its own `RenderTexture` at map load — trees are drawn top-to-bottom like a painter, so lower trees overdraw higher ones — and every frame after that blits a single quad instead of ~1900 sprites.

## How it works

**`TreeBandComponent`** (new, `ECS/Components/`) owns one band's render texture, paints it once, overrides `Bounds` so camera culling uses the real band rect, and disposes the RT on teardown. Two instances hang off a shared `"tree-bands"` entity created at the end of `MainGameScene.LoadMap()`.

Layout comes from a **local `System.Random` seeded from a fixed key**, so the bands are byte-identical every run without consuming the global `Nez.Random` stream — its call order is a combat save/replay contract. This follows the `VirtualPitGenerator` precedent.

**Grass backdrop.** Each band first tiles the map tileset's own grass tile across the part of the band outside the map, then draws trees over it. Without it the gaps between trunks fell through to the window's ungraded background colour — fine by day, but conspicuous once the terrain is graded at night. Backdrop and trees share one render texture, so the single `ColorGradingController` material tints them together and the bands track the terrain at every hour. The tile is resolved through `TmxMap.GetTilesetForTileGid` + `TmxTileset.TileRegions` (both keyed by gid), so no duplicate atlas entry was needed — gid 13 already makes up 59% of the Base layer.

**Anchoring.** Each band anchors its rows on the edge that faces the map:

- **Top band** — trees stand above the map, so rows anchor by **trunk base**. Only trunk bottoms reach the map and the texture clips them flush; a cut trunk just reads as the tree standing on the ground.
- **Bottom band** — trees grow upward toward the map, so rows anchor by **canopy top**. That holds the first row's crowns `TreeBandCanopyPeekPx` (6px) over the bottom tile row instead of burying it, and it holds regardless of which sprite is picked (the two differ by 15px in height). Its texture is sized to contain whole trees, so no canopy is cut. Tilled farm soil on that row stays visible.

Grass stops at the map edge in both bands, leaving the overhang strip transparent so the real tilemap shows through it.

## Render layer

New `RenderLayerTreeBand = 80` — in front of the Base/Detail tilemap layers so the overhanging fringe covers terrain, behind fog and actors, and deliberately outside 60/61 so `YSortManager` ignores it (the bands are static and never sort).

## Note on `IsVisibleFromCamera`

Both bands sit entirely off-camera at the default 1x zoom, so the normal cull would have deferred the one-time paint until the player first zoomed out — a visible hitch. `IsVisibleFromCamera` returns `true` until the paint completes; the extra off-screen quad on frame one is GPU-clipped.

## Tuning

All 14 knobs live in `GameConfig.cs` under `// Tree Bands (#348)` — band tile ranges, seed, grass gid, overlap/peek, spacing and jitter, sprite-mix and flip chances.

## Testing

- `dotnet build PitHero.sln` — clean, 0 errors.
- `dotnet test PitHero.Tests/PitHero.Tests.csproj` — 1662 passed, 0 failed, matching the pre-existing baseline.
- Verified in-game at 0.5x zoom: both bands cover the full 240-tile width, day/night grading tracks the terrain, and the map's outer tile rows stay readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)