### PR TITLE
Various cleanup: hero preview rotation, log noise, scissor rect warnings (#357)

### DIFF
--- a/PitHero/AI/AttackMonsterAction.cs
+++ b/PitHero/AI/AttackMonsterAction.cs
@@ -35,7 +35,6 @@ namespace PitHero.AI
         {
             if (_battleCoroutine != null)
             {
-                Debug.Log("[AttackMonster] Multi-participant battle already in progress");
                 return !HeroStateMachine.IsBattleInProgress;
             }
 

--- a/PitHero/AI/HeroStateMachine.cs
+++ b/PitHero/AI/HeroStateMachine.cs
@@ -573,7 +573,6 @@ namespace PitHero.AI
 
             if (_currentAction == null)
             {
-                Debug.Warn("[HeroStateMachine] PerformAction_Tick: No current action");
                 CurrentState = ActorState.Idle;
                 return;
             }
@@ -1476,16 +1475,10 @@ namespace PitHero.AI
             int cost = stopped ? 1 : 99;
 
             if (_jumpOutOfPitForStopAction != null)
-            {
                 _jumpOutOfPitForStopAction.Cost = cost;
-                Debug.Log($"[HeroStateMachine] Set JumpOutOfPitForStopAction cost to {cost}");
-            }
 
             if (_walkToTavernForStopAction != null)
-            {
                 _walkToTavernForStopAction.Cost = cost;
-                Debug.Log($"[HeroStateMachine] Set WalkToTavernForStopAction cost to {cost}");
-            }
 
             _lastStoppedAdventure = stopped;
         }

--- a/PitHero/AI/OpenChestAction.cs
+++ b/PitHero/AI/OpenChestAction.cs
@@ -198,7 +198,6 @@ namespace PitHero.AI
                 faceDir = delta.Y < 0 ? Direction.Up : Direction.Down;
             var facing = hero.Entity.GetComponent<ActorFacingComponent>();
             facing?.SetFacing(faceDir);
-            Debug.Log($"[OpenChest] Hero facing direction set to {faceDir} using delta ({delta.X},{delta.Y})");
         }
 
         /// <summary>
@@ -291,7 +290,6 @@ namespace PitHero.AI
                 animationEntity.Transform.Position = _chestEntity.Transform.Position;
                 animationEntity.AddComponent(new ItemPickupAnimationComponent(containedItem));
 
-                Debug.Log($"[OpenChest] Created pickup animation for {containedItem.Name} at position X: {_chestEntity.Transform.Position.X}, Y: {_chestEntity.Transform.Position.Y}");
             }
 
             // When the bag is full, auto-sell the weakest excess item to make room (if enabled).
@@ -309,7 +307,7 @@ namespace PitHero.AI
             // Try to add item using hero's TryAddItem method (handles consumable priority logic)
             if (hero.TryAddItem(containedItem))
             {
-                Debug.Log($"[OpenChest] Added {containedItem.Name} to hero's main bag. Bag contents:");
+                Debug.Log($"[OpenChest] Added {containedItem.Name} to hero's main bag");
 
                 Services.Analytics.AnalyticsService.LogItemAcquired(containedItem,
                     Core.Services.GetService<PitWidthManager>()?.CurrentPitLevel ?? 0, treasureComponent.Level);
@@ -317,7 +315,6 @@ namespace PitHero.AI
                 Core.Services.GetService<GameEventService>()?.EmitLocalized(UITextKey.ConsoleItemFound,
                     (hero.LinkedHero.Name, GameConfig.ConsoleColorHeroName),
                     (containedItem.Name, RarityUtils.GetRarityColor(containedItem.Rarity)));
-                LogBagContents(hero.Bag);
 
                 // Reset HealingItemExhausted if picked up item is a healing consumable
                 if (containedItem is Consumable consumable && consumable.HPRestoreAmount > 0)
@@ -352,18 +349,5 @@ namespace PitHero.AI
             return item is Consumable || item is IGear;
         }
 
-        /// <summary>
-        /// Debug log the contents of the hero's bag
-        /// </summary>
-        private void LogBagContents(RolePlayingFramework.Inventory.ItemBag bag)
-        {
-            Debug.Log($"[OpenChest] Hero bag contains {bag.Count}/{bag.Capacity} items:");
-            for (int i = 0; i < bag.Items.Count; i++)
-            {
-                var item = bag.Items[i];
-                Debug.Log($"[OpenChest]   {i + 1}. {item.Name} ({item.Rarity})");
-            }
-        }
-
-    }
+}
 }

--- a/PitHero/AI/WanderPitAction.cs
+++ b/PitHero/AI/WanderPitAction.cs
@@ -41,7 +41,6 @@ namespace PitHero.AI
 
             // Get current tile position
             var currentTile = tileMover.GetCurrentTileCoordinates();
-            Debug.Log($"[WanderPitAction] Executing at tile ({currentTile.X},{currentTile.Y})");
 
             // Clear fog of war around this tile using hero's UncoverRadius
             var tiledMapService = Core.Services.GetService<TiledMapService>();
@@ -64,15 +63,12 @@ namespace PitHero.AI
 
                 // After any fog changes or discoveries, update ExploredPit based on the current priority order
                 hero.UpdateExploredPitBasedOnPriorities();
-
-                Debug.Log($"[WanderPitAction] Adjacent check: Monster={hero.AdjacentToMonster}, Chest={hero.AdjacentToChest}");
             }
             else
             {
                 Debug.Warn("[WanderPitAction] No TiledMapService available");
             }
 
-            Debug.Log("[WanderPitAction] Action completed");
             return true; // Action completed
         }
 
@@ -128,10 +124,7 @@ namespace PitHero.AI
         private void CheckWizardOrbFound(HeroComponent hero, TiledMapService tiledMapService, Point position)
         {
             if (hero.FoundWizardOrb)
-            {
-                Debug.Log("[Wander] CheckWizardOrbFound: Already found");
                 return;
-            }
 
             var scene = Core.Scene;
             if (scene == null)
@@ -151,7 +144,6 @@ namespace PitHero.AI
             var wizardOrbEntity = wizardOrbEntities[0];
             var worldPos = wizardOrbEntity.Transform.Position;
             var orbTile = new Point((int)(worldPos.X / GameConfig.TileSize), (int)(worldPos.Y / GameConfig.TileSize));
-            Debug.Log($"[Wander] CheckWizardOrbFound: Orb at world {worldPos.X},{worldPos.Y} tile {orbTile.X},{orbTile.Y}");
 
             // Inspect FogOfWar layer at the orb tile
             var fogLayer = tiledMapService.CurrentMap.GetLayer<TmxLayer>("FogOfWar");
@@ -165,8 +157,6 @@ namespace PitHero.AI
             if (orbTile.X >= 0 && orbTile.Y >= 0 && orbTile.X < fogLayer.Width && orbTile.Y < fogLayer.Height)
             {
                 var fogTile = fogLayer.GetTile(orbTile.X, orbTile.Y);
-                Debug.Log($"[Wander] CheckWizardOrbFound: Fog tile at orb {orbTile.X},{orbTile.Y}: {(fogTile == null ? "NULL (cleared)" : "EXISTS (not cleared)")}");
-
                 if (fogTile == null)
                 {
                     HandleWizardOrbFound(hero, $"at tile {orbTile.X},{orbTile.Y}");

--- a/PitHero/ECS/Components/CameraControllerComponent.cs
+++ b/PitHero/ECS/Components/CameraControllerComponent.cs
@@ -226,7 +226,6 @@ namespace PitHero.ECS.Components
 
             _camera.RawZoom = newZoom;
             RecenterAroundMouse(mouseWorldPos);
-            Debug.Log($"[CameraController] Wheel zoom newZoom={_camera.RawZoom}");
         }
 
         /// <summary>

--- a/PitHero/ECS/Components/EnemyAnimationComponent.cs
+++ b/PitHero/ECS/Components/EnemyAnimationComponent.cs
@@ -59,7 +59,6 @@ namespace PitHero.ECS.Components
                 {
                     AddAnimationsFromAtlas(actorsAtlas);
                     Play(DefaultAnimation, LoopMode.Loop);
-                    Debug.Log($"[EnemyAnimationComponent] Loaded animations from Actors.atlas and started {DefaultAnimation}");
                 }
                 else
                 {
@@ -278,7 +277,6 @@ namespace PitHero.ECS.Components
             if (Animations != null && Animations.ContainsKey(animationName))
             {
                 Play(animationName, LoopMode.Loop);
-                Debug.Log($"[EnemyAnimationComponent] Switched to animation: {animationName} for direction: {direction}");
             }
             else
             {

--- a/PitHero/ECS/Components/HeroAnimationComponent.cs
+++ b/PitHero/ECS/Components/HeroAnimationComponent.cs
@@ -69,7 +69,6 @@ namespace PitHero.ECS.Components
                 {
                     AddAnimationsFromAtlas(actorsAtlas);
                     Play(DefaultAnimation, LoopMode.Loop);
-                    Debug.Log($"[HeroAnimationComponent] Loaded animations from Actors.atlas and started {DefaultAnimation}");
                 }
                 else
                 {
@@ -165,7 +164,6 @@ namespace PitHero.ECS.Components
             if (Animations != null && Animations.ContainsKey(animationName))
             {
                 Play(animationName, LoopMode.Once);
-                Debug.Log($"[HeroAnimationComponent] Started jump animation: {animationName} for direction: {direction}");
             }
             else
             {

--- a/PitHero/ECS/Components/HeroComponent.cs
+++ b/PitHero/ECS/Components/HeroComponent.cs
@@ -636,7 +636,6 @@ namespace PitHero.ECS.Components
                             consumable.StackCount = savedItem.StackCount;
                         }
                         Bag.SetSlotItem(savedItem.SlotIndex, item);
-                        Debug.Log("[HeroComponent] Restored item '" + savedItem.Name + "' at slot " + savedItem.SlotIndex);
                     }
                     else
                     {
@@ -848,7 +847,6 @@ namespace PitHero.ECS.Components
 
             mover.MovementSpeed = newSpeed;
 
-            Debug.Log($"[HeroComponent] Movement speed set based on pit state. InsidePit={_insidePit}, FogCooldown={_fogCooldown:F2}, Speed={newSpeed}");
         }
 
         /// <summary>
@@ -860,7 +858,6 @@ namespace PitHero.ECS.Components
             {
                 _fogCooldown = GameConfig.HeroFogCooldownDuration;
                 ApplyMovementSpeedForPitState();
-                Debug.Log($"[HeroComponent] Fog cooldown triggered. Duration={_fogCooldown:F2}s");
             }
         }
 
@@ -1026,11 +1023,6 @@ namespace PitHero.ECS.Components
         public override void OnTriggerEnter(Collider other, Collider local)
         {
             base.OnTriggerEnter(other, local);
-
-            Debug.Log($"[HeroComponent] OnTriggerEnter: other.Entity.Name={other.Entity.Name}, " +
-                      $"other.Entity.Tag={other.Entity.Tag}, " +
-                      $"other.PhysicsLayer={other.PhysicsLayer}, " +
-                      $"HeroPos={Entity.Transform.Position.X},{Entity.Transform.Position.Y}");
 
             // Handle pit trigger separately from tilemap
             if (other.Entity.Tag == GameConfig.TAG_PIT)

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -1585,7 +1585,6 @@ namespace PitHero.ECS.Scenes
                 // Add wall to hero's pathfinding graph
                 heroComponent.AddWall(tilePos);
                 addedWalls++;
-                Debug.Log($"[MainGameScene] Added existing obstacle at ({tileX},{tileY}) to hero pathfinding");
             }
 
             Debug.Log($"[MainGameScene] Added {addedWalls} existing obstacle walls to hero pathfinding graph");

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -396,7 +396,7 @@ namespace PitHero
         public const string FontMainUI = "Content/Fonts/Express.fnt";
         public const string FontPathHud = "Content/Fonts/Skullboy.fnt";
         public const string FontPathHud2x = "Content/Fonts/Skullboy2x.fnt";
-        public const string FontPathHudSmall = "Content/Fonts/CratesSmall.fnt";
+        public const string FontPathHudSmall = "Content/Fonts/SkullboySmall.fnt";
 
         // UI Button Spacing
         public const float UIButtonPadding = 4f; // Padding between UI buttons

--- a/PitHero/PitGenerator.cs
+++ b/PitHero/PitGenerator.cs
@@ -758,11 +758,6 @@ namespace PitHero
                         if (heroComponent != null && heroComponent.IsPathfindingInitialized)
                         {
                             heroComponent.AddWall(tilePos);
-                            Debug.Log($"[PitGenerator] Added obstacle tile to hero pathfinding at ({tilePos.X},{tilePos.Y})");
-                        }
-                        else
-                        {
-                            Debug.Log($"[PitGenerator] Hero found but pathfinding not initialized for obstacle at ({tilePos.X},{tilePos.Y})");
                         }
                     }
                     else
@@ -789,10 +784,6 @@ namespace PitHero
                             }
                         }
                         
-                        if (mercenariesUpdated > 0)
-                        {
-                            Debug.Log($"[PitGenerator] Added obstacle tile to {mercenariesUpdated} mercenary pathfinding graphs at ({tilePos.X},{tilePos.Y})");
-                        }
                     }
 
                     // Leave collider defaults so hero collides with obstacle (physics layer 0)
@@ -909,7 +900,6 @@ namespace PitHero
                     Flags.SetFlagExclusive(ref collider.PhysicsLayer, GameConfig.PhysicsHeroWorldLayer);
                 }
 
-                Debug.Log($"[PitGenerator] Created {entityTypeName} at tile ({tilePos.X},{tilePos.Y}), world ({worldPos.X},{worldPos.Y})");
             }
         }
 
@@ -1074,7 +1064,6 @@ namespace PitHero
                 collider.IsTrigger = true;
                 Flags.SetFlagExclusive(ref collider.PhysicsLayer, GameConfig.PhysicsHeroWorldLayer);
 
-                Debug.Log($"[PitGenerator] Created trap at tile ({tilePos.X},{tilePos.Y}), damage={5 + effectiveDepth * 2}");
             }
         }
 

--- a/PitHero/PitWidthManager.cs
+++ b/PitHero/PitWidthManager.cs
@@ -229,7 +229,6 @@ namespace PitHero
                 var tile = layer.GetTile(x, y);
                 int tileIndex = tile?.Gid ?? 0;
                 dictionary[y] = tileIndex;
-                Debug.Log($"[PitWidthManager] {patternName}[{y}] = {tileIndex}");
                 if (tileIndex != 0) nonZeroCount++;
             }
             Debug.Log($"[PitWidthManager] {patternName} total: {dictionary.Count} tiles, {nonZeroCount} non-zero");
@@ -527,34 +526,6 @@ namespace PitHero
                 r.AddColliders();
                 rebuiltCount++;
 
-                // After rebuild, validate collision at expanded inner floor columns
-                var collisionLayer = r.CollisionLayer;
-                int tileSize = GameConfig.TileSize;
-
-                // We expect x=12 and x=13 (new inner floors at level 10) to be passable for y=3..9
-                for (int x = 12; x <= 13; x++)
-                {
-                    for (int y = 3; y <= 9; y++)
-                    {
-                        int gid = 0;
-                        var t = collisionLayer.GetTile(x, y);
-                        gid = t != null ? t.Gid : 0;
-
-                        // Count how many collision rectangles intersect this tile area
-                        var tileRect = new Rectangle(x * tileSize, y * tileSize, tileSize, tileSize);
-                        int intersectCount = 0;
-                        var rects = collisionLayer.GetCollisionRectangles();
-                        for (int ri = 0; ri < rects.Count; ri++)
-                        {
-                            if (rects[ri].Intersects(tileRect))
-                                intersectCount++;
-                        }
-
-                        Debug.Log($"[PitWidthManager] Post-rebuild check: Collision[{x},{y}] gid={gid}, intersectingRects={intersectCount}");
-                    }
-                }
-
-                // Also log rectangle count after rebuild
                 var afterRects = r.CollisionLayer.GetCollisionRectangles();
                 Debug.Log($"[PitWidthManager] Collision rectangles AFTER rebuild: {afterRects.Count}");
             }
@@ -644,8 +615,6 @@ namespace PitHero
         /// </summary>
         private void ExtendColumn(ITiledMapService tiledMapService, int x, Dictionary<int, int> basePattern, Dictionary<int, int> collisionPattern, string columnType)
         {
-            Debug.Log($"[PitWidthManager] Extending {columnType} column at x={x}");
-
             // Set tiles from y=1 to y=11
             for (int y = 1; y <= 11; y++)
             {

--- a/PitHero/UI/HeroCreationUI.cs
+++ b/PitHero/UI/HeroCreationUI.cs
@@ -51,7 +51,7 @@ namespace PitHero.UI
 
         // Direction cycling for preview
         private int _currentDirectionIndex;
-        private static readonly Direction[] PreviewDirections = { Direction.Down, Direction.Left, Direction.Up, Direction.Right };
+        private static readonly Direction[] PreviewDirections = { Direction.Down, Direction.Right, Direction.Up, Direction.Left };
 
         // Job Info window elements
         private Table _jobInfoContentTable;

--- a/PitHero/Util/TiledMapService.cs
+++ b/PitHero/Util/TiledMapService.cs
@@ -91,7 +91,6 @@ namespace PitHero.Util
             }
 
             RemoveTile("FogOfWar", tileX, tileY);
-            Debug.Log($"FogOfWar tile removed at {tileX}, {tileY}");
             UpdateFogBitmasks(tileX, tileY);
             return true;
         }


### PR DESCRIPTION
Fixes #357

## Hero creation rotation buttons
`>` now rotates the preview right (Down → Right → Up → Left) and `<` rotates left. The `PreviewDirections` cycle order was reversed.

## Scissor rect / viewport warning (root cause found and fixed)
The FNA3D warning `Scissor rect and viewport appear not to overlap` was firing every frame (13k+ lines in LogSample.txt). Instrumenting `ScissorStack.PushScissors` showed the offender: the hidden **EventConsolePanel** (480×120 ScrollPane) is parked just off the bottom of the screen (y=364 in a 360-high viewport) and still draws each frame, submitting a scissor rect fully outside the viewport. The zoom-to-0.5 correlation in the log sample was coincidental — the auto-hide slide-out was the actual trigger.

Two Nez fixes (submodule bumped to `c7f720bb` on `rpillai/customUpdates`):
- `ScissorStack.PushScissors` clamps the scissor to the viewport and returns false when there's no overlap — callers (ScrollPane/Table/SplitPane) already treat that as "skip clipped content", so hidden off-screen panels no longer draw or warn.
- `Element.ClipBegin` now uses `Stage.Camera` (the camera the stage actually renders with) like ScrollPane/SplitPane already do, instead of the scene's world camera, so clipped Table/Window scissors no longer shift with world-camera pan/zoom.

**Verified:** 60s game run before the fix produced 7,135 warnings; after the fix, 0. Test suite: 1739 passed, 0 failed.

## FileNotFoundException spam + missing HUD font
`GameConfig.FontPathHudSmall` pointed at `Content/Fonts/CratesSmall.fnt`, which doesn't exist. Every `InventorySlot`, `VaultItemSlot`, `ShortcutBar`, and `InventoryGrid` instance probed it in a try/catch — ~340 first-chance `FileNotFoundException`s per scene load in the debugger log, plus the "Failed to load mercenary name font" message — then silently fell back to the default font. Now points at `SkullboySmall.fnt`, so the intended small HUD font actually loads (once, then cached).

## Log noise removal
Removed the high-frequency `Debug.Log` calls that dominated LogSample.txt (counts from the sample):
- `[AttackMonster] Multi-participant battle already in progress` (678)
- `FogOfWar tile removed` (247), `[HeroComponent]` movement-speed/fog-cooldown (295)
- `[EnemyAnimationComponent]`/`[HeroAnimationComponent]` animation switch + load logs (~300)
- `[WanderPitAction]` per-tile execute/adjacent/completed + wizard-orb probe logs (~460)
- `[HeroStateMachine]` stop-action cost logs (216) and the by-design planless `PerformAction_Tick` warn (103)
- `[PitWidthManager]` per-column/per-tile pattern dumps and post-rebuild checks (~150)
- `[PitGenerator]`/`[MainGameScene]` per-obstacle/trap creation and pathfinding-add logs
- `[OpenChest]` full bag dumps after every pickup, `[HeroComponent]` per-item restore logs (~130)
- `[CameraController]` wheel zoom logs

Meaningful one-time logs (level transitions, init summaries, warnings for genuine anomalies, battle narration) are kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)