### PR TITLE
Auto-hire mercenaries with job-slot designations (#350)

### DIFF
--- a/PitHero.Tests/AutoHireMercenaryServiceTests.cs
+++ b/PitHero.Tests/AutoHireMercenaryServiceTests.cs
@@ -1,0 +1,134 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Services;
+using RolePlayingFramework.Jobs;
+
+namespace PitHero.Tests
+{
+    /// <summary>Tests for the auto-hire mercenary matching and affordability logic (issue #350).</summary>
+    [TestClass]
+    public class AutoHireMercenaryServiceTests
+    {
+        [TestMethod]
+        public void JobQualifies_BothSlotsNone_NeverQualifies()
+        {
+            Assert.IsFalse(AutoHireMercenaryService.JobQualifies(
+                JobType.Knight, JobType.None, JobType.None, JobType.None, JobType.None));
+        }
+
+        [TestMethod]
+        public void JobQualifies_CandidateNone_NeverQualifies()
+        {
+            Assert.IsFalse(AutoHireMercenaryService.JobQualifies(
+                JobType.None, JobType.Priest, JobType.Mage, JobType.None, JobType.None));
+        }
+
+        [TestMethod]
+        public void JobQualifies_MatchingSlot_Qualifies()
+        {
+            Assert.IsTrue(AutoHireMercenaryService.JobQualifies(
+                JobType.Priest, JobType.Priest, JobType.None, JobType.None, JobType.None));
+            Assert.IsTrue(AutoHireMercenaryService.JobQualifies(
+                JobType.Mage, JobType.Priest, JobType.Mage, JobType.None, JobType.None));
+        }
+
+        [TestMethod]
+        public void JobQualifies_JobNotInSlots_DoesNotQualify()
+        {
+            Assert.IsFalse(AutoHireMercenaryService.JobQualifies(
+                JobType.Thief, JobType.Priest, JobType.Mage, JobType.None, JobType.None));
+        }
+
+        [TestMethod]
+        public void JobQualifies_SlotSatisfiedByHiredMerc_DoesNotQualify()
+        {
+            Assert.IsFalse(AutoHireMercenaryService.JobQualifies(
+                JobType.Priest, JobType.Priest, JobType.None, JobType.Priest, JobType.None));
+        }
+
+        [TestMethod]
+        public void JobQualifies_DuplicateSlotsWithOneHired_SecondStillQualifies()
+        {
+            Assert.IsTrue(AutoHireMercenaryService.JobQualifies(
+                JobType.Knight, JobType.Knight, JobType.Knight, JobType.Knight, JobType.None));
+        }
+
+        [TestMethod]
+        public void JobQualifies_DuplicateSlotsWithBothHired_DoesNotQualify()
+        {
+            Assert.IsFalse(AutoHireMercenaryService.JobQualifies(
+                JobType.Knight, JobType.Knight, JobType.Knight, JobType.Knight, JobType.Knight));
+        }
+
+        [TestMethod]
+        public void JobQualifies_NonMatchingHiredMerc_ConsumesNoSlot()
+        {
+            // A manually hired Mage occupies a party slot but not a desired Knight entry
+            Assert.IsTrue(AutoHireMercenaryService.JobQualifies(
+                JobType.Knight, JobType.Knight, JobType.None, JobType.Mage, JobType.None));
+        }
+
+        [TestMethod]
+        public void JobQualifies_OneHiredSatisfiesOnlyOneDuplicateSlot()
+        {
+            // Slots {Priest, Priest}, one Priest hired: a second Priest still qualifies,
+            // but a third does not once both are hired.
+            Assert.IsTrue(AutoHireMercenaryService.JobQualifies(
+                JobType.Priest, JobType.Priest, JobType.Priest, JobType.Priest, JobType.None));
+            Assert.IsFalse(AutoHireMercenaryService.JobQualifies(
+                JobType.Priest, JobType.Priest, JobType.Priest, JobType.Priest, JobType.Priest));
+        }
+
+        [TestMethod]
+        public void CanAffordHire_ExactlyAtBuffer_Affordable()
+        {
+            Assert.IsTrue(AutoHireMercenaryService.CanAffordHire(700, 500, 200));
+        }
+
+        [TestMethod]
+        public void CanAffordHire_OneGoldBelowBuffer_NotAffordable()
+        {
+            Assert.IsFalse(AutoHireMercenaryService.CanAffordHire(699, 500, 200));
+        }
+
+        [TestMethod]
+        public void SanitizeJob_ValidSingleJobs_RoundTrip()
+        {
+            Assert.AreEqual(JobType.Knight, AutoHireMercenaryService.SanitizeJob(JobType.Knight));
+            Assert.AreEqual(JobType.Monk, AutoHireMercenaryService.SanitizeJob(JobType.Monk));
+            Assert.AreEqual(JobType.Mage, AutoHireMercenaryService.SanitizeJob(JobType.Mage));
+            Assert.AreEqual(JobType.Priest, AutoHireMercenaryService.SanitizeJob(JobType.Priest));
+            Assert.AreEqual(JobType.Thief, AutoHireMercenaryService.SanitizeJob(JobType.Thief));
+            Assert.AreEqual(JobType.Archer, AutoHireMercenaryService.SanitizeJob(JobType.Archer));
+        }
+
+        [TestMethod]
+        public void SanitizeJob_UnknownValues_BecomeNone()
+        {
+            Assert.AreEqual(JobType.None, AutoHireMercenaryService.SanitizeJob(JobType.None));
+            Assert.AreEqual(JobType.None, AutoHireMercenaryService.SanitizeJob(JobType.All));
+            Assert.AreEqual(JobType.None, AutoHireMercenaryService.SanitizeJob(JobType.Knight | JobType.Mage));
+            Assert.AreEqual(JobType.None, AutoHireMercenaryService.SanitizeJob((JobType)999));
+        }
+
+        [TestMethod]
+        public void TryHirePass_NullDependencies_ReturnsZeroWithoutThrowing()
+        {
+            var service = new AutoHireMercenaryService(null, null, null) { Enabled = true };
+            Assert.AreEqual(0, service.TryHirePass());
+        }
+
+        [TestMethod]
+        public void TryAutoHire_NullEntity_ReturnsFalseWithoutThrowing()
+        {
+            var service = new AutoHireMercenaryService(null, null, null) { Enabled = true };
+            Assert.IsFalse(service.TryAutoHire(null));
+        }
+
+        [TestMethod]
+        public void GoldBuffer_NullSource_IsZero()
+        {
+            var service = new AutoHireMercenaryService(null, null, null);
+            Assert.AreEqual(0, service.GoldBuffer);
+        }
+    }
+}

--- a/PitHero.Tests/PitWidthManagerTests.cs
+++ b/PitHero.Tests/PitWidthManagerTests.cs
@@ -89,6 +89,22 @@ namespace PitHero.Tests
         }
 
         [TestMethod]
