### PR TITLE
Auto-learn hero skills (Smart/Active/Passive modes)

### DIFF
--- a/PitHero.Tests/AutoLearnSkillsServiceTests.cs
+++ b/PitHero.Tests/AutoLearnSkillsServiceTests.cs
@@ -1,0 +1,268 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Services;
+using RolePlayingFramework.Heroes;
+using RolePlayingFramework.Jobs.Primary;
+using RolePlayingFramework.Stats;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Unit tests for AutoLearnSkillsService — pure static helpers and TryLearnPass are
+    /// fully headless (Core.Instance is null in the test host).
+    /// </summary>
+    [TestClass]
+    public class AutoLearnSkillsServiceTests
+    {
+        // ─── helpers ────────────────────────────────────────────────────────────────
+
+        private static Hero MakeHero(string name, RolePlayingFramework.Jobs.IJob job, int jp = 0)
+        {
+            var stats   = new StatBlock(4, 3, 5, 1);
+            var crystal = new HeroCrystal(name, job, 1, stats);
+            if (jp > 0) crystal.EarnJP(jp);
+            var hero = new Hero(name, job, 1, stats, crystal);
+            return hero;
+        }
+
+        // ─── Test 1: Smart mode selects job signature active skill first ─────────
+
+        [TestMethod]
+        public void Smart_SelectsSignatureSkill_Priest()
+        {
+            var hero = MakeHero("Reza", new Priest());
+            var skill = AutoLearnSkillsService.SelectNextSkill(hero, AutoLearnMode.Smart);
+            Assert.IsNotNull(skill, "Expected a skill; job has unlearned skills");
+            Assert.AreEqual("priest.heal", skill.Id, "Priest Smart rank-0 should be Heal");
+        }
+
+        [TestMethod]
+        public void Smart_SelectsSignatureSkill_Mage()
+        {
+            var hero = MakeHero("Lyra", new Mage());
+            var skill = AutoLearnSkillsService.SelectNextSkill(hero, AutoLearnMode.Smart);
+            Assert.IsNotNull(skill);
+            Assert.AreEqual("mage.fire", skill.Id, "Mage Smart rank-0 should be Fire");
+        }
+
+        [TestMethod]
+        public void Smart_SelectsSignatureSkill_Knight()
+        {
+            var hero = MakeHero("Arn", new Knight());
+            var skill = AutoLearnSkillsService.SelectNextSkill(hero, AutoLearnMode.Smart);
+            Assert.IsNotNull(skill);
+            Assert.AreEqual("knight.spin_slash", skill.Id, "Knight Smart rank-0 should be Spin Slash");
+        }
+
+        // ─── Test 2: Smart full 4-skill order per job ───────────────────────────
+
+        [TestMethod]
+        public void Smart_FullOrder_Knight()
+        {
+            // Smart ranks: spin_slash(0,120), light_armor(1,50), heavy_armor(2,100), heavy_strike(3,180)
+            string[] expected = { "knight.spin_slash", "knight.light_armor", "knight.heavy_armor", "knight.heavy_strike" };
+            VerifySmartOrder(new Knight(), expected);
+        }
+
+        [TestMethod]
+        public void Smart_FullOrder_Mage()
+        {
+            // Smart ranks: fire(0,120), heart_fire(1,60), economist(2,80), firestorm(3,200)
+            string[] expected = { "mage.fire", "mage.heart_fire", "mage.economist", "mage.firestorm" };
+            VerifySmartOrder(new Mage(), expected);
+        }
+
+        [TestMethod]
+        public void Smart_FullOrder_Priest()
+        {
+            // Smart ranks: heal(0,100), calm_spirit(1,50), mender(2,80), defup(3,160)
+            string[] expected = { "priest.heal", "priest.calm_spirit", "priest.mender", "priest.defup" };
+            VerifySmartOrder(new Priest(), expected);
+        }
+
+        [TestMethod]
+        public void Smart_FullOrder_Monk()
+        {
+            // Smart ranks: roundhouse(0,120), counter(1,70), deflect(2,90), flaming_fist(3,170)
+            string[] expected = { "monk.roundhouse", "monk.counter", "monk.deflect", "monk.flaming_fist" };
+            VerifySmartOrder(new Monk(), expected);
+        }
+
+        [TestMethod]
+        public void Smart_FullOrder_Thief()
+        {
+            // Smart ranks: sneak_attack(0,130), shadowstep(1,70), trap_sense(2,90), vanish(3,180)
+            string[] expected = { "thief.sneak_attack", "thief.shadowstep", "thief.trap_sense", "thief.vanish" };
+            VerifySmartOrder(new Thief(), expected);
+        }
+
+        [TestMethod]
+        public void Smart_FullOrder_Archer()
+        {
+            // Smart ranks: power_shot(0,130), eagle_eye(1,70), quickdraw(2,100), volley(3,200)
+            string[] expected = { "archer.power_shot", "archer.eagle_eye", "archer.quickdraw", "archer.volley" };
+            VerifySmartOrder(new Archer(), expected);
+        }
+
+        private static void VerifySmartOrder(RolePlayingFramework.Jobs.IJob job, string[] expectedIds)
+        {
+            // Build a hero with no JP (skills will be unaffordable, but SelectNextSkill is JP-agnostic)
+            var hero = MakeHero("Test", job);
+            for (int i = 0; i < expectedIds.Length; i++)
+            {
+                var skill = AutoLearnSkillsService.SelectNextSkill(hero, AutoLearnMode.Smart);
+                Assert.IsNotNull(skill, $"Expected skill at position {i} but got null");
+                Assert.AreEqual(expectedIds[i], skill.Id,
+                    $"Position {i}: expected {expectedIds[i]} but got {skill.Id}");
+
+                // Earn enough JP and purchase the skill to advance state
+                hero.EarnJP(skill.JPCost);
+                bool purchased = hero.TryPurchaseSkill(skill);
+                Assert.IsTrue(purchased, $"Could not purchase {skill.Id} for test setup");
+            }
+            // After all skills learned, SelectNextSkill should return null
+            var none = AutoLearnSkillsService.SelectNextSkill(hero, AutoLearnMode.Smart);
+            Assert.IsNull(none, "Expected null when all skills are learned");
+        }
+
+        // ─── Test 3: Smart strict-order — Priest with 60 JP learns nothing ──────
+
+        [TestMethod]
+        public void Smart_StrictOrder_PriestWith60JP_LearnsNothing()
+        {
+            // Heal (rank 0) costs 100 JP; CalmSpirit costs 50 but is rank 1.
+            // With 60 JP strict-order stops at Heal (unaffordable) and returns 0.
+            var hero = MakeHero("Reza", new Priest(), jp: 60);
+            var svc  = new AutoLearnSkillsService { Enabled = true, Mode = AutoLearnMode.Smart };
+
+            int learned = svc.TryLearnPass(hero);
+            Assert.AreEqual(0, learned, "Strict order should not skip Heal to buy CalmSpirit");
+        }
+
+        // ─── Test 4: Active mode Knight order ───────────────────────────────────
+
+        [TestMethod]
+        public void Active_Mode_Knight_Order()
+        {
+            // Active → actives cheapest-first, then passives cheapest-first
+            // Knight actives: SpinSlash(120,idx 2), HeavyStrike(180,idx 3)
+            // Knight passives: LightArmor(50,idx 0), HeavyArmor(100,idx 1)
+            // Expected: spin_slash → heavy_strike → light_armor → heavy_armor
+            string[] expected = { "knight.spin_slash", "knight.heavy_strike", "knight.light_armor", "knight.heavy_armor" };
+            VerifyModeOrder(new Knight(), AutoLearnMode.Active, expected);
+        }
+
+        // ─── Test 5: Passive mode Knight mirror ─────────────────────────────────
+
+        [TestMethod]
+        public void Passive_Mode_Knight_Order()
+        {
+            // Passive → passives cheapest-first, then actives cheapest-first
+            // Knight passives: LightArmor(50,idx 0), HeavyArmor(100,idx 1)
+            // Knight actives: SpinSlash(120,idx 2), HeavyStrike(180,idx 3)
+            // Expected: light_armor → heavy_armor → spin_slash → heavy_strike
+            string[] expected = { "knight.light_armor", "knight.heavy_armor", "knight.spin_slash", "knight.heavy_strike" };
+            VerifyModeOrder(new Knight(), AutoLearnMode.Passive, expected);
+        }
+
+        private static void VerifyModeOrder(RolePlayingFramework.Jobs.IJob job, AutoLearnMode mode, string[] expectedIds)
+        {
+            var hero = MakeHero("Test", job);
+            for (int i = 0; i < expectedIds.Length; i++)
+            {
+                var skill = AutoLearnSkillsService.SelectNextSkill(hero, mode);
+                Assert.IsNotNull(skill, $"Expected skill at position {i} but got null");
+                Assert.AreEqual(expectedIds[i], skill.Id,
+                    $"Position {i}: expected {expectedIds[i]} but got {skill.Id}");
+
+                hero.EarnJP(skill.JPCost);
+                bool purchased = hero.TryPurchaseSkill(skill);
+                Assert.IsTrue(purchased, $"Could not purchase {skill.Id} for test setup");
+            }
+            var none = AutoLearnSkillsService.SelectNextSkill(hero, mode);
+            Assert.IsNull(none, "Expected null when all skills are learned");
+        }
+
+        // ─── Test 6: Composite job tie-breaks ───────────────────────────────────
+
+        [TestMethod]
+        public void Smart_CompositeTieBreak_KnightMage_SpinSlashBeforeFire()
+        {
+            // Knight+Mage: SpinSlash (rank 0, cost 120, index 2) vs Fire (rank 0, cost 120, index 6)
+            // Tie on rank and cost → lower index wins → spin_slash
+            var compositeJob = new CompositeJob(new Knight(), new Mage());
+            var hero         = MakeHero("Arn", compositeJob);
+            var skill        = AutoLearnSkillsService.SelectNextSkill(hero, AutoLearnMode.Smart);
+            Assert.IsNotNull(skill);
+            Assert.AreEqual("knight.spin_slash", skill.Id,
+                "Index tie-break: spin_slash (idx 2) should beat fire (idx 6)");
+        }
+
+        [TestMethod]
+        public void Smart_CompositeTieBreak_PriestMage_HealBeforeFire()
+        {
+            // Priest+Mage: Heal (rank 0, cost 100, index 2) vs Fire (rank 0, cost 120, index 6)
+            // Heal wins on cost alone
+            var compositeJob = new CompositeJob(new Priest(), new Mage());
+            var hero         = MakeHero("Reza", compositeJob);
+            var skill        = AutoLearnSkillsService.SelectNextSkill(hero, AutoLearnMode.Smart);
+            Assert.IsNotNull(skill);
+            Assert.AreEqual("priest.heal", skill.Id,
+                "Cost tie-break: heal (cost 100) should beat fire (cost 120)");
+        }
+
+        // ─── Test 7: Multi-learn, disabled guard, null guard, SanitizeMode ──────
+
+        [TestMethod]
+        public void TryLearnPass_MultiLearn_OnePass()
+        {
+            // Knight Smart order: spin_slash(120), light_armor(50), heavy_armor(100), heavy_strike(180)
+            // With 400 JP: 120+50+100=270 spent → 130 left; heavy_strike costs 180 → stops.
+            // Expects 3 skills learned.
+            var hero = MakeHero("Arn", new Knight(), jp: 400);
+            var svc  = new AutoLearnSkillsService { Enabled = true, Mode = AutoLearnMode.Smart };
+
+            int learned = svc.TryLearnPass(hero);
+            Assert.AreEqual(3, learned, "Should learn spin_slash + light_armor + heavy_armor before running short");
+        }
+
+        [TestMethod]
+        public void TryLearnNow_Headless_ReturnsZero()
+        {
+            // In headless tests Core.Instance is null; TryLearnNow guards this.
+            var svc = new AutoLearnSkillsService { Enabled = true };
+            int result = svc.TryLearnNow();
+            Assert.AreEqual(0, result, "TryLearnNow should return 0 when Core.Instance is null");
+        }
+
+        [TestMethod]
+        public void TryLearnPass_NullHero_ReturnsZero()
+        {
+            var svc = new AutoLearnSkillsService { Enabled = true };
+            int result = svc.TryLearnPass(null);
+            Assert.AreEqual(0, result, "TryLearnPass(null) should return 0");
+        }
+
+        [TestMethod]
+        public void SelectNextSkill_NullHero_ReturnsNull()
+        {
+            var skill = AutoLearnSkillsService.SelectNextSkill(null, AutoLearnMode.Smart);
+            Assert.IsNull(skill, "SelectNextSkill(null hero) should return null");
+        }
+
+        [TestMethod]
+        public void SanitizeMode_OutOfRange_ReturnsSmart()
+        {
+            Assert.AreEqual(AutoLearnMode.Smart, AutoLearnSkillsService.SanitizeMode(-1),  "Negative → Smart");
+            Assert.AreEqual(AutoLearnMode.Smart, AutoLearnSkillsService.SanitizeMode(3),   "3 → Smart");
+            Assert.AreEqual(AutoLearnMode.Smart, AutoLearnSkillsService.SanitizeMode(99),  "99 → Smart");
+        }
+
+        [TestMethod]
+        public void SanitizeMode_ValidValues_RoundTrip()
+        {
+            Assert.AreEqual(AutoLearnMode.Smart,   AutoLearnSkillsService.SanitizeMode(0));
+            Assert.AreEqual(AutoLearnMode.Active,  AutoLearnSkillsService.SanitizeMode(1));
+            Assert.AreEqual(AutoLearnMode.Passive, AutoLearnSkillsService.SanitizeMode(2));
+        }
+    }
+}

--- a/PitHero.Tests/SaveLoadTests.cs
+++ b/PitHero.Tests/SaveLoadTests.cs
@@ -1181,5 +1181,69 @@ namespace PitHero.Tests
                     Directory.Delete(tempDir, true);
             }
         }
+
+        /// <summary>Verifies the v25 auto-learn settings round-trip (enabled, Passive mode).</summary>
+        [TestMethod]
+        public void SaveData_V25_AutoLearnSkills_RoundTrip()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "pithero_v25_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var dataStore = new FileDataStore(tempDir);
+
+                var original = new SaveData();
+                original.AutoLearnSkillsEnabled = true;
+                original.AutoLearnMode = (int)PitHero.Services.AutoLearnMode.Passive;
+
+                dataStore.Save("v25_autolearn.bin", original);
+
+                var loaded = new SaveData();
+                dataStore.Load("v25_autolearn.bin", loaded);
+
+                Assert.IsTrue(loaded.AutoLearnSkillsEnabled, "AutoLearnSkillsEnabled should round-trip");
+                Assert.AreEqual((int)PitHero.Services.AutoLearnMode.Passive, loaded.AutoLearnMode,
+                    "AutoLearnMode Passive should round-trip");
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
+            }
+        }
+
+        /// <summary>
+        /// Verifies the v25 auto-learn defaults: disabled and Smart mode, both on a fresh SaveData
+        /// and after a default save/load cycle.
+        /// </summary>
+        [TestMethod]
+        public void SaveData_V25_AutoLearnSkills_Defaults()
+        {
+            var fresh = new SaveData();
+            Assert.IsFalse(fresh.AutoLearnSkillsEnabled, "AutoLearnSkillsEnabled defaults to OFF");
+            Assert.AreEqual((int)PitHero.Services.AutoLearnMode.Smart, fresh.AutoLearnMode,
+                "AutoLearnMode defaults to Smart (0)");
+
+            var tempDir = Path.Combine(Path.GetTempPath(), "pithero_v25d_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var dataStore = new FileDataStore(tempDir);
+                dataStore.Save("v25_defaults.bin", new SaveData());
+
+                var loaded = new SaveData();
+                dataStore.Load("v25_defaults.bin", loaded);
+
+                Assert.IsFalse(loaded.AutoLearnSkillsEnabled);
+                Assert.AreEqual((int)PitHero.Services.AutoLearnMode.Smart, loaded.AutoLearnMode);
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
+            }
+        }
     }
 }

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -405,3 +405,11 @@ SettingsAutoHireMerc1Job,Mercenary1 Job
 SettingsAutoHireMerc1JobTooltip,Job to auto-hire for the first mercenary slot. None disables auto-hiring this slot
 SettingsAutoHireMerc2Job,Mercenary2 Job
 SettingsAutoHireMerc2JobTooltip,Job to auto-hire for the second mercenary slot. Requires Mercenary1 Job to be set
+SettingsAutoLearnSkills,Auto-Learn Hero Skills
+SettingsAutoLearnSkillsTooltip,Automatically spend hero JP on skills between pit dives
+SettingsAutoLearnMode,Learn Mode
+SettingsAutoLearnModeTooltip,Smart: priority order per job. Active: cheapest active first then passives. Passive: mirror
+AutoLearnModeSmart,Smart
+AutoLearnModeActive,Active
+AutoLearnModePassive,Passive
+ConsoleAutoLearnedSkill,{0} learned {1}!

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -219,6 +219,7 @@ namespace PitHero.ECS.Scenes
             Core.Services.RemoveService(typeof(Services.AutoSellExcessItemsService));
             Core.Services.RemoveService(typeof(Services.AutoItemPurchaseService));
             Core.Services.RemoveService(typeof(Services.AutoHireMercenaryService));
+            Core.Services.RemoveService(typeof(Services.AutoLearnSkillsService));
             Core.Services.GetService<Services.FarmTaskCoordinator>()?.Detach();
             Core.Services.RemoveService(typeof(Services.FarmTaskCoordinator));
             Core.Services.RemoveService(typeof(Services.MealBuffService));
@@ -320,6 +321,10 @@ namespace PitHero.ECS.Scenes
                 Core.Services.GetService<Services.GameStateService>(),
                 autoSeedPurchaseService,
                 mercenaryManager));
+
+            // Auto-learn skills service spends hero JP automatically (issue #353).
+            // Registered after AutoHireMercenaryService to keep service order consistent.
+            Core.Services.AddService(new Services.AutoLearnSkillsService());
 
             // Meal buff service holds each party member's day-long food buffs (issue #319)
             Core.Services.AddService(new Services.MealBuffService());
@@ -634,6 +639,12 @@ namespace PitHero.ECS.Scenes
                 // Slot 2 is only meaningful while slot 1 holds a job — enforce the invariant on load
                 if (autoHireSvc.Merc1Job == RolePlayingFramework.Jobs.JobType.None)
                     autoHireSvc.Merc2Job = RolePlayingFramework.Jobs.JobType.None;
+            }
+            var autoLearnSvc = Core.Services.GetService<Services.AutoLearnSkillsService>();
+            if (autoLearnSvc != null)
+            {
+                autoLearnSvc.Enabled = pendingData.AutoLearnSkillsEnabled;
+                autoLearnSvc.Mode = Services.AutoLearnSkillsService.SanitizeMode(pendingData.AutoLearnMode);
             }
             _settingsUI?.SyncAutomationControlsFromService();
 
@@ -1402,7 +1413,6 @@ namespace PitHero.ECS.Scenes
                 var heroJob = JobFactory.CreateJob(design.JobName);
                 var baseStats = new StatBlock(strength: 4, agility: 3, vitality: 5, magic: 1);
                 var heroCrystal = new HeroCrystal(design.Name, heroJob, 1, baseStats);
-                heroCrystal.EarnJP(550);
 
                 // Create the linked Hero from the crystal
                 heroComponent.LinkedHero = new RolePlayingFramework.Heroes.Hero(design.Name, heroJob, 1, baseStats, heroCrystal);
@@ -2531,6 +2541,7 @@ namespace PitHero.ECS.Scenes
                 Core.Services.GetService<Services.AutoSeedPurchaseService>()?.Update();
                 Core.Services.GetService<Services.AutoCropSellService>()?.Update();
                 Core.Services.GetService<Services.AutoJobAssignmentService>()?.Update();
+                Core.Services.GetService<Services.AutoLearnSkillsService>()?.Update();
             }
 
             // Check if a living hero who respawned without a crystal has arrived at the statue

--- a/PitHero/Services/AutoLearnSkillsService.cs
+++ b/PitHero/Services/AutoLearnSkillsService.cs
@@ -1,0 +1,287 @@
+using Microsoft.Xna.Framework;
+using Nez;
+using PitHero.ECS.Components;
+using RolePlayingFramework.Heroes;
+using RolePlayingFramework.Skills;
+using System.Collections.Generic;
+
+namespace PitHero.Services
+{
+    /// <summary>Which skills the Auto-Learn service prioritises for purchase.</summary>
+    public enum AutoLearnMode
+    {
+        /// <summary>Learn skills in the job-defined priority order (signature active first, then passives, then second active).</summary>
+        Smart = 0,
+
+        /// <summary>Cheapest unlearned active first; passives only after all actives are learned.</summary>
+        Active = 1,
+
+        /// <summary>Cheapest unlearned passive first; actives only after all passives are learned.</summary>
+        Passive = 2,
+    }
+
+    /// <summary>
+    /// Automatically spends available JP on hero skills once per second (issue #353).
+    /// Enabled = false by default; mode defaults to Smart.
+    /// </summary>
+    public class AutoLearnSkillsService
+    {
+        // Static smart-rank lookup built once. Unknown IDs get int.MaxValue (cheap-first fallback).
+        private static readonly Dictionary<string, int> _smartRankTable;
+
+        static AutoLearnSkillsService()
+        {
+            _smartRankTable = new Dictionary<string, int>(24);
+
+            // Knight
+            _smartRankTable["knight.spin_slash"]   = 0;
+            _smartRankTable["knight.light_armor"]  = 1;
+            _smartRankTable["knight.heavy_armor"]  = 2;
+            _smartRankTable["knight.heavy_strike"] = 3;
+
+            // Mage
+            _smartRankTable["mage.fire"]       = 0;
+            _smartRankTable["mage.heart_fire"] = 1;
+            _smartRankTable["mage.economist"]  = 2;
+            _smartRankTable["mage.firestorm"]  = 3;
+
+            // Priest
+            _smartRankTable["priest.heal"]        = 0;
+            _smartRankTable["priest.calm_spirit"] = 1;
+            _smartRankTable["priest.mender"]      = 2;
+            _smartRankTable["priest.defup"]       = 3;
+
+            // Monk
+            _smartRankTable["monk.roundhouse"]   = 0;
+            _smartRankTable["monk.counter"]      = 1;
+            _smartRankTable["monk.deflect"]      = 2;
+            _smartRankTable["monk.flaming_fist"] = 3;
+
+            // Thief
+            _smartRankTable["thief.sneak_attack"] = 0;
+            _smartRankTable["thief.shadowstep"]   = 1;
+            _smartRankTable["thief.trap_sense"]   = 2;
+            _smartRankTable["thief.vanish"]       = 3;
+
+            // Archer
+            _smartRankTable["archer.power_shot"] = 0;
+            _smartRankTable["archer.eagle_eye"]  = 1;
+            _smartRankTable["archer.quickdraw"]  = 2;
+            _smartRankTable["archer.volley"]     = 3;
+        }
+
+        private float _throttleTimer;
+
+        /// <summary>Whether automatic skill learning is active. Off by default.</summary>
+        public bool Enabled { get; set; } = false;
+
+        /// <summary>Which prioritisation mode is used when selecting the next skill.</summary>
+        public AutoLearnMode Mode { get; set; } = AutoLearnMode.Smart;
+
+        /// <summary>
+        /// Advances the throttle and, when enabled, attempts one learn pass per second.
+        /// Called once per game frame while the game is unpaused.
+        /// </summary>
+        public void Update()
+        {
+            if (!Enabled) return;
+
+            _throttleTimer += Time.DeltaTime;
+            if (_throttleTimer < 1f) return;
+            _throttleTimer = 0f;
+
+            TryLearnNow();
+        }
+
+        /// <summary>
+        /// Immediately attempts one learn pass for the current hero. Returns the number of skills
+        /// learned (0 when no hero is found, the service is disabled, or no skill is affordable).
+        /// Guards <c>Core.Instance != null</c> so it is safe to call in headless test contexts that
+        /// supply a <see cref="Hero"/> directly via <see cref="TryLearnPass"/> instead.
+        /// </summary>
+        public int TryLearnNow()
+        {
+            if (Core.Instance == null) return 0;
+
+            var heroEntity = Core.Scene?.FindEntity("hero");
+            var hero = heroEntity?.GetComponent<HeroComponent>()?.LinkedHero;
+            if (hero == null) return 0;
+
+            return TryLearnPass(hero);
+        }
+
+        /// <summary>
+        /// Executes one full learn pass for <paramref name="hero"/>: loops <see cref="SelectNextSkill"/>
+        /// until either null (nothing left to learn) or the next skill is unaffordable (strict-order
+        /// wait). Emits one console line per skill learned. Returns the count of skills purchased.
+        /// </summary>
+        public int TryLearnPass(Hero hero)
+        {
+            if (hero == null) return 0;
+
+            int learned = 0;
+            while (true)
+            {
+                var skill = SelectNextSkill(hero, Mode);
+                if (skill == null) break;                         // nothing left to learn
+                if (hero.GetCurrentJP() < skill.JPCost) break;   // strict-order: wait for JP
+
+                if (!hero.TryPurchaseSkill(skill)) break;        // shouldn't happen; safety exit
+                learned++;
+                EmitLearnConsole(hero.Name, skill.Name);
+            }
+            return learned;
+        }
+
+        /// <summary>
+        /// Selects the next skill to learn for <paramref name="hero"/> according to <paramref name="mode"/>.
+        /// Returns null when every skill in the job is already learned. Returns the skill even if
+        /// currently unaffordable — the caller decides whether to wait or skip.
+        /// Pure and headless-testable (no Nez/scene access).
+        /// </summary>
+        public static ISkill SelectNextSkill(Hero hero, AutoLearnMode mode)
+        {
+            if (hero == null) return null;
+
+            var skills = hero.Job.Skills;
+            int count = skills.Count;
+
+            if (mode == AutoLearnMode.Smart)
+            {
+                // Min by (smartRank, JPCost, job-list index). Unknown IDs fall back to int.MaxValue.
+                ISkill best = null;
+                int bestRank  = int.MaxValue;
+                int bestCost  = int.MaxValue;
+                int bestIndex = int.MaxValue;
+
+                for (int i = 0; i < count; i++)
+                {
+                    var s = skills[i];
+                    if (hero.LearnedSkills.ContainsKey(s.Id)) continue;
+
+                    int rank = GetSmartRank(s.Id);
+                    if (rank < bestRank
+                        || (rank == bestRank && s.JPCost < bestCost)
+                        || (rank == bestRank && s.JPCost == bestCost && i < bestIndex))
+                    {
+                        best      = s;
+                        bestRank  = rank;
+                        bestCost  = s.JPCost;
+                        bestIndex = i;
+                    }
+                }
+                return best;
+            }
+            else if (mode == AutoLearnMode.Active)
+            {
+                // Cheapest unlearned active first; when all actives learned → cheapest unlearned passive.
+                ISkill bestActive  = null;
+                int    baCost      = int.MaxValue;
+                int    baIndex     = int.MaxValue;
+                ISkill bestPassive = null;
+                int    bpCost      = int.MaxValue;
+                int    bpIndex     = int.MaxValue;
+
+                for (int i = 0; i < count; i++)
+                {
+                    var s = skills[i];
+                    if (hero.LearnedSkills.ContainsKey(s.Id)) continue;
+
+                    if (s.Kind == SkillKind.Active)
+                    {
+                        if (s.JPCost < baCost || (s.JPCost == baCost && i < baIndex))
+                        {
+                            bestActive = s;
+                            baCost     = s.JPCost;
+                            baIndex    = i;
+                        }
+                    }
+                    else
+                    {
+                        if (s.JPCost < bpCost || (s.JPCost == bpCost && i < bpIndex))
+                        {
+                            bestPassive = s;
+                            bpCost      = s.JPCost;
+                            bpIndex     = i;
+                        }
+                    }
+                }
+                return bestActive ?? bestPassive;
+            }
+            else // Passive
+            {
+                // Cheapest unlearned passive first; when all passives learned → cheapest unlearned active.
+                ISkill bestPassive = null;
+                int    bpCost      = int.MaxValue;
+                int    bpIndex     = int.MaxValue;
+                ISkill bestActive  = null;
+                int    baCost      = int.MaxValue;
+                int    baIndex     = int.MaxValue;
+
+                for (int i = 0; i < count; i++)
+                {
+                    var s = skills[i];
+                    if (hero.LearnedSkills.ContainsKey(s.Id)) continue;
+
+                    if (s.Kind == SkillKind.Passive)
+                    {
+                        if (s.JPCost < bpCost || (s.JPCost == bpCost && i < bpIndex))
+                        {
+                            bestPassive = s;
+                            bpCost      = s.JPCost;
+                            bpIndex     = i;
+                        }
+                    }
+                    else
+                    {
+                        if (s.JPCost < baCost || (s.JPCost == baCost && i < baIndex))
+                        {
+                            bestActive = s;
+                            baCost     = s.JPCost;
+                            baIndex    = i;
+                        }
+                    }
+                }
+                return bestPassive ?? bestActive;
+            }
+        }
+
+        /// <summary>
+        /// Returns the smart-priority rank for a skill ID (0 = highest priority).
+        /// Unknown IDs return <see cref="int.MaxValue"/> so they sort last but deterministically by
+        /// cost and job-list index.
+        /// </summary>
+        public static int GetSmartRank(string skillId)
+        {
+            if (skillId == null) return int.MaxValue;
+            int rank;
+            if (_smartRankTable.TryGetValue(skillId, out rank))
+                return rank;
+            return int.MaxValue;
+        }
+
+        /// <summary>
+        /// Clamps a raw persisted integer to a valid <see cref="AutoLearnMode"/>.
+        /// Out-of-range values (negative or &gt; 2) become <see cref="AutoLearnMode.Smart"/>.
+        /// </summary>
+        public static AutoLearnMode SanitizeMode(int raw)
+        {
+            switch (raw)
+            {
+                case 0: return AutoLearnMode.Smart;
+                case 1: return AutoLearnMode.Active;
+                case 2: return AutoLearnMode.Passive;
+                default: return AutoLearnMode.Smart;
+            }
+        }
+
+        /// <summary>Emits a console line when a skill is learned. No-ops in headless test contexts.</summary>
+        private static void EmitLearnConsole(string heroName, string skillName)
+        {
+            if (Core.Instance == null) return;
+            Core.Services?.GetService<GameEventService>()?.EmitLocalized(UITextKey.ConsoleAutoLearnedSkill,
+                (heroName, GameConfig.ConsoleColorHeroName),
+                (skillName, Color.White));
+        }
+    }
+}

--- a/PitHero/Services/SaveData.cs
+++ b/PitHero/Services/SaveData.cs
@@ -255,14 +255,15 @@ namespace PitHero.Services
     public class SaveData : IPersistable
     {
         /// <summary>Current save file version.</summary>
-        public const int CurrentVersion = 24;
+        public const int CurrentVersion = 25;
 
         /// <summary>
-        /// Oldest save file version this build can still load. v17–v23 files are byte-exact
-        /// prefixes of v24 (sections 33 dining, 34 automation, 35 auto-dine resume,
+        /// Oldest save file version this build can still load. v17–v24 files are byte-exact
+        /// prefixes of v25 (sections 33 dining, 34 automation, 35 auto-dine resume,
         /// 36 auto-sell excess items, 37 auto-sell priority, 38 gear sell types,
-        /// 39 auto-purchase items, 40 auto-equip, and 41 auto-hire mercenaries were
-        /// appended at the end), so they load with default state for the missing sections.
+        /// 39 auto-purchase items, 40 auto-equip, 41 auto-hire mercenaries, and
+        /// 42 auto-learn hero skills were appended at the end), so they load with default
+        /// state for the missing sections.
         /// </summary>
         public const int MinSupportedVersion = 17;
 
@@ -566,6 +567,13 @@ namespace PitHero.Services
 
         /// <summary>Job auto-hired for the second party slot as a raw JobType value (0 = None).</summary>
         public int AutoHireMerc2Job = 0;
+
+        // Auto-learn hero skills (v25)
+        /// <summary>Whether automatic hero skill learning is active (issue #353).</summary>
+        public bool AutoLearnSkillsEnabled = false;
+
+        /// <summary>Raw AutoLearnMode value: 0=Smart, 1=Active, 2=Passive.</summary>
+        public int AutoLearnMode = 0;
 
         /// <summary>Initializes a new SaveData with default empty collections.</summary>
         public SaveData()
@@ -1023,6 +1031,10 @@ namespace PitHero.Services
             writer.Write(AutoHireMercenariesEnabled);
             writer.Write(AutoHireMerc1Job);
             writer.Write(AutoHireMerc2Job);
+
+            // 42. Auto-learn hero skills (v25)
+            writer.Write(AutoLearnSkillsEnabled);
+            writer.Write(AutoLearnMode);
         }
 
         /// <summary>Reads all game state from the persistence reader.</summary>
@@ -1544,6 +1556,15 @@ namespace PitHero.Services
                 AutoHireMercenariesEnabled = reader.ReadBool();
                 AutoHireMerc1Job = reader.ReadInt();
                 AutoHireMerc2Job = reader.ReadInt();
+            }
+
+            // 42. Auto-learn hero skills (v25+). Older files default to disabled, Smart mode.
+            AutoLearnSkillsEnabled = false;
+            AutoLearnMode = 0;
+            if (fileVersion >= 25)
+            {
+                AutoLearnSkillsEnabled = reader.ReadBool();
+                AutoLearnMode = reader.ReadInt();
             }
         }
 

--- a/PitHero/Services/SaveLoadService.cs
+++ b/PitHero/Services/SaveLoadService.cs
@@ -856,6 +856,14 @@ namespace PitHero.Services
                 data.AutoHireMerc2Job = (int)autoHireService.Merc2Job;
             }
 
+            // Auto-learn hero skills (v25+)
+            var autoLearnService = Core.Services.GetService<AutoLearnSkillsService>();
+            if (autoLearnService != null)
+            {
+                data.AutoLearnSkillsEnabled = autoLearnService.Enabled;
+                data.AutoLearnMode = (int)autoLearnService.Mode;
+            }
+
             return data;
         }
 

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -111,6 +111,14 @@ namespace PitHero.UI
         private int _autoHireMerc1Index;
         private int _autoHireMerc2Index;
 
+        // Auto-learn hero skills (issue #353)
+        private HoverableCheckBox _autoLearnSkillsCheckBox;
+        private HoverableLabel _autoLearnModeLabel;
+        private TextButton _autoLearnModeLeftButton;
+        private TextButton _autoLearnModeRightButton;
+        private Label _autoLearnModeValueLabel;
+        private int _autoLearnModeIndex;
+
         // Confirmation dialogs
         private Window _exitConfirmationDialog;
         private Window _quitToTitleConfirmationDialog;
@@ -1035,6 +1043,7 @@ namespace PitHero.UI
 
             PopulateAutoPurchaseControls(autoShopTable, skin);
             PopulateAutoEquipControls(autoShopTable, skin);
+            PopulateAutoLearnControls(autoShopTable, skin);
             PopulateAutoHireControls(autoShopTable, skin);
 
             // The tab keeps growing as automation options are added, so it scrolls vertically.
@@ -1219,6 +1228,102 @@ namespace PitHero.UI
                 out _autoHireMerc2ValueLabel, out _autoHireMerc2RightButton);
 
             SetAutoHireControlsActive(false);
+        }
+
+        /// <summary>Adds the "Auto-Learn Hero Skills" checkbox and its mode cycler to the Automation tab.</summary>
+        private void PopulateAutoLearnControls(Table autoShopTable, Skin skin)
+        {
+            string autoLearnTooltip = GetText(TextType.UI, UITextKey.SettingsAutoLearnSkillsTooltip);
+            _autoLearnSkillsCheckBox = new HoverableCheckBox(
+                GetText(TextType.UI, UITextKey.SettingsAutoLearnSkills),
+                skin,
+                autoLearnTooltip,
+                _stage);
+            _autoLearnSkillsCheckBox.IsChecked = false;
+            _autoLearnSkillsCheckBox.OnChanged += (isChecked) =>
+            {
+                var svc = Core.Services?.GetService<AutoLearnSkillsService>();
+                if (svc != null)
+                {
+                    svc.Enabled = isChecked;
+                    if (isChecked)
+                        svc.TryLearnNow();
+                }
+                SetAutoLearnControlsActive(isChecked);
+            };
+            autoShopTable.Add(_autoLearnSkillsCheckBox).Left().SetPadTop(15f).SetPadBottom(8f);
+            autoShopTable.Row();
+
+            // "Learn Mode" cycler row
+            _autoLearnModeLabel = new HoverableLabel(
+                GetText(TextType.UI, UITextKey.SettingsAutoLearnMode),
+                skin, "ph-default",
+                GetText(TextType.UI, UITextKey.SettingsAutoLearnModeTooltip), _stage);
+            _autoLearnModeLeftButton  = new TextButton("<", skin, "ph-default");
+            _autoLearnModeRightButton = new TextButton(">", skin, "ph-default");
+            _autoLearnModeValueLabel  = new Label(GetAutoLearnModeDisplayName(AutoLearnMode.Smart), skin, "ph-default");
+            _autoLearnModeLeftButton.OnClicked  += (_) => CycleAutoLearnMode(-1);
+            _autoLearnModeRightButton.OnClicked += (_) => CycleAutoLearnMode(+1);
+
+            var modeRow = new Table();
+            modeRow.Add(_autoLearnModeLabel).Left().Width(110f).SetPadRight(10f);
+            modeRow.Add(_autoLearnModeLeftButton).Size(30f, 22f);
+            modeRow.Add(_autoLearnModeValueLabel).Width(70f).SetPadLeft(6f).SetPadRight(6f);
+            modeRow.Add(_autoLearnModeRightButton).Size(30f, 22f);
+            autoShopTable.Add(modeRow).Left().SetPadBottom(8f);
+            autoShopTable.Row();
+
+            SetAutoLearnControlsActive(false);
+        }
+
+        /// <summary>
+        /// Cycles the auto-learn mode by the given direction, wrapping at both ends, and pushes the
+        /// selection to the service. If the service is enabled a learn pass fires immediately.
+        /// </summary>
+        private void CycleAutoLearnMode(int delta)
+        {
+            const int modeCount = 3; // Smart=0, Active=1, Passive=2
+            _autoLearnModeIndex += delta;
+            if (_autoLearnModeIndex < 0)
+                _autoLearnModeIndex = modeCount - 1;
+            else if (_autoLearnModeIndex >= modeCount)
+                _autoLearnModeIndex = 0;
+
+            var mode = AutoLearnSkillsService.SanitizeMode(_autoLearnModeIndex);
+            var svc  = Core.Services?.GetService<AutoLearnSkillsService>();
+            if (svc != null)
+            {
+                svc.Mode = mode;
+                if (svc.Enabled) svc.TryLearnNow();
+            }
+            _autoLearnModeValueLabel?.SetText(GetAutoLearnModeDisplayName(mode));
+        }
+
+        /// <summary>Activates or deactivates the auto-learn mode cycler controls.</summary>
+        private void SetAutoLearnControlsActive(bool active)
+        {
+            var skin       = PitHeroSkin.CreateSkin();
+            var labelStyle = skin.Get<LabelStyle>(active ? "ph-default" : "ph-grayed");
+
+            if (_autoLearnModeLabel != null)
+            {
+                _autoLearnModeLabel.SetStyle(labelStyle);
+                _autoLearnModeLabel.SetTooltipEnabled(active);
+            }
+            _autoLearnModeValueLabel?.SetStyle(labelStyle);
+            SetButtonActive(_autoLearnModeLeftButton, active, skin);
+            SetButtonActive(_autoLearnModeRightButton, active, skin);
+        }
+
+        /// <summary>Localized display name for an auto-learn mode option.</summary>
+        private string GetAutoLearnModeDisplayName(AutoLearnMode mode)
+        {
+            switch (mode)
+            {
+                case AutoLearnMode.Active:  return GetText(TextType.UI, UITextKey.AutoLearnModeActive);
+                case AutoLearnMode.Passive: return GetText(TextType.UI, UITextKey.AutoLearnModePassive);
+                default:                    return GetText(TextType.UI, UITextKey.AutoLearnModeSmart);
+            }
         }
 
         /// <summary>Builds one "MercenaryN Job" cycler row: caption, left arrow, value label, right arrow.</summary>
@@ -1530,6 +1635,17 @@ namespace PitHero.UI
                 _autoHireMerc1ValueLabel?.SetText(GetAutoHireJobDisplayName(AutoHireJobOptions[_autoHireMerc1Index]));
                 _autoHireMerc2ValueLabel?.SetText(GetAutoHireJobDisplayName(AutoHireJobOptions[_autoHireMerc2Index]));
                 SetAutoHireControlsActive(autoHireSvc.Enabled);
+            }
+
+            var autoLearnSvc = Core.Services?.GetService<AutoLearnSkillsService>();
+            if (autoLearnSvc != null)
+            {
+                // Programmatic IsChecked assignment does not fire OnChanged — safe to set directly.
+                if (_autoLearnSkillsCheckBox != null)
+                    _autoLearnSkillsCheckBox.IsChecked = autoLearnSvc.Enabled;
+                _autoLearnModeIndex = (int)autoLearnSvc.Mode;
+                _autoLearnModeValueLabel?.SetText(GetAutoLearnModeDisplayName(autoLearnSvc.Mode));
+                SetAutoLearnControlsActive(autoLearnSvc.Enabled);
             }
         }
 

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -400,5 +400,15 @@ namespace PitHero
         public const string SettingsAutoHireMerc1JobTooltip = "SettingsAutoHireMerc1JobTooltip";
         public const string SettingsAutoHireMerc2Job = "SettingsAutoHireMerc2Job";
         public const string SettingsAutoHireMerc2JobTooltip = "SettingsAutoHireMerc2JobTooltip";
+
+        // Auto-Learn Hero Skills (v25 / issue #353)
+        public const string SettingsAutoLearnSkills = "SettingsAutoLearnSkills";
+        public const string SettingsAutoLearnSkillsTooltip = "SettingsAutoLearnSkillsTooltip";
+        public const string SettingsAutoLearnMode = "SettingsAutoLearnMode";
+        public const string SettingsAutoLearnModeTooltip = "SettingsAutoLearnModeTooltip";
+        public const string AutoLearnModeSmart = "AutoLearnModeSmart";
+        public const string AutoLearnModeActive = "AutoLearnModeActive";
+        public const string AutoLearnModePassive = "AutoLearnModePassive";
+        public const string ConsoleAutoLearnedSkill = "ConsoleAutoLearnedSkill";
     }
 }

--- a/PitHero/docs/AutomationSystem.md
+++ b/PitHero/docs/AutomationSystem.md
@@ -11,10 +11,10 @@ Monster job assignment is the one automation with its own deep-dive — see
 ## The tab at a glance
 
 Built by `SettingsUI.PopulateAutomationTab` (`PitHero/UI/SettingsUI.cs`), which delegates the
-newest blocks to `PopulateAutoPurchaseControls`, `PopulateAutoEquipControls` and
-`PopulateAutoHireControls`. The whole tab is wrapped in a vertical `ScrollPane` — it has outgrown
-the 450×350 settings window, so **new controls just get appended; do not try to keep the tab
-short**.
+newest blocks to `PopulateAutoPurchaseControls`, `PopulateAutoEquipControls`,
+`PopulateAutoLearnControls` and `PopulateAutoHireControls`. The whole tab is wrapped in a vertical
+`ScrollPane` — it has outgrown the 450×350 settings window, so **new controls just get appended;
+do not try to keep the tab short**.
 
 | Control group | Owning service / state | Runs | Save section |
 |---|---|---|---|
@@ -25,6 +25,7 @@ short**.
 | Auto-Sell Excess Items + priority + "Gear Sell Options" | `AutoSellExcessItemsService` | Call-driven | 36–38 (v21/v22/v23) |
 | Auto-Purchase Items + priority + merc opt-in + "Gear Purchase Options" + "Consumable Purchase Options" | `AutoItemPurchaseService` | Call-driven | 39 (v23) |
 | Auto-Equip Options | `HeroComponent.AutoEquipHero` / `.AutoEquipMercenaries` (**no service**) | Call-driven | 40 (v23) |
+| Auto-Learn Hero Skills + "Learn Mode" cycler | `AutoLearnSkillsService` | Ticked (1s throttle) | 42 (v25) |
 | Auto-Hire Mercenaries + two "MercenaryN Job" cyclers | `AutoHireMercenaryService` | Call-driven | 41 (v24) |
 
 Dialogs opened from the tab:
@@ -65,9 +66,10 @@ together near the top of `Unload()`.
 Two distinct patterns — pick deliberately:
 
 - **Ticked** — `Update()` called from the unpaused block of `MainGameScene.Update()`.
-  `AutoSeedPurchaseService` (1-second throttle), `AutoCropSellService`, `AutoJobAssignmentService`.
+  `AutoSeedPurchaseService` (1-second throttle), `AutoCropSellService`, `AutoJobAssignmentService`,
+  `AutoLearnSkillsService` (1-second throttle).
   Each exposes a public, throttle-free pass method (`TryPurchasePass()`, `TrySellPass()`,
-  `ReassessNow()`) so tests can drive it directly.
+  `ReassessNow()`, `TryLearnPass()`) so tests can drive it directly.
 - **Call-driven** — no update loop; invoked from the game action that creates the situation.
   - `AutoSellExcessItemsService.TryMakeRoom(bag, incoming)` ← `OpenChestAction`, before adding a
     chest item to a full bag.
@@ -222,6 +224,7 @@ and call the pass method rather than simulating frames:
 | Excess-item selling + gear filters | `PitHero.Tests/AutoSellExcessItemsTests.cs` |
 | Item purchasing | `PitHero.Tests/AutoItemPurchaseServiceTests.cs` |
 | Auto-equip | `PitHero.Tests/GearAutoEquipServiceTests.cs` |
+| Hero skill auto-learn | `PitHero.Tests/AutoLearnSkillsServiceTests.cs` |
 | Mercenary auto-hire matching | `PitHero.Tests/AutoHireMercenaryServiceTests.cs` |
 | Save round-trips + defaults | `PitHero.Tests/SaveLoadTests.cs` |
 

--- a/PitHero/docs/JpSystem.md
+++ b/PitHero/docs/JpSystem.md
@@ -96,9 +96,57 @@ The `Hero` class now supports JP mechanics through its bound crystal:
   3. Power Shot (Active, JP: 130, Level: 2) - AP: 4, 1.5x damage
   4. Volley (Active, JP: 200, Level: 3) - AP: 7, ranged AoE
 
+## Starting JP
+
+Heroes start a new game with **0 JP** (issue #353 removed the 550 JP startup grant). JP is earned
+exclusively from kills (`BattleEngine.AwardEnemyDeathRewards`) and accumulates on `HeroCrystal`.
+
+## Auto-Learn Hero Skills
+
+Issue #353 adds an automation option in **Settings → Automation → Auto-Learn Hero Skills** that
+spends available JP on skills automatically once per second. It is **off by default**.
+
+### Learn Mode
+
+Three modes are selectable via a `<`/`>` cycler:
+
+| Mode | Behaviour |
+|---|---|
+| **Smart** (default) | Learns skills in a job-defined priority order (signature active first, then passives cheapest-to-most-expensive, then second active). Unknown skill IDs (e.g. from composite jobs) sort last, deterministically by cost then job-list index. |
+| **Active** | Cheapest unlearned active first; when all actives are learned, switches to cheapest unlearned passive. |
+| **Passive** | Mirror of Active (passives first). |
+
+### Smart-mode priority table
+
+| Job | Rank 0 (first) | Rank 1 | Rank 2 | Rank 3 (last) |
+|---|---|---|---|---|
+| Knight | knight.spin_slash (120 JP) | knight.light_armor (50 JP) | knight.heavy_armor (100 JP) | knight.heavy_strike (180 JP) |
+| Mage | mage.fire (120 JP) | mage.heart_fire (60 JP) | mage.economist (80 JP) | mage.firestorm (200 JP) |
+| Priest | priest.heal (100 JP) | priest.calm_spirit (50 JP) | priest.mender (80 JP) | priest.defup (160 JP) |
+| Monk | monk.roundhouse (120 JP) | monk.counter (70 JP) | monk.deflect (90 JP) | monk.flaming_fist (170 JP) |
+| Thief | thief.sneak_attack (130 JP) | thief.shadowstep (70 JP) | thief.trap_sense (90 JP) | thief.vanish (180 JP) |
+| Archer | archer.power_shot (130 JP) | archer.eagle_eye (70 JP) | archer.quickdraw (100 JP) | archer.volley (200 JP) |
+
+### Strict-order semantics and tie-breaks
+
+Smart mode uses **strict order**: if the next-priority skill is unaffordable, the service waits —
+it never skips to a cheaper lower-priority skill. This guarantees the learning order is always
+correct regardless of how JP arrives (e.g. a Priest with 60 JP will not buy Calm Spirit before
+earning the 100 JP needed for Heal).
+
+Tie-break rule when two skills share the same rank and cost (common in composite jobs):
+lower job-list index wins. Knight's SpinSlash (index 2 in the composite list) beats Mage's Fire
+(index 6) when both have rank 0 and cost 120 JP.
+
+### Persistence
+
+Stored in save section 42 (v25): `AutoLearnSkillsEnabled` (bool) and `AutoLearnMode` (int 0–2).
+Older saves default to off and Smart. The mode is clamped via `AutoLearnSkillsService.SanitizeMode`
+on load.
+
 ## JP Progression Flow
 
-1. **Earn JP**: Heroes earn JP through battles, chests, events, or quests
+1. **Earn JP**: Heroes earn JP through kills (no startup grant)
 2. **Check Requirements**: To purchase a skill, hero must:
    - Have sufficient CurrentJP to pay the skill's JPCost
    - Meet the hero level requirement (Level >= skill.LearnLevel)


### PR DESCRIPTION
Closes #353

## Summary
- Heroes no longer receive the free 550 JP grant on new game — JP is earned only from monster kills.
- New **Auto-Learn Hero Skills** option in the Automation tab (below Auto-Equip Options, above Auto-Hire Mercenaries): a checkbox (OFF by default) plus a **Learn Mode** cycler with wrapping `<` `>` arrows over **Smart** (default), **Active**, **Passive**.
- New `AutoLearnSkillsService` (1s-throttled tick, same pattern as other automation services) spends available JP automatically:
  - **Smart** — learns the job's most beneficial skills in strict priority order (signature active first: Priest→Heal, Mage→Fire, Knight→Spin Slash, Monk→Roundhouse, Thief→Sneak Attack, Archer→Power Shot; then passives cheapest-first, then the second active). If the next-priority skill is unaffordable, it waits rather than skipping ahead.
  - **Active** — cheapest unlearned active first; once all actives are learned, passives (cheapest first).
  - **Passive** — mirror of Active.
  - Ties break deterministically by JP cost then job-list order; composite jobs (union of both parents' skills) are handled.
- Enabling the checkbox or cycling the mode triggers an immediate learn pass; each auto-learned skill emits a console line.
- Persisted as save **v25** (append-only section 42: enabled flag + mode, sanitized on load). Older saves load with defaults (off/Smart).

## Testing
- 22 new tests: `AutoLearnSkillsServiceTests` (20 — signature-first per job, full Smart order for all six jobs, strict-order wait, Active/Passive ordering, composite-job tie-breaks, multi-learn pass, sanitize) and v25 save round-trip/defaults in `SaveLoadTests`.
- Full suite: **1736 passed / 0 failed / 6 skipped** (baseline 1714/0/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)