### PR TITLE
Prioritize farming over kitchen in auto job assignment

### DIFF
--- a/PitHero.Tests/AutoJobAssignmentServiceTests.cs
+++ b/PitHero.Tests/AutoJobAssignmentServiceTests.cs
@@ -1,8 +1,10 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PitHero;
+using PitHero.Dining;
 using PitHero.Farming;
 using PitHero.Services;
 using PitHero.Services.AutoJob;
+using PitHero.Util;
 using RolePlayingFramework.AlliedMonsters;
 
 namespace PitHero.Tests
@@ -465,6 +467,82 @@ namespace PitHero.Tests
             var d = KitchenJobDemandEvaluator.ComputeDemand(1000, rosterSize: 20, availableWorkers: 20);
             Assert.AreEqual(GameConfig.AutoJobKitchenMaxWorkers, d.DesiredWorkers,
                 "Kitchen demand is capped at the coordinator's worker limit");
+        }
+
+        [TestMethod]
+        public void KitchenDemand_NothingOrderable_FieldsNoOne()
+        {
+            // No coverable dish means servers can never take an order, so no ticket can ever
+            // exist — staffing the kitchen would be dead weight.
+            var d = KitchenJobDemandEvaluator.ComputeDemand(0, rosterSize: 10, availableWorkers: 10,
+                anyDishOrderable: false);
+            Assert.AreEqual(0, d.DesiredWorkers);
+            Assert.AreEqual(0, d.MinWorkers);
+            Assert.IsTrue(d.Sticky,
+                "Workers already in the kitchen stay put when the larder runs dry mid-day");
+        }
+
+        // ── Kitchen evaluator: empty-larder gate ─────────────────────────────
+
+        private static KitchenTaskCoordinator CreateHeadlessKitchen(
+            out BuildingService buildings, out CropStorageInventoryService storage)
+        {
+            buildings = new BuildingService();
+            buildings.AddBuilding(new PlacedBuilding
+            {
+                Type = BuildingType.CropStorage,
+                TileX = GameConfig.NewGameCropStorageAnchorTileX,
+                TileY = GameConfig.NewGameCropStorageAnchorTileY,
+                UniqueId = 1,
+            });
+            storage = new CropStorageInventoryService(buildings);
+            var coordinator = new KitchenTaskCoordinator(null, buildings, 240, 12);
+            coordinator.SetHeadlessServices(storage, new GameStateService());
+            return coordinator;
+        }
+
+        [TestMethod]
+        public void KitchenEvaluator_EmptyLarder_ReportsZeroDemand()
+        {
+            var coordinator = CreateHeadlessKitchen(out _, out _);
+            var evaluator = new KitchenJobDemandEvaluator(coordinator, null, null);
+
+            var d = evaluator.EvaluateDemand(rosterSize: 3, availableWorkers: 3);
+
+            Assert.AreEqual(0, d.DesiredWorkers, "Empty fridge + storage: no dish is coverable");
+            Assert.AreEqual(0, d.MinWorkers);
+        }
+
+        [TestMethod]
+        public void KitchenEvaluator_StockedLarder_WantsBaseCrew()
+        {
+            var coordinator = CreateHeadlessKitchen(out _, out var storage);
+            var def = DishConfig.GetDefinition((DishType)0);
+            for (int i = 0; i < def.Recipe.Length; i++)
+                Assert.IsTrue(storage.TryDeposit(1, def.Recipe[i].Crop, def.Recipe[i].Qty));
+            var evaluator = new KitchenJobDemandEvaluator(coordinator, null, null);
+
+            var d = evaluator.EvaluateDemand(rosterSize: 3, availableWorkers: 3);
+
+            Assert.AreEqual(GameConfig.AutoJobKitchenBaseStaff, d.DesiredWorkers,
+                "One coverable dish is enough to staff the kitchen");
+        }
+
+        [TestMethod]
+        public void ReassessNow_LoneMonsterNewGame_StaysHomeInsteadOfKitchen()
+        {
+            // The reported scenario: fresh game, one monster, no farm workload, nothing in
+            // storage to cook with. The monster must stay home, not take the chef hat.
+            var coordinator = CreateHeadlessKitchen(out _, out _);
+            var roster = new AlliedMonsterManager();
+            roster.AddAlliedMonster(Monster("Solo", 1, 9, 1));
+            var service = new AutoJobAssignmentService(roster,
+                new KitchenJobDemandEvaluator(coordinator, null, null),
+                new FarmingJobDemandEvaluator(null, null, null));
+
+            service.ReassessNow();
+
+            Assert.AreEqual(MonsterJob.None, roster.AlliedMonsters[0].Job);
         }
     }
 }

--- a/PitHero.Tests/AutoJobAssignmentServiceTests.cs
+++ b/PitHero.Tests/AutoJobAssignmentServiceTests.cs
@@ -56,8 +56,8 @@ namespace PitHero.Tests
         [TestMethod]
         public void ReassessNow_AppliesSolverOutputToRoster()
         {
-            // Zero backlog/workload: kitchen still wants its base crew of 3 (desired, non-min),
-            // farming wants none. The 3 best cooks staff the kitchen; the rest go home.
+            // Zero backlog/workload: kitchen still wants its base crew of 3, farming wants none.
+            // The 3 best cooks staff the kitchen; the rest go home.
             var roster = new AlliedMonsterManager();
             roster.AddAlliedMonster(Monster("A", 1, 2, 9, MonsterJob.Farming));
             roster.AddAlliedMonster(Monster("B", 1, 8, 1));
@@ -230,13 +230,139 @@ namespace PitHero.Tests
                 "Sticky night kitchen worker keeps the job");
         }
 
+        // ── Farming priority over kitchen (issue: dead-end kitchen with unworked farm) ──
+
+        /// <summary>Service whose farming evaluator sees a real workload of planCount placed plans.</summary>
+        private static AutoJobAssignmentService CreateServiceWithFarmWorkload(
+            AlliedMonsterManager roster, int planCount)
+        {
+            var planting = new CropPlantingService();
+            var growth = new CropGrowthService(planting);
+            for (int i = 0; i < planCount; i++)
+                planting.AddPlan(new PlacedCropPlan { Type = CropType.Wheat, TileX = i, TileY = 0 });
+            return new AutoJobAssignmentService(roster,
+                new KitchenJobDemandEvaluator(null, null, null),
+                new FarmingJobDemandEvaluator(null, growth, planting));
+        }
+
+        [TestMethod]
+        public void ReassessNow_TwoMonstersWithFarmWorkload_BothFarm()
+        {
+            // The reported bug: with only 2 workers and farm work outstanding, both used to be
+            // sunk into a dead-end kitchen. Farming now takes priority and the kitchen (which
+            // can't field its 3-monster crew anyway) stands down.
+            var roster = new AlliedMonsterManager();
+            roster.AddAlliedMonster(Monster("A", 1, 5, 5));
+            roster.AddAlliedMonster(Monster("B", 1, 5, 5));
+            var service = CreateServiceWithFarmWorkload(roster,
+                planCount: GameConfig.AutoJobFarmCropsPerWorkerBaseline + 1);   // farming desired = 2
+
+            service.ReassessNow();
+
+            Assert.AreEqual(MonsterJob.Farming, roster.AlliedMonsters[0].Job, "Both workers farm");
+            Assert.AreEqual(MonsterJob.Farming, roster.AlliedMonsters[1].Job, "Both workers farm");
+        }
+
+        [TestMethod]
+        public void ReassessNow_FourMonsters_OneFarmerThreeKitchen()
+        {
+            // With 4 monsters the kitchen's full crew fits alongside the guaranteed farmer:
+            // 1 farms (even though farming wants 2), 3 staff the kitchen.
+            var roster = new AlliedMonsterManager();
+            roster.AddAlliedMonster(Monster("A", 1, 5, 5));
+            roster.AddAlliedMonster(Monster("B", 1, 5, 5));
+            roster.AddAlliedMonster(Monster("C", 1, 5, 5));
+            roster.AddAlliedMonster(Monster("D", 1, 5, 5));
+            var service = CreateServiceWithFarmWorkload(roster,
+                planCount: GameConfig.AutoJobFarmCropsPerWorkerBaseline + 1);   // farming desired = 2
+
+            service.ReassessNow();
+
+            int farmers = 0, cooks = 0;
+            for (int i = 0; i < roster.AlliedMonsters.Count; i++)
+            {
+                if (roster.AlliedMonsters[i].Job == MonsterJob.Farming) farmers++;
+                if (roster.AlliedMonsters[i].Job == MonsterJob.Cooking) cooks++;
+            }
+            Assert.AreEqual(1, farmers, "One guaranteed farmer");
+            Assert.AreEqual(3, cooks, "Kitchen keeps its full base crew");
+        }
+
+        [TestMethod]
+        public void ReassessNow_StickyKitchenCrew_ReleasedWhenFarmTasksAppearWithZeroFarmers()
+        {
+            // The one exception to all-day kitchen stickiness: farm work exists but nobody at all
+            // is farming, so kitchen work is pointless and the crew is released to the farm.
+            var roster = new AlliedMonsterManager();
+            roster.AddAlliedMonster(Monster("A", 1, 5, 5, MonsterJob.Cooking));
+            roster.AddAlliedMonster(Monster("B", 1, 5, 5, MonsterJob.Cooking));
+            var service = CreateServiceWithFarmWorkload(roster, planCount: 1);
+
+            service.ReassessNow();
+
+            int farmers = 0;
+            for (int i = 0; i < roster.AlliedMonsters.Count; i++)
+            {
+                if (roster.AlliedMonsters[i].Job == MonsterJob.Farming) farmers++;
+            }
+            Assert.IsTrue(farmers >= 1, "At least one sticky kitchen worker must be released to the farm");
+        }
+
+        [TestMethod]
+        public void ReassessNow_FarmerGuaranteeHoldsPerShift()
+        {
+            // Each shift is a disjoint workforce, so the ≥1-farmer guarantee applies to the day
+            // crew and the night crew independently.
+            var roster = new AlliedMonsterManager();
+            roster.AddAlliedMonster(Monster("DayA", 1, 5, 5, MonsterJob.Cooking));
+            roster.AddAlliedMonster(Monster("DayB", 1, 5, 5, MonsterJob.Cooking));
+            roster.AddAlliedMonster(Monster("NightA", 1, 5, 5, MonsterJob.Cooking, typeName: "Monster_Orc"));
+            roster.AddAlliedMonster(Monster("NightB", 1, 5, 5, MonsterJob.Cooking, typeName: "Monster_Orc"));
+            var service = CreateServiceWithFarmWorkload(roster, planCount: 1);
+
+            service.ReassessNow();
+
+            int dayFarmers = 0, nightFarmers = 0;
+            for (int i = 0; i < roster.AlliedMonsters.Count; i++)
+            {
+                if (roster.AlliedMonsters[i].Job != MonsterJob.Farming)
+                    continue;
+                if (roster.AlliedMonsters[i].MonsterTypeName == "Monster_Orc") nightFarmers++;
+                else dayFarmers++;
+            }
+            Assert.IsTrue(dayFarmers >= 1, "Day shift must field its own farmer");
+            Assert.IsTrue(nightFarmers >= 1, "Night shift must field its own farmer");
+        }
+
+        [TestMethod]
+        public void ReassessNow_LargeRoster_KitchenStillFieldsBaseCrew()
+        {
+            // Regression guard: farming priority must not starve the kitchen when workers are
+            // plentiful — 6 monsters with a small farm workload still yield a full kitchen crew.
+            var roster = new AlliedMonsterManager();
+            for (int i = 0; i < 6; i++)
+                roster.AddAlliedMonster(Monster($"M{i}", 1, 5, 5));
+            var service = CreateServiceWithFarmWorkload(roster, planCount: 1);   // farming desired = 1
+
+            service.ReassessNow();
+
+            int farmers = 0, cooks = 0;
+            for (int i = 0; i < roster.AlliedMonsters.Count; i++)
+            {
+                if (roster.AlliedMonsters[i].Job == MonsterJob.Farming) farmers++;
+                if (roster.AlliedMonsters[i].Job == MonsterJob.Cooking) cooks++;
+            }
+            Assert.AreEqual(1, farmers, "Small farm workload wants exactly one farmer");
+            Assert.AreEqual(3, cooks, "Kitchen fields its full base crew from the surplus");
+        }
+
         private sealed class FixedDemandEvaluator : IJobDemandEvaluator
         {
             private readonly JobDemandEntry _entry;
             public FixedDemandEvaluator(MonsterJob job, int min, int desired)
                 => _entry = new JobDemandEntry { Job = job, MinWorkers = min, DesiredWorkers = desired, Sticky = false };
             public MonsterJob Job => _entry.Job;
-            public JobDemandEntry EvaluateDemand(int rosterSize) => _entry;
+            public JobDemandEntry EvaluateDemand(int rosterSize, int availableWorkers) => _entry;
         }
 
         // ── Farming demand math ──────────────────────────────────────────────
@@ -244,7 +370,7 @@ namespace PitHero.Tests
         [TestMethod]
         public void FarmingDemand_ZeroWorkload_WantsNoWorkers()
         {
-            var d = FarmingJobDemandEvaluator.ComputeDemand(0, 0, rosterSize: 10);
+            var d = FarmingJobDemandEvaluator.ComputeDemand(0, 0, availableWorkers: 10);
             Assert.AreEqual(0, d.DesiredWorkers);
             Assert.AreEqual(0, d.MinWorkers);
             Assert.IsFalse(d.Sticky, "Farming is not sticky — farmers are released during lulls");
@@ -265,16 +391,16 @@ namespace PitHero.Tests
             // A watering/harvest wave (many outstanding tasks) demands more workers than the
             // baseline care load alone would.
             int tasksPer = GameConfig.AutoJobFarmTasksPerWorker;
-            var d = FarmingJobDemandEvaluator.ComputeDemand(tasksPer * 3, careLoad: 1, rosterSize: 10);
+            var d = FarmingJobDemandEvaluator.ComputeDemand(tasksPer * 3, careLoad: 1, availableWorkers: 10);
             Assert.AreEqual(3, d.DesiredWorkers, "Burst signal should win when larger than baseline");
             Assert.AreEqual(1, d.MinWorkers, "At least one farmer whenever any workload exists");
         }
 
         [TestMethod]
-        public void FarmingDemand_ClampsToRosterSize()
+        public void FarmingDemand_ClampsToAvailableWorkers()
         {
-            var d = FarmingJobDemandEvaluator.ComputeDemand(1000, 1000, rosterSize: 4);
-            Assert.AreEqual(4, d.DesiredWorkers, "Demand can never exceed the roster");
+            var d = FarmingJobDemandEvaluator.ComputeDemand(1000, 1000, availableWorkers: 4);
+            Assert.AreEqual(4, d.DesiredWorkers, "Demand can never exceed the available workers");
         }
 
         [TestMethod]
@@ -287,7 +413,7 @@ namespace PitHero.Tests
                 planting.AddPlan(new PlacedCropPlan { Type = CropType.Wheat, TileX = i, TileY = 0 });
             var evaluator = new FarmingJobDemandEvaluator(null, growth, planting);
 
-            var d = evaluator.EvaluateDemand(rosterSize: 10);
+            var d = evaluator.EvaluateDemand(rosterSize: 10, availableWorkers: 10);
 
             Assert.AreEqual(2, d.DesiredWorkers, "Placed plans count toward the baseline care load");
         }
@@ -297,34 +423,46 @@ namespace PitHero.Tests
         [TestMethod]
         public void KitchenDemand_ZeroBacklog_StillWantsBaseCrew()
         {
-            var d = KitchenJobDemandEvaluator.ComputeDemand(0, rosterSize: 10);
+            var d = KitchenJobDemandEvaluator.ComputeDemand(0, rosterSize: 10, availableWorkers: 10);
             Assert.AreEqual(GameConfig.AutoJobKitchenBaseStaff, d.DesiredWorkers,
                 "Kitchen keeps a cook + server + runner crew even with no orders");
-            Assert.AreEqual(0, d.MinWorkers, "Base crew is desired, not mandatory, when there is no backlog");
+            Assert.AreEqual(GameConfig.AutoJobKitchenBaseStaff, d.MinWorkers,
+                "Base crew is a firm minimum so it fills before farming's desired extras");
             Assert.IsTrue(d.Sticky, "Kitchen workers must never be pulled away");
         }
 
         [TestMethod]
         public void KitchenDemand_BaseCrewClampsToTinyRoster()
         {
-            var d = KitchenJobDemandEvaluator.ComputeDemand(0, rosterSize: 2);
+            // Available equals the full roster (no farming reservation), so a partial crew is
+            // still fielded on tiny rosters, exactly as before the farming-priority change.
+            var d = KitchenJobDemandEvaluator.ComputeDemand(0, rosterSize: 2, availableWorkers: 2);
             Assert.AreEqual(2, d.DesiredWorkers);
+        }
+
+        [TestMethod]
+        public void KitchenDemand_ZeroedWhenFarmingReservationLeavesUnderBaseCrew()
+        {
+            // Farming reserved a worker and fewer than cook+server+runner remain: a partial
+            // kitchen has no runner and is pointless, so the kitchen cedes the shortage entirely.
+            var d = KitchenJobDemandEvaluator.ComputeDemand(0, rosterSize: 3, availableWorkers: 2);
+            Assert.AreEqual(0, d.DesiredWorkers, "All-or-nothing when competing with farming");
+            Assert.AreEqual(0, d.MinWorkers);
         }
 
         [TestMethod]
         public void KitchenDemand_BacklogAddsExtraWorkers()
         {
             int per = GameConfig.AutoJobKitchenBacklogPerExtraWorker;
-            var d = KitchenJobDemandEvaluator.ComputeDemand(per * 2, rosterSize: 10);
+            var d = KitchenJobDemandEvaluator.ComputeDemand(per * 2, rosterSize: 10, availableWorkers: 10);
             Assert.AreEqual(GameConfig.AutoJobKitchenBaseStaff + 2, d.DesiredWorkers);
-            Assert.AreEqual(GameConfig.AutoJobKitchenBaseStaff, d.MinWorkers,
-                "With a backlog the base crew becomes mandatory");
+            Assert.AreEqual(GameConfig.AutoJobKitchenBaseStaff, d.MinWorkers);
         }
 
         [TestMethod]
         public void KitchenDemand_CapsAtMaxWorkers()
         {
-            var d = KitchenJobDemandEvaluator.ComputeDemand(1000, rosterSize: 20);
+            var d = KitchenJobDemandEvaluator.ComputeDemand(1000, rosterSize: 20, availableWorkers: 20);
             Assert.AreEqual(GameConfig.AutoJobKitchenMaxWorkers, d.DesiredWorkers,
                 "Kitchen demand is capped at the coordinator's worker limit");
         }

--- a/PitHero.Tests/JobAssignmentSolverTests.cs
+++ b/PitHero.Tests/JobAssignmentSolverTests.cs
@@ -7,7 +7,8 @@ namespace PitHero.Tests
 {
     /// <summary>
     /// Tests for the pure JobAssignmentSolver: sticky/min/desired fill order, proficiency selection
-    /// with deterministic tie-breaks, surplus demotion, and the strict-double-improvement swap pass.
+    /// with deterministic tie-breaks, surplus demotion, the starvation release pass (the one
+    /// exception to stickiness), and the strict-double-improvement swap pass.
     /// </summary>
     [TestClass]
     public class JobAssignmentSolverTests
@@ -93,9 +94,10 @@ namespace PitHero.Tests
         }
 
         [TestMethod]
-        public void Solve_KitchenMin_FilledByCookingSkillBeforeFarmingDesired()
+        public void Solve_FirstListedDemandMin_OutranksLaterListedDemands()
         {
-            // One monster, kitchen min 1 listed first: kitchen wins even though farming wants 1 too.
+            // One monster, two competing minimums: demand-list order is priority, so the
+            // first-listed job wins the lone worker.
             var monsters = new List<MonsterJobSnapshot>
             {
                 Monster(0, MonsterJob.None, 9, 2),
@@ -257,6 +259,178 @@ namespace PitHero.Tests
 
             Assert.AreEqual(MonsterJob.Cooking, _result[0], "First-listed demand takes the whole short roster");
             Assert.AreEqual(MonsterJob.Cooking, _result[1], "First-listed demand takes the whole short roster");
+        }
+
+        // ── Starvation release: the one exception to kitchen stickiness ──────
+
+        [TestMethod]
+        public void Solve_StarvedFarming_PullsStickyKitchenWorker()
+        {
+            // Every monster is sticky-locked in the kitchen while farming demands workers:
+            // with no kitchen floor (min 0), farming pulls as many as it needs.
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.Cooking, 5, 5),
+                Monster(1, MonsterJob.Cooking, 5, 5),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Farming, 1, 2, sticky: false),
+                Demand(MonsterJob.Cooking, 0, 0, sticky: true),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            Assert.AreEqual(MonsterJob.Farming, _result[0], "Sticky cook is released when farming has zero workers");
+            Assert.AreEqual(MonsterJob.Farming, _result[1], "Farming pulls up to its desired count");
+        }
+
+        [TestMethod]
+        public void Solve_StarvedFarming_RespectsRaidedJobMinimum()
+        {
+            // Four sticky cooks; farming wants 3 but the kitchen's own minimum of 3 is a floor
+            // the release pass never raids below — exactly one worker is pulled.
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.Cooking, 5, 5),
+                Monster(1, MonsterJob.Cooking, 5, 5),
+                Monster(2, MonsterJob.Cooking, 5, 5),
+                Monster(3, MonsterJob.Cooking, 5, 5),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Farming, 1, 3, sticky: false),
+                Demand(MonsterJob.Cooking, 3, 3, sticky: true),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            int farmers = 0, cooks = 0;
+            for (int i = 0; i < _result.Count; i++)
+            {
+                if (_result[i] == MonsterJob.Farming) farmers++;
+                if (_result[i] == MonsterJob.Cooking) cooks++;
+            }
+            Assert.AreEqual(1, farmers, "Only one worker can be pulled before the kitchen hits its minimum");
+            Assert.AreEqual(3, cooks, "Kitchen never drops below its own MinWorkers");
+        }
+
+        [TestMethod]
+        public void Solve_StarvedFarming_PicksBestFarmerFromKitchen()
+        {
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.Cooking, 3, 5),
+                Monster(1, MonsterJob.Cooking, 9, 5),
+                Monster(2, MonsterJob.Cooking, 9, 5),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Farming, 1, 1, sticky: false),
+                Demand(MonsterJob.Cooking, 0, 0, sticky: true),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            Assert.AreEqual(MonsterJob.Cooking, _result[0], "Weakest farmer stays in the kitchen");
+            Assert.AreEqual(MonsterJob.Farming, _result[1], "Best farmer is pulled; proficiency tie breaks to lowest index");
+            Assert.AreEqual(MonsterJob.Cooking, _result[2]);
+        }
+
+        [TestMethod]
+        public void Solve_FarmingHasAnyWorker_KitchenStickinessHolds()
+        {
+            // The exception fires only at ZERO farm workers: with one free monster available for
+            // farming, understaffed farming never raids the sticky kitchen.
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.None, 5, 5),
+                Monster(1, MonsterJob.Cooking, 5, 5),
+                Monster(2, MonsterJob.Cooking, 5, 5),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Farming, 1, 3, sticky: false),
+                Demand(MonsterJob.Cooking, 0, 3, sticky: true),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            Assert.AreEqual(MonsterJob.Farming, _result[0], "Free monster staffs the farm");
+            Assert.AreEqual(MonsterJob.Cooking, _result[1], "Sticky cook stays — farming has a worker");
+            Assert.AreEqual(MonsterJob.Cooking, _result[2], "Sticky cook stays — farming has a worker");
+        }
+
+        [TestMethod]
+        public void Solve_StarvedDemand_NeverRaidsHigherPriorityStickyJob()
+        {
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.Cooking, 5, 5),
+                Monster(1, MonsterJob.Cooking, 5, 5),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Cooking, 0, 0, sticky: true),
+                Demand(MonsterJob.Farming, 1, 2, sticky: false),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            Assert.AreEqual(MonsterJob.Cooking, _result[0], "A starved demand only raids lower-priority jobs");
+            Assert.AreEqual(MonsterJob.Cooking, _result[1], "A starved demand only raids lower-priority jobs");
+        }
+
+        [TestMethod]
+        public void Solve_ZeroFarmingDemand_NoStickyRelease()
+        {
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.Cooking, 9, 5),
+                Monster(1, MonsterJob.Cooking, 9, 5),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Farming, 0, 0, sticky: false),
+                Demand(MonsterJob.Cooking, 0, 3, sticky: true),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            Assert.AreEqual(MonsterJob.Cooking, _result[0], "No farm workload — no exception, cooks stay");
+            Assert.AreEqual(MonsterJob.Cooking, _result[1], "No farm workload — no exception, cooks stay");
+        }
+
+        [TestMethod]
+        public void Solve_AfterStickyRelease_NextSolveIsStable()
+        {
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.Cooking, 5, 5),
+                Monster(1, MonsterJob.Cooking, 5, 5),
+                Monster(2, MonsterJob.Cooking, 5, 5),
+                Monster(3, MonsterJob.Cooking, 5, 5),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Farming, 1, 3, sticky: false),
+                Demand(MonsterJob.Cooking, 3, 3, sticky: true),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+            var first = new List<MonsterJob>(_result);
+
+            // Apply the results as the new current jobs and solve again with identical demands.
+            for (int i = 0; i < monsters.Count; i++)
+            {
+                var m = monsters[i];
+                m.CurrentJob = first[i];
+                monsters[i] = m;
+            }
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            CollectionAssert.AreEqual(first, _result,
+                "Release must not oscillate: once a farmer exists the exception never re-fires");
         }
 
         [TestMethod]

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -333,6 +333,11 @@ namespace PitHero.ECS.Scenes
             kitchenCoordinator.Initialize(this);
             Core.Services.AddService(kitchenCoordinator);
 
+            // Peer the worker coordinators: on a job change, the monster's old-job entity must
+            // walk home and despawn before the new job's entity spawns (one entity per monster).
+            farmTaskCoordinator.AddPeer(kitchenCoordinator);
+            kitchenCoordinator.AddPeer(farmTaskCoordinator);
+
             // Party dining service orchestrates once-a-day tavern meals for the party (issue #319)
             var partyDiningService = new Services.PartyDiningService();
             kitchenCoordinator.SetPartyOrderSource(partyDiningService);

--- a/PitHero/Services/AutoJob/FarmingJobDemandEvaluator.cs
+++ b/PitHero/Services/AutoJob/FarmingJobDemandEvaluator.cs
@@ -26,22 +26,22 @@ namespace PitHero.Services.AutoJob
         public MonsterJob Job => MonsterJob.Farming;
 
         /// <inheritdoc/>
-        public JobDemandEntry EvaluateDemand(int rosterSize)
+        public JobDemandEntry EvaluateDemand(int rosterSize, int availableWorkers)
         {
             int outstanding = _coordinator != null ? _coordinator.OutstandingTaskCount : 0;
             int careLoad = (_cropGrowth != null ? _cropGrowth.CropCount : 0)
                 + (_cropPlanting != null ? _cropPlanting.PlanCount : 0);
-            return ComputeDemand(outstanding, careLoad, rosterSize);
+            return ComputeDemand(outstanding, careLoad, availableWorkers);
         }
 
-        /// <summary>Pure demand math: max of the burst and baseline worker counts, clamped to the roster.</summary>
-        public static JobDemandEntry ComputeDemand(int outstandingTasks, int careLoad, int rosterSize)
+        /// <summary>Pure demand math: max of the burst and baseline worker counts, clamped to the available workers.</summary>
+        public static JobDemandEntry ComputeDemand(int outstandingTasks, int careLoad, int availableWorkers)
         {
             int burst = CeilDiv(outstandingTasks, GameConfig.AutoJobFarmTasksPerWorker);
             int baseline = CeilDiv(careLoad, GameConfig.AutoJobFarmCropsPerWorkerBaseline);
             int desired = burst > baseline ? burst : baseline;
-            if (desired > rosterSize)
-                desired = rosterSize;
+            if (desired > availableWorkers)
+                desired = availableWorkers;
 
             return new JobDemandEntry
             {

--- a/PitHero/Services/AutoJob/IJobDemandEvaluator.cs
+++ b/PitHero/Services/AutoJob/IJobDemandEvaluator.cs
@@ -8,7 +8,11 @@ namespace PitHero.Services.AutoJob
         /// <summary>The job this evaluator staffs.</summary>
         MonsterJob Job { get; }
 
-        /// <summary>Computes how many workers this job wants right now, given the roster size.</summary>
-        JobDemandEntry EvaluateDemand(int rosterSize);
+        /// <summary>
+        /// Computes how many workers this job wants right now. rosterSize is the full shift roster;
+        /// availableWorkers is the roster minus the MinWorkers already reserved by higher-priority
+        /// evaluators (registration order = priority), so lower-priority jobs only claim what's left.
+        /// </summary>
+        JobDemandEntry EvaluateDemand(int rosterSize, int availableWorkers);
     }
 }

--- a/PitHero/Services/AutoJob/JobAssignmentSolver.cs
+++ b/PitHero/Services/AutoJob/JobAssignmentSolver.cs
@@ -40,8 +40,10 @@ namespace PitHero.Services.AutoJob
 
     /// <summary>
     /// Pure, deterministic assignment solver: fills each job's minimum staffing first (by proficiency),
-    /// then desired staffing, honoring sticky jobs whose workers are never demoted. Monsters left
-    /// unassigned get MonsterJob.None so the coordinators send them home.
+    /// then desired staffing, honoring sticky jobs whose workers are never demoted — except that a
+    /// higher-priority job left with zero workers may pull sticky workers from lower-priority jobs
+    /// (StarvationReleasePass). Monsters left unassigned get MonsterJob.None so the coordinators
+    /// send them home.
     /// </summary>
     public static class JobAssignmentSolver
     {
@@ -87,6 +89,7 @@ namespace PitHero.Services.AutoJob
 
             FillPass(monsters, demands, resultJobs, true);
             FillPass(monsters, demands, resultJobs, false);
+            StarvationReleasePass(monsters, demands, resultJobs);
             SwapPass(monsters, demands, resultJobs);
         }
 
@@ -106,6 +109,55 @@ namespace PitHero.Services.AutoJob
                     for (int i = 0; i < monsters.Count; i++)
                     {
                         if (resultJobs[i] != MonsterJob.None)
+                            continue;
+                        int proficiency = GetProficiency(monsters[i], demand.Job);
+                        if (proficiency > bestProficiency)
+                        {
+                            best = i;
+                            bestProficiency = proficiency;
+                        }
+                    }
+                    if (best < 0)
+                        break;
+                    resultJobs[best] = demand.Job;
+                    assigned++;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The one exception to stickiness: a demand with MinWorkers > 0 that ends the fill passes with
+        /// ZERO workers proves every candidate is sticky-locked elsewhere (fill exhausts free monsters
+        /// first). Pull sticky-held workers from LOWER-priority demands, up to the starved job's
+        /// DesiredWorkers, never dropping a raided job below its own MinWorkers.
+        /// </summary>
+        private static void StarvationReleasePass(List<MonsterJobSnapshot> monsters,
+            List<JobDemandEntry> demands, List<MonsterJob> resultJobs)
+        {
+            for (int d = 0; d < demands.Count; d++)
+            {
+                var demand = demands[d];
+                if (demand.MinWorkers <= 0)
+                    continue;
+                if (CountAssigned(resultJobs, demand.Job) > 0)
+                    continue;
+
+                int assigned = 0;
+                while (assigned < demand.DesiredWorkers)
+                {
+                    int best = -1;
+                    int bestProficiency = -1;
+                    for (int i = 0; i < monsters.Count; i++)
+                    {
+                        var job = resultJobs[i];
+                        if (job == MonsterJob.None || job == demand.Job)
+                            continue;
+                        int otherIndex = IndexOfDemand(demands, job);
+                        if (otherIndex <= d)
+                            continue;
+                        if (!demands[otherIndex].Sticky || monsters[i].CurrentJob != job)
+                            continue;
+                        if (CountAssigned(resultJobs, job) <= demands[otherIndex].MinWorkers)
                             continue;
                         int proficiency = GetProficiency(monsters[i], demand.Job);
                         if (proficiency > bestProficiency)
@@ -165,6 +217,16 @@ namespace PitHero.Services.AutoJob
                     }
                 }
             }
+        }
+
+        private static int IndexOfDemand(List<JobDemandEntry> demands, MonsterJob job)
+        {
+            for (int d = 0; d < demands.Count; d++)
+            {
+                if (demands[d].Job == job)
+                    return d;
+            }
+            return -1;
         }
 
         private static bool IsSticky(List<JobDemandEntry> demands, MonsterJob job)

--- a/PitHero/Services/AutoJob/KitchenJobDemandEvaluator.cs
+++ b/PitHero/Services/AutoJob/KitchenJobDemandEvaluator.cs
@@ -3,10 +3,12 @@ using RolePlayingFramework.AlliedMonsters;
 namespace PitHero.Services.AutoJob
 {
     /// <summary>
-    /// Kitchen demand: a base crew of cook + server + runner whenever any monsters are available
-    /// (the kitchen must be open before tickets or party dining can flow, and without a runner the
-    /// fridge runs dry), plus extra workers as the order backlog grows, capped at the coordinator's
-    /// worker limit. Sticky: kitchen workers are never pulled away by the solver.
+    /// Kitchen demand: a base crew of cook + server + runner, plus extra workers as the order backlog
+    /// grows, capped at the coordinator's worker limit. The base crew is all-or-nothing when competing
+    /// with farming: if higher-priority reservations leave fewer than the base crew available, the
+    /// kitchen fields no one (a partial kitchen has no runner and the fridge runs dry — and without
+    /// farm workers there'd be no ingredients anyway). Sticky: kitchen workers are never pulled away
+    /// by the solver except when farming would otherwise have zero workers.
     /// </summary>
     public sealed class KitchenJobDemandEvaluator : IJobDemandEvaluator
     {
@@ -27,31 +29,45 @@ namespace PitHero.Services.AutoJob
         public MonsterJob Job => MonsterJob.Cooking;
 
         /// <inheritdoc/>
-        public JobDemandEntry EvaluateDemand(int rosterSize)
+        public JobDemandEntry EvaluateDemand(int rosterSize, int availableWorkers)
         {
             int backlog = (_coordinator != null ? _coordinator.ActiveTicketCount : 0)
                 + (_mercenaryManager != null ? _mercenaryManager.CountSeatedPatrons() : 0)
                 + (_partyDining != null ? _partyDining.CountPendingPartyDiners() : 0);
-            return ComputeDemand(backlog, rosterSize);
+            return ComputeDemand(backlog, rosterSize, availableWorkers);
         }
 
         /// <summary>Pure demand math: base crew plus one extra worker per backlog block, capped.</summary>
-        public static JobDemandEntry ComputeDemand(int backlog, int rosterSize)
+        public static JobDemandEntry ComputeDemand(int backlog, int rosterSize, int availableWorkers)
         {
             int baseStaff = GameConfig.AutoJobKitchenBaseStaff;
-            if (baseStaff > rosterSize)
-                baseStaff = rosterSize;
+
+            // All-or-nothing when a higher-priority job (farming) has reserved workers: a kitchen crew
+            // below cook+server+runner is nonfunctional, so cede the shortage to farming entirely.
+            if (availableWorkers < baseStaff && availableWorkers < rosterSize)
+            {
+                return new JobDemandEntry
+                {
+                    Job = MonsterJob.Cooking,
+                    MinWorkers = 0,
+                    DesiredWorkers = 0,
+                    Sticky = true,
+                };
+            }
+
+            if (baseStaff > availableWorkers)
+                baseStaff = availableWorkers;
 
             int desired = baseStaff + backlog / GameConfig.AutoJobKitchenBacklogPerExtraWorker;
             if (desired > GameConfig.AutoJobKitchenMaxWorkers)
                 desired = GameConfig.AutoJobKitchenMaxWorkers;
 
-            int min = backlog > 0 ? (baseStaff < desired ? baseStaff : desired) : 0;
-
+            // A firm minimum keeps the base crew staffed ahead of farming's desired extras, and doubles
+            // as the floor the StarvationReleasePass won't raid below.
             return new JobDemandEntry
             {
                 Job = MonsterJob.Cooking,
-                MinWorkers = min,
+                MinWorkers = baseStaff,
                 DesiredWorkers = desired,
                 Sticky = true,
             };

--- a/PitHero/Services/AutoJob/KitchenJobDemandEvaluator.cs
+++ b/PitHero/Services/AutoJob/KitchenJobDemandEvaluator.cs
@@ -7,8 +7,10 @@ namespace PitHero.Services.AutoJob
     /// grows, capped at the coordinator's worker limit. The base crew is all-or-nothing when competing
     /// with farming: if higher-priority reservations leave fewer than the base crew available, the
     /// kitchen fields no one (a partial kitchen has no runner and the fridge runs dry — and without
-    /// farm workers there'd be no ingredients anyway). Sticky: kitchen workers are never pulled away
-    /// by the solver except when farming would otherwise have zero workers.
+    /// farm workers there'd be no ingredients anyway). The kitchen also fields no one while no dish
+    /// is coverable from fridge + storage: servers refuse orders they can't cover, so staff would be
+    /// dead weight until crops exist (e.g. a new game before any harvest). Sticky: kitchen workers
+    /// are never pulled away by the solver except when farming would otherwise have zero workers.
     /// </summary>
     public sealed class KitchenJobDemandEvaluator : IJobDemandEvaluator
     {
@@ -34,13 +36,29 @@ namespace PitHero.Services.AutoJob
             int backlog = (_coordinator != null ? _coordinator.ActiveTicketCount : 0)
                 + (_mercenaryManager != null ? _mercenaryManager.CountSeatedPatrons() : 0)
                 + (_partyDining != null ? _partyDining.CountPendingPartyDiners() : 0);
-            return ComputeDemand(backlog, rosterSize, availableWorkers);
+            bool anyDishOrderable = _coordinator == null || _coordinator.HasAnyOrderableDish();
+            return ComputeDemand(backlog, rosterSize, availableWorkers, anyDishOrderable);
         }
 
         /// <summary>Pure demand math: base crew plus one extra worker per backlog block, capped.</summary>
-        public static JobDemandEntry ComputeDemand(int backlog, int rosterSize, int availableWorkers)
+        public static JobDemandEntry ComputeDemand(int backlog, int rosterSize, int availableWorkers,
+            bool anyDishOrderable = true)
         {
             int baseStaff = GameConfig.AutoJobKitchenBaseStaff;
+
+            // A kitchen that can't cook anything is dead weight: servers only take orders whose
+            // recipe is coverable from fridge + storage, so with no coverable dish no ticket can
+            // ever be created. Field no one until crops exist (new game, or the larder ran dry).
+            if (!anyDishOrderable)
+            {
+                return new JobDemandEntry
+                {
+                    Job = MonsterJob.Cooking,
+                    MinWorkers = 0,
+                    DesiredWorkers = 0,
+                    Sticky = true,
+                };
+            }
 
             // All-or-nothing when a higher-priority job (farming) has reserved workers: a kitchen crew
             // below cook+server+runner is nonfunctional, so cede the shortage to farming entirely.

--- a/PitHero/Services/AutoJobAssignmentService.cs
+++ b/PitHero/Services/AutoJobAssignmentService.cs
@@ -33,16 +33,17 @@ namespace PitHero.Services
 
         /// <summary>
         /// Initialises the service with the roster and the initial demand evaluators, in priority order
-        /// (kitchen first: its small sticky crew is staffed before farming absorbs the rest).
+        /// (farming first: the kitchen depends on farm output, so farm demand is covered before the
+        /// kitchen staffs — kitchen work is a dead end with nothing being grown).
         /// </summary>
         public AutoJobAssignmentService(AlliedMonsterManager alliedMonsters,
             KitchenJobDemandEvaluator kitchenEvaluator, FarmingJobDemandEvaluator farmingEvaluator)
         {
             _alliedMonsters = alliedMonsters;
-            if (kitchenEvaluator != null)
-                _evaluators.Add(kitchenEvaluator);
             if (farmingEvaluator != null)
                 _evaluators.Add(farmingEvaluator);
+            if (kitchenEvaluator != null)
+                _evaluators.Add(kitchenEvaluator);
         }
 
         /// <summary>Registers an additional demand evaluator (future jobs, e.g. fishing).</summary>
@@ -137,9 +138,19 @@ namespace PitHero.Services
             if (_snapshots.Count == 0)
                 return;
 
+            // Each evaluator sees the roster minus the minimums already reserved by higher-priority
+            // evaluators, so a lower-priority job (kitchen) only claims workers farming doesn't need.
             _demands.Clear();
+            int reserved = 0;
             for (int i = 0; i < _evaluators.Count; i++)
-                _demands.Add(_evaluators[i].EvaluateDemand(_snapshots.Count));
+            {
+                int available = _snapshots.Count - reserved;
+                if (available < 0)
+                    available = 0;
+                var demand = _evaluators[i].EvaluateDemand(_snapshots.Count, available);
+                _demands.Add(demand);
+                reserved += demand.MinWorkers;
+            }
 
             JobAssignmentSolver.Solve(_snapshots, _demands, _resultJobs);
 

--- a/PitHero/Services/FarmTaskCoordinator.cs
+++ b/PitHero/Services/FarmTaskCoordinator.cs
@@ -14,7 +14,7 @@ namespace PitHero.Services
     /// — no per-frame scans) and hands actions out to farming monsters so multiple workers never
     /// target the same tile. Also owns the shared farm pathfinder.
     /// </summary>
-    public class FarmTaskCoordinator
+    public class FarmTaskCoordinator : IMonsterWorkerHost
     {
         private struct ActiveWorker
         {
@@ -56,6 +56,7 @@ namespace PitHero.Services
         private DroppedCropService _droppedCropService;
 
         private readonly List<ActiveWorker> _workers = new List<ActiveWorker>(16);
+        private readonly List<IMonsterWorkerHost> _peers = new List<IMonsterWorkerHost>(2);
         private Scene _scene;
 
         /// <summary>Provides the dropped-crop service used to recover crops dropped on the ground.</summary>
@@ -115,6 +116,33 @@ namespace PitHero.Services
         public void Initialize(Scene scene) => _scene = scene;
 
         /// <summary>
+        /// Registers a coordinator for another job. A farm worker is only spawned once no peer
+        /// still has a live entity for the monster (its old-job worker walked home and despawned).
+        /// </summary>
+        public void AddPeer(IMonsterWorkerHost peer)
+        {
+            if (peer != null && !ReferenceEquals(peer, this))
+                _peers.Add(peer);
+        }
+
+        /// <inheritdoc/>
+        public bool HasLiveWorkerFor(AlliedMonster monster)
+        {
+            for (int i = 0; i < _workers.Count; i++)
+                if (ReferenceEquals(_workers[i].Monster, monster) && !_workers[i].Entity.IsDestroyed)
+                    return true;
+            return false;
+        }
+
+        private bool AnyPeerHasLiveWorkerFor(AlliedMonster monster)
+        {
+            for (int i = 0; i < _peers.Count; i++)
+                if (_peers[i].HasLiveWorkerFor(monster))
+                    return true;
+            return false;
+        }
+
+        /// <summary>
         /// Per-frame tick: keeps world entities in sync with job assignments. Spawns a worker for
         /// every Farming-job allied monster, asks workers whose job changed to walk home, and reaps
         /// despawned entities. One code path covers UI assignment, load restore, and reassignment.
@@ -137,10 +165,12 @@ namespace PitHero.Services
 
                 if (monster.Job == MonsterJob.Farming && awake)
                 {
-                    if (workerIndex < 0)
-                        SpawnWorker(monster);
-                    else
+                    if (workerIndex >= 0)
                         _workers[workerIndex].Fsm.CancelReturnHome();
+                    else if (!AnyPeerHasLiveWorkerFor(monster))
+                        // A job change mid-shift waits for the old job's entity to walk home and
+                        // despawn before this one emerges — one entity per monster, ever.
+                        SpawnWorker(monster);
                 }
                 else if (workerIndex >= 0)
                 {

--- a/PitHero/Services/IMonsterWorkerHost.cs
+++ b/PitHero/Services/IMonsterWorkerHost.cs
@@ -1,0 +1,17 @@
+using RolePlayingFramework.AlliedMonsters;
+
+namespace PitHero.Services
+{
+    /// <summary>
+    /// A coordinator that owns live worker entities for allied monsters (farm, kitchen, future
+    /// jobs). Coordinators register each other as peers so a worker is never spawned for a
+    /// monster while its previous job's entity still exists in the world — the old worker must
+    /// finish walking home and despawn first. Without this gate, a mid-day job change shows two
+    /// entities for the same monster at once.
+    /// </summary>
+    public interface IMonsterWorkerHost
+    {
+        /// <summary>True while this coordinator has a non-destroyed worker entity for the monster.</summary>
+        bool HasLiveWorkerFor(AlliedMonster monster);
+    }
+}

--- a/PitHero/Services/KitchenTaskCoordinator.cs
+++ b/PitHero/Services/KitchenTaskCoordinator.cs
@@ -23,7 +23,7 @@ namespace PitHero.Services
     /// all three are full. The server whose zone owns the table picks up (up to 2 dishes) and
     /// delivers; dishes whose patron left go to the sink (86,2).
     /// </summary>
-    public class KitchenTaskCoordinator
+    public class KitchenTaskCoordinator : IMonsterWorkerHost
     {
         // ── Internal types ──────────────────────────────────────────────────────
 
@@ -58,13 +58,13 @@ namespace PitHero.Services
 
         // ── Workers ─────────────────────────────────────────────────────────────
         private readonly List<ActiveWorker> _workers = new List<ActiveWorker>(8);
+        private readonly List<IMonsterWorkerHost> _peers = new List<IMonsterWorkerHost>(2);
         private Scene _scene;
         private float _hatCheckElapsed;
 
         // Scratch arrays for role assignment (pre-allocated, reset each reconcile)
         private readonly List<AlliedMonster> _wantedAssignments = new List<AlliedMonster>(8);
         private readonly List<KitchenRole> _wantedRoles = new List<KitchenRole>(8);
-        private readonly List<bool> _matchedWorkerScratch = new List<bool>(8);
 
         // ── Pathfinder ──────────────────────────────────────────────────────────
         /// <summary>Shared A* grid for all kitchen monsters.</summary>
@@ -201,6 +201,33 @@ namespace PitHero.Services
                 _buildingService.BuildingsChanged -= HandleBuildingsChanged;
         }
 
+        /// <summary>
+        /// Registers a coordinator for another job. A kitchen worker is only spawned once no peer
+        /// still has a live entity for the monster (its old-job worker walked home and despawned).
+        /// </summary>
+        public void AddPeer(IMonsterWorkerHost peer)
+        {
+            if (peer != null && !ReferenceEquals(peer, this))
+                _peers.Add(peer);
+        }
+
+        /// <inheritdoc/>
+        public bool HasLiveWorkerFor(AlliedMonster monster)
+        {
+            for (int i = 0; i < _workers.Count; i++)
+                if (ReferenceEquals(_workers[i].Monster, monster) && !_workers[i].Entity.IsDestroyed)
+                    return true;
+            return false;
+        }
+
+        private bool AnyPeerHasLiveWorkerFor(AlliedMonster monster)
+        {
+            for (int i = 0; i < _peers.Count; i++)
+                if (_peers[i].HasLiveWorkerFor(monster))
+                    return true;
+            return false;
+        }
+
         // ── Per-frame tick ───────────────────────────────────────────────────────
 
         /// <summary>Per-frame tick: reconciles worker assignments and reaps destroyed entities.</summary>
@@ -241,12 +268,8 @@ namespace PitHero.Services
                 ? _wantedAssignments.Count : MaxWorkerPosts;
             FillRoleMix(postCount, _wantedRoles);
 
-            // Track which pre-existing workers keep their assignment. SpawnWorker appends to
-            // _workers mid-pass, so snapshot the count and never index past it.
+            // SpawnWorker appends to _workers mid-pass, so snapshot the count and never index past it.
             int existingWorkerCount = _workers.Count;
-            _matchedWorkerScratch.Clear();
-            for (int wi = 0; wi < existingWorkerCount; wi++)
-                _matchedWorkerScratch.Add(false);
 
             for (int wi = 0; wi < existingWorkerCount; wi++)
             {
@@ -268,7 +291,6 @@ namespace PitHero.Services
                 else if (w.Role == _wantedRoles[wantedIdx])
                 {
                     w.Fsm.CancelReturnHome();
-                    _matchedWorkerScratch[wi] = true;
                 }
                 else
                 {
@@ -280,16 +302,10 @@ namespace PitHero.Services
             for (int j = 0; j < postCount; j++)
             {
                 var monster = _wantedAssignments[j];
-                bool hasWorker = false;
-                for (int wi = 0; wi < existingWorkerCount; wi++)
-                {
-                    if (_matchedWorkerScratch[wi] && ReferenceEquals(_workers[wi].Monster, monster))
-                    {
-                        hasWorker = true;
-                        break;
-                    }
-                }
-                if (!hasWorker)
+                // A live worker for this monster is either the matched one keeping its role, or
+                // one still walking home (role change here, or a farm worker after a job change —
+                // peers). Either way, never spawn until it's gone: one entity per monster, ever.
+                if (!HasLiveWorkerFor(monster) && !AnyPeerHasLiveWorkerFor(monster))
                     SpawnWorker(monster, _wantedRoles[j]);
             }
 

--- a/PitHero/docs/AutoJobAssignmentSystem.md
+++ b/PitHero/docs/AutoJobAssignmentSystem.md
@@ -7,6 +7,11 @@ assignment action: `FarmTaskCoordinator.Update()` and `KitchenTaskCoordinator.Up
 worker entities against `Job` + awake state every frame, so no entity or FSM code is involved in
 assignment.
 
+The coordinators are peered via `IMonsterWorkerHost` (`MainGameScene` wires `AddPeer` both ways):
+on a mid-shift job change the monster's old-job worker entity must walk home and despawn before
+the new job's coordinator spawns its worker — never two entities for the same monster at once.
+The same gate covers kitchen role changes (the replacement waits for the old worker to despawn).
+
 ## Components
 
 | Piece | File | Role |

--- a/PitHero/docs/AutoJobAssignmentSystem.md
+++ b/PitHero/docs/AutoJobAssignmentSystem.md
@@ -96,6 +96,11 @@ so a lower-priority job only claims workers its betters don't need.
   (`availableWorkers < baseStaff && availableWorkers < rosterSize`), the kitchen fields no one — a
   partial kitchen has no runner, and with no farm workers there'd be no ingredients anyway. On
   tiny rosters with no farm workload, the base crew still clamps down to the roster as before.
+  **Empty-larder gate:** demand is also zero while no dish is coverable from fridge + storage
+  (`KitchenTaskCoordinator.HasAnyOrderableDish`) — servers refuse orders they can't cover, so
+  staff would be dead weight (a new game's lone monster stays home instead of taking the chef
+  hat). Workers already in the kitchen stay (sticky) if the larder runs dry mid-day; the gate
+  only blocks fresh staffing until the next cadence tick after crops land in storage.
 
   The demand model's granularity is `MonsterJob`, not `KitchenRole` — it asks for *N kitchen
   workers* and the coordinator decides the cook/server/runner split (`FillRoleMix`).

--- a/PitHero/docs/AutoJobAssignmentSystem.md
+++ b/PitHero/docs/AutoJobAssignmentSystem.md
@@ -51,9 +51,16 @@ assigned normally — the coordinators keep them home until their work window.
 2. **Min pass** — each demand, in list order, fills up to `MinWorkers` from unassigned monsters by
    highest proficiency for that job.
 3. **Desired pass** — same, up to `DesiredWorkers`.
-4. **Swap pass** — a sticky worker swaps with a non-sticky assignee only when **both** jobs
+4. **Starvation release pass** — the one exception to stickiness. A demand with `MinWorkers > 0`
+   that ends the fill passes with **zero** workers (proof that every candidate is sticky-locked
+   elsewhere — fill exhausts free monsters first) pulls sticky-held workers from **lower-priority**
+   demands only, up to its `DesiredWorkers`, never dropping a raided job below its own
+   `MinWorkers`. In practice: farm tasks with no farmer at all release kitchen workers to the farm
+   (kitchen work is pointless with nothing being grown), but the kitchen is never raided below its
+   base crew when the shift is big enough to field one.
+5. **Swap pass** — a sticky worker swaps with a non-sticky assignee only when **both** jobs
    strictly gain proficiency (prevents oscillation between reassessments).
-5. Everyone unassigned gets `MonsterJob.None` → the coordinators send them home.
+6. Everyone unassigned gets `MonsterJob.None` → the coordinators send them home.
 
 A monster holding a job with **no demand entry** is non-sticky by definition and gets pooled and
 reassigned — this is the extensibility guarantee (a Fishing-assigned monster before a fishing
@@ -61,22 +68,35 @@ evaluator exists just returns to the pool).
 
 ## Current demand models
 
-- **Kitchen** (`Sticky = true`, listed first so its small crew staffs before farming absorbs the
-  rest): base crew `AutoJobKitchenBaseStaff` = 3 — **cook + server + runner; never less, a
-  runner-less kitchen runs the fridge dry and leaves dirty plates on the tables** — plus one
-  worker per `AutoJobKitchenBacklogPerExtraWorker` backlog items (open tickets + seated patrons +
-  pending party diners), capped at `AutoJobKitchenMaxWorkers` (must mirror
+Evaluators run in priority order (**farming first** — the kitchen depends on farm output, so farm
+demand is covered before the kitchen staffs). Each evaluator receives the shift's `rosterSize` and
+`availableWorkers` = roster minus the `MinWorkers` already reserved by higher-priority evaluators,
+so a lower-priority job only claims workers its betters don't need.
+
+- **Farming** (`Sticky = false`, listed first): `max(burst, baseline)` where burst =
+  `FarmTaskCoordinator.OutstandingTaskCount / AutoJobFarmTasksPerWorker` (catches watering/harvest
+  waves) and baseline = `(CropCount + PlanCount) / AutoJobFarmCropsPerWorkerBaseline` (quiet
+  growth periods), ceil-divided, clamped to available workers. `MinWorkers` = 1 whenever any
+  workload exists — the ≥1-farmer guarantee. Released farmers become the pool that staffs the
+  kitchen or goes home.
+- **Kitchen** (`Sticky = true`): base crew `AutoJobKitchenBaseStaff` = 3 — **cook + server +
+  runner; never less, a runner-less kitchen runs the fridge dry and leaves dirty plates on the
+  tables** — plus one worker per `AutoJobKitchenBacklogPerExtraWorker` backlog items (open tickets
+  + seated patrons + pending party diners), capped at `AutoJobKitchenMaxWorkers` (must mirror
   `KitchenTaskCoordinator.MaxWorkerPosts` = 3 cooks + 2 servers + 3 runners = 8; asserted by
   `KitchenServiceLoopTests.RoleMix_RespectsPerRoleCapsAndNeverExceedsMaxPosts`).
-  `MinWorkers` = base crew only when backlog > 0.
+  `MinWorkers` = the base crew (firm, so it fills ahead of farming's desired extras and doubles as
+  the floor the starvation release pass won't raid below). **All-or-nothing when competing with
+  farming:** if farming's reservation leaves fewer than the base crew available
+  (`availableWorkers < baseStaff && availableWorkers < rosterSize`), the kitchen fields no one — a
+  partial kitchen has no runner, and with no farm workers there'd be no ingredients anyway. On
+  tiny rosters with no farm workload, the base crew still clamps down to the roster as before.
 
   The demand model's granularity is `MonsterJob`, not `KitchenRole` — it asks for *N kitchen
   workers* and the coordinator decides the cook/server/runner split (`FillRoleMix`).
-- **Farming** (`Sticky = false`): `max(burst, baseline)` where burst =
-  `FarmTaskCoordinator.OutstandingTaskCount / AutoJobFarmTasksPerWorker` (catches watering/harvest
-  waves) and baseline = `(CropCount + PlanCount) / AutoJobFarmCropsPerWorkerBaseline` (quiet
-  growth periods), ceil-divided, clamped to shift size. Released farmers become the pool that
-  staffs the kitchen or goes home.
+
+Worked examples (farm workload present): 2 monsters → both farm, no kitchen. Exactly 4 → 1 farmer
++ 3 kitchen (even if farming wants more). 6 with light farm work → 1 farmer + 3 kitchen + 2 home.
 
 Workload getters added for this system: `FarmTaskCoordinator.OutstandingTaskCount`,
 `KitchenTaskCoordinator.ActiveTicketCount`, `CropGrowthService.CropCount`,
@@ -94,12 +114,14 @@ The solver never changes. Steps:
    `IJobDemandEvaluator`: report `Job = MonsterJob.Fishing` and a `JobDemandEntry` computed from
    whatever workload signal fits (keep the arithmetic in a `public static ComputeDemand(...)` so
    it's unit-testable headless, like the existing evaluators; take service dependencies as
-   nullable constructor params).
+   nullable constructor params). `EvaluateDemand(rosterSize, availableWorkers)` — clamp to
+   `availableWorkers`, the workers left after higher-priority evaluators' minimums.
 3. Decide `Sticky`: true only if pulling workers off the job mid-shift is harmful (kitchen-style
    continuity); false if workers can be freely rebalanced (farming-style).
 4. Register it in `MainGameScene.Begin()` via `autoJobAssignmentService.AddEvaluator(...)` —
    or add a constructor parameter if it should always exist. **List order = priority order** for
-   the min/desired fill passes.
+   the min/desired fill passes, the `availableWorkers` reservation, and the starvation release
+   pass (which only raids lower-priority jobs).
 5. Add `GameConfig` constants for its tunables (`AutoJob*` prefix).
 6. Proficiency: `JobAssignmentSolver.GetProficiency` already maps `MonsterJob.Fishing` →
    `FishingProficiency`. A brand-new job beyond the existing three needs a case added there.


### PR DESCRIPTION
## Summary

Fixes three defects in the auto monster job assignment system (issue #321) observed in play:

- **Farming now outranks the kitchen.** With 2 monsters and outstanding farm tasks, both were auto-assigned to the kitchen — a dead end, since the kitchen depends on farm output. Evaluators now run farming-first, and each evaluator only sees the workers left after higher-priority minimums are reserved. The kitchen base crew (cook + server + runner) is all-or-nothing: it only forms when a farmer can also be fielded. Roster < 4 with farm work → everyone farms; exactly 4 → 1 farmer + 3 kitchen; more → surplus goes wherever demand points.
- **One exception to all-day kitchen stickiness.** A new `StarvationReleasePass` in the solver fires only when a job with demand ends up with zero workers (everyone sticky-locked in the kitchen). It pulls the best-suited kitchen workers to the farm, up to farming's desired count, never dropping the kitchen below its own minimum. Self-stabilizing — cannot oscillate between reassessments. The ≥1-farmer guarantee holds per day/night shift independently.
- **No more duplicate monsters on job change.** A mid-shift job flip showed two entities for the same monster: the old coordinator sent its worker walking home while the new one spawned a replacement the same frame. The farm and kitchen coordinators are now peered via `IMonsterWorkerHost` — a worker only spawns once no peer still has a live entity for the monster. Also covers kitchen role changes, which previously duplicated within the kitchen itself.
- **Empty-larder gate.** A new game's lone monster took the chef hat despite nothing being cookable. Kitchen demand is now zero while no dish is coverable from fridge + storage (`HasAnyOrderableDish`) — idle monsters stay home until crops exist. Workers already in the kitchen stay sticky if the larder runs dry mid-day.

## Changes

- `JobAssignmentSolver`: new `StarvationReleasePass` between the fill passes and `SwapPass`
- `IJobDemandEvaluator`: `EvaluateDemand(rosterSize, availableWorkers)` — reservation semantics, registration order = priority
- `KitchenJobDemandEvaluator`: all-or-nothing base crew, firm minimum, empty-larder gate
- `FarmingJobDemandEvaluator`: clamps to available workers
- `AutoJobAssignmentService`: farming registered first; reservation threaded through evaluators
- `FarmTaskCoordinator` / `KitchenTaskCoordinator`: peered spawn gate via new `IMonsterWorkerHost`
- Docs: `PitHero/docs/AutoJobAssignmentSystem.md` synced

## Testing

- 16 new tests across `JobAssignmentSolverTests` and `AutoJobAssignmentServiceTests` (solver release pass, kitchen gates, per-shift farmer guarantee, and the reported scenarios end-to-end)
- Full suite: 1714 passed, 0 failed, 6 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)