+        public void PitWidthManager_IsTileInsidePitInterior_UninitializedUsesDefaultEdge()
+        {
+            // Uninitialized fallback right edge is x=13 (matching GetCurrentPitCandidateTargets),
+            // so the walkable interior spans x=2..11, y=3..9.
+            var pitWidthManager = new PitWidthManager();
+
+            Assert.IsTrue(pitWidthManager.IsTileInsidePitInterior(new Microsoft.Xna.Framework.Point(2, 3)), "Top-left interior tile");
+            Assert.IsTrue(pitWidthManager.IsTileInsidePitInterior(new Microsoft.Xna.Framework.Point(11, 9)), "Bottom-right interior tile");
+            Assert.IsFalse(pitWidthManager.IsTileInsidePitInterior(new Microsoft.Xna.Framework.Point(1, 6)), "Left wall ring is not interior");
+            Assert.IsFalse(pitWidthManager.IsTileInsidePitInterior(new Microsoft.Xna.Framework.Point(12, 6)), "Wall column (rightEdge-1) is not interior");
+            Assert.IsFalse(pitWidthManager.IsTileInsidePitInterior(new Microsoft.Xna.Framework.Point(13, 6)), "Jump rim (rightEdge) is not interior");
+            Assert.IsFalse(pitWidthManager.IsTileInsidePitInterior(new Microsoft.Xna.Framework.Point(6, 2)), "Top wall row is not interior");
+            Assert.IsFalse(pitWidthManager.IsTileInsidePitInterior(new Microsoft.Xna.Framework.Point(6, 10)), "Bottom wall row is not interior");
+        }
+
+        [TestMethod]
         public void GameConfig_PitRectConfiguration_ShouldSupportDynamicExpansion()
         {
             // Arrange & Act

--- a/PitHero.Tests/SaveLoadTests.cs
+++ b/PitHero.Tests/SaveLoadTests.cs
@@ -1115,5 +1115,71 @@ namespace PitHero.Tests
                     Directory.Delete(tempDir, true);
             }
         }
+
+        /// <summary>Verifies the v24 auto-hire mercenary settings round-trip, including duplicate job slots.</summary>
+        [TestMethod]
+        public void SaveData_V24_AutoHireMercenaries_RoundTrip()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "pithero_v24_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var dataStore = new FileDataStore(tempDir);
+
+                var original = new SaveData();
+                original.AutoHireMercenariesEnabled = true;
+                original.AutoHireMerc1Job = (int)JobType.Knight;
+                original.AutoHireMerc2Job = (int)JobType.Knight;
+
+                dataStore.Save("v24_autohire.bin", original);
+
+                var loaded = new SaveData();
+                dataStore.Load("v24_autohire.bin", loaded);
+
+                Assert.IsTrue(loaded.AutoHireMercenariesEnabled, "Auto-hire enabled should round-trip");
+                Assert.AreEqual((int)JobType.Knight, loaded.AutoHireMerc1Job, "Slot 1 job should round-trip");
+                Assert.AreEqual((int)JobType.Knight, loaded.AutoHireMerc2Job, "Duplicate slot 2 job should round-trip");
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
+            }
+        }
+
+        /// <summary>
+        /// Verifies the v24 auto-hire defaults: disabled with both slots None, both on a fresh
+        /// SaveData and after a default save/load cycle (the state older files recover with).
+        /// </summary>
+        [TestMethod]
+        public void SaveData_V24_AutoHireMercenaries_Defaults()
+        {
+            var fresh = new SaveData();
+            Assert.IsFalse(fresh.AutoHireMercenariesEnabled, "Auto-hire defaults to OFF");
+            Assert.AreEqual((int)JobType.None, fresh.AutoHireMerc1Job, "Slot 1 defaults to None");
+            Assert.AreEqual((int)JobType.None, fresh.AutoHireMerc2Job, "Slot 2 defaults to None");
+
+            var tempDir = Path.Combine(Path.GetTempPath(), "pithero_v24d_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var dataStore = new FileDataStore(tempDir);
+                dataStore.Save("v24_defaults.bin", new SaveData());
+
+                var loaded = new SaveData();
+                dataStore.Load("v24_defaults.bin", loaded);
+
+                Assert.IsFalse(loaded.AutoHireMercenariesEnabled);
+                Assert.AreEqual((int)JobType.None, loaded.AutoHireMerc1Job);
+                Assert.AreEqual((int)JobType.None, loaded.AutoHireMerc2Job);
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
+            }
+        }
     }
 }

--- a/PitHero/AI/MercenaryJumpIntoPitAction.cs
+++ b/PitHero/AI/MercenaryJumpIntoPitAction.cs
@@ -158,35 +158,11 @@ namespace PitHero.AI
 
             // Mercenaries do not clear fog of war - only heroes can
 
-            // Refresh pathfinding to pick up collision layer, then add all existing obstacles
+            // Refresh pathfinding to pick up collision layer plus all runtime obstacles
             var pathfinding = entity.GetComponent<PathfindingActorComponent>();
             if (pathfinding != null)
             {
-                pathfinding.RefreshPathfinding();
-                
-                // Add all existing obstacle entities to the pathfinding graph
-                var scene = entity.Scene;
-                if (scene != null)
-                {
-                    var obstacles = scene.FindEntitiesWithTag(GameConfig.TAG_OBSTACLE);
-                    int obstaclesAdded = 0;
-                    
-                    for (int i = 0; i < obstacles.Count; i++)
-                    {
-                        var obstacle = obstacles[i];
-                        var obstaclePos = obstacle.Transform.Position;
-                        var obstacleTile = new Point(
-                            (int)(obstaclePos.X / GameConfig.TileSize),
-                            (int)(obstaclePos.Y / GameConfig.TileSize)
-                        );
-                        
-                        pathfinding.AddWall(obstacleTile);
-                        obstaclesAdded++;
-                    }
-                    
-                    Debug.Log($"[MercenaryJumpIntoPit] Added {obstaclesAdded} existing obstacles to {entity.Name} pathfinding graph");
-                }
-                
+                pathfinding.RefreshPathfindingWithObstacles();
                 Debug.Log($"[MercenaryJumpIntoPit] Refreshed pathfinding for {entity.Name} after entering pit");
             }
 

--- a/PitHero/AI/MercenaryStateMachine.cs
+++ b/PitHero/AI/MercenaryStateMachine.cs
@@ -273,8 +273,11 @@ namespace PitHero.AI
 
         private bool IsMercenaryInsidePit()
         {
-            var myTile = GetCurrentTile();
-            return IsInsidePit(myTile);
+            // The flag is authoritative: it flips only when a jump completes (or the follow
+            // component warps across the pit boundary). Deriving it from position misclassifies
+            // a merc standing over the pit rect that never jumped in (e.g. the pit widened
+            // underneath it), which silently disables the walk-to-edge -> jump plan.
+            return _mercenary != null && _mercenary.InsidePit;
         }
 
         private bool IsTargetInsidePit()
@@ -288,14 +291,12 @@ namespace PitHero.AI
                 return targetHero.InsidePit;
             }
 
+            // Same flag-based read as the hero path. A position-derived answer flickers while
+            // the target lerps over the pit wall mid-jump, aborting this merc's plan every time.
             var targetMerc = _mercenary.FollowTarget.GetComponent<MercenaryComponent>();
             if (targetMerc != null)
             {
-                var targetTile = new Point(
-                    (int)(targetMerc.Entity.Transform.Position.X / GameConfig.TileSize),
-                    (int)(targetMerc.Entity.Transform.Position.Y / GameConfig.TileSize)
-                );
-                return IsInsidePit(targetTile);
+                return targetMerc.InsidePit;
             }
 
             return false;
@@ -328,23 +329,6 @@ namespace PitHero.AI
                 (int)(pos.X / GameConfig.TileSize),
                 (int)(pos.Y / GameConfig.TileSize)
             );
-        }
-
-        private bool IsInsidePit(Point tile)
-        {
-            var pitWidthManager = Core.Services.GetService<PitWidthManager>();
-            if (pitWidthManager == null)
-                return false;
-
-            var pitLeft = GameConfig.PitRectX;
-            var pitTop = GameConfig.PitRectY;
-            var pitWidth = pitWidthManager.CurrentPitRectWidthTiles;
-            var pitHeight = GameConfig.PitRectHeight;
-            var pitRight = pitLeft + pitWidth - 1;
-            var pitBottom = pitTop + pitHeight - 1;
-
-            // Use exclusive boundaries - pit edge is NOT inside the pit
-            return tile.X > pitLeft && tile.X < pitRight && tile.Y > pitTop && tile.Y < pitBottom;
         }
     }
 }

--- a/PitHero/AI/WalkToPitEdgeAction.cs
+++ b/PitHero/AI/WalkToPitEdgeAction.cs
@@ -57,6 +57,22 @@ namespace PitHero.AI
             var path = pathfinding.CalculatePath(currentTile, _pitEdgeTile);
             if (path == null || path.Count == 0)
             {
+                // Never cache the edge tile across attempts — the pit can widen between them
+                _pathCalculated = false;
+
+                // A merc standing on the pit's interior floor without ever having jumped (the pit
+                // widened underneath it mid-walk) can never reach the rim on foot. Adopt the
+                // position as truth so the next plan follows the target inside instead of walking
+                // to the edge forever.
+                var pitWidthManager = Core.Services.GetService<PitWidthManager>();
+                if (pitWidthManager != null && pitWidthManager.IsTileInsidePitInterior(currentTile))
+                {
+                    Debug.Warn($"[WalkToPitEdge] {mercenary.Entity.Name} is stranded on the pit floor at ({currentTile.X},{currentTile.Y}) — marking InsidePit and refreshing pathfinding");
+                    mercenary.InsidePit = true;
+                    pathfinding.RefreshPathfindingWithObstacles();
+                    return true;
+                }
+
                 Debug.Warn($"[WalkToPitEdge] {mercenary.Entity.Name} cannot find path to pit edge");
                 return true;
             }

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -399,3 +399,9 @@ SettingsConsumableStacks,Stacks: {0}
 SettingsConsumableStacksTooltip,Minimum stacks to maintain in inventory if space allows
 SettingsAutoEquipOptionsTooltip,Auto-equip gear after finding in chest or auto-purchased
 ConsoleAutoPurchasedItem,Auto-purchased {0} for {1}G.
+SettingsAutoHireMercenaries,Auto-Hire Mercenaries
+SettingsAutoHireMercenariesTooltip,Automatically hire tavern mercenaries whose job matches a configured slot
+SettingsAutoHireMerc1Job,Mercenary1 Job
+SettingsAutoHireMerc1JobTooltip,Job to auto-hire for the first mercenary slot. None disables auto-hiring this slot
+SettingsAutoHireMerc2Job,Mercenary2 Job
+SettingsAutoHireMerc2JobTooltip,Job to auto-hire for the second mercenary slot. Requires Mercenary1 Job to be set

--- a/PitHero/ECS/Components/MercenaryFollowComponent.cs
+++ b/PitHero/ECS/Components/MercenaryFollowComponent.cs
@@ -120,8 +120,24 @@ namespace PitHero.ECS.Components
             // Stuck detection: if mercenary has been at the same tile too long while needing to move, warp near target
             if (_stuckTimer >= GameConfig.MovementStuckTimeoutSeconds && _tileMover != null)
             {
+                // Never warp onto an impassable tile — the target's truncated position sits on the
+                // pit wall while it lerps through a jump. Keep the timer running and retry next frame.
+                if (_pathfinding.PathfindingGraph?.Walls?.Contains(targetTile) == true)
+                {
+                    return;
+                }
+
                 Debug.Warn($"[MercenaryFollowComponent] {Entity.Name} stuck at ({myTile.X},{myTile.Y}) for {_stuckTimer:F1}s, warping near target ({targetTile.X},{targetTile.Y})");
                 _tileMover.WarpToTile(targetTile);
+
+                // A warp can cross the pit boundary without a jump — keep the authoritative
+                // InsidePit flag and this merc's pathfinding graph in sync, exactly as the jump
+                // actions do after landing.
+                var pitWidthManager = Core.Services.GetService<PitWidthManager>();
+                if (pitWidthManager != null)
+                    _mercComponent.InsidePit = pitWidthManager.IsTileInsidePitInterior(targetTile);
+                _pathfinding.RefreshPathfindingWithObstacles();
+
                 _currentPath = null;
                 _pathIndex = 0;
                 _stuckTimer = 0f;

--- a/PitHero/ECS/Components/PathfindingActorComponent.cs
+++ b/PitHero/ECS/Components/PathfindingActorComponent.cs
@@ -116,6 +116,30 @@ namespace PitHero.ECS.Components
         }
 
         /// <summary>
+        /// Refreshes the graph from the collision layer and re-adds every obstacle entity's tile.
+        /// Use after any teleport across the pit boundary — a bare refresh loses runtime obstacles.
+        /// </summary>
+        public virtual void RefreshPathfindingWithObstacles()
+        {
+            RefreshPathfinding();
+            if (!_isPathfindingInitialized)
+                return;
+
+            var scene = Entity?.Scene;
+            if (scene == null)
+                return;
+
+            var obstacles = scene.FindEntitiesWithTag(GameConfig.TAG_OBSTACLE);
+            for (int i = 0; i < obstacles.Count; i++)
+            {
+                var obstaclePos = obstacles[i].Transform.Position;
+                _astarGraph.Walls.Add(new Point(
+                    (int)(obstaclePos.X / GameConfig.TileSize),
+                    (int)(obstaclePos.Y / GameConfig.TileSize)));
+            }
+        }
+
+        /// <summary>
         /// Calculate a path from start to target using A* pathfinding
         /// </summary>
         public virtual List<Point> CalculatePath(Point start, Point target)

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -218,6 +218,7 @@ namespace PitHero.ECS.Scenes
             Core.Services.RemoveService(typeof(Services.AutoCropSellService));
             Core.Services.RemoveService(typeof(Services.AutoSellExcessItemsService));
             Core.Services.RemoveService(typeof(Services.AutoItemPurchaseService));
+            Core.Services.RemoveService(typeof(Services.AutoHireMercenaryService));
             Core.Services.GetService<Services.FarmTaskCoordinator>()?.Detach();
             Core.Services.RemoveService(typeof(Services.FarmTaskCoordinator));
             Core.Services.RemoveService(typeof(Services.MealBuffService));
@@ -311,6 +312,14 @@ namespace PitHero.ECS.Scenes
                 Core.Services.GetService<Services.GameStateService>(),
                 Core.Services.GetService<Services.SecondChanceMerchantVault>(),
                 autoSeedPurchaseService));
+
+            // Auto-hire mercenary service hires tavern mercenaries matching the configured job slots.
+            // Registered after AutoSeedPurchaseService, which owns the shared Gold Buffer setting it
+            // reads (issue #350).
+            Core.Services.AddService(new Services.AutoHireMercenaryService(
+                Core.Services.GetService<Services.GameStateService>(),
+                autoSeedPurchaseService,
+                mercenaryManager));
 
             // Meal buff service holds each party member's day-long food buffs (issue #319)
             Core.Services.AddService(new Services.MealBuffService());
@@ -608,6 +617,18 @@ namespace PitHero.ECS.Scenes
                     for (int i = 0; i < count; i++)
                         autoItemPurchaseSvc.ConsumableStackTargets[i] = pendingData.AutoPurchaseConsumableStacks[i];
                 }
+            }
+            var autoHireSvc = Core.Services.GetService<Services.AutoHireMercenaryService>();
+            if (autoHireSvc != null)
+            {
+                autoHireSvc.Enabled = pendingData.AutoHireMercenariesEnabled;
+                autoHireSvc.Merc1Job = Services.AutoHireMercenaryService.SanitizeJob(
+                    (RolePlayingFramework.Jobs.JobType)pendingData.AutoHireMerc1Job);
+                autoHireSvc.Merc2Job = Services.AutoHireMercenaryService.SanitizeJob(
+                    (RolePlayingFramework.Jobs.JobType)pendingData.AutoHireMerc2Job);
+                // Slot 2 is only meaningful while slot 1 holds a job — enforce the invariant on load
+                if (autoHireSvc.Merc1Job == RolePlayingFramework.Jobs.JobType.None)
+                    autoHireSvc.Merc2Job = RolePlayingFramework.Jobs.JobType.None;
             }
             _settingsUI?.SyncAutomationControlsFromService();
 

--- a/PitHero/PitWidthManager.cs
+++ b/PitHero/PitWidthManager.cs
@@ -93,6 +93,26 @@ namespace PitHero
             }
         }
 
+        /// <summary>
+        /// True when the tile is on the pit's walkable interior floor. Excludes the wall ring and
+        /// the jump rim: interior x spans PitRectX+1 .. CurrentPitRightEdge-2 (the wall column sits
+        /// at CurrentPitRightEdge-1 and the rim actors jump from at CurrentPitRightEdge).
+        /// </summary>
+        public bool IsTileInsidePitInterior(Point tile)
+        {
+            int rightEdge = _isInitialized
+                ? _currentPitRightEdge
+                : GameConfig.PitRectX + GameConfig.PitRectWidth;
+
+            int leftInteriorX = GameConfig.PitRectX + 1;
+            int rightInteriorX = rightEdge - 2;
+            int topInteriorY = GameConfig.PitRectY + 1;
+            int bottomInteriorY = GameConfig.PitRectY + GameConfig.PitRectHeight - 2;
+
+            return tile.X >= leftInteriorX && tile.X <= rightInteriorX
+                && tile.Y >= topInteriorY && tile.Y <= bottomInteriorY;
+        }
+
 
         /// <summary>
         /// Initialize the tile pattern dictionaries from the map

--- a/PitHero/Services/AutoHireMercenaryService.cs
+++ b/PitHero/Services/AutoHireMercenaryService.cs
@@ -1,0 +1,185 @@
+using Nez;
+using PitHero.ECS.Components;
+using RolePlayingFramework.Balance;
+using RolePlayingFramework.Jobs;
+
+namespace PitHero.Services
+{
+    /// <summary>
+    /// Auto-hires tavern mercenaries whose job matches one of the two configured slots (issue #350).
+    /// Call-driven (no update loop): <see cref="MercenaryManager"/> invokes <see cref="TryAutoHire"/>
+    /// when a mercenary arrives at the tavern, and SettingsUI invokes <see cref="TryHirePass"/> when
+    /// the settings window closes so already-seated mercenaries are considered too.
+    ///
+    /// A slot set to <see cref="JobType.None"/> hires nothing; duplicate slots hire two of the same
+    /// job. Every hire honors the shared Gold Buffer and the party cap.
+    /// </summary>
+    public class AutoHireMercenaryService
+    {
+        private readonly GameStateService _gameState;
+        private readonly AutoSeedPurchaseService _goldBufferSource;
+        private readonly MercenaryManager _mercenaryManager;
+
+        /// <summary>Master toggle. Off by default.</summary>
+        public bool Enabled { get; set; } = false;
+
+        /// <summary>Job to auto-hire for the first party slot. None disables the slot.</summary>
+        public JobType Merc1Job { get; set; } = JobType.None;
+
+        /// <summary>Job to auto-hire for the second party slot. None disables the slot.</summary>
+        public JobType Merc2Job { get; set; } = JobType.None;
+
+        /// <summary>Gold floor shared with all automated spending; no hire may take funds below it.</summary>
+        public int GoldBuffer => _goldBufferSource?.GoldBuffer ?? 0;
+
+        /// <summary>
+        /// Initialises the service. <paramref name="goldBufferSource"/> owns the single shared
+        /// Gold Buffer setting, so this service must be registered after it.
+        /// </summary>
+        public AutoHireMercenaryService(GameStateService gameState, AutoSeedPurchaseService goldBufferSource, MercenaryManager mercenaryManager)
+        {
+            _gameState = gameState;
+            _goldBufferSource = goldBufferSource;
+            _mercenaryManager = mercenaryManager;
+        }
+
+        /// <summary>
+        /// Attempts to auto-hire one just-arrived tavern mercenary. Returns true if it was hired.
+        /// Pre-checks the party cap (via CanHireMore, which also covers the hero-dead hiring block)
+        /// and the Gold Buffer, since HireMercenary enforces neither.
+        /// </summary>
+        public bool TryAutoHire(Entity mercEntity)
+        {
+            if (!Enabled || mercEntity == null || _mercenaryManager == null || _gameState == null)
+                return false;
+
+            var comp = mercEntity.GetComponent<MercenaryComponent>();
+            if (comp == null || comp.LinkedMercenary == null || comp.IsHired || comp.IsBeingRemoved || !comp.IsWaitingInTavern)
+                return false;
+
+            if (!_mercenaryManager.CanHireMore())
+                return false;
+
+            GetHiredJobs(out var hiredJob1, out var hiredJob2);
+            if (!JobQualifies(comp.LinkedMercenary.Job.JobFlag, Merc1Job, Merc2Job, hiredJob1, hiredJob2))
+                return false;
+
+            var hireCost = BalanceConfig.CalculateMercenaryHireCost(comp.LinkedMercenary.Level);
+            if (!CanAffordHire(_gameState.Funds, hireCost, GoldBuffer))
+                return false;
+
+            return _mercenaryManager.HireMercenary(mercEntity);
+        }
+
+        /// <summary>
+        /// Sweeps mercenaries already seated in the tavern and hires every match, oldest first.
+        /// Returns the number of hires made.
+        /// </summary>
+        public int TryHirePass()
+        {
+            if (!Enabled || _mercenaryManager == null || _gameState == null)
+                return 0;
+
+            var hires = 0;
+            var hiredOne = true;
+            while (hiredOne && _mercenaryManager.CanHireMore())
+            {
+                hiredOne = false;
+                GetHiredJobs(out var hiredJob1, out var hiredJob2);
+
+                // Oldest qualifying, affordable, seated mercenary wins this round
+                var candidates = _mercenaryManager.GetUnhiredMercenaries();
+                Entity best = null;
+                var bestSpawnId = int.MaxValue;
+                for (int i = 0; i < candidates.Count; i++)
+                {
+                    var comp = candidates[i].GetComponent<MercenaryComponent>();
+                    if (comp == null || comp.LinkedMercenary == null || comp.IsHired || comp.IsBeingRemoved || !comp.IsWaitingInTavern)
+                        continue;
+                    if (!JobQualifies(comp.LinkedMercenary.Job.JobFlag, Merc1Job, Merc2Job, hiredJob1, hiredJob2))
+                        continue;
+                    var hireCost = BalanceConfig.CalculateMercenaryHireCost(comp.LinkedMercenary.Level);
+                    if (!CanAffordHire(_gameState.Funds, hireCost, GoldBuffer))
+                        continue;
+                    if (comp.SpawnId < bestSpawnId)
+                    {
+                        best = candidates[i];
+                        bestSpawnId = comp.SpawnId;
+                    }
+                }
+
+                if (best != null && _mercenaryManager.HireMercenary(best))
+                {
+                    hires++;
+                    hiredOne = true;
+                }
+            }
+            return hires;
+        }
+
+        /// <summary>Reads the jobs of the currently hired party mercenaries (None when a slot is empty).</summary>
+        private void GetHiredJobs(out JobType hiredJob1, out JobType hiredJob2)
+        {
+            hiredJob1 = JobType.None;
+            hiredJob2 = JobType.None;
+            var hired = _mercenaryManager.GetHiredMercenaries();
+            for (int i = 0; i < hired.Count; i++)
+            {
+                var comp = hired[i].GetComponent<MercenaryComponent>();
+                if (comp == null || comp.LinkedMercenary == null)
+                    continue;
+                if (hiredJob1 == JobType.None)
+                    hiredJob1 = comp.LinkedMercenary.Job.JobFlag;
+                else
+                    hiredJob2 = comp.LinkedMercenary.Job.JobFlag;
+            }
+        }
+
+        /// <summary>
+        /// Multiset matching: each hired mercenary satisfies at most one desired slot of its job;
+        /// the candidate qualifies only if an unsatisfied slot of its job remains.
+        /// </summary>
+        public static bool JobQualifies(JobType candidateJob, JobType slot1, JobType slot2, JobType hiredJob1, JobType hiredJob2)
+        {
+            if (candidateJob == JobType.None)
+                return false;
+
+            var d1 = slot1 != JobType.None;
+            var d2 = slot2 != JobType.None;
+            if (hiredJob1 != JobType.None)
+            {
+                if (d1 && slot1 == hiredJob1) d1 = false;
+                else if (d2 && slot2 == hiredJob1) d2 = false;
+            }
+            if (hiredJob2 != JobType.None)
+            {
+                if (d1 && slot1 == hiredJob2) d1 = false;
+                else if (d2 && slot2 == hiredJob2) d2 = false;
+            }
+            return (d1 && slot1 == candidateJob) || (d2 && slot2 == candidateJob);
+        }
+
+        /// <summary>True when paying the hire cost leaves funds at or above the gold buffer.</summary>
+        public static bool CanAffordHire(int funds, int hireCost, int goldBuffer)
+        {
+            return funds - hireCost >= goldBuffer;
+        }
+
+        /// <summary>Clamps a persisted job value to the supported single-job options (unknown values become None).</summary>
+        public static JobType SanitizeJob(JobType job)
+        {
+            switch (job)
+            {
+                case JobType.Knight:
+                case JobType.Monk:
+                case JobType.Mage:
+                case JobType.Priest:
+                case JobType.Thief:
+                case JobType.Archer:
+                    return job;
+                default:
+                    return JobType.None;
+            }
+        }
+    }
+}

--- a/PitHero/Services/MercenaryManager.cs
+++ b/PitHero/Services/MercenaryManager.cs
@@ -361,6 +361,9 @@ namespace PitHero.Services
             }
 
             Debug.Log($"[MercenaryManager] Mercenary {mercComponent.LinkedMercenary.Name} arrived at tavern");
+
+            // Now that the merc is seated (IsWaitingInTavern + patron component), offer it to auto-hire
+            Core.Services.GetService<AutoHireMercenaryService>()?.TryAutoHire(mercEntity);
         }
 
         /// <summary>

--- a/PitHero/Services/SaveData.cs
+++ b/PitHero/Services/SaveData.cs
@@ -255,14 +255,14 @@ namespace PitHero.Services
     public class SaveData : IPersistable
     {
         /// <summary>Current save file version.</summary>
-        public const int CurrentVersion = 23;
+        public const int CurrentVersion = 24;
 
         /// <summary>
-        /// Oldest save file version this build can still load. v17–v22 files are byte-exact
-        /// prefixes of v23 (sections 33 dining, 34 automation, 35 auto-dine resume,
+        /// Oldest save file version this build can still load. v17–v23 files are byte-exact
+        /// prefixes of v24 (sections 33 dining, 34 automation, 35 auto-dine resume,
         /// 36 auto-sell excess items, 37 auto-sell priority, 38 gear sell types,
-        /// 39 auto-purchase items, and 40 auto-equip were appended at the end),
-        /// so they load with default state for the missing sections.
+        /// 39 auto-purchase items, 40 auto-equip, and 41 auto-hire mercenaries were
+        /// appended at the end), so they load with default state for the missing sections.
         /// </summary>
         public const int MinSupportedVersion = 17;
 
@@ -556,6 +556,16 @@ namespace PitHero.Services
 
         /// <summary>Whether looted or purchased gear is auto-equipped on mercenaries.</summary>
         public bool AutoEquipMercenaries = true;
+
+        // Auto-hire mercenaries (v24)
+        /// <summary>Whether tavern mercenaries matching the configured job slots are auto-hired.</summary>
+        public bool AutoHireMercenariesEnabled = false;
+
+        /// <summary>Job auto-hired for the first party slot as a raw JobType value (0 = None).</summary>
+        public int AutoHireMerc1Job = 0;
+
+        /// <summary>Job auto-hired for the second party slot as a raw JobType value (0 = None).</summary>
+        public int AutoHireMerc2Job = 0;
 
         /// <summary>Initializes a new SaveData with default empty collections.</summary>
         public SaveData()
@@ -1008,6 +1018,11 @@ namespace PitHero.Services
             // 40. Auto-equip (v23)
             writer.Write(AutoEquipHero);
             writer.Write(AutoEquipMercenaries);
+
+            // 41. Auto-hire mercenaries (v24)
+            writer.Write(AutoHireMercenariesEnabled);
+            writer.Write(AutoHireMerc1Job);
+            writer.Write(AutoHireMerc2Job);
         }
 
         /// <summary>Reads all game state from the persistence reader.</summary>
@@ -1518,6 +1533,17 @@ namespace PitHero.Services
             {
                 AutoEquipHero = reader.ReadBool();
                 AutoEquipMercenaries = reader.ReadBool();
+            }
+
+            // 41. Auto-hire mercenaries (v24+). Older files default to disabled, both slots None.
+            AutoHireMercenariesEnabled = false;
+            AutoHireMerc1Job = 0;
+            AutoHireMerc2Job = 0;
+            if (fileVersion >= 24)
+            {
+                AutoHireMercenariesEnabled = reader.ReadBool();
+                AutoHireMerc1Job = reader.ReadInt();
+                AutoHireMerc2Job = reader.ReadInt();
             }
         }
 

--- a/PitHero/Services/SaveLoadService.cs
+++ b/PitHero/Services/SaveLoadService.cs
@@ -847,6 +847,15 @@ namespace PitHero.Services
                 }
             }
 
+            // Auto-hire mercenaries (v24+)
+            var autoHireService = Core.Services.GetService<AutoHireMercenaryService>();
+            if (autoHireService != null)
+            {
+                data.AutoHireMercenariesEnabled = autoHireService.Enabled;
+                data.AutoHireMerc1Job = (int)autoHireService.Merc1Job;
+                data.AutoHireMerc2Job = (int)autoHireService.Merc2Job;
+            }
+
             return data;
         }
 

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -5,6 +5,7 @@ using Nez.UI;
 using PitHero.ECS.Components;
 using PitHero.ECS.Scenes;
 using PitHero.Services;
+using RolePlayingFramework.Jobs;
 using System;
 using System.Collections.Generic;
 
@@ -91,6 +92,24 @@ namespace PitHero.UI
         private HoverableLabel _autoEquipOptionsLabel;
         private CheckBox _autoEquipHeroCheckBox;
         private CheckBox _autoEquipMercsCheckBox;
+
+        // Automation tab — auto-hire mercenaries (issue #350)
+        private static readonly JobType[] AutoHireJobOptions =
+        {
+            JobType.None, JobType.Priest, JobType.Mage, JobType.Knight,
+            JobType.Thief, JobType.Monk, JobType.Archer
+        };
+        private HoverableCheckBox _autoHireMercsCheckBox;
+        private HoverableLabel _autoHireMerc1Label;
+        private HoverableLabel _autoHireMerc2Label;
+        private Label _autoHireMerc1ValueLabel;
+        private Label _autoHireMerc2ValueLabel;
+        private TextButton _autoHireMerc1LeftButton;
+        private TextButton _autoHireMerc1RightButton;
+        private TextButton _autoHireMerc2LeftButton;
+        private TextButton _autoHireMerc2RightButton;
+        private int _autoHireMerc1Index;
+        private int _autoHireMerc2Index;
 
         // Confirmation dialogs
         private Window _exitConfirmationDialog;
@@ -1016,6 +1035,7 @@ namespace PitHero.UI
 
             PopulateAutoPurchaseControls(autoShopTable, skin);
             PopulateAutoEquipControls(autoShopTable, skin);
+            PopulateAutoHireControls(autoShopTable, skin);
 
             // The tab keeps growing as automation options are added, so it scrolls vertically.
             // The right pad insets the scrollbar from the window edge instead of hugging it.
@@ -1168,6 +1188,161 @@ namespace PitHero.UI
             _designateCropsButton.SetDisabled(!active);
             _designateCropsButton.SetStyle(skin.Get<TextButtonStyle>(active ? "ph-default" : "ph-grayed"));
             _designateCropsButton.SetTouchable(active ? Touchable.Enabled : Touchable.Disabled);
+        }
+
+        /// <summary>Adds the "Auto-Hire Mercenaries" checkbox and its two job cyclers to the Automation tab.</summary>
+        private void PopulateAutoHireControls(Table autoShopTable, Skin skin)
+        {
+            string autoHireTooltip = GetText(TextType.UI, UITextKey.SettingsAutoHireMercenariesTooltip);
+            _autoHireMercsCheckBox = new HoverableCheckBox(
+                GetText(TextType.UI, UITextKey.SettingsAutoHireMercenaries),
+                skin,
+                autoHireTooltip,
+                _stage);
+            _autoHireMercsCheckBox.IsChecked = false;
+            _autoHireMercsCheckBox.OnChanged += (isChecked) =>
+            {
+                var svc = Core.Services?.GetService<AutoHireMercenaryService>();
+                if (svc != null) svc.Enabled = isChecked;
+                SetAutoHireControlsActive(isChecked);
+            };
+            autoShopTable.Add(_autoHireMercsCheckBox).Left().SetPadTop(15f).SetPadBottom(8f);
+            autoShopTable.Row();
+
+            BuildAutoHireCyclerRow(autoShopTable, skin, 1,
+                UITextKey.SettingsAutoHireMerc1Job, UITextKey.SettingsAutoHireMerc1JobTooltip,
+                out _autoHireMerc1Label, out _autoHireMerc1LeftButton,
+                out _autoHireMerc1ValueLabel, out _autoHireMerc1RightButton);
+            BuildAutoHireCyclerRow(autoShopTable, skin, 2,
+                UITextKey.SettingsAutoHireMerc2Job, UITextKey.SettingsAutoHireMerc2JobTooltip,
+                out _autoHireMerc2Label, out _autoHireMerc2LeftButton,
+                out _autoHireMerc2ValueLabel, out _autoHireMerc2RightButton);
+
+            SetAutoHireControlsActive(false);
+        }
+
+        /// <summary>Builds one "MercenaryN Job" cycler row: caption, left arrow, value label, right arrow.</summary>
+        private void BuildAutoHireCyclerRow(Table autoShopTable, Skin skin, int slot,
+            string captionKey, string tooltipKey,
+            out HoverableLabel captionLabel, out TextButton leftButton,
+            out Label valueLabel, out TextButton rightButton)
+        {
+            captionLabel = new HoverableLabel(
+                GetText(TextType.UI, captionKey),
+                skin, "ph-default",
+                GetText(TextType.UI, tooltipKey), _stage);
+            leftButton = new TextButton("<", skin, "ph-default");
+            valueLabel = new Label(GetAutoHireJobDisplayName(JobType.None), skin, "ph-default");
+            rightButton = new TextButton(">", skin, "ph-default");
+            leftButton.OnClicked += (_) => CycleAutoHireJob(slot, -1);
+            rightButton.OnClicked += (_) => CycleAutoHireJob(slot, +1);
+
+            var row = new Table();
+            row.Add(captionLabel).Left().Width(110f).SetPadRight(10f);
+            row.Add(leftButton).Size(30f, 22f);
+            row.Add(valueLabel).Width(70f).SetPadLeft(6f).SetPadRight(6f);
+            row.Add(rightButton).Size(30f, 22f);
+            autoShopTable.Add(row).Left().SetPadBottom(8f);
+            autoShopTable.Row();
+        }
+
+        /// <summary>
+        /// Cycles one auto-hire job slot by the given direction, wrapping at both ends, and pushes
+        /// the selection to the service. Clearing slot 1 also clears slot 2, which is only
+        /// selectable while slot 1 holds a job.
+        /// </summary>
+        private void CycleAutoHireJob(int slot, int delta)
+        {
+            var svc = Core.Services?.GetService<AutoHireMercenaryService>();
+            if (slot == 1)
+            {
+                _autoHireMerc1Index += delta;
+                if (_autoHireMerc1Index < 0)
+                    _autoHireMerc1Index = AutoHireJobOptions.Length - 1;
+                else if (_autoHireMerc1Index >= AutoHireJobOptions.Length)
+                    _autoHireMerc1Index = 0;
+
+                var job = AutoHireJobOptions[_autoHireMerc1Index];
+                if (svc != null) svc.Merc1Job = job;
+                _autoHireMerc1ValueLabel?.SetText(GetAutoHireJobDisplayName(job));
+
+                if (job == JobType.None && _autoHireMerc2Index != 0)
+                {
+                    _autoHireMerc2Index = 0;
+                    if (svc != null) svc.Merc2Job = JobType.None;
+                    _autoHireMerc2ValueLabel?.SetText(GetAutoHireJobDisplayName(JobType.None));
+                }
+            }
+            else
+            {
+                _autoHireMerc2Index += delta;
+                if (_autoHireMerc2Index < 0)
+                    _autoHireMerc2Index = AutoHireJobOptions.Length - 1;
+                else if (_autoHireMerc2Index >= AutoHireJobOptions.Length)
+                    _autoHireMerc2Index = 0;
+
+                var job = AutoHireJobOptions[_autoHireMerc2Index];
+                if (svc != null) svc.Merc2Job = job;
+                _autoHireMerc2ValueLabel?.SetText(GetAutoHireJobDisplayName(job));
+            }
+
+            SetAutoHireControlsActive(_autoHireMercsCheckBox?.IsChecked ?? false);
+        }
+
+        /// <summary>
+        /// Activates or deactivates the auto-hire job cyclers. Slot 2 additionally requires slot 1
+        /// to hold a job, so the two gates compose.
+        /// </summary>
+        private void SetAutoHireControlsActive(bool active)
+        {
+            var skin = PitHeroSkin.CreateSkin();
+            var labelStyle = skin.Get<LabelStyle>(active ? "ph-default" : "ph-grayed");
+
+            if (_autoHireMerc1Label != null)
+            {
+                _autoHireMerc1Label.SetStyle(labelStyle);
+                _autoHireMerc1Label.SetTooltipEnabled(active);
+            }
+            _autoHireMerc1ValueLabel?.SetStyle(labelStyle);
+            SetButtonActive(_autoHireMerc1LeftButton, active, skin);
+            SetButtonActive(_autoHireMerc1RightButton, active, skin);
+
+            var merc2Active = active && AutoHireJobOptions[_autoHireMerc1Index] != JobType.None;
+            var merc2LabelStyle = skin.Get<LabelStyle>(merc2Active ? "ph-default" : "ph-grayed");
+            if (_autoHireMerc2Label != null)
+            {
+                _autoHireMerc2Label.SetStyle(merc2LabelStyle);
+                _autoHireMerc2Label.SetTooltipEnabled(merc2Active);
+            }
+            _autoHireMerc2ValueLabel?.SetStyle(merc2LabelStyle);
+            SetButtonActive(_autoHireMerc2LeftButton, merc2Active, skin);
+            SetButtonActive(_autoHireMerc2RightButton, merc2Active, skin);
+        }
+
+        /// <summary>Localized display name for an auto-hire cycler option.</summary>
+        private string GetAutoHireJobDisplayName(JobType job)
+        {
+            switch (job)
+            {
+                case JobType.Knight: return GetText(TextType.Job, JobTextKey.Job_Knight_Name);
+                case JobType.Monk: return GetText(TextType.Job, JobTextKey.Job_Monk_Name);
+                case JobType.Mage: return GetText(TextType.Job, JobTextKey.Job_Mage_Name);
+                case JobType.Priest: return GetText(TextType.Job, JobTextKey.Job_Priest_Name);
+                case JobType.Thief: return GetText(TextType.Job, JobTextKey.Job_Thief_Name);
+                case JobType.Archer: return GetText(TextType.Job, JobTextKey.Job_Archer_Name);
+                default: return GetText(TextType.UI, UITextKey.JobNameNone);
+            }
+        }
+
+        /// <summary>Index of a job in the cycler options (unknown values fall back to None at index 0).</summary>
+        private static int IndexOfAutoHireJob(JobType job)
+        {
+            for (int i = 0; i < AutoHireJobOptions.Length; i++)
+            {
+                if (AutoHireJobOptions[i] == job)
+                    return i;
+            }
+            return 0;
         }
 
         /// <summary>
@@ -1343,6 +1518,18 @@ namespace PitHero.UI
                 {
                     _consumablePurchaseOptionsDialog?.Hide();
                 }
+            }
+
+            var autoHireSvc = Core.Services?.GetService<AutoHireMercenaryService>();
+            if (autoHireSvc != null)
+            {
+                if (_autoHireMercsCheckBox != null)
+                    _autoHireMercsCheckBox.IsChecked = autoHireSvc.Enabled;
+                _autoHireMerc1Index = IndexOfAutoHireJob(autoHireSvc.Merc1Job);
+                _autoHireMerc2Index = IndexOfAutoHireJob(autoHireSvc.Merc2Job);
+                _autoHireMerc1ValueLabel?.SetText(GetAutoHireJobDisplayName(AutoHireJobOptions[_autoHireMerc1Index]));
+                _autoHireMerc2ValueLabel?.SetText(GetAutoHireJobDisplayName(AutoHireJobOptions[_autoHireMerc2Index]));
+                SetAutoHireControlsActive(autoHireSvc.Enabled);
             }
         }
 
@@ -1679,6 +1866,11 @@ namespace PitHero.UI
             if (_isVisible)
                 _settingsWindow.ToFront();
             LayoutUI();
+
+            // Closing settings sweeps the tavern so mercs seated before auto-hire was configured
+            // are considered (TryHirePass no-ops while the option is disabled)
+            if (!_isVisible)
+                Core.Services.GetService<AutoHireMercenaryService>()?.TryHirePass();
         }
 
         /// <summary>
@@ -1698,6 +1890,7 @@ namespace PitHero.UI
                 if (pauseService != null)
                     pauseService.IsPaused = false;
                 LayoutUI();
+                Core.Services.GetService<AutoHireMercenaryService>()?.TryHirePass();
                 Debug.Log("[SettingsUI] Settings force closed by single window policy");
             }
         }

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -394,5 +394,11 @@ namespace PitHero
         public const string SettingsConsumableStacksTooltip = "SettingsConsumableStacksTooltip";
         public const string SettingsAutoEquipOptionsTooltip = "SettingsAutoEquipOptionsTooltip";
         public const string ConsoleAutoPurchasedItem = "ConsoleAutoPurchasedItem";
+        public const string SettingsAutoHireMercenaries = "SettingsAutoHireMercenaries";
+        public const string SettingsAutoHireMercenariesTooltip = "SettingsAutoHireMercenariesTooltip";
+        public const string SettingsAutoHireMerc1Job = "SettingsAutoHireMerc1Job";
+        public const string SettingsAutoHireMerc1JobTooltip = "SettingsAutoHireMerc1JobTooltip";
+        public const string SettingsAutoHireMerc2Job = "SettingsAutoHireMerc2Job";
+        public const string SettingsAutoHireMerc2JobTooltip = "SettingsAutoHireMerc2JobTooltip";
     }
 }

--- a/PitHero/docs/AutomationSystem.md
+++ b/PitHero/docs/AutomationSystem.md
@@ -10,10 +10,11 @@ Monster job assignment is the one automation with its own deep-dive — see
 
 ## The tab at a glance
 
-Built by `SettingsUI.PopulateAutomationTab` (`PitHero/UI/SettingsUI.cs`), which delegates the two
-newest blocks to `PopulateAutoPurchaseControls` and `PopulateAutoEquipControls`. The whole tab is
-wrapped in a vertical `ScrollPane` — it has outgrown the 450×350 settings window, so **new controls
-just get appended; do not try to keep the tab short**.
+Built by `SettingsUI.PopulateAutomationTab` (`PitHero/UI/SettingsUI.cs`), which delegates the
+newest blocks to `PopulateAutoPurchaseControls`, `PopulateAutoEquipControls` and
+`PopulateAutoHireControls`. The whole tab is wrapped in a vertical `ScrollPane` — it has outgrown
+the 450×350 settings window, so **new controls just get appended; do not try to keep the tab
+short**.
 
 | Control group | Owning service / state | Runs | Save section |
 |---|---|---|---|
@@ -24,6 +25,7 @@ just get appended; do not try to keep the tab short**.
 | Auto-Sell Excess Items + priority + "Gear Sell Options" | `AutoSellExcessItemsService` | Call-driven | 36–38 (v21/v22/v23) |
 | Auto-Purchase Items + priority + merc opt-in + "Gear Purchase Options" + "Consumable Purchase Options" | `AutoItemPurchaseService` | Call-driven | 39 (v23) |
 | Auto-Equip Options | `HeroComponent.AutoEquipHero` / `.AutoEquipMercenaries` (**no service**) | Call-driven | 40 (v23) |
+| Auto-Hire Mercenaries + two "MercenaryN Job" cyclers | `AutoHireMercenaryService` | Call-driven | 41 (v24) |
 
 Dialogs opened from the tab:
 
@@ -45,8 +47,8 @@ setting predates item purchasing and kept its home, so `AutoItemPurchaseService`
 `AutoSeedPurchaseService` by constructor injection and exposes a read-only
 `GoldBuffer => _goldBufferSource?.GoldBuffer ?? 0`. Consequences:
 
-- `AutoItemPurchaseService` **must be registered after** `AutoSeedPurchaseService` in
-  `MainGameScene.Begin()`.
+- `AutoItemPurchaseService` and `AutoHireMercenaryService` **must be registered after**
+  `AutoSeedPurchaseService` in `MainGameScene.Begin()`.
 - There is exactly one slider in the UI and one persisted field (`SaveData.AutoShopGoldBuffer`).
   Do not add a second buffer; route new automated spending through the same property.
 
@@ -74,6 +76,12 @@ Two distinct patterns — pick deliberately:
     after validation means an aborted jump never spends gold; the branch runs once per jump.
   - `PartyAutoEquipHelper.TryAutoEquipForParty(heroComp, item)` ← `OpenChestAction` (chest loot) and
     `AutoItemPurchaseService` (each purchased item).
+  - `AutoHireMercenaryService.TryAutoHire(mercEntity)` ← `MercenaryManager.WalkToTavern`, after the
+    merc is seated (`IsWaitingInTavern` + patron component) — hiring earlier corrupts seat state.
+    `TryHirePass()` ← both settings-close paths (`ToggleSettingsVisibility`, `ForceCloseSettings`),
+    so mercs already seated when the option is configured get hired on exit. The service pre-checks
+    `CanHireMore()` (which covers the hero-dead hiring block) and the Gold Buffer, because
+    `MercenaryManager.HireMercenary` enforces neither.
 
 ## Persistence
 
@@ -137,8 +145,8 @@ hoverableLabel.SetTooltipEnabled(active);   // hoverable labels only
 
 `PitHeroSkin` provides `ph-grayed` variants of `LabelStyle`, `TextButtonStyle` and `CheckBoxStyle`.
 Helpers in `SettingsUI`: `SetButtonActive` (shared), `SetDesignateCropsActive`,
-`SetExcessItemControlsActive`, `SetItemPurchaseControlsActive`, `SetConsumablePurchaseControlsActive`.
-`ReorderableTableList` has its own `SetGrayed(bool)`.
+`SetExcessItemControlsActive`, `SetItemPurchaseControlsActive`, `SetConsumablePurchaseControlsActive`,
+`SetAutoHireControlsActive`. `ReorderableTableList` has its own `SetGrayed(bool)`.
 
 Gotchas:
 
@@ -149,7 +157,9 @@ Gotchas:
 - **Nested gates compose.** "Consumable Purchase Options" is enabled only when *both*
   "Auto-Purchase Items" and "Auto-Purchase Consumables" are checked;
   `SetItemPurchaseControlsActive` ends by calling `SetConsumablePurchaseControlsActive` with the
-  combined condition. Follow that pattern rather than gating on one checkbox.
+  combined condition. Follow that pattern rather than gating on one checkbox. Same for the
+  "Mercenary2 Job" cycler, which needs the auto-hire checkbox on *and* slot 1 holding a job
+  (cycling slot 1 to None also resets slot 2 to None).
 - **Hide open dialogs when the parent turns off**, or a deactivated feature's dialog stays on screen.
 - `PitHeroSkin.CreateSkin()` returns a **cached singleton** — never mutate a shared style; `Clone()`
   first if you need a variant (see `VaultBuyQuantityDialog`).
@@ -212,6 +222,7 @@ and call the pass method rather than simulating frames:
 | Excess-item selling + gear filters | `PitHero.Tests/AutoSellExcessItemsTests.cs` |
 | Item purchasing | `PitHero.Tests/AutoItemPurchaseServiceTests.cs` |
 | Auto-equip | `PitHero.Tests/GearAutoEquipServiceTests.cs` |
+| Mercenary auto-hire matching | `PitHero.Tests/AutoHireMercenaryServiceTests.cs` |
 | Save round-trips + defaults | `PitHero.Tests/SaveLoadTests.cs` |
 
 `AutoItemPurchaseService` splits its entry point for this reason: `TryPurchasePass(HeroComponent)`


### PR DESCRIPTION
Closes #350.

## Feature (design revised from the issue text)

Instead of the priority-list dialog, the Automation tab gets direct party-composition control:

- **Auto-Hire Mercenaries** checkbox, plus two wrapping arrow cyclers **Mercenary1 Job** / **Mercenary2 Job** (None, Priest, Mage, Knight, Thief, Monk, Archer). None disables a slot, duplicates are allowed (two Knights), and slot 2 is only selectable while slot 1 holds a job (clearing slot 1 clears slot 2). Both rows gray out when the checkbox is off.
- `AutoHireMercenaryService` (call-driven): hires a matching mercenary the moment it is seated in the tavern, and sweeps already-seated mercenaries when the Settings window closes. Every hire pre-checks `CanHireMore()` (party cap + hero-dead hiring block) and the shared Gold Buffer (`funds - cost >= buffer`), since `HireMercenary` enforces neither.
- Matching is a desired-multiset test: each hired party member satisfies at most one slot of its job; manual hires with other jobs consume only party capacity.
- Save format v24 (append-only section 41: enabled + two JobType slots), with sanitization and the slot-2 invariant enforced on load. `AutomationSystem.md` updated.

## Bug fix surfaced by playtesting the feature

A mercenary auto-hired while the party was already diving could get permanently stuck outside the pit (pathfinding warnings at the pit wall, endless replans). Root cause: `MercenaryStateMachine` derived pit membership from truncated tile positions, which flickers while the follow target lerps over the pit wall mid-jump and misclassifies a merc stranded over the pit rect (widened underneath it, or teleported by the follow stuck-warp) as already inside — so the walk-to-edge/jump plan was never scheduled again.

- Pit membership now reads the authoritative `InsidePit` flags (positions are never persisted, so load defaults stay correct).
- The follow stuck-warp refuses impassable tiles and, after crossing the pit boundary, syncs the flag and refreshes the pathfinding graph like the jump actions do.
- `WalkToPitEdgeAction` no longer caches a stale edge tile across failures and self-heals a merc stranded on the pit floor.
- New shared helpers: `PitWidthManager.IsTileInsidePitInterior` and `PathfindingActorComponent.RefreshPathfindingWithObstacles`.

## Testing

- `dotnet test`: 1687 tests, 0 failures (18 new: matching/affordability/sanitization, v24 round-trip + defaults, pit-interior bounds).
- Manual: checkbox/cycler gray-out and wrap, arrival auto-hire, settings-close sweep, gold-buffer refusal, save/load round-trip, and a mid-dive auto-hire joining the party.

🤖 Generated with [Claude Code](https://claude.com/claude-code)