### PR TITLE
Add Consumable Sell Options with min-stack floors; remove redundant Auto-Purchase Consumables toggle

### DIFF
--- a/PitHero.Tests/AutoItemPurchaseServiceTests.cs
+++ b/PitHero.Tests/AutoItemPurchaseServiceTests.cs
@@ -224,7 +224,7 @@ namespace PitHero.Tests
         // ── Consumables ───────────────────────────────────────────────────────────
 
         [TestMethod]
-        public void Consumables_NotBoughtWhenToggleOff()
+        public void Consumables_NotBoughtWhenNoneSelected()
         {
             var gameState = new GameStateService { Funds = 10000 };
             var vault = new SecondChanceMerchantVault();
@@ -232,9 +232,8 @@ namespace PitHero.Tests
             potion.StackCount = 8;
             vault.AddItem(potion);
 
+            // No ConsumableSelected entries checked — selection alone gates consumable buying
             var svc = MakeService(gameState, vault);
-            svc.PurchaseConsumables = false;
-            svc.ConsumableSelected[0] = true;
 
             Assert.AreEqual(0, RunPass(svc, MakeHero(), new ItemBag("Test", 10)));
             Assert.AreEqual(10000, gameState.Funds);
@@ -252,7 +251,6 @@ namespace PitHero.Tests
             vault.AddItem(stocked);
 
             var svc = MakeService(gameState, vault);
-            svc.PurchaseConsumables = true;
             svc.ConsumableSelected[0] = true;
             svc.ConsumableStackTargets[0] = 2;
 
@@ -275,7 +273,6 @@ namespace PitHero.Tests
             vault.AddItem(stocked);
 
             var svc = MakeService(gameState, vault);
-            svc.PurchaseConsumables = true;
             svc.ConsumableSelected[0] = true;
             svc.ConsumableStackTargets[0] = 3;
 
@@ -291,7 +288,6 @@ namespace PitHero.Tests
         {
             var gameState = new GameStateService { Funds = 10000 };
             var svc = MakeService(gameState, new SecondChanceMerchantVault());
-            svc.PurchaseConsumables = true;
             svc.ConsumableSelected[0] = true;
 
             Assert.AreEqual(0, RunPass(svc, MakeHero(), new ItemBag("Test", 10)));
@@ -313,7 +309,6 @@ namespace PitHero.Tests
             var gearFirstState = new GameStateService { Funds = funds };
             var gearFirstVault = BuildMixedVault(funds);
             var gearFirst = MakeService(gearFirstState, gearFirstVault);
-            gearFirst.PurchaseConsumables = true;
             gearFirst.ConsumableSelected[0] = true;
             gearFirst.ConsumablesFirst = false;
 
@@ -324,7 +319,6 @@ namespace PitHero.Tests
             var consumablesFirstState = new GameStateService { Funds = funds };
             var consumablesFirstVault = BuildMixedVault(funds);
             var consumablesFirst = MakeService(consumablesFirstState, consumablesFirstVault);
-            consumablesFirst.PurchaseConsumables = true;
             consumablesFirst.ConsumableSelected[0] = true;
             consumablesFirst.ConsumablesFirst = true;
 
@@ -353,7 +347,6 @@ namespace PitHero.Tests
             Assert.IsFalse(svc.Enabled, "Auto-purchase is off by default");
             Assert.IsFalse(svc.ConsumablesFirst, "Gear outranks consumables by default");
             Assert.IsFalse(svc.PurchaseMercenaryGear, "Mercenary gear is opt-in");
-            Assert.IsFalse(svc.PurchaseConsumables, "Consumable buying is opt-in");
 
             for (int i = 0; i < svc.BuyRarityAllowed.Length; i++)
                 Assert.IsTrue(svc.BuyRarityAllowed[i], $"Rarity {i} should be buyable by default");

--- a/PitHero.Tests/AutoSellExcessItemsTests.cs
+++ b/PitHero.Tests/AutoSellExcessItemsTests.cs
@@ -224,6 +224,106 @@ namespace PitHero.Tests
             Assert.AreEqual(0, selection.BagIndex);
         }
 
+        // ── Consumable sell options (selection + min-stacks floor) ────────────────
+
+        [TestMethod]
+        public void Selector_UnselectedConsumable_NeverSells_FallsThroughToGear()
+        {
+            var bag = new ItemBag("Test", 2);
+            bag.SetSlotItem(0, new TestPotion("Potion", 20, 30));
+            bag.SetSlotItem(1, MakeGear("JunkShield", ItemKind.Shield, 1));
+
+            var selection = ExcessItemSellSelector.Select(bag, MakeGear("New", ItemKind.WeaponSword, 10), null, null,
+                consumableSellAllowed: c => false);
+
+            Assert.AreEqual(1, selection.BagIndex, "With every consumable deselected the weakest gear sells instead");
+        }
+
+        [TestMethod]
+        public void Selector_UnselectedIncomingConsumable_SellsGearToMakeRoom()
+        {
+            var bag = new ItemBag("Test", 1);
+            bag.SetSlotItem(0, MakeGear("Shield", ItemKind.Shield, 5));
+
+            var selection = ExcessItemSellSelector.Select(bag, new TestPotion("Potion", 20, 30), null, null,
+                consumableSellAllowed: c => false);
+
+            Assert.IsFalse(selection.SellIncoming, "A never-sell incoming consumable must be kept");
+            Assert.AreEqual(0, selection.BagIndex, "Gear sells to make room for it");
+        }
+
+        [TestMethod]
+        public void Selector_MinStacksFloor_BlocksSellingTheLastStack()
+        {
+            var bag = new ItemBag("Test", 2);
+            bag.SetSlotItem(0, new TestPotion("Potion", 20, 30));
+            bag.SetSlotItem(1, MakeGear("JunkShield", ItemKind.Shield, 1));
+
+            var selection = ExcessItemSellSelector.Select(bag, MakeGear("New", ItemKind.WeaponSword, 10), null, null,
+                consumableKeepStacks: c => 1);
+
+            Assert.AreEqual(1, selection.BagIndex, "Selling the only Potion stack would drop below the floor of 1");
+        }
+
+        [TestMethod]
+        public void Selector_MinStacksFloor_AllowsSellingExcessStacks()
+        {
+            var bag = new ItemBag("Test", 3);
+            var partial = new TestPotion("Potion", 20, 30);
+            var full = new TestPotion("Potion", 20, 30);
+            full.StackCount = full.StackSize;
+            bag.SetSlotItem(0, full);
+            bag.SetSlotItem(1, partial);
+            bag.SetSlotItem(2, MakeGear("JunkShield", ItemKind.Shield, 1));
+
+            var selection = ExcessItemSellSelector.Select(bag, MakeGear("New", ItemKind.WeaponSword, 10), null, null,
+                consumableKeepStacks: c => 1);
+
+            Assert.AreEqual(1, selection.BagIndex, "Two stacks minus one sale still meets the floor; the smaller stack sells");
+        }
+
+        [TestMethod]
+        public void Selector_MinStacksFloor_IncomingSellableWhenBagMeetsFloor()
+        {
+            // One Potion stack in the bag satisfies a floor of 1 on its own, so the incoming
+            // duplicate may sell (N >= floor); the bag stack may not (N-1 < floor).
+            var bag = new ItemBag("Test", 1);
+            var carried = new TestPotion("Potion", 20, 30);
+            carried.StackCount = carried.StackSize;
+            bag.SetSlotItem(0, carried);
+
+            var selection = ExcessItemSellSelector.Select(bag, new TestPotion("Potion", 20, 30), null, null,
+                consumableKeepStacks: c => 1);
+
+            Assert.IsTrue(selection.SellIncoming);
+        }
+
+        [TestMethod]
+        public void Selector_ZeroFloor_ReproducesUnflooredBehavior()
+        {
+            var bag = new ItemBag("Test", 2);
+            bag.SetSlotItem(0, new TestPotion("Potion", 20, 30));
+            bag.SetSlotItem(1, MakeGear("JunkShield", ItemKind.Shield, 1));
+
+            var selection = ExcessItemSellSelector.Select(bag, MakeGear("New", ItemKind.WeaponSword, 10), null, null,
+                consumableSellAllowed: c => true, consumableKeepStacks: c => 0);
+
+            Assert.AreEqual(0, selection.BagIndex, "Floor 0 lets the last consumable stack sell, as before");
+        }
+
+        [TestMethod]
+        public void Selector_AllConsumablesBlockedAndGearFiltered_ReturnsNone()
+        {
+            var bag = new ItemBag("Test", 2);
+            bag.SetSlotItem(0, new TestPotion("Potion", 20, 30));
+            bag.SetSlotItem(1, MakeGear("Legendary", ItemKind.WeaponSword, 50, ItemRarity.Legendary));
+
+            var selection = ExcessItemSellSelector.Select(bag, MakeGear("New", ItemKind.WeaponSword, 10, ItemRarity.Legendary),
+                null, r => r != ItemRarity.Legendary, consumableSellAllowed: c => false);
+
+            Assert.IsFalse(selection.HasSelection);
+        }
+
         // ── ItemBag full-bag stacking fix ─────────────────────────────────────────
 
         [TestMethod]
@@ -264,6 +364,11 @@ namespace PitHero.Tests
             Assert.IsTrue(svc.ConsumablesFirst, "Sell priority should default to consumables-first");
             for (int i = 0; i < svc.RarityAllowed.Length; i++)
                 Assert.IsTrue(svc.RarityAllowed[i], $"Rarity {i} should be allowed by default");
+            for (int i = 0; i < svc.ConsumableSellAllowed.Length; i++)
+            {
+                Assert.IsTrue(svc.ConsumableSellAllowed[i], $"Consumable {i} should be sellable by default");
+                Assert.AreEqual(1, svc.ConsumableMinStacks[i], $"Consumable {i} should keep one stack by default");
+            }
         }
 
         [TestMethod]
@@ -333,6 +438,95 @@ namespace PitHero.Tests
 
             Assert.AreEqual(AutoSellOutcome.SoldIncoming, outcome);
             Assert.IsNotNull(bag.GetSlotItem(0), "The bag item must be untouched when the incoming item sells");
+        }
+
+        [TestMethod]
+        public void Service_DefaultFloor_ProtectsLastCatalogConsumableStack()
+        {
+            var svc = new AutoSellExcessItemsService();
+            var bag = new ItemBag("Test", 2);
+            bag.SetSlotItem(0, ConsumableCatalog.CreateFresh(0));   // the party's only HP Potion stack
+            bag.SetSlotItem(1, MakeGear("JunkShield", ItemKind.Shield, 2));
+
+            var outcome = svc.TryMakeRoom(bag, MakeGear("NewArmor", ItemKind.ArmorMail, 20));
+
+            Assert.AreEqual(AutoSellOutcome.SoldBagItem, outcome);
+            Assert.IsNotNull(bag.GetSlotItem(0), "The last potion stack is floored at 1 and must survive");
+            Assert.IsNull(bag.GetSlotItem(1), "The weakest gear sells instead");
+        }
+
+        [TestMethod]
+        public void Service_DefaultFloor_SellsExcessCatalogConsumableStack()
+        {
+            var svc = new AutoSellExcessItemsService();
+            var bag = new ItemBag("Test", 3);
+            var full = ConsumableCatalog.CreateFresh(0);
+            full.StackCount = full.StackSize;
+            bag.SetSlotItem(0, full);
+            bag.SetSlotItem(1, ConsumableCatalog.CreateFresh(0));   // second, partial stack — above the floor
+            bag.SetSlotItem(2, MakeGear("GoodSword", ItemKind.WeaponSword, 30));
+
+            var outcome = svc.TryMakeRoom(bag, MakeGear("NewArmor", ItemKind.ArmorMail, 20));
+
+            Assert.AreEqual(AutoSellOutcome.SoldBagItem, outcome);
+            Assert.IsNull(bag.GetSlotItem(1), "With two stacks the smaller one may sell");
+            Assert.IsNotNull(bag.GetSlotItem(0), "One stack must remain");
+        }
+
+        [TestMethod]
+        public void Service_UnselectedCatalogConsumable_NeverSold()
+        {
+            var svc = new AutoSellExcessItemsService();
+            svc.ConsumableSellAllowed[0] = false;
+            svc.ConsumableMinStacks[0] = 0;                          // even with no floor…
+            var bag = new ItemBag("Test", 2);
+            bag.SetSlotItem(0, ConsumableCatalog.CreateFresh(0));
+            bag.SetSlotItem(1, MakeGear("JunkShield", ItemKind.Shield, 2));
+
+            var outcome = svc.TryMakeRoom(bag, MakeGear("NewArmor", ItemKind.ArmorMail, 20));
+
+            Assert.AreEqual(AutoSellOutcome.SoldBagItem, outcome);
+            Assert.IsNotNull(bag.GetSlotItem(0), "…a deselected consumable is never auto-sold");
+            Assert.IsNull(bag.GetSlotItem(1));
+        }
+
+        [TestMethod]
+        public void Service_EffectiveMinStacks_RaisedToPurchaseTarget()
+        {
+            var sellSvc = new AutoSellExcessItemsService();
+            sellSvc.ConsumableMinStacks[0] = 1;
+
+            var gameState = new GameStateService();
+            var seedSvc = new AutoSeedPurchaseService(null, null, gameState, null);
+            var purchaseSvc = new AutoItemPurchaseService(gameState, new SecondChanceMerchantVault(), seedSvc) { Enabled = true };
+            purchaseSvc.ConsumableSelected[0] = true;
+            purchaseSvc.ConsumableStackTargets[0] = 3;
+
+            var potion = ConsumableCatalog.CreateFresh(0);
+            Assert.AreEqual(3, sellSvc.GetEffectiveMinStacks(potion, purchaseSvc),
+                "Selling below the purchase target would just be bought back at a loss");
+
+            purchaseSvc.Enabled = false;
+            Assert.AreEqual(1, sellSvc.GetEffectiveMinStacks(potion, purchaseSvc),
+                "A disabled purchase service cannot raise the floor");
+
+            purchaseSvc.Enabled = true;
+            purchaseSvc.ConsumableSelected[0] = false;
+            Assert.AreEqual(1, sellSvc.GetEffectiveMinStacks(potion, purchaseSvc),
+                "An unselected consumable cannot raise the floor");
+
+            Assert.AreEqual(1, sellSvc.GetEffectiveMinStacks(potion, null),
+                "No purchase service leaves the player's floor untouched");
+        }
+
+        [TestMethod]
+        public void Service_NonCatalogConsumable_SellableWithNoFloor()
+        {
+            var svc = new AutoSellExcessItemsService();
+            var potion = new TestPotion("Potion", 20, 30);
+
+            Assert.IsTrue(svc.IsConsumableSellAllowed(potion));
+            Assert.AreEqual(0, svc.GetEffectiveMinStacks(potion, null));
         }
 
         // ── Virtual layer (VirtualBattleRunner.CollectChestItem) ──────────────────

--- a/PitHero.Tests/SaveLoadTests.cs
+++ b/PitHero.Tests/SaveLoadTests.cs
@@ -1063,7 +1063,7 @@ namespace PitHero.Tests
             Assert.IsFalse(fresh.AutoPurchaseItems, "Auto-purchase defaults to off");
             Assert.IsFalse(fresh.AutoPurchaseConsumablesFirst, "Purchase priority defaults to gear-first");
             Assert.IsFalse(fresh.AutoPurchaseMercenaryGear);
-            Assert.IsFalse(fresh.AutoPurchaseConsumables);
+            Assert.IsTrue(fresh.AutoPurchaseConsumables, "Legacy v23-v25 slot; v26 removed the master flag and always writes true");
             Assert.IsTrue(fresh.AutoEquipHero, "Auto-equip defaults to on");
             Assert.IsTrue(fresh.AutoEquipMercenaries, "Auto-equip defaults to on");
 
@@ -1244,6 +1244,99 @@ namespace PitHero.Tests
                 if (Directory.Exists(tempDir))
                     Directory.Delete(tempDir, true);
             }
+        }
+
+        /// <summary>Verifies the v26 consumable sell options round-trip (mixed selections and floors).</summary>
+        [TestMethod]
+        public void SaveData_V26_ConsumableSellOptions_RoundTrip()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "pithero_v26_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var dataStore = new FileDataStore(tempDir);
+
+                int count = RolePlayingFramework.Equipment.ConsumableCatalog.Count;
+                var original = new SaveData();
+                original.AutoSellConsumableSelected = new bool[count];
+                original.AutoSellConsumableMinStacks = new int[count];
+                for (int i = 0; i < count; i++)
+                {
+                    original.AutoSellConsumableSelected[i] = i % 2 == 0;
+                    original.AutoSellConsumableMinStacks[i] = i % 4;
+                }
+
+                dataStore.Save("v26_sellopts.bin", original);
+
+                var loaded = new SaveData();
+                dataStore.Load("v26_sellopts.bin", loaded);
+
+                for (int i = 0; i < count; i++)
+                {
+                    Assert.AreEqual(i % 2 == 0, loaded.AutoSellConsumableSelected[i], $"Selection {i} should round-trip");
+                    Assert.AreEqual(i % 4, loaded.AutoSellConsumableMinStacks[i], $"Min stacks {i} should round-trip");
+                }
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
+            }
+        }
+
+        /// <summary>
+        /// Verifies the v26 consumable sell defaults: everything sellable with a floor of one stack,
+        /// both after Recover normalizes a default save and on the wire.
+        /// </summary>
+        [TestMethod]
+        public void SaveData_V26_ConsumableSellOptions_Defaults()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "pithero_v26d_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var dataStore = new FileDataStore(tempDir);
+                dataStore.Save("v26_defaults.bin", new SaveData());
+
+                var loaded = new SaveData();
+                dataStore.Load("v26_defaults.bin", loaded);
+
+                Assert.AreEqual(RolePlayingFramework.Equipment.ConsumableCatalog.Count, loaded.AutoSellConsumableSelected.Length);
+                for (int i = 0; i < loaded.AutoSellConsumableSelected.Length; i++)
+                {
+                    Assert.IsTrue(loaded.AutoSellConsumableSelected[i], $"Consumable {i} should be sellable by default");
+                    Assert.AreEqual(1, loaded.AutoSellConsumableMinStacks[i], $"Consumable {i} should keep one stack by default");
+                }
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
+            }
+        }
+
+        /// <summary>
+        /// v23–v25 gated consumable auto-purchasing behind a master flag v26 removed. Loading an old
+        /// file with the flag off must clear the selections so behavior is preserved; v26+ files and
+        /// flag-on files must keep them.
+        /// </summary>
+        [TestMethod]
+        public void SaveData_LegacyPurchaseConsumablesMigration()
+        {
+            var selected = new bool[] { true, false, true };
+
+            SaveData.ApplyLegacyPurchaseConsumablesMigration(25, purchaseConsumables: false, selected);
+            CollectionAssert.AreEqual(new bool[3], selected, "Pre-v26 with the flag off clears every selection");
+
+            selected = new bool[] { true, false, true };
+            SaveData.ApplyLegacyPurchaseConsumablesMigration(25, purchaseConsumables: true, selected);
+            CollectionAssert.AreEqual(new[] { true, false, true }, selected, "Pre-v26 with the flag on keeps selections");
+
+            selected = new bool[] { true, false, true };
+            SaveData.ApplyLegacyPurchaseConsumablesMigration(26, purchaseConsumables: false, selected);
+            CollectionAssert.AreEqual(new[] { true, false, true }, selected, "v26+ files never migrate — the flag is a dead slot");
         }
     }
 }

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -374,6 +374,12 @@ ButtonGearSellOptions,Gear Sell Options
 WindowGearSellOptions,Gear Sell Options
 SettingsSellGearTypes,Gear Types to Sell
 SettingsSellGearTypesTooltip,Gear of unchecked types will never be auto-sold
+ButtonConsumableSellOptions,Consumable Sell Options
+WindowConsumableSellOptions,Consumable Sell Options
+LabelConsumablesAutoSold,Selected items are auto-sold
+LabelConsumablesAutoPurchased,Selected items are auto-purchased
+SettingsConsumableMinStacks,Min Stacks: {0}
+SettingsConsumableMinStacksTooltip,Minimum stacks to keep in inventory; never auto-sold below this
 GearTypeWeapon,Weapon
 GearTypeHelm,Helm
 GearTypeShield,Shield
@@ -391,8 +397,6 @@ SettingsBuyRarities,Gear Rarities to Buy
 SettingsBuyRaritiesTooltip,Gear of unchecked rarities will never be auto-purchased
 SettingsBuyGearTypes,Gear Types to Buy
 SettingsBuyGearTypesTooltip,Gear of unchecked types will never be auto-purchased
-SettingsAutoPurchaseConsumables,Auto-Purchase Consumables
-SettingsAutoPurchaseConsumablesTooltip,Also buy the selected consumables before entering pit
 ButtonConsumablePurchaseOptions,Consumable Purchase Options
 WindowConsumablePurchaseOptions,Consumable Purchase Options
 SettingsConsumableStacks,Stacks: {0}

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -588,6 +588,22 @@ namespace PitHero.ECS.Scenes
                     for (int i = 0; i < count; i++)
                         autoSellExcessSvc.GearTypeAllowed[i] = pendingData.AutoSellGearTypeAllowed[i];
                 }
+                if (pendingData.AutoSellConsumableSelected != null)
+                {
+                    int count = pendingData.AutoSellConsumableSelected.Length < autoSellExcessSvc.ConsumableSellAllowed.Length
+                        ? pendingData.AutoSellConsumableSelected.Length
+                        : autoSellExcessSvc.ConsumableSellAllowed.Length;
+                    for (int i = 0; i < count; i++)
+                        autoSellExcessSvc.ConsumableSellAllowed[i] = pendingData.AutoSellConsumableSelected[i];
+                }
+                if (pendingData.AutoSellConsumableMinStacks != null)
+                {
+                    int count = pendingData.AutoSellConsumableMinStacks.Length < autoSellExcessSvc.ConsumableMinStacks.Length
+                        ? pendingData.AutoSellConsumableMinStacks.Length
+                        : autoSellExcessSvc.ConsumableMinStacks.Length;
+                    for (int i = 0; i < count; i++)
+                        autoSellExcessSvc.ConsumableMinStacks[i] = pendingData.AutoSellConsumableMinStacks[i];
+                }
             }
             var autoItemPurchaseSvc = Core.Services.GetService<Services.AutoItemPurchaseService>();
             if (autoItemPurchaseSvc != null)
@@ -595,7 +611,6 @@ namespace PitHero.ECS.Scenes
                 autoItemPurchaseSvc.Enabled = pendingData.AutoPurchaseItems;
                 autoItemPurchaseSvc.ConsumablesFirst = pendingData.AutoPurchaseConsumablesFirst;
                 autoItemPurchaseSvc.PurchaseMercenaryGear = pendingData.AutoPurchaseMercenaryGear;
-                autoItemPurchaseSvc.PurchaseConsumables = pendingData.AutoPurchaseConsumables;
                 if (pendingData.AutoPurchaseRarityAllowed != null)
                 {
                     int count = pendingData.AutoPurchaseRarityAllowed.Length < autoItemPurchaseSvc.BuyRarityAllowed.Length

--- a/PitHero/RolePlayingFramework/Equipment/ExcessItemSellSelector.cs
+++ b/PitHero/RolePlayingFramework/Equipment/ExcessItemSellSelector.cs
@@ -24,6 +24,8 @@ namespace RolePlayingFramework.Equipment
     /// considered when the first category has no sellable candidate. Among gear, weakness is compared across
     /// ALL gear types at once so a lone strong item of one type never sells before a weak item of another.
     /// The incoming item participates in the comparison so junk loot never displaces better items.
+    /// Consumables can additionally be excluded outright or protected by a minimum-stacks floor
+    /// (the "Consumable Sell Options" dialog) so auto-sell never drains the party's potions to zero.
     /// </summary>
     public static class ExcessItemSellSelector
     {
@@ -32,43 +34,82 @@ namespace RolePlayingFramework.Equipment
 
         /// <summary>
         /// Selects the item to sell to free a bag slot for <paramref name="incoming"/>.
-        /// Consumable pass: weakest-effect unprotected consumable stack (HP+MP restore, then sell price, then stack count).
+        /// Consumable pass: weakest-effect unprotected consumable stack (HP+MP restore, then sell price, then stack count),
+        /// filtered by <paramref name="consumableSellAllowed"/> and <paramref name="consumableKeepStacks"/>
+        /// (minimum stacks of that consumable that must remain in the bag; null means "no floor").
         /// Gear pass: weakest unprotected gear across all types by gear score (then rarity, then sell price),
         /// filtered by <paramref name="rarityAllowed"/> and <paramref name="gearTypeAllowed"/> (gear only;
         /// null means "allow everything"). <paramref name="consumablesFirst"/> picks
         /// which pass runs first; the other pass only runs when the first finds no candidate.
         /// Bag items win ties against the incoming item.
         /// </summary>
-        public static SellSelection Select(ItemBag bag, IItem incoming, Func<int, bool> isProtectedBagIndex, Func<ItemRarity, bool> rarityAllowed, bool consumablesFirst = true, Func<ItemKind, bool> gearTypeAllowed = null)
+        public static SellSelection Select(ItemBag bag, IItem incoming, Func<int, bool> isProtectedBagIndex, Func<ItemRarity, bool> rarityAllowed, bool consumablesFirst = true, Func<ItemKind, bool> gearTypeAllowed = null, Func<Consumable, bool> consumableSellAllowed = null, Func<Consumable, int> consumableKeepStacks = null)
         {
             if (bag == null)
                 return SellSelection.None;
 
             var first = consumablesFirst
-                ? SelectConsumable(bag, incoming, isProtectedBagIndex)
+                ? SelectConsumable(bag, incoming, isProtectedBagIndex, consumableSellAllowed, consumableKeepStacks)
                 : SelectGear(bag, incoming, isProtectedBagIndex, rarityAllowed, gearTypeAllowed);
             if (first.HasSelection)
                 return first;
 
             return consumablesFirst
                 ? SelectGear(bag, incoming, isProtectedBagIndex, rarityAllowed, gearTypeAllowed)
-                : SelectConsumable(bag, incoming, isProtectedBagIndex);
+                : SelectConsumable(bag, incoming, isProtectedBagIndex, consumableSellAllowed, consumableKeepStacks);
         }
 
         /// <summary>Picks the weakest-effect unprotected consumable stack, or none.</summary>
-        private static SellSelection SelectConsumable(ItemBag bag, IItem incoming, Func<int, bool> isProtectedBagIndex)
+        private static SellSelection SelectConsumable(ItemBag bag, IItem incoming, Func<int, bool> isProtectedBagIndex, Func<Consumable, bool> sellAllowed, Func<Consumable, int> keepStacks)
         {
             int bestIndex = -1;
             long bestKeyA = 0, bestKeyB = 0, bestKeyC = 0;
             for (int i = 0; i < bag.Capacity; i++)
             {
-                if (bag.GetSlotItem(i) is Consumable c && !IsProtected(isProtectedBagIndex, i))
+                if (bag.GetSlotItem(i) is Consumable c && !IsProtected(isProtectedBagIndex, i) &&
+                    ConsumableOk(bag, c, sellAllowed, keepStacks, inBag: true))
                     ConsiderConsumable(c, i, ref bestIndex, ref bestKeyA, ref bestKeyB, ref bestKeyC);
             }
-            if (incoming is Consumable incomingConsumable)
+            if (incoming is Consumable incomingConsumable &&
+                ConsumableOk(bag, incomingConsumable, sellAllowed, keepStacks, inBag: false))
                 ConsiderConsumable(incomingConsumable, IncomingIndex, ref bestIndex, ref bestKeyA, ref bestKeyB, ref bestKeyC);
 
             return ToSelection(bestIndex);
+        }
+
+        /// <summary>
+        /// True when the consumable may be sold: it is allowed, and after the sale the bag still holds
+        /// at least the required stack count. A bag stack removes itself from the count; the incoming
+        /// item was never in the bag, so the existing stacks must already satisfy the floor.
+        /// </summary>
+        private static bool ConsumableOk(ItemBag bag, Consumable c, Func<Consumable, bool> sellAllowed, Func<Consumable, int> keepStacks, bool inBag)
+        {
+            if (sellAllowed != null && !sellAllowed(c))
+                return false;
+            if (keepStacks == null)
+                return true;
+
+            int floor = keepStacks(c);
+            if (floor <= 0)
+                return true;
+
+            int remaining = CountStacks(bag, c.Name) - (inBag ? 1 : 0);
+            return remaining >= floor;
+        }
+
+        /// <summary>
+        /// Number of bag slots holding the given consumable (a partial stack still counts as one).
+        /// Matches by name — the same identity bag stacking uses — not by sprite.
+        /// </summary>
+        private static int CountStacks(ItemBag bag, string name)
+        {
+            int count = 0;
+            for (int i = 0; i < bag.Capacity; i++)
+            {
+                if (bag.GetSlotItem(i) is Consumable c && c.Name == name)
+                    count++;
+            }
+            return count;
         }
 
         /// <summary>Picks the weakest unprotected gear across all gear types (rarity- and type-filtered), or none.</summary>

--- a/PitHero/Services/AutoItemPurchaseService.cs
+++ b/PitHero/Services/AutoItemPurchaseService.cs
@@ -52,9 +52,6 @@ namespace PitHero.Services
         /// <summary>Whether gear is also bought for hired mercenaries. Off by default.</summary>
         public bool PurchaseMercenaryGear { get; set; } = false;
 
-        /// <summary>Whether the selected consumables are bought. Off by default.</summary>
-        public bool PurchaseConsumables { get; set; } = false;
-
         /// <summary>Whether gear of each rarity may be auto-purchased, indexed by ItemRarity. All true by default.</summary>
         public bool[] BuyRarityAllowed { get; } = new bool[5];
 
@@ -315,9 +312,6 @@ namespace PitHero.Services
         /// <summary>Tops each selected consumable up to its stack target, buying whole stacks from the vault.</summary>
         private int BuyConsumables(ItemBag bag, List<IItem> purchasedOut)
         {
-            if (!PurchaseConsumables)
-                return 0;
-
             int bought = 0;
             for (int i = 0; i < ConsumableCatalog.Count; i++)
             {

--- a/PitHero/Services/AutoSellExcessItemsService.cs
+++ b/PitHero/Services/AutoSellExcessItemsService.cs
@@ -22,8 +22,11 @@ namespace PitHero.Services
     /// Call-driven (no update loop): OpenChestAction invokes TryMakeRoom before adding the item.
     /// Items in an active synergy or under a placed stencil are never sold; gear rarities and gear
     /// categories can be excluded via RarityAllowed / GearTypeAllowed (both edited from the
-    /// "Gear Sell Options" dialog). ConsumablesFirst picks whether the weakest consumable or the
-    /// weakest gear (compared across all gear types at once) sells first.
+    /// "Gear Sell Options" dialog). Consumables can be excluded or floored per catalog entry via
+    /// ConsumableSellAllowed / ConsumableMinStacks (the "Consumable Sell Options" dialog); the floor
+    /// is raised to the auto-purchase stack target so auto-sell never undoes what auto-purchase just
+    /// bought. ConsumablesFirst picks whether the weakest consumable or the weakest gear (compared
+    /// across all gear types at once) sells first.
     /// </summary>
     public class AutoSellExcessItemsService
     {
@@ -41,12 +44,26 @@ namespace PitHero.Services
         /// <summary>Whether gear of each category may be auto-sold, indexed by GearCategory. All true by default.</summary>
         public bool[] GearTypeAllowed { get; } = new bool[GearCategoryUtils.Count];
 
+        /// <summary>Whether each catalog consumable may be auto-sold, indexed by ConsumableCatalog index. All true by default.</summary>
+        public bool[] ConsumableSellAllowed { get; } = new bool[ConsumableCatalog.Count];
+
+        /// <summary>Minimum stacks of each catalog consumable to keep in the bag, indexed by ConsumableCatalog index. 1 by default.</summary>
+        public int[] ConsumableMinStacks { get; } = new int[ConsumableCatalog.Count];
+
+        /// <summary>Lowest and highest minimum-stacks value the options slider offers (0 = may sell every stack).</summary>
+        public const int MinKeepStacks = 0;
+        public const int MaxKeepStacks = 3;
+
         public AutoSellExcessItemsService()
         {
             for (int i = 0; i < RarityAllowed.Length; i++)
                 RarityAllowed[i] = true;
             for (int i = 0; i < GearTypeAllowed.Length; i++)
                 GearTypeAllowed[i] = true;
+            for (int i = 0; i < ConsumableSellAllowed.Length; i++)
+                ConsumableSellAllowed[i] = true;
+            for (int i = 0; i < ConsumableMinStacks.Length; i++)
+                ConsumableMinStacks[i] = 1;
         }
 
         /// <summary>True when gear of the given rarity may be auto-sold. Consumables are never rarity-filtered.</summary>
@@ -60,6 +77,31 @@ namespace PitHero.Services
         public bool IsGearTypeAllowed(ItemKind kind)
         {
             return GearCategoryUtils.IsAllowed(GearTypeAllowed, kind);
+        }
+
+        /// <summary>True when the given consumable may be auto-sold. Unknown (non-catalog) consumables are sellable.</summary>
+        public bool IsConsumableSellAllowed(Consumable consumable)
+        {
+            int i = ConsumableCatalog.IndexOfSpriteName(consumable?.SpriteName);
+            return i < 0 || ConsumableSellAllowed[i];
+        }
+
+        /// <summary>
+        /// Minimum stacks of the given consumable that must remain in the bag after an auto-sale.
+        /// The player's floor is raised to the auto-purchase stack target when that service would just
+        /// buy the stacks back — selling below the target burns gold on the round trip for nothing.
+        /// </summary>
+        public int GetEffectiveMinStacks(Consumable consumable, AutoItemPurchaseService purchaseSvc)
+        {
+            int i = ConsumableCatalog.IndexOfSpriteName(consumable?.SpriteName);
+            if (i < 0)
+                return 0;
+
+            int floor = ConsumableMinStacks[i];
+            if (purchaseSvc != null && purchaseSvc.Enabled && purchaseSvc.ConsumableSelected[i] &&
+                purchaseSvc.ConsumableStackTargets[i] > floor)
+                floor = purchaseSvc.ConsumableStackTargets[i];
+            return floor;
         }
 
         /// <summary>
@@ -80,7 +122,9 @@ namespace PitHero.Services
             grid?.UpdateItemsFromBag();
             System.Func<int, bool> isProtected = grid != null ? grid.IsBagIndexProtected : (System.Func<int, bool>)null;
 
-            var selection = ExcessItemSellSelector.Select(bag, incoming, isProtected, IsRarityAllowed, ConsumablesFirst, IsGearTypeAllowed);
+            var purchaseSvc = Core.Instance != null ? Core.Services?.GetService<AutoItemPurchaseService>() : null;
+            var selection = ExcessItemSellSelector.Select(bag, incoming, isProtected, IsRarityAllowed, ConsumablesFirst, IsGearTypeAllowed,
+                IsConsumableSellAllowed, c => GetEffectiveMinStacks(c, purchaseSvc));
             if (!selection.HasSelection)
                 return AutoSellOutcome.None;
 

--- a/PitHero/Services/SaveData.cs
+++ b/PitHero/Services/SaveData.cs
@@ -255,15 +255,15 @@ namespace PitHero.Services
     public class SaveData : IPersistable
     {
         /// <summary>Current save file version.</summary>
-        public const int CurrentVersion = 25;
+        public const int CurrentVersion = 26;
 
         /// <summary>
-        /// Oldest save file version this build can still load. v17–v24 files are byte-exact
-        /// prefixes of v25 (sections 33 dining, 34 automation, 35 auto-dine resume,
+        /// Oldest save file version this build can still load. v17–v25 files are byte-exact
+        /// prefixes of v26 (sections 33 dining, 34 automation, 35 auto-dine resume,
         /// 36 auto-sell excess items, 37 auto-sell priority, 38 gear sell types,
-        /// 39 auto-purchase items, 40 auto-equip, 41 auto-hire mercenaries, and
-        /// 42 auto-learn hero skills were appended at the end), so they load with default
-        /// state for the missing sections.
+        /// 39 auto-purchase items, 40 auto-equip, 41 auto-hire mercenaries,
+        /// 42 auto-learn hero skills, and 43 consumable sell options were appended at
+        /// the end), so they load with default state for the missing sections.
         /// </summary>
         public const int MinSupportedVersion = 17;
 
@@ -536,8 +536,13 @@ namespace PitHero.Services
         /// <summary>Whether gear is also auto-purchased for hired mercenaries.</summary>
         public bool AutoPurchaseMercenaryGear = false;
 
-        /// <summary>Whether the selected consumables are auto-purchased.</summary>
-        public bool AutoPurchaseConsumables = false;
+        /// <summary>
+        /// Legacy (v23–v25): whether the selected consumables were auto-purchased. The master flag
+        /// was removed in v26 — selection alone decides — but the slot stays in section 39 to keep
+        /// old files byte-exact prefixes; v26+ always writes true. On pre-v26 loads a false value
+        /// clears AutoPurchaseConsumableSelected so old behavior is preserved.
+        /// </summary>
+        public bool AutoPurchaseConsumables = true;
 
         /// <summary>Which gear rarities may be auto-purchased, indexed by ItemRarity. Null until Recover normalizes it.</summary>
         public bool[] AutoPurchaseRarityAllowed;
@@ -574,6 +579,13 @@ namespace PitHero.Services
 
         /// <summary>Raw AutoLearnMode value: 0=Smart, 1=Active, 2=Passive.</summary>
         public int AutoLearnMode = 0;
+
+        // Consumable sell options (v26)
+        /// <summary>Which catalog consumables may be auto-sold, indexed by ConsumableCatalog index. Null until Recover normalizes it.</summary>
+        public bool[] AutoSellConsumableSelected;
+
+        /// <summary>Minimum stacks to keep per catalog consumable, indexed by ConsumableCatalog index. Null until Recover normalizes it.</summary>
+        public int[] AutoSellConsumableMinStacks;
 
         /// <summary>Initializes a new SaveData with default empty collections.</summary>
         public SaveData()
@@ -1001,7 +1013,7 @@ namespace PitHero.Services
             writer.Write(AutoPurchaseItems);
             writer.Write(AutoPurchaseConsumablesFirst);
             writer.Write(AutoPurchaseMercenaryGear);
-            writer.Write(AutoPurchaseConsumables);
+            writer.Write(true); // legacy AutoPurchaseConsumables slot — master flag removed in v26
 
             int buyRarityCount = AutoPurchaseRarityAllowed != null ? AutoPurchaseRarityAllowed.Length : 0;
             writer.Write(buyRarityCount);
@@ -1035,6 +1047,17 @@ namespace PitHero.Services
             // 42. Auto-learn hero skills (v25)
             writer.Write(AutoLearnSkillsEnabled);
             writer.Write(AutoLearnMode);
+
+            // 43. Consumable sell options (v26)
+            int sellConsumableCount = AutoSellConsumableSelected != null ? AutoSellConsumableSelected.Length : 0;
+            writer.Write(sellConsumableCount);
+            for (int i = 0; i < sellConsumableCount; i++)
+            {
+                writer.Write(AutoSellConsumableSelected[i]);
+                writer.Write(AutoSellConsumableMinStacks != null && i < AutoSellConsumableMinStacks.Length
+                    ? AutoSellConsumableMinStacks[i]
+                    : 1);
+            }
         }
 
         /// <summary>Reads all game state from the persistence reader.</summary>
@@ -1491,7 +1514,7 @@ namespace PitHero.Services
             AutoPurchaseItems = false;
             AutoPurchaseConsumablesFirst = false;
             AutoPurchaseMercenaryGear = false;
-            AutoPurchaseConsumables = false;
+            AutoPurchaseConsumables = true;
             AutoPurchaseRarityAllowed = new bool[5];
             for (int i = 0; i < AutoPurchaseRarityAllowed.Length; i++)
                 AutoPurchaseRarityAllowed[i] = true;
@@ -1536,6 +1559,8 @@ namespace PitHero.Services
                         AutoPurchaseConsumableStacks[i] = stacks;
                     }
                 }
+
+                ApplyLegacyPurchaseConsumablesMigration(fileVersion, AutoPurchaseConsumables, AutoPurchaseConsumableSelected);
             }
 
             // 40. Auto-equip (v23+). Older files default to both on, matching the runtime defaults.
@@ -1566,6 +1591,42 @@ namespace PitHero.Services
                 AutoLearnSkillsEnabled = reader.ReadBool();
                 AutoLearnMode = reader.ReadInt();
             }
+
+            // 43. Consumable sell options (v26+). Older files default to everything sellable, keep 1 stack.
+            AutoSellConsumableSelected = new bool[RolePlayingFramework.Equipment.ConsumableCatalog.Count];
+            AutoSellConsumableMinStacks = new int[RolePlayingFramework.Equipment.ConsumableCatalog.Count];
+            for (int i = 0; i < AutoSellConsumableSelected.Length; i++)
+            {
+                AutoSellConsumableSelected[i] = true;
+                AutoSellConsumableMinStacks[i] = 1;
+            }
+            if (fileVersion >= 26)
+            {
+                int sellConsumableCount = reader.ReadInt();
+                for (int i = 0; i < sellConsumableCount; i++)
+                {
+                    bool selected = reader.ReadBool();
+                    int minStacks = reader.ReadInt();
+                    if (i < AutoSellConsumableSelected.Length)
+                    {
+                        AutoSellConsumableSelected[i] = selected;
+                        AutoSellConsumableMinStacks[i] = minStacks;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// v23–v25 gated consumable auto-purchasing behind a master flag that v26 removed. A pre-v26
+        /// file with the flag off must come back with no consumables selected, otherwise selections
+        /// the player made while the flag was off would silently start purchasing.
+        /// </summary>
+        public static void ApplyLegacyPurchaseConsumablesMigration(int fileVersion, bool purchaseConsumables, bool[] consumableSelected)
+        {
+            if (fileVersion >= 26 || purchaseConsumables || consumableSelected == null)
+                return;
+            for (int i = 0; i < consumableSelected.Length; i++)
+                consumableSelected[i] = false;
         }
 
         /// <summary>Writes a Color as four individual int components (R, G, B, A).</summary>

--- a/PitHero/Services/SaveLoadService.cs
+++ b/PitHero/Services/SaveLoadService.cs
@@ -819,6 +819,15 @@ namespace PitHero.Services
                 data.AutoSellGearTypeAllowed = new bool[autoSellExcessService.GearTypeAllowed.Length];
                 for (int i = 0; i < data.AutoSellGearTypeAllowed.Length; i++)
                     data.AutoSellGearTypeAllowed[i] = autoSellExcessService.GearTypeAllowed[i];
+
+                // Consumable sell options (v26+)
+                data.AutoSellConsumableSelected = new bool[autoSellExcessService.ConsumableSellAllowed.Length];
+                data.AutoSellConsumableMinStacks = new int[autoSellExcessService.ConsumableMinStacks.Length];
+                for (int i = 0; i < data.AutoSellConsumableSelected.Length; i++)
+                {
+                    data.AutoSellConsumableSelected[i] = autoSellExcessService.ConsumableSellAllowed[i];
+                    data.AutoSellConsumableMinStacks[i] = autoSellExcessService.ConsumableMinStacks[i];
+                }
             }
 
             // Auto-purchase items (v23+)
@@ -828,7 +837,6 @@ namespace PitHero.Services
                 data.AutoPurchaseItems = autoItemPurchaseService.Enabled;
                 data.AutoPurchaseConsumablesFirst = autoItemPurchaseService.ConsumablesFirst;
                 data.AutoPurchaseMercenaryGear = autoItemPurchaseService.PurchaseMercenaryGear;
-                data.AutoPurchaseConsumables = autoItemPurchaseService.PurchaseConsumables;
 
                 data.AutoPurchaseRarityAllowed = new bool[autoItemPurchaseService.BuyRarityAllowed.Length];
                 for (int i = 0; i < data.AutoPurchaseRarityAllowed.Length; i++)

--- a/PitHero/UI/ConsumableSellOptionsDialog.cs
+++ b/PitHero/UI/ConsumableSellOptionsDialog.cs
@@ -8,13 +8,14 @@ using RolePlayingFramework.Equipment;
 namespace PitHero.UI
 {
     /// <summary>
-    /// The "Consumable Purchase Options" window opened from the Automation tab (issue #345).
-    /// Shows every catalog consumable with its sprite, a selection checkbox, and a 1-3 "Stacks"
-    /// slider naming how many stacks of that item the party should hold. Changes commit immediately
-    /// to <see cref="AutoItemPurchaseService.ConsumableSelected"/> /
-    /// <see cref="AutoItemPurchaseService.ConsumableStackTargets"/>.
+    /// The "Consumable Sell Options" window opened from the Automation tab. Shows every catalog
+    /// consumable with its sprite, a selection checkbox (checked = may be auto-sold; everything is
+    /// selected by default), and a 0-3 "Min Stacks" slider naming how many stacks auto-sell must
+    /// leave in the bag. Changes commit immediately to
+    /// <see cref="AutoSellExcessItemsService.ConsumableSellAllowed"/> /
+    /// <see cref="AutoSellExcessItemsService.ConsumableMinStacks"/>.
     /// </summary>
-    public class ConsumablePurchaseOptionsDialog
+    public class ConsumableSellOptionsDialog
     {
         private const int Columns = 3;
         private const float SpriteSize = 32f;
@@ -31,7 +32,7 @@ namespace PitHero.UI
         private Window _window;
         private TextService _textService;
 
-        public ConsumablePurchaseOptionsDialog(Stage stage)
+        public ConsumableSellOptionsDialog(Stage stage)
         {
             _stage = stage;
             _itemsAtlas = Core.Content.LoadSpriteAtlas("Content/Atlases/Items.atlas");
@@ -49,14 +50,14 @@ namespace PitHero.UI
         private void CreateWindow()
         {
             var skin = PitHeroSkin.CreateSkin();
-            _window = new Window(GetText(UITextKey.WindowConsumablePurchaseOptions), skin, "ph-default");
+            _window = new Window(GetText(UITextKey.WindowConsumableSellOptions), skin, "ph-default");
             _window.SetMovable(false);
             _window.SetResizable(false);
 
             var content = new Table();
             content.Pad(WinPad);
 
-            content.Add(new Label(GetText(UITextKey.LabelConsumablesAutoPurchased), skin, "ph-default")).Left().SetPadBottom(8f);
+            content.Add(new Label(GetText(UITextKey.LabelConsumablesAutoSold), skin, "ph-default")).Left().SetPadBottom(8f);
             content.Row();
 
             var grid = new Table();
@@ -75,12 +76,12 @@ namespace PitHero.UI
                 }
 
                 var check = new CheckBox(ConsumableCatalog.GetDisplayName(i), skin, "ph-default");
-                check.IsChecked = false;
+                check.IsChecked = true;
                 check.OnChanged += (isChecked) =>
                 {
-                    var svc = Core.Services?.GetService<AutoItemPurchaseService>();
-                    if (svc != null && index < svc.ConsumableSelected.Length)
-                        svc.ConsumableSelected[index] = isChecked;
+                    var svc = Core.Services?.GetService<AutoSellExcessItemsService>();
+                    if (svc != null && index < svc.ConsumableSellAllowed.Length)
+                        svc.ConsumableSellAllowed[index] = isChecked;
                     SetStackControlsActive(index, isChecked);
                 };
                 _checks[i] = check;
@@ -90,30 +91,27 @@ namespace PitHero.UI
                 cell.Row();
 
                 var stackLabel = new HoverableLabel(
-                    string.Format(GetText(UITextKey.SettingsConsumableStacks), AutoItemPurchaseService.MinStackTarget),
-                    skin, "ph-default", GetText(UITextKey.SettingsConsumableStacksTooltip), _stage);
+                    string.Format(GetText(UITextKey.SettingsConsumableMinStacks), 1),
+                    skin, "ph-default", GetText(UITextKey.SettingsConsumableMinStacksTooltip), _stage);
                 _stackLabels[i] = stackLabel;
                 cell.Add(stackLabel).Left().SetPadTop(2f);
                 cell.Row();
 
                 var slider = new EnhancedSlider(
-                    AutoItemPurchaseService.MinStackTarget, AutoItemPurchaseService.MaxStackTarget, 1, false, skin, null, false);
-                slider.SetValueAndCommit(AutoItemPurchaseService.MinStackTarget);
+                    AutoSellExcessItemsService.MinKeepStacks, AutoSellExcessItemsService.MaxKeepStacks, 1, false, skin, null, false);
+                slider.SetValueAndCommit(1);
                 slider.OnChanged += (value) =>
                 {
-                    _stackLabels[index].SetText(string.Format(GetText(UITextKey.SettingsConsumableStacks), (int)value));
+                    _stackLabels[index].SetText(string.Format(GetText(UITextKey.SettingsConsumableMinStacks), (int)value));
                 };
                 slider.OnValueCommitted += (value) =>
                 {
-                    var svc = Core.Services?.GetService<AutoItemPurchaseService>();
-                    if (svc != null && index < svc.ConsumableStackTargets.Length)
-                        svc.ConsumableStackTargets[index] = (int)value;
+                    var svc = Core.Services?.GetService<AutoSellExcessItemsService>();
+                    if (svc != null && index < svc.ConsumableMinStacks.Length)
+                        svc.ConsumableMinStacks[index] = (int)value;
                 };
                 _stackSliders[i] = slider;
                 cell.Add(slider).Width(SliderWidth).Left();
-
-                // Nothing is selected by default, so every stack control starts deactivated
-                SetStackControlsActive(i, false);
 
                 grid.Add(cell).Left().Top().Pad(6f);
                 if ((i + 1) % Columns == 0)
@@ -170,11 +168,11 @@ namespace PitHero.UI
         /// </summary>
         private void SetAllSelected(bool selected)
         {
-            var svc = Core.Services?.GetService<AutoItemPurchaseService>();
+            var svc = Core.Services?.GetService<AutoSellExcessItemsService>();
             for (int i = 0; i < _checks.Length; i++)
             {
-                if (svc != null && i < svc.ConsumableSelected.Length)
-                    svc.ConsumableSelected[i] = selected;
+                if (svc != null && i < svc.ConsumableSellAllowed.Length)
+                    svc.ConsumableSellAllowed[i] = selected;
                 if (_checks[i] != null)
                     _checks[i].IsChecked = selected;
                 SetStackControlsActive(i, selected);
@@ -182,9 +180,9 @@ namespace PitHero.UI
         }
 
         /// <summary>
-        /// Activates or deactivates one row's "Stacks" label and slider. When deactivated they stay
-        /// on screen but are drawn grayed out with the tooltip, hover and dragging disabled — the
-        /// stack target only means anything while that consumable is selected.
+        /// Activates or deactivates one row's "Min Stacks" label and slider. When deactivated they
+        /// stay on screen but are drawn grayed out with the tooltip, hover and dragging disabled —
+        /// an unselected consumable is never auto-sold, so its floor means nothing.
         /// </summary>
         private void SetStackControlsActive(int index, bool active)
         {
@@ -208,27 +206,27 @@ namespace PitHero.UI
             }
         }
 
-        /// <summary>Copies the service's current selections and stack targets into the controls.</summary>
+        /// <summary>Copies the service's current selections and stack floors into the controls.</summary>
         public void SyncFromService()
         {
-            var svc = Core.Services?.GetService<AutoItemPurchaseService>();
+            var svc = Core.Services?.GetService<AutoSellExcessItemsService>();
             if (svc == null) return;
 
-            for (int i = 0; i < _checks.Length && i < svc.ConsumableSelected.Length; i++)
+            for (int i = 0; i < _checks.Length && i < svc.ConsumableSellAllowed.Length; i++)
             {
                 if (_checks[i] != null)
-                    _checks[i].IsChecked = svc.ConsumableSelected[i];
+                    _checks[i].IsChecked = svc.ConsumableSellAllowed[i];
             }
 
-            for (int i = 0; i < _stackSliders.Length && i < svc.ConsumableStackTargets.Length; i++)
+            for (int i = 0; i < _stackSliders.Length && i < svc.ConsumableMinStacks.Length; i++)
             {
-                int target = svc.ConsumableStackTargets[i];
-                _stackSliders[i]?.SetValueAndCommit(target);
-                _stackLabels[i]?.SetText(string.Format(GetText(UITextKey.SettingsConsumableStacks), target));
+                int floor = svc.ConsumableMinStacks[i];
+                _stackSliders[i]?.SetValueAndCommit(floor);
+                _stackLabels[i]?.SetText(string.Format(GetText(UITextKey.SettingsConsumableMinStacks), floor));
             }
 
             for (int i = 0; i < _stackSliders.Length; i++)
-                SetStackControlsActive(i, i < svc.ConsumableSelected.Length && svc.ConsumableSelected[i]);
+                SetStackControlsActive(i, i < svc.ConsumableSellAllowed.Length && svc.ConsumableSellAllowed[i]);
         }
     }
 }

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -75,6 +75,8 @@ namespace PitHero.UI
         private List<string> _sellPriorityItems;
         private TextButton _gearSellOptionsButton;
         private GearFilterOptionsDialog _gearSellOptionsDialog;
+        private TextButton _consumableSellOptionsButton;
+        private ConsumableSellOptionsDialog _consumableSellOptionsDialog;
 
         // Automation tab — auto-purchase items (issue #345)
         private HoverableCheckBox _autoPurchaseItemsCheckBox;
@@ -84,7 +86,6 @@ namespace PitHero.UI
         private HoverableCheckBox _autoPurchaseMercGearCheckBox;
         private TextButton _gearPurchaseOptionsButton;
         private GearFilterOptionsDialog _gearPurchaseOptionsDialog;
-        private HoverableCheckBox _autoPurchaseConsumablesCheckBox;
         private TextButton _consumablePurchaseOptionsButton;
         private ConsumablePurchaseOptionsDialog _consumablePurchaseOptionsDialog;
 
@@ -1002,7 +1003,10 @@ namespace PitHero.UI
                 if (svc != null) svc.Enabled = isChecked;
                 SetExcessItemControlsActive(isChecked);
                 if (!isChecked)
+                {
                     _gearSellOptionsDialog?.Hide();
+                    _consumableSellOptionsDialog?.Hide();
+                }
             };
             autoShopTable.Add(_autoSellExcessCheckBox).Left().SetPadTop(15f).SetPadBottom(8f);
             autoShopTable.Row();
@@ -1037,7 +1041,17 @@ namespace PitHero.UI
                 }
                 _gearSellOptionsDialog.Show();
             };
-            autoShopTable.Add(_gearSellOptionsButton).Left().SetMinWidth(140f).SetMinHeight(16f);
+            autoShopTable.Add(_gearSellOptionsButton).Left().SetMinWidth(140f).SetMinHeight(16f).SetPadBottom(8f);
+            autoShopTable.Row();
+
+            _consumableSellOptionsButton = new TextButton(GetText(TextType.UI, UITextKey.ButtonConsumableSellOptions), skin, "ph-default");
+            _consumableSellOptionsButton.OnClicked += (_) =>
+            {
+                if (_consumableSellOptionsDialog == null)
+                    _consumableSellOptionsDialog = new ConsumableSellOptionsDialog(_stage);
+                _consumableSellOptionsDialog.Show();
+            };
+            autoShopTable.Add(_consumableSellOptionsButton).Left().SetMinWidth(180f).SetMinHeight(16f);
             autoShopTable.Row();
             SetExcessItemControlsActive(_autoSellExcessCheckBox.IsChecked);
 
@@ -1122,23 +1136,6 @@ namespace PitHero.UI
                 _gearPurchaseOptionsDialog.Show();
             };
             autoShopTable.Add(_gearPurchaseOptionsButton).Left().SetMinWidth(140f).SetMinHeight(16f).SetPadBottom(8f);
-            autoShopTable.Row();
-
-            _autoPurchaseConsumablesCheckBox = new HoverableCheckBox(
-                GetText(TextType.UI, UITextKey.SettingsAutoPurchaseConsumables),
-                skin,
-                GetText(TextType.UI, UITextKey.SettingsAutoPurchaseConsumablesTooltip),
-                _stage);
-            _autoPurchaseConsumablesCheckBox.IsChecked = false;
-            _autoPurchaseConsumablesCheckBox.OnChanged += (isChecked) =>
-            {
-                var svc = Core.Services?.GetService<AutoItemPurchaseService>();
-                if (svc != null) svc.PurchaseConsumables = isChecked;
-                SetConsumablePurchaseControlsActive(isChecked && _autoPurchaseItemsCheckBox.IsChecked);
-                if (!isChecked)
-                    _consumablePurchaseOptionsDialog?.Hide();
-            };
-            autoShopTable.Add(_autoPurchaseConsumablesCheckBox).Left().SetPadBottom(8f);
             autoShopTable.Row();
 
             _consumablePurchaseOptionsButton = new TextButton(GetText(TextType.UI, UITextKey.ButtonConsumablePurchaseOptions), skin, "ph-default");
@@ -1452,8 +1449,8 @@ namespace PitHero.UI
 
         /// <summary>
         /// Activates or deactivates the auto-sell-excess sub-controls (sell priority list and the
-        /// "Gear Sell Options" button). When deactivated they stay on screen but are drawn grayed
-        /// out with tooltips, hover and click disabled.
+        /// "Gear Sell Options" / "Consumable Sell Options" buttons). When deactivated they stay on
+        /// screen but are drawn grayed out with tooltips, hover and click disabled.
         /// </summary>
         private void SetExcessItemControlsActive(bool active)
         {
@@ -1468,12 +1465,10 @@ namespace PitHero.UI
 
             _sellPriorityList?.SetGrayed(!active);
             SetButtonActive(_gearSellOptionsButton, active, skin);
+            SetButtonActive(_consumableSellOptionsButton, active, skin);
         }
 
-        /// <summary>
-        /// Activates or deactivates the auto-purchase sub-controls. The consumable options button
-        /// additionally needs its own checkbox on, so the two gates compose.
-        /// </summary>
+        /// <summary>Activates or deactivates the auto-purchase sub-controls.</summary>
         private void SetItemPurchaseControlsActive(bool active)
         {
             var skin = PitHeroSkin.CreateSkin();
@@ -1496,15 +1491,8 @@ namespace PitHero.UI
                 _autoPurchaseMercGearCheckBox.SetTouchable(touchable);
             }
 
-            if (_autoPurchaseConsumablesCheckBox != null)
-            {
-                _autoPurchaseConsumablesCheckBox.SetDisabled(!active);
-                _autoPurchaseConsumablesCheckBox.SetStyle(checkBoxStyle);
-                _autoPurchaseConsumablesCheckBox.SetTouchable(touchable);
-            }
-
             SetButtonActive(_gearPurchaseOptionsButton, active, skin);
-            SetConsumablePurchaseControlsActive(active && (_autoPurchaseConsumablesCheckBox?.IsChecked ?? false));
+            SetConsumablePurchaseControlsActive(active);
         }
 
         /// <summary>Activates or deactivates the "Consumable Purchase Options" button.</summary>
@@ -1586,9 +1574,13 @@ namespace PitHero.UI
                     _sellPriorityList?.Rebuild();
                 }
                 _gearSellOptionsDialog?.SyncFromService();
+                _consumableSellOptionsDialog?.SyncFromService();
                 SetExcessItemControlsActive(excessSvc.Enabled);
                 if (!excessSvc.Enabled)
+                {
                     _gearSellOptionsDialog?.Hide();
+                    _consumableSellOptionsDialog?.Hide();
+                }
             }
 
             var purchaseSvc = Core.Services?.GetService<AutoItemPurchaseService>();
@@ -1598,8 +1590,6 @@ namespace PitHero.UI
                     _autoPurchaseItemsCheckBox.IsChecked = purchaseSvc.Enabled;
                 if (_autoPurchaseMercGearCheckBox != null)
                     _autoPurchaseMercGearCheckBox.IsChecked = purchaseSvc.PurchaseMercenaryGear;
-                if (_autoPurchaseConsumablesCheckBox != null)
-                    _autoPurchaseConsumablesCheckBox.IsChecked = purchaseSvc.PurchaseConsumables;
 
                 if (_purchasePriorityItems != null)
                 {
@@ -1617,10 +1607,6 @@ namespace PitHero.UI
                 if (!purchaseSvc.Enabled)
                 {
                     _gearPurchaseOptionsDialog?.Hide();
-                    _consumablePurchaseOptionsDialog?.Hide();
-                }
-                else if (!purchaseSvc.PurchaseConsumables)
-                {
                     _consumablePurchaseOptionsDialog?.Hide();
                 }
             }

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -369,6 +369,12 @@ namespace PitHero
         public const string WindowGearSellOptions = "WindowGearSellOptions";
         public const string SettingsSellGearTypes = "SettingsSellGearTypes";
         public const string SettingsSellGearTypesTooltip = "SettingsSellGearTypesTooltip";
+        public const string ButtonConsumableSellOptions = "ButtonConsumableSellOptions";
+        public const string WindowConsumableSellOptions = "WindowConsumableSellOptions";
+        public const string LabelConsumablesAutoSold = "LabelConsumablesAutoSold";
+        public const string LabelConsumablesAutoPurchased = "LabelConsumablesAutoPurchased";
+        public const string SettingsConsumableMinStacks = "SettingsConsumableMinStacks";
+        public const string SettingsConsumableMinStacksTooltip = "SettingsConsumableMinStacksTooltip";
         public const string GearTypeWeapon = "GearTypeWeapon";
         public const string GearTypeHelm = "GearTypeHelm";
         public const string GearTypeShield = "GearTypeShield";
@@ -386,8 +392,6 @@ namespace PitHero
         public const string SettingsBuyRaritiesTooltip = "SettingsBuyRaritiesTooltip";
         public const string SettingsBuyGearTypes = "SettingsBuyGearTypes";
         public const string SettingsBuyGearTypesTooltip = "SettingsBuyGearTypesTooltip";
-        public const string SettingsAutoPurchaseConsumables = "SettingsAutoPurchaseConsumables";
-        public const string SettingsAutoPurchaseConsumablesTooltip = "SettingsAutoPurchaseConsumablesTooltip";
         public const string ButtonConsumablePurchaseOptions = "ButtonConsumablePurchaseOptions";
         public const string WindowConsumablePurchaseOptions = "WindowConsumablePurchaseOptions";
         public const string SettingsConsumableStacks = "SettingsConsumableStacks";

--- a/PitHero/VirtualGame/VirtualBattleRunner.cs
+++ b/PitHero/VirtualGame/VirtualBattleRunner.cs
@@ -110,8 +110,9 @@ namespace PitHero.VirtualGame
         /// When true, <see cref="CollectChestItem"/> mirrors <c>AutoSellExcessItemsService</c>:
         /// on a full bag the weakest item is sold to make room, ordered by
         /// <see cref="AutoSellConsumablesFirst"/>. Off by default to preserve existing balance
-        /// baselines. The virtual layer has no synergy/stencil model, so nothing is protected
-        /// and all rarities are sellable (documented Delta-Plan gap).
+        /// baselines. The virtual layer has no synergy/stencil model, so nothing is protected,
+        /// all rarities are sellable, and the per-consumable sell selections / min-stack floors
+        /// are not applied (documented Delta-Plan gap).
         /// </summary>
         public bool AutoSellExcessItems { get; set; } = false;
 

--- a/PitHero/docs/AutomationSystem.md
+++ b/PitHero/docs/AutomationSystem.md
@@ -22,7 +22,7 @@ do not try to keep the tab short**.
 | **Gold Buffer** (label + slider) | `AutoSeedPurchaseService.GoldBuffer` | — (read by others) | 30 (v15) |
 | Auto-Purchase Seeds | `AutoSeedPurchaseService` | Ticked (1s throttle) | 30 (v15) |
 | Auto-Sell Crops + "Choose Crops to Sell" | `AutoCropSellService` | Ticked | 31–32 (v16/v17) |
-| Auto-Sell Excess Items + priority + "Gear Sell Options" | `AutoSellExcessItemsService` | Call-driven | 36–38 (v21/v22/v23) |
+| Auto-Sell Excess Items + priority + "Gear Sell Options" + "Consumable Sell Options" | `AutoSellExcessItemsService` | Call-driven | 36–38, 43 (v21/v22/v23/v26) |
 | Auto-Purchase Items + priority + merc opt-in + "Gear Purchase Options" + "Consumable Purchase Options" | `AutoItemPurchaseService` | Call-driven | 39 (v23) |
 | Auto-Equip Options | `HeroComponent.AutoEquipHero` / `.AutoEquipMercenaries` (**no service**) | Call-driven | 40 (v23) |
 | Auto-Learn Hero Skills + "Learn Mode" cycler | `AutoLearnSkillsService` | Ticked (1s throttle) | 42 (v25) |
@@ -34,7 +34,8 @@ Dialogs opened from the tab:
 |---|---|---|
 | Auto-Sell Crop Types | `PitHero/UI/AutoSellCropTypesDialog.cs` | Per-crop checkboxes + keep-stacks slider |
 | Gear Sell Options / Gear Purchase Options | `PitHero/UI/GearFilterOptionsDialog.cs` | **One class, two instances** — rarity + gear-type filters, parameterized by title/label keys and `Func<bool[]>` accessors |
-| Consumable Purchase Options | `PitHero/UI/ConsumablePurchaseOptionsDialog.cs` | Sprite + checkbox + per-item 1–3 "Stacks" slider |
+| Consumable Purchase Options | `PitHero/UI/ConsumablePurchaseOptionsDialog.cs` | Sprite + checkbox + per-item 1–3 "Stacks" slider; nothing selected by default |
+| Consumable Sell Options | `PitHero/UI/ConsumableSellOptionsDialog.cs` | Sprite + checkbox + per-item 0–3 "Min Stacks" floor; everything selected by default, floor 1 — auto-sell never drains a potion to zero unless asked |
 
 All dialogs follow the same shape: a plain class owning a `Nez.UI.Window`, built once in the
 constructor, `SetVisible(false)`, added to the stage; `Show()` syncs from the service, packs,
@@ -91,6 +92,12 @@ Save version constants live in `PitHero/Services/SaveData.cs` (`CurrentVersion`,
 `MinSupportedVersion`). The format is **strictly append-only**: older files are byte-exact prefixes
 of newer ones, so a v17 file still loads into a v23 build with defaults for the missing tail.
 
+Removing a setting does **not** remove its bytes. The v26 removal of the "Auto-Purchase
+Consumables" master flag kept its bool slot in section 39 (always written `true` now) so older
+files stay byte-exact prefixes; `SaveData.ApplyLegacyPurchaseConsumablesMigration` translates a
+pre-v26 flag-off file into cleared selections on load. Follow that pattern — a dead slot plus a
+version-gated migration — rather than reshaping an existing section.
+
 Adding a persisted setting means, in order:
 
 1. Add the field to `SaveData` with a default and a `// Feature name (vNN)` comment.
@@ -109,8 +116,9 @@ Adding a persisted setting means, in order:
 **Two indices are persisted identities and must stay append-only:**
 
 - `ConsumableCatalog` (`PitHero/RolePlayingFramework/Equipment/ConsumableCatalog.cs`) — the order of
-  its 9 entries is what `AutoPurchaseConsumableSelected` / `AutoPurchaseConsumableStacks` index
-  into. Reordering silently remaps a player's selections onto the wrong potions.
+  its 9 entries is what `AutoPurchaseConsumableSelected` / `AutoPurchaseConsumableStacks` and
+  `AutoSellConsumableSelected` / `AutoSellConsumableMinStacks` index into. Reordering silently
+  remaps a player's selections onto the wrong potions.
 - `GearCategory` — indexes every gear filter array (`AutoSellGearTypeAllowed`,
   `AutoPurchaseGearTypeAllowed`).
 
@@ -156,12 +164,11 @@ Gotchas:
   `ph-default` `SliderStyle`, so deactivating one is `slider.Disabled = true` for the look — and
   Nez's `Slider` input listener **ignores `Disabled`**, so `SetTouchable(Touchable.Disabled)` is
   what actually stops dragging. You need both.
-- **Nested gates compose.** "Consumable Purchase Options" is enabled only when *both*
-  "Auto-Purchase Items" and "Auto-Purchase Consumables" are checked;
-  `SetItemPurchaseControlsActive` ends by calling `SetConsumablePurchaseControlsActive` with the
-  combined condition. Follow that pattern rather than gating on one checkbox. Same for the
-  "Mercenary2 Job" cycler, which needs the auto-hire checkbox on *and* slot 1 holding a job
-  (cycling slot 1 to None also resets slot 2 to None).
+- **Nested gates compose.** The "Mercenary2 Job" cycler needs the auto-hire checkbox on *and*
+  slot 1 holding a job (cycling slot 1 to None also resets slot 2 to None) —
+  `SetAutoHireControlsActive` passes the combined condition down rather than gating on one
+  checkbox. (The old "Auto-Purchase Consumables" master checkbox was the other example until v26
+  removed it as redundant: with nothing selected in the dialog, nothing is bought anyway.)
 - **Hide open dialogs when the parent turns off**, or a deactivated feature's dialog stays on screen.
 - `PitHeroSkin.CreateSkin()` returns a **cached singleton** — never mutate a shared style; `Clone()`
   first if you need a variant (see `VaultBuyQuantityDialog`).
@@ -221,7 +228,7 @@ and call the pass method rather than simulating frames:
 | Seed purchasing | `PitHero.Tests/AutoSeedPurchaseServiceTests.cs` |
 | Crop selling | `PitHero.Tests/AutoCropSellServiceTests.cs` |
 | Monster jobs | `PitHero.Tests/AutoJobAssignmentServiceTests.cs` |
-| Excess-item selling + gear filters | `PitHero.Tests/AutoSellExcessItemsTests.cs` |
+| Excess-item selling + gear filters + consumable sell options | `PitHero.Tests/AutoSellExcessItemsTests.cs` |
 | Item purchasing | `PitHero.Tests/AutoItemPurchaseServiceTests.cs` |
 | Auto-equip | `PitHero.Tests/GearAutoEquipServiceTests.cs` |
 | Hero skill auto-learn | `PitHero.Tests/AutoLearnSkillsServiceTests.cs` |

--- a/PitHero/docs/VirtualGameLogicLayer.md
+++ b/PitHero/docs/VirtualGameLogicLayer.md
@@ -157,8 +157,9 @@ same-seed ⇒ identical-event-stream determinism test that catches accidental dr
   baselines) mirrors the live `AutoSellExcessItemsService` — on a full bag the weakest item
   (consumables by restore effect first, then gear across all types by gear score, via the
   shared `ExcessItemSellSelector`) is sold and the gold lands in `AutoSellGold`/the wallet.
-  Delta-Plan gap: the virtual layer has no synergy/stencil model, so nothing is protected
-  and all rarities are sellable; selling consumes no RNG, so parity is unaffected either way.
+  Delta-Plan gap: the virtual layer has no synergy/stencil model, so nothing is protected,
+  all rarities are sellable, and the per-consumable sell selections / min-stack floors (v26)
+  are not applied; selling consumes no RNG, so parity is unaffected either way.
 
 ## Metrics & CSV Reference
 


### PR DESCRIPTION
## Summary

Auto-Sell Excess Items previously had no floor on consumables: with consumables-first priority (the default), repeated gear pickups on a full bag sold off **every** potion stack before gear ever sold, leaving the party with nothing. Incoming gear was never compared against consumables — category order alone decided.

- **New "Consumable Sell Options" dialog** (mirrors Consumable Purchase Options): per-catalog-consumable checkbox (checked = may be auto-sold, all checked by default) + a 0–3 **Min Stacks** slider (default 1) naming how many stacks auto-sell must leave in the bag. Top label "Selected items are auto-sold"; Select All / Deselect All / Close with 16px min height.
- **Sell pass**: a consumable only sells when selected AND the floor holds afterwards — bag stacks need N−1 ≥ floor, the incoming item needs N ≥ floor (counted by name, the same identity bag stacking uses). No eligible consumable → weakest gear sells, as before. Default settings now guarantee the last stack of every potion survives.
- **Anti-churn guard**: the floor is raised to the auto-purchase stack target for purchase-selected consumables while Auto-Purchase Items is on, so auto-sell can't dump stacks the next shop pass would buy right back at a loss.
- **Removed the "Auto-Purchase Consumables" master checkbox** — redundant with Deselect All; dialog selection alone gates buying. The SaveData bool remains as a dead slot in section 39 (always written true) so older files stay byte-exact prefixes, and `ApplyLegacyPurchaseConsumablesMigration` clears selections when loading a pre-v26 file that had the flag off, preserving old behavior. This dead-slot + version-gated-migration pattern is now documented in AutomationSystem.md as the way to retire a persisted setting.
- **Save v26**: appended section 43 (count-prefixed selected/min-stacks pairs).
- Purchase dialog polish: "Selected items are auto-purchased" top label + 16px min-height buttons.
- Virtual layer unchanged (auto-sell defaults off there); gap note extended to cover the new filters.

## Testing

- `dotnet test`: **1,754 passed, 0 failed** (6 pre-existing demonstration skips), including 18 new tests: selector eligibility/floor rules (N−1 vs N, zero floor, unchecked incoming falls through to gear), service defaults, effective-floor max with a headless purchase service, v26 round-trip + defaults, and the legacy-flag migration.
- One pre-existing v23 defaults assertion updated for the legacy slot's new always-true value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)