### PR TITLE
Add map quadrant camera shortcuts (1-4) and move shortcut bar to SHIFT+1-8

### DIFF
--- a/PitHero.Tests/CameraQuadrantTests.cs
+++ b/PitHero.Tests/CameraQuadrantTests.cs
@@ -1,0 +1,43 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Xna.Framework;
+using PitHero.ECS.Components;
+
+namespace PitHero.Tests
+{
+    [TestClass]
+    public class CameraQuadrantTests
+    {
+        [TestMethod]
+        public void GetQuadrantCenter_FullMapBounds_ReturnsScreenWidthCenters()
+        {
+            // 240x12 tile map at 32px = 7680x384; quadrants are exactly one 1920px screen wide
+            var bounds = new Rectangle(0, 0, 7680, 384);
+
+            Assert.AreEqual(new Vector2(960f, 192f), CameraControllerComponent.GetQuadrantCenter(bounds, 0));
+            Assert.AreEqual(new Vector2(2880f, 192f), CameraControllerComponent.GetQuadrantCenter(bounds, 1));
+            Assert.AreEqual(new Vector2(4800f, 192f), CameraControllerComponent.GetQuadrantCenter(bounds, 2));
+            Assert.AreEqual(new Vector2(6720f, 192f), CameraControllerComponent.GetQuadrantCenter(bounds, 3));
+        }
+
+        [TestMethod]
+        public void GetQuadrantCenter_FallbackBounds_ReturnsQuarterWidthCenters()
+        {
+            // Default bounds used when no tilemap is found
+            var bounds = new Rectangle(0, 0, 1920, 384);
+
+            Assert.AreEqual(new Vector2(240f, 192f), CameraControllerComponent.GetQuadrantCenter(bounds, 0));
+            Assert.AreEqual(new Vector2(720f, 192f), CameraControllerComponent.GetQuadrantCenter(bounds, 1));
+            Assert.AreEqual(new Vector2(1200f, 192f), CameraControllerComponent.GetQuadrantCenter(bounds, 2));
+            Assert.AreEqual(new Vector2(1680f, 192f), CameraControllerComponent.GetQuadrantCenter(bounds, 3));
+        }
+
+        [TestMethod]
+        public void GetQuadrantCenter_NonZeroOrigin_RespectsBoundsOffset()
+        {
+            var bounds = new Rectangle(100, 50, 400, 200);
+
+            Assert.AreEqual(new Vector2(150f, 150f), CameraControllerComponent.GetQuadrantCenter(bounds, 0));
+            Assert.AreEqual(new Vector2(450f, 150f), CameraControllerComponent.GetQuadrantCenter(bounds, 3));
+        }
+    }
+}

--- a/PitHero/ECS/Components/CameraControllerComponent.cs
+++ b/PitHero/ECS/Components/CameraControllerComponent.cs
@@ -32,6 +32,12 @@ namespace PitHero.ECS.Components
         public System.Func<bool> IsPointerOverUI;
 
         /// <summary>
+        /// Optional hook set by the scene; returns true when a UI text field has keyboard focus.
+        /// Gates the quadrant jump keys so typing digits into a text field doesn't move the camera.
+        /// </summary>
+        public System.Func<bool> HasKeyboardFocus;
+
+        /// <summary>
         /// Gets whether this component should respect the manual pause state.
         /// We shouldn't modify camera size or zoom while paused from menu.
         /// The farm-mode pause gate is deliberately ignored so the player can pan/zoom the map
@@ -94,6 +100,7 @@ namespace PitHero.ECS.Components
 
             HandleZoomInput();
             HandlePanInput();
+            HandleQuadrantJumpInput();
             HandleKeyboardPanInput();
             HandleHeroFollowing();
         }
@@ -258,6 +265,43 @@ namespace PitHero.ECS.Components
             pos.X = (float)System.Math.Round(pos.X / step) * step;
             pos.Y = (float)System.Math.Round(pos.Y / step) * step;
             _camera.Position = pos;
+        }
+
+        /// <summary>
+        /// Returns the world-space center of the given horizontal map quadrant (0-based index).
+        /// </summary>
+        public static Vector2 GetQuadrantCenter(Rectangle mapBounds, int quadrantIndex)
+        {
+            return new Vector2(
+                mapBounds.X + mapBounds.Width * (quadrantIndex + 0.5f) / GameConfig.MapQuadrantCount,
+                mapBounds.Y + mapBounds.Height / 2f);
+        }
+
+        /// <summary>
+        /// Centers the camera on one of the horizontal map quadrants when keys 1-4 are pressed.
+        /// SHIFT+number is reserved for the shortcut bar and CTRL for zoom modifiers.
+        /// </summary>
+        private void HandleQuadrantJumpInput()
+        {
+            if (Input.IsKeyDown(Keys.LeftShift) || Input.IsKeyDown(Keys.RightShift) ||
+                Input.IsKeyDown(Keys.LeftControl) || Input.IsKeyDown(Keys.RightControl))
+                return;
+
+            if (HasKeyboardFocus?.Invoke() == true)
+                return;
+
+            for (int i = 0; i < GameConfig.MapQuadrantCount; i++)
+            {
+                var key = (Keys)((int)Keys.D1 + i);
+                if (!Input.IsKeyPressed(key)) continue;
+
+                SwitchToManualControl();
+                _manualControlTimer = 0f;
+                _camera.Position = ConstrainCameraPosition(GetQuadrantCenter(_tileMapBounds, i));
+                QuantizeCameraPosition();
+                Debug.Log($"[CameraController] Quadrant jump {i + 1} positionX={_camera.Position.X} positionY={_camera.Position.Y}");
+                break;
+            }
         }
 
         private void CenterCameraOnMap()

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -138,6 +138,7 @@ namespace PitHero.ECS.Scenes
             _cameraController = cameraEntity.AddComponent(new CameraControllerComponent());
             // Delegate reads _uiStage at call time, so it is safe to wire before the stage exists
             _cameraController.IsPointerOverUI = () => _uiStage != null && _uiStage.Hit(_uiStage.GetMousePosition()) != null;
+            _cameraController.HasKeyboardFocus = () => _uiStage != null && _uiStage.GetKeyboardFocus() != null;
 
             // Load HUD fonts (normal, 2x, 4x for shrink levels)
             _hudFontNormal = Content.LoadBitmapFont(GameConfig.FontPathHud);

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -256,6 +256,7 @@ namespace PitHero
         public const float CameraFollowLerpSpeed = 5f; // speed at which camera lerps to hero position
         public const float CameraManualControlTimeout = 7f; // seconds of inactivity before auto-following resumes (paused when player interacts with selectables)
         public const bool CameraAutoScrollToHeroDefault = true; // default value for auto-scroll to hero setting
+        public const int MapQuadrantCount = 4; // horizontal map quadrants reachable via keys 1-4
 
         // World Bounds
         public static readonly Rectangle WorldBounds = new Rectangle(0, 0, InternalWorldWidth, InternalWorldHeight);

--- a/PitHero/UI/InventoryGrid.cs
+++ b/PitHero/UI/InventoryGrid.cs
@@ -543,9 +543,12 @@ namespace PitHero.UI
             }
         }
 
-        /// <summary>Handles shortcut key presses (1-8).</summary>
+        /// <summary>Handles shortcut key presses (SHIFT+1-8). Plain 1-4 is reserved for camera quadrant jumps.</summary>
         public void HandleKeyboardShortcuts()
         {
+            if (!Input.IsKeyDown(Keys.LeftShift) && !Input.IsKeyDown(Keys.RightShift))
+                return;
+
             for (int keyOffset = 0; keyOffset < 8; keyOffset++)
             {
                 var key = (Keys)((int)Keys.D1 + keyOffset);

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -2123,13 +2123,14 @@ namespace PitHero.UI
             if (JustPressed(Microsoft.Xna.Framework.Input.Keys.Tab))
                 ToggleUIBarVisibility();
 
-            // If the shortcut bar is hidden and a shortcut number key is pressed, unhide it for feedback.
+            // If the shortcut bar is hidden and a SHIFT+number shortcut is pressed, unhide it for feedback.
+            // Plain 1-4 is reserved for camera quadrant jumps and must not unhide the bar.
             if (_shortcutBarHidden)
             {
                 for (int k = 0; k < 8; k++)
                 {
                     var numKey = (Microsoft.Xna.Framework.Input.Keys)((int)Microsoft.Xna.Framework.Input.Keys.D1 + k);
-                    if (JustPressed(numKey))
+                    if (ShortcutPressed(numKey))
                     {
                         ShowShortcutBar();
                         break;

--- a/PitHero/UI/ShortcutBar.cs
+++ b/PitHero/UI/ShortcutBar.cs
@@ -1055,9 +1055,14 @@ namespace PitHero.UI
             RefreshVisualSlots();
         }
 
-        /// <summary>Handles shortcut key presses (1-8).</summary>
+        /// <summary>Handles shortcut key presses (SHIFT+1-8). Plain 1-4 is reserved for camera quadrant jumps.</summary>
         public void HandleKeyboardShortcuts()
         {
+            if (GetStage()?.GetKeyboardFocus() != null)
+                return;
+            if (!Input.IsKeyDown(Keys.LeftShift) && !Input.IsKeyDown(Keys.RightShift))
+                return;
+
             for (int keyOffset = 0; keyOffset < SHORTCUT_COUNT; keyOffset++)
             {
                 var key = (Keys)((int)Keys.D1 + keyOffset);


### PR DESCRIPTION
Closes #355

## Summary
- Pressing **1–4** centers the camera on one of 4 equal horizontal map quadrants (the 240-tile map is exactly 4 screen-widths at 1x zoom, so each key lands on one screen).
- Shortcut bar slots now require **SHIFT+1–8** so plain number presses no longer conflict. Slot labels remain "1"–"8" per discussion.

## Changes
- `CameraControllerComponent`: new `HandleQuadrantJumpInput()` (called from `Update()`), a public static `GetQuadrantCenter(Rectangle, int)` helper, and a scene-provided `HasKeyboardFocus` hook mirroring `IsPointerOverUI`. Jumps switch to manual control (7s timeout resumes hero-follow) and reuse existing `ConstrainCameraPosition`/`QuantizeCameraPosition`, so zoomed-in edge quadrants clamp correctly. Suppressed while SHIFT/CTRL is held or a text field has keyboard focus; inert while menu-paused (consistent with pan/zoom).
- `ShortcutBar.HandleKeyboardShortcuts()`: requires SHIFT and now ignores input while a text field has keyboard focus.
- `SettingsUI`: hidden-shortcut-bar auto-unhide switched to the shift-gated `ShortcutPressed` path so quadrant jumps don't unhide the bar.
- `InventoryGrid.HandleKeyboardShortcuts()` (uncalled): same shift gate for consistency.
- `GameConfig.MapQuadrantCount = 4`.

## Testing
- `dotnet build PitHero.sln` — 0 errors.
- `dotnet test` — 1739 passed, 0 failed (includes new `CameraQuadrantTests` covering full-map, fallback, and nonzero-origin bounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)