### PR TITLE
Free movement of game window (#364)

### DIFF
--- a/PitHero.Tests/WindowClampTests.cs
+++ b/PitHero.Tests/WindowClampTests.cs
@@ -1,0 +1,80 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PitHero.Tests
+{
+    /// <summary>Tests for WindowManager.ClampRectToBounds (pure math used by free-move window mode, issue #364)</summary>
+    [TestClass]
+    public class WindowClampTests
+    {
+        [TestMethod]
+        public void FullWidthWindow_XPinnedToBoundsOrigin()
+        {
+            // Window as wide as the display: horizontal movement is impossible
+            int x = 500, y = 300;
+            WindowManager.ClampRectToBounds(ref x, ref y, 1920, 360, 0, 0, 1920, 1080);
+
+            Assert.AreEqual(0, x);
+            Assert.AreEqual(300, y);
+        }
+
+        [TestMethod]
+        public void FullWidthWindow_YClampsAtTopAndBottom()
+        {
+            int x = 0, y = -50;
+            WindowManager.ClampRectToBounds(ref x, ref y, 1920, 360, 0, 0, 1920, 1080);
+            Assert.AreEqual(0, y);
+
+            y = 2000;
+            WindowManager.ClampRectToBounds(ref x, ref y, 1920, 360, 0, 0, 1920, 1080);
+            Assert.AreEqual(1080 - 360, y);
+        }
+
+        [TestMethod]
+        public void HalfSizeWindow_InteriorPositionUnchanged()
+        {
+            int x = 400, y = 200;
+            WindowManager.ClampRectToBounds(ref x, ref y, 960, 180, 0, 0, 1920, 1080);
+
+            Assert.AreEqual(400, x);
+            Assert.AreEqual(200, y);
+        }
+
+        [TestMethod]
+        public void HalfSizeWindow_ClampsOnAllFourEdges()
+        {
+            int x = -100, y = -100;
+            WindowManager.ClampRectToBounds(ref x, ref y, 960, 180, 0, 0, 1920, 1080);
+            Assert.AreEqual(0, x);
+            Assert.AreEqual(0, y);
+
+            x = 5000; y = 5000;
+            WindowManager.ClampRectToBounds(ref x, ref y, 960, 180, 0, 0, 1920, 1080);
+            Assert.AreEqual(1920 - 960, x);
+            Assert.AreEqual(1080 - 180, y);
+        }
+
+        [TestMethod]
+        public void NegativeOriginMonitor_ClampsToNegativeCoordinates()
+        {
+            // Secondary monitor left of primary: bounds origin at (-2560, 0)
+            int x = -9999, y = 500;
+            WindowManager.ClampRectToBounds(ref x, ref y, 1280, 360, -2560, 0, 2560, 1440);
+            Assert.AreEqual(-2560, x);
+            Assert.AreEqual(500, y);
+
+            x = 100; // past the right edge of the negative-origin monitor (max is -2560 + 2560 - 1280 = -1280)
+            WindowManager.ClampRectToBounds(ref x, ref y, 1280, 360, -2560, 0, 2560, 1440);
+            Assert.AreEqual(-1280, x);
+        }
+
+        [TestMethod]
+        public void WindowLargerThanBoundsAxis_PinsToBoundsOrigin()
+        {
+            int x = 300, y = 300;
+            WindowManager.ClampRectToBounds(ref x, ref y, 2500, 1500, 0, 0, 1920, 1080);
+
+            Assert.AreEqual(0, x);
+            Assert.AreEqual(0, y);
+        }
+    }
+}

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -106,7 +106,9 @@ TabWindow,Window
 TabSession,Session
 TabButtons,UI Buttons
 SettingsAlwaysOnTop,Always On Top
+SettingsAlwaysOnTopTooltip,Game window always on top of everything
 SettingsAutoScrollToHero,Auto-scroll to Hero
+SettingsAutoScrollToHeroTooltip,Window follows hero and auto-scrolls back after being scrolled elsewhere
 SettingsSwapMonitor,Swap Monitor
 SettingsZoom,Zoom: {0}x
 SettingsWindowSize,Window Size:

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -116,6 +116,8 @@ SettingsWindowSizeHalf,Half
 SettingsDockTop,Dock Top
 SettingsDockBottom,Dock Bottom
 SettingsDockCenter,Dock Center
+SettingsFreeMoveWindow,Free Move Window
+SettingsExitFreeMove,Exit Free Move
 SettingsGameSession,Game Session
 SettingsReplenishLabel,Replenish Button Thresholds
 SettingsReplenishThresholdHint,(HP or MP must be below this level to replenish)

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -106,7 +106,7 @@ TabWindow,Window
 TabSession,Session
 TabButtons,UI Buttons
 SettingsAlwaysOnTop,Always On Top
-SettingsAlwaysOnTopTooltip,Game window always on top of everything
+SettingsAlwaysOnTopTooltip,Game window is always on top of everything
 SettingsAutoScrollToHero,Auto-scroll to Hero
 SettingsAutoScrollToHeroTooltip,Window follows hero and auto-scrolls back after being scrolled elsewhere
 SettingsSwapMonitor,Swap Monitor

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -108,7 +108,6 @@ TabButtons,UI Buttons
 SettingsAlwaysOnTop,Always On Top
 SettingsAutoScrollToHero,Auto-scroll to Hero
 SettingsSwapMonitor,Swap Monitor
-SettingsYOffset,Y Offset: {0}
 SettingsZoom,Zoom: {0}x
 SettingsWindowSize,Window Size:
 SettingsWindowSizeNormal,Normal

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -2400,11 +2400,13 @@ namespace PitHero.ECS.Scenes
             _settingsUI?.Update();
             // Remove duplicate HeroUI update since SettingsUI handles it
 
-            // Update pause overlay visibility based on pause state
+            // Update pause overlay visibility based on pause state. During free-move mode the
+            // overlay (which renders above the UI stage) is suppressed — the free-move blocker
+            // draws the identical dim below the Exit Free Move button so the button stays bright.
             var pauseService = Core.Services.GetService<PauseService>();
             if (pauseService != null && _pauseOverlayEntity != null)
             {
-                _pauseOverlayEntity.SetEnabled(pauseService.IsPaused);
+                _pauseOverlayEntity.SetEnabled(pauseService.IsPaused && !(_settingsUI?.IsFreeMoveModeActive ?? false));
             }
 
             // Keep pit level label up to date
@@ -2779,7 +2781,8 @@ namespace PitHero.ECS.Scenes
                 return true;
             if (_settingsUI != null &&
                 (_settingsUI.IsFarmSubMenuOpen || _settingsUI.IsTillModeActive || _settingsUI.IsBuildingModeActive ||
-                 _settingsUI.IsSeedModeActive || _settingsUI.IsRemoveCropsModeActive || _settingsUI.IsHarvestedCropsModeActive))
+                 _settingsUI.IsSeedModeActive || _settingsUI.IsRemoveCropsModeActive || _settingsUI.IsHarvestedCropsModeActive ||
+                 _settingsUI.IsFreeMoveModeActive))
                 return true;
             if (_uiStage != null && _uiStage.Hit(_uiStage.GetMousePosition()) != null)
                 return true;

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -580,7 +580,11 @@ namespace PitHero.UI
             var scrollContent = new Table();
 
             // Always On Top checkbox
-            _alwaysOnTopCheckBox = new CheckBox(GetText(TextType.UI, UITextKey.SettingsAlwaysOnTop), skin, "ph-default");
+            _alwaysOnTopCheckBox = new HoverableCheckBox(
+                GetText(TextType.UI, UITextKey.SettingsAlwaysOnTop),
+                skin,
+                GetText(TextType.UI, UITextKey.SettingsAlwaysOnTopTooltip),
+                _stage);
             _alwaysOnTopCheckBox.IsChecked = _alwaysOnTop;
             _alwaysOnTopCheckBox.OnChanged += (isChecked) =>
             {
@@ -591,7 +595,11 @@ namespace PitHero.UI
             scrollContent.Row();
 
             // Auto-scroll to Hero checkbox
-            _autoScrollToHeroCheckBox = new CheckBox(GetText(TextType.UI, UITextKey.SettingsAutoScrollToHero), skin, "ph-default");
+            _autoScrollToHeroCheckBox = new HoverableCheckBox(
+                GetText(TextType.UI, UITextKey.SettingsAutoScrollToHero),
+                skin,
+                GetText(TextType.UI, UITextKey.SettingsAutoScrollToHeroTooltip),
+                _stage);
             _autoScrollToHeroCheckBox.IsChecked = UIWindowManager.AutoScrollToHeroEnabled;
             _autoScrollToHeroCheckBox.OnChanged += (isChecked) =>
             {

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -134,6 +134,11 @@ namespace PitHero.UI
         private FreeMoveInputBlocker _freeMoveBlocker;
         private TextButton _freeMoveExitButton;
         private TextButton _freeMoveButton;
+        // Half-size position picked via free move, reapplied after the settings-close shrink
+        // re-centers X (the drag position wouldn't survive the Normal->Half round trip otherwise)
+        private bool _hasFreeMoveSavedHalfPosition;
+        private int _freeMoveSavedHalfX;
+        private int _freeMoveSavedHalfY;
 
         private Game _game;
         private TextService _textService;
@@ -615,6 +620,8 @@ namespace PitHero.UI
             _swapMonitorButton.OnClicked += (button) =>
             {
                 WindowManager.SwapToNextMonitor(_game);
+                // The saved free-move position belongs to the previous monitor
+                _hasFreeMoveSavedHalfPosition = false;
                 // Reapply current docking after monitor swap
                 ApplyCurrentWindowPosition();
             };
@@ -1971,6 +1978,9 @@ namespace PitHero.UI
                 // Use centralized UI window manager for closing behavior
                 UIWindowManager.OnUIWindowClosing();
 
+                // The shrink back to Half re-centers X; restore the free-move dragged position
+                ReapplyFreeMoveHalfPositionIfNeeded();
+
                 // Hide any open confirmation dialogs
                 HideConfirmationDialog(_exitConfirmationDialog);
                 HideConfirmationDialog(_quitToTitleConfirmationDialog);
@@ -2001,6 +2011,7 @@ namespace PitHero.UI
             {
                 _isVisible = false;
                 UIWindowManager.OnUIWindowClosing();
+                ReapplyFreeMoveHalfPositionIfNeeded();
                 HideConfirmationDialog(_exitConfirmationDialog);
                 HideConfirmationDialog(_quitToTitleConfirmationDialog);
                 _settingsWindow.SetVisible(false);
@@ -2367,6 +2378,10 @@ namespace PitHero.UI
             // Stop any ongoing animation and apply immediately
             _isAnimatingToOffset = false;
 
+            // Docking takes over positioning: forget any free-move dragged position
+            if (_isDockedTop || _isDockedBottom || _isDockedCenter)
+                _hasFreeMoveSavedHalfPosition = false;
+
             if (_isDockedTop)
             {
                 WindowManager.DockTop(_game, _currentYOffset);
@@ -2436,6 +2451,12 @@ namespace PitHero.UI
                 return;
 
             _freeMoveDragging = false;
+
+            // Save the dragged half-size position: the Normal restore below forces X back to the
+            // display edge (full-width strip) and the settings-close shrink re-centers X, so the
+            // dragged X must be reapplied after that shrink (ReapplyFreeMoveHalfPositionIfNeeded)
+            _hasFreeMoveSavedHalfPosition = WindowManager.IsHalfHeightMode() &&
+                WindowManager.TryGetWindowRect(_game, out _freeMoveSavedHalfX, out _freeMoveSavedHalfY, out _, out _);
 
             // Mirror OnUIWindowOpening's temp-restore: settings is reappearing, so a Half window
             // goes back to Normal for UI viewing. Dock mode is None, so this anchors to the
@@ -2508,6 +2529,17 @@ namespace PitHero.UI
                 int newY = _freeMoveDragStartWindowY + (int)(gy - _freeMoveDragStartMouseY);
                 WindowManager.MoveWindowClampedToCurrentDisplay(_game, newX, newY);
             }
+        }
+
+        /// <summary>
+        /// Reapplies the half-size position picked via free move after the settings-close shrink
+        /// re-centered X. Kept across open/close cycles so the spot doesn't drift; invalidated when
+        /// docking or swapping monitors takes over positioning.
+        /// </summary>
+        private void ReapplyFreeMoveHalfPositionIfNeeded()
+        {
+            if (_hasFreeMoveSavedHalfPosition && WindowManager.IsHalfHeightMode())
+                WindowManager.MoveWindowClampedToCurrentDisplay(_game, _freeMoveSavedHalfX, _freeMoveSavedHalfY);
         }
 
         /// <summary>Creates the free-move input blocker and exit button on first use</summary>

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -134,11 +134,6 @@ namespace PitHero.UI
         private FreeMoveInputBlocker _freeMoveBlocker;
         private TextButton _freeMoveExitButton;
         private TextButton _freeMoveButton;
-        // Half-size position picked via free move, reapplied after the settings-close shrink
-        // re-centers X (the drag position wouldn't survive the Normal->Half round trip otherwise)
-        private bool _hasFreeMoveSavedHalfPosition;
-        private int _freeMoveSavedHalfX;
-        private int _freeMoveSavedHalfY;
 
         private Game _game;
         private TextService _textService;
@@ -621,7 +616,7 @@ namespace PitHero.UI
             {
                 WindowManager.SwapToNextMonitor(_game);
                 // The saved free-move position belongs to the previous monitor
-                _hasFreeMoveSavedHalfPosition = false;
+                UIWindowManager.ClearFreeMoveHalfPosition();
                 // Reapply current docking after monitor swap
                 ApplyCurrentWindowPosition();
             };
@@ -1978,9 +1973,6 @@ namespace PitHero.UI
                 // Use centralized UI window manager for closing behavior
                 UIWindowManager.OnUIWindowClosing();
 
-                // The shrink back to Half re-centers X; restore the free-move dragged position
-                ReapplyFreeMoveHalfPositionIfNeeded();
-
                 // Hide any open confirmation dialogs
                 HideConfirmationDialog(_exitConfirmationDialog);
                 HideConfirmationDialog(_quitToTitleConfirmationDialog);
@@ -2011,7 +2003,6 @@ namespace PitHero.UI
             {
                 _isVisible = false;
                 UIWindowManager.OnUIWindowClosing();
-                ReapplyFreeMoveHalfPositionIfNeeded();
                 HideConfirmationDialog(_exitConfirmationDialog);
                 HideConfirmationDialog(_quitToTitleConfirmationDialog);
                 _settingsWindow.SetVisible(false);
@@ -2380,7 +2371,7 @@ namespace PitHero.UI
 
             // Docking takes over positioning: forget any free-move dragged position
             if (_isDockedTop || _isDockedBottom || _isDockedCenter)
-                _hasFreeMoveSavedHalfPosition = false;
+                UIWindowManager.ClearFreeMoveHalfPosition();
 
             if (_isDockedTop)
             {
@@ -2453,10 +2444,13 @@ namespace PitHero.UI
             _freeMoveDragging = false;
 
             // Save the dragged half-size position: the Normal restore below forces X back to the
-            // display edge (full-width strip) and the settings-close shrink re-centers X, so the
-            // dragged X must be reapplied after that shrink (ReapplyFreeMoveHalfPositionIfNeeded)
-            _hasFreeMoveSavedHalfPosition = WindowManager.IsHalfHeightMode() &&
-                WindowManager.TryGetWindowRect(_game, out _freeMoveSavedHalfX, out _freeMoveSavedHalfY, out _, out _);
+            // display edge (full-width strip) and every UI window's close-time shrink re-centers X.
+            // UIWindowManager reapplies this after each Half restore (settings, hero, monster, shop)
+            if (WindowManager.IsHalfHeightMode() &&
+                WindowManager.TryGetWindowRect(_game, out int halfX, out int halfY, out _, out _))
+                UIWindowManager.SetFreeMoveHalfPosition(halfX, halfY);
+            else
+                UIWindowManager.ClearFreeMoveHalfPosition();
 
             // Mirror OnUIWindowOpening's temp-restore: settings is reappearing, so a Half window
             // goes back to Normal for UI viewing. Dock mode is None, so this anchors to the
@@ -2529,17 +2523,6 @@ namespace PitHero.UI
                 int newY = _freeMoveDragStartWindowY + (int)(gy - _freeMoveDragStartMouseY);
                 WindowManager.MoveWindowClampedToCurrentDisplay(_game, newX, newY);
             }
-        }
-
-        /// <summary>
-        /// Reapplies the half-size position picked via free move after the settings-close shrink
-        /// re-centered X. Kept across open/close cycles so the spot doesn't drift; invalidated when
-        /// docking or swapping monitors takes over positioning.
-        /// </summary>
-        private void ReapplyFreeMoveHalfPositionIfNeeded()
-        {
-            if (_hasFreeMoveSavedHalfPosition && WindowManager.IsHalfHeightMode())
-                WindowManager.MoveWindowClampedToCurrentDisplay(_game, _freeMoveSavedHalfX, _freeMoveSavedHalfY);
         }
 
         /// <summary>Creates the free-move input blocker and exit button on first use</summary>

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -30,12 +30,10 @@ namespace PitHero.UI
         private Tab _automationTab;
 
         // Window positioning controls
-        private EnhancedSlider _yOffsetSlider;
         private EnhancedSlider _zoomSlider;
         private TextButton _dockTopButton;
         private TextButton _dockBottomButton;
         private TextButton _dockCenterButton;
-        private Label _yOffsetLabel;
         private Label _zoomLabel;
         private TextButton _resetZoomButton;
 
@@ -137,18 +135,10 @@ namespace PitHero.UI
 
         private Game _game;
         private TextService _textService;
-        private int _currentYOffset = 0;
         private bool _isDockedTop = false;
         private bool _isDockedBottom = true; // Default to bottom dock
         private bool _isDockedCenter = false;
         private bool _alwaysOnTop = true; // Track current always-on-top state
-
-        // Smooth scrolling animation
-        private bool _isAnimatingToOffset = false;
-        private float _animationStartOffset;
-        private float _animationTargetOffset;
-        private float _animationDuration = 0.3f; // 300ms
-        private float _animationTimer = 0f;
 
         // Track previous shrink mode so we can restore it after closing settings
         private bool _prevWasHalfShrink = false;
@@ -610,59 +600,6 @@ namespace PitHero.UI
             scrollContent.Add(_autoScrollToHeroCheckBox).Left().SetPadBottom(15);
             scrollContent.Row();
 
-            // Swap Monitor button
-            _swapMonitorButton = new TextButton(GetText(TextType.UI, UITextKey.SettingsSwapMonitor), skin, "ph-default");
-            _swapMonitorButton.OnClicked += (button) =>
-            {
-                WindowManager.SwapToNextMonitor(_game);
-                // The saved free-move position belongs to the previous monitor
-                UIWindowManager.ClearFreeMoveHalfPosition();
-                // Reapply current docking after monitor swap
-                ApplyCurrentWindowPosition();
-            };
-            scrollContent.Add(_swapMonitorButton).Width(100f).Height(24f).SetPadBottom(15);
-            scrollContent.Row();
-
-            // Y Offset slider (left-aligned label)
-            _yOffsetLabel = new Label(string.Format(GetText(TextType.UI, UITextKey.SettingsYOffset), 0), skin, "ph-default");
-            scrollContent.Add(_yOffsetLabel).Left().SetPadBottom(10);
-            scrollContent.Row();
-
-
-            // Create table for y offset slider and reset button side by side
-            var yOffsetTable = new Table();
-
-            // Create enhanced slider with initial range for bottom dock
-            _yOffsetSlider = new EnhancedSlider(-200, 0, 1, false, skin, null, false);
-            _yOffsetSlider.SetValueAndCommit(0);
-
-            // Update label during dragging (immediate feedback)
-            _yOffsetSlider.OnChanged += (value) =>
-            {
-                _yOffsetLabel.SetText(string.Format(GetText(TextType.UI, UITextKey.SettingsYOffset), (int)value));
-            };
-
-            // Apply window position when value is committed (mouse released)
-            _yOffsetSlider.OnValueCommitted += (value) =>
-            {
-                _currentYOffset = (int)value;
-                StartSmoothScrollToOffset(_currentYOffset);
-            };
-
-            yOffsetTable.Add(_yOffsetSlider).Width(240).SetPadRight(10);
-
-            // Reset Y Offset button
-            var resetYOffsetButton = new TextButton(GetText(TextType.UI, UITextKey.ButtonReset), skin, "ph-default");
-            resetYOffsetButton.OnClicked += (button) =>
-            {
-                _yOffsetSlider.SetValueAndCommit(0);
-                _yOffsetLabel.SetText(string.Format(GetText(TextType.UI, UITextKey.SettingsYOffset), 0));
-            };
-            yOffsetTable.Add(resetYOffsetButton).Width(50).Height(16f);
-
-            scrollContent.Add(yOffsetTable).SetPadBottom(20);
-            scrollContent.Row();
-
             // Zoom level slider with reset button (left-aligned label)
             _zoomLabel = new Label(string.Format(GetText(TextType.UI, UITextKey.SettingsZoom), GameConfig.CameraDefaultZoom.ToString("F2")), skin, "ph-default");
             scrollContent.Add(_zoomLabel).Left().SetPadBottom(10);
@@ -746,6 +683,19 @@ namespace PitHero.UI
             windowSizeTable.Add(_halfSizeButton);
 
             scrollContent.Add(windowSizeTable).Left().SetPadBottom(20);
+            scrollContent.Row();
+
+            // Swap Monitor button
+            _swapMonitorButton = new TextButton(GetText(TextType.UI, UITextKey.SettingsSwapMonitor), skin, "ph-default");
+            _swapMonitorButton.OnClicked += (button) =>
+            {
+                WindowManager.SwapToNextMonitor(_game);
+                // The saved free-move position belongs to the previous monitor
+                UIWindowManager.ClearFreeMoveHalfPosition();
+                // Reapply current docking after monitor swap
+                ApplyCurrentWindowPosition();
+            };
+            scrollContent.Add(_swapMonitorButton).Width(100f).Height(24f).SetPadBottom(10);
             scrollContent.Row();
 
             // Dock buttons
@@ -2191,9 +2141,6 @@ namespace PitHero.UI
             if (anyNonFarmPanelOpen && (IsFarmSubMenuOpen || IsTillModeActive || IsBuildingModeActive || IsSeedModeActive || IsRemoveCropsModeActive || IsHarvestedCropsModeActive))
                 DismissAllFarmUI();
 
-            // Update smooth scrolling animation
-            UpdateSmoothScrolling();
-
             // Update gear button style dynamically when shrink mode changes
             UpdateGearButtonStyleIfNeeded();
 
@@ -2270,10 +2217,6 @@ namespace PitHero.UI
             _isDockedTop = true;
             _isDockedBottom = false;
             _isDockedCenter = false;
-            _currentYOffset = 0;
-            UpdateSliderRange(0, 200);
-            _yOffsetSlider.SetValueAndCommit(0);
-            _yOffsetLabel.SetText(string.Format(GetText(TextType.UI, UITextKey.SettingsYOffset), 0));
             ApplyCurrentWindowPosition();
         }
 
@@ -2282,10 +2225,6 @@ namespace PitHero.UI
             _isDockedTop = false;
             _isDockedBottom = true;
             _isDockedCenter = false;
-            _currentYOffset = 0;
-            UpdateSliderRange(-200, 0);
-            _yOffsetSlider.SetValueAndCommit(0);
-            _yOffsetLabel.SetText(string.Format(GetText(TextType.UI, UITextKey.SettingsYOffset), 0));
             ApplyCurrentWindowPosition();
         }
 
@@ -2294,96 +2233,26 @@ namespace PitHero.UI
             _isDockedTop = false;
             _isDockedBottom = false;
             _isDockedCenter = true;
-            _currentYOffset = 0;
-            UpdateSliderRange(-200, 200);
-            _yOffsetSlider.SetValueAndCommit(0);
-            _yOffsetLabel.SetText(string.Format(GetText(TextType.UI, UITextKey.SettingsYOffset), 0));
             ApplyCurrentWindowPosition();
-        }
-
-        private void UpdateSliderRange(float min, float max)
-        {
-            _yOffsetSlider.SetMinMax(min, max);
-        }
-
-        /// <summary>
-        /// Starts smooth scrolling animation to the target offset
-        /// </summary>
-        private void StartSmoothScrollToOffset(int targetOffset)
-        {
-            if (_isAnimatingToOffset)
-            {
-                // If already animating, update the target
-                _animationTargetOffset = targetOffset;
-            }
-            else
-            {
-                _animationStartOffset = _currentYOffset;
-                _animationTargetOffset = targetOffset;
-                _animationTimer = 0f;
-                _isAnimatingToOffset = true;
-            }
-        }
-
-        /// <summary>
-        /// Updates smooth scrolling animation
-        /// </summary>
-        private void UpdateSmoothScrolling()
-        {
-            if (!_isAnimatingToOffset)
-                return;
-
-            _animationTimer += Time.DeltaTime;
-            float progress = Math.Min(1f, _animationTimer / _animationDuration);
-
-            // Use easing for smooth animation (ease out)
-            float easedProgress = 1f - (1f - progress) * (1f - progress);
-
-            float currentOffset = _animationStartOffset + (_animationTargetOffset - _animationStartOffset) * easedProgress;
-
-            // Apply the interpolated position
-            int roundedOffset = (int)Math.Round(currentOffset);
-            if (_isDockedTop)
-            {
-                WindowManager.DockTop(_game, roundedOffset);
-            }
-            else if (_isDockedBottom)
-            {
-                WindowManager.DockBottom(_game, roundedOffset);
-            }
-            else if (_isDockedCenter)
-            {
-                WindowManager.DockCenter(_game, roundedOffset);
-            }
-
-            // Check if animation is complete
-            if (progress >= 1f)
-            {
-                _isAnimatingToOffset = false;
-                _currentYOffset = (int)_animationTargetOffset;
-            }
         }
 
         private void ApplyCurrentWindowPosition()
         {
-            // Stop any ongoing animation and apply immediately
-            _isAnimatingToOffset = false;
-
             // Docking takes over positioning: forget any free-move dragged position
             if (_isDockedTop || _isDockedBottom || _isDockedCenter)
                 UIWindowManager.ClearFreeMoveHalfPosition();
 
             if (_isDockedTop)
             {
-                WindowManager.DockTop(_game, _currentYOffset);
+                WindowManager.DockTop(_game);
             }
             else if (_isDockedBottom)
             {
-                WindowManager.DockBottom(_game, _currentYOffset);
+                WindowManager.DockBottom(_game);
             }
             else if (_isDockedCenter)
             {
-                WindowManager.DockCenter(_game, _currentYOffset);
+                WindowManager.DockCenter(_game);
             }
         }
 
@@ -2409,7 +2278,6 @@ namespace PitHero.UI
 
             // Forget docking so the exit-time shrink/restore anchors to the dragged position
             // instead of snapping back to the old dock
-            _isAnimatingToOffset = false;
             _isDockedTop = false;
             _isDockedBottom = false;
             _isDockedCenter = false;

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -124,6 +124,17 @@ namespace PitHero.UI
         private Window _exitConfirmationDialog;
         private Window _quitToTitleConfirmationDialog;
 
+        // Free-move window mode (issue #364)
+        private bool _isFreeMoveModeActive;
+        private bool _freeMoveDragging;
+        private float _freeMoveDragStartMouseX;
+        private float _freeMoveDragStartMouseY;
+        private int _freeMoveDragStartWindowX;
+        private int _freeMoveDragStartWindowY;
+        private FreeMoveInputBlocker _freeMoveBlocker;
+        private TextButton _freeMoveExitButton;
+        private TextButton _freeMoveButton;
+
         private Game _game;
         private TextService _textService;
         private int _currentYOffset = 0;
@@ -748,7 +759,12 @@ namespace PitHero.UI
 
             _dockCenterButton = new TextButton(GetText(TextType.UI, UITextKey.SettingsDockCenter), skin, "ph-default");
             _dockCenterButton.OnClicked += (button) => DockCenter();
-            scrollContent.Add(_dockCenterButton).Width(100f).Height(24f);
+            scrollContent.Add(_dockCenterButton).Width(100f).Height(24f).SetPadBottom(10);
+            scrollContent.Row();
+
+            _freeMoveButton = new TextButton(GetText(TextType.UI, UITextKey.SettingsFreeMoveWindow), skin, "ph-default");
+            _freeMoveButton.OnClicked += (button) => EnterFreeMoveMode();
+            scrollContent.Add(_freeMoveButton).Width(140f).Height(24f);
 
             // Create scroll pane with the content
             var scrollPane = new ScrollPane(scrollContent, skin, "ph-default");
@@ -2132,6 +2148,13 @@ namespace PitHero.UI
         /// </summary>
         public void Update()
         {
+            // Free-move mode suspends shortcuts, farm modes, auto-hide and smooth scrolling for its duration
+            if (_isFreeMoveModeActive)
+            {
+                UpdateFreeMoveMode();
+                return;
+            }
+
             // OnClicked (mouse-up) already ran in base.Update() before this method is called.
             // If till mode is now active but wasn't at the end of last frame, the click that activated
             // it is the same LeftMouseButtonReleased event we'd use to exit — suppress the exit check
@@ -2356,6 +2379,202 @@ namespace PitHero.UI
             {
                 WindowManager.DockCenter(_game, _currentYOffset);
             }
+        }
+
+        // ── Free-move window mode (issue #364) ───────────────────────────────────
+
+        /// <summary>Returns true while the player is in free window move mode</summary>
+        public bool IsFreeMoveModeActive => _isFreeMoveModeActive;
+
+        /// <summary>
+        /// Enters free window move mode: hides settings while keeping it logically open (pause and
+        /// UIWindowManager refcount untouched), shrinks to the persistent Half size if applicable,
+        /// and shows the drag overlay with a centered Exit Free Move button.
+        /// </summary>
+        public void EnterFreeMoveMode()
+        {
+            if (!_isVisible || _isFreeMoveModeActive)
+                return;
+
+            // Hide settings WITHOUT the close path: no OnUIWindowClosing, no unpause, _isVisible stays true
+            HideConfirmationDialog(_exitConfirmationDialog);
+            HideConfirmationDialog(_quitToTitleConfirmationDialog);
+            _settingsWindow.SetVisible(false);
+
+            // Forget docking so the exit-time shrink/restore anchors to the dragged position
+            // instead of snapping back to the old dock
+            _isAnimatingToOffset = false;
+            _isDockedTop = false;
+            _isDockedBottom = false;
+            _isDockedCenter = false;
+            WindowManager.ClearDockMode();
+
+            // Half-persistent users drag the half-size window (settings had temp-restored it to Normal)
+            if (UIWindowManager.PersistentWindowSize == UIWindowManager.WindowSizeMode.Half)
+                WindowManager.ShrinkHeightToHalf(_game);
+
+            EnsureFreeMoveOverlayCreated();
+            _freeMoveBlocker.SetVisible(true);
+            _freeMoveBlocker.ToFront();
+            _freeMoveExitButton.SetVisible(true);
+            _freeMoveExitButton.ToFront();
+            LayoutFreeMoveOverlay();
+
+            _isFreeMoveModeActive = true;
+            _freeMoveDragging = false;
+            LayoutUI();
+            PositionUI();
+        }
+
+        /// <summary>
+        /// Exits free move mode: restores Normal size for UI viewing if needed (anchored at the
+        /// dragged position), hides the overlay, and re-shows the settings window.
+        /// </summary>
+        public void ExitFreeMoveMode()
+        {
+            if (!_isFreeMoveModeActive)
+                return;
+
+            _freeMoveDragging = false;
+
+            // Mirror OnUIWindowOpening's temp-restore: settings is reappearing, so a Half window
+            // goes back to Normal for UI viewing. Dock mode is None, so this anchors to the
+            // window's current bottom edge.
+            if (WindowManager.IsHalfHeightMode())
+                WindowManager.RestoreOriginalSize(_game);
+
+            // RestoreOriginalSize's X handling isn't display-aware after a drag; snap fully back inside
+            if (WindowManager.TryGetWindowRect(_game, out int wx, out int wy, out _, out _))
+                WindowManager.MoveWindowClampedToCurrentDisplay(_game, wx, wy);
+
+            _freeMoveBlocker.SetVisible(false);
+            _freeMoveExitButton.SetVisible(false);
+            _settingsWindow.SetVisible(true);
+            _settingsWindow.ToFront();
+
+            _isFreeMoveModeActive = false;
+            LayoutUI();
+            PositionUI();
+        }
+
+        /// <summary>
+        /// Per-frame free-move handling: Escape exit, drag start/track/release. Uses global desktop
+        /// mouse coordinates because client-relative coordinates shift as the window moves under the cursor.
+        /// </summary>
+        private void UpdateFreeMoveMode()
+        {
+            LayoutFreeMoveOverlay();
+
+            if (Input.IsKeyPressed(Microsoft.Xna.Framework.Input.Keys.Escape))
+            {
+                ExitFreeMoveMode();
+                return;
+            }
+
+            bool leftDown = WindowManager.GetGlobalMouseLeftDown(out float gx, out float gy);
+
+            if (!_freeMoveDragging)
+            {
+                if (Input.LeftMouseButtonPressed && Util.MouseUtils.IsMouseInsideWindow())
+                {
+                    // Presses on the Exit Free Move button must not start a drag
+                    var hit = _stage.Hit(_stage.GetMousePosition());
+                    bool onExitButton = false;
+                    for (Element e = hit; e != null; e = e.GetParent())
+                    {
+                        if (e == _freeMoveExitButton)
+                        {
+                            onExitButton = true;
+                            break;
+                        }
+                    }
+
+                    if (!onExitButton &&
+                        WindowManager.TryGetWindowRect(_game, out _freeMoveDragStartWindowX, out _freeMoveDragStartWindowY, out _, out _))
+                    {
+                        _freeMoveDragStartMouseX = gx;
+                        _freeMoveDragStartMouseY = gy;
+                        _freeMoveDragging = true;
+                    }
+                }
+            }
+            else if (!leftDown)
+            {
+                _freeMoveDragging = false;
+            }
+            else
+            {
+                int newX = _freeMoveDragStartWindowX + (int)(gx - _freeMoveDragStartMouseX);
+                int newY = _freeMoveDragStartWindowY + (int)(gy - _freeMoveDragStartMouseY);
+                WindowManager.MoveWindowClampedToCurrentDisplay(_game, newX, newY);
+            }
+        }
+
+        /// <summary>Creates the free-move input blocker and exit button on first use</summary>
+        private void EnsureFreeMoveOverlayCreated()
+        {
+            if (_freeMoveBlocker != null)
+                return;
+
+            var skin = PitHeroSkin.CreateSkin();
+
+            _freeMoveBlocker = new FreeMoveInputBlocker();
+            _stage.AddElement(_freeMoveBlocker);
+
+            _freeMoveExitButton = new TextButton(GetText(TextType.UI, UITextKey.SettingsExitFreeMove), skin, "ph-default");
+            _freeMoveExitButton.OnClicked += (button) => ExitFreeMoveMode();
+            _freeMoveExitButton.SetSize(160f, 32f);
+            _stage.AddElement(_freeMoveExitButton);
+
+            _freeMoveBlocker.SetVisible(false);
+            _freeMoveExitButton.SetVisible(false);
+        }
+
+        /// <summary>Keeps the blocker full-stage and the exit button centered (stage dims change on shrink/move)</summary>
+        private void LayoutFreeMoveOverlay()
+        {
+            if (_freeMoveBlocker == null)
+                return;
+
+            _freeMoveBlocker.SetBounds(0, 0, _stage.GetWidth(), _stage.GetHeight());
+            _freeMoveExitButton.SetPosition(
+                (_stage.GetWidth() - _freeMoveExitButton.GetWidth()) / 2f,
+                (_stage.GetHeight() - _freeMoveExitButton.GetHeight()) / 2f);
+        }
+
+        /// <summary>
+        /// Full-screen element that swallows every click while free-move mode is active and draws the
+        /// pause dim below the exit button (the engine pause overlay is suppressed during the mode so
+        /// the button renders bright). Making stage.Hit non-null everywhere also blocks the camera
+        /// controller and world interactions.
+        /// </summary>
+        private class FreeMoveInputBlocker : Element, IInputListener
+        {
+            public FreeMoveInputBlocker()
+            {
+                SetTouchable(Touchable.Enabled);
+            }
+
+            public override void Draw(Batcher batcher, float parentAlpha)
+            {
+                batcher.DrawRect(GetX(), GetY(), GetWidth(), GetHeight(), new Color(0, 0, 0, 100));
+            }
+
+            void IInputListener.OnMouseEnter() { }
+
+            void IInputListener.OnMouseExit() { }
+
+            void IInputListener.OnMouseMoved(Vector2 mousePos) { }
+
+            bool IInputListener.OnLeftMousePressed(Vector2 mousePos) => true;
+
+            void IInputListener.OnLeftMouseUp(Vector2 mousePos) { }
+
+            bool IInputListener.OnRightMousePressed(Vector2 mousePos) => true;
+
+            void IInputListener.OnRightMouseUp(Vector2 mousePos) { }
+
+            bool IInputListener.OnMouseScrolled(int mouseWheelDelta) => true;
         }
 
         /// <summary>

--- a/PitHero/UI/UIWindowManager.cs
+++ b/PitHero/UI/UIWindowManager.cs
@@ -27,6 +27,26 @@ namespace PitHero.UI
         // Track auto-scroll to hero setting
         private static bool _autoScrollToHeroEnabled = GameConfig.CameraAutoScrollToHeroDefault;
 
+        // Half-size position picked via free move (issue #364), reapplied whenever the persistent
+        // Half size is restored on a UI window close (the shrink itself re-centers X)
+        private static bool _hasFreeMoveHalfPosition;
+        private static int _freeMoveHalfX;
+        private static int _freeMoveHalfY;
+
+        /// <summary>Remembers the half-size position picked via free move for later Half restores</summary>
+        public static void SetFreeMoveHalfPosition(int x, int y)
+        {
+            _freeMoveHalfX = x;
+            _freeMoveHalfY = y;
+            _hasFreeMoveHalfPosition = true;
+        }
+
+        /// <summary>Forgets the free-move half position (docking or a monitor swap took over positioning)</summary>
+        public static void ClearFreeMoveHalfPosition()
+        {
+            _hasFreeMoveHalfPosition = false;
+        }
+
         /// <summary>
         /// Initialize the UI window manager with the game instance
         /// </summary>
@@ -277,6 +297,11 @@ namespace PitHero.UI
                     {
                         Debug.Log("[UIWindowManager] Already at Half size");
                     }
+
+                    // The shrink re-centers X; land on the position picked via free move instead.
+                    // This runs on every UI window's close path (settings, hero, monster, shop)
+                    if (_hasFreeMoveHalfPosition)
+                        WindowManager.MoveWindowClampedToCurrentDisplay(_game, _freeMoveHalfX, _freeMoveHalfY);
                     break;
             }
 

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -126,7 +126,6 @@ namespace PitHero
         public const string SettingsAlwaysOnTop = "SettingsAlwaysOnTop";
         public const string SettingsAutoScrollToHero = "SettingsAutoScrollToHero";
         public const string SettingsSwapMonitor = "SettingsSwapMonitor";
-        public const string SettingsYOffset = "SettingsYOffset";
         public const string SettingsZoom = "SettingsZoom";
         public const string SettingsWindowSize = "SettingsWindowSize";
         public const string SettingsWindowSizeNormal = "SettingsWindowSizeNormal";

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -134,6 +134,8 @@ namespace PitHero
         public const string SettingsDockTop = "SettingsDockTop";
         public const string SettingsDockBottom = "SettingsDockBottom";
         public const string SettingsDockCenter = "SettingsDockCenter";
+        public const string SettingsFreeMoveWindow = "SettingsFreeMoveWindow";
+        public const string SettingsExitFreeMove = "SettingsExitFreeMove";
         public const string SettingsGameSession = "SettingsGameSession";
         public const string SettingsReplenishLabel = "SettingsReplenishLabel";
         public const string SettingsReplenishThresholdHint = "SettingsReplenishThresholdHint";

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -124,7 +124,9 @@ namespace PitHero
         public const string TabSession = "TabSession";
         public const string TabButtons = "TabButtons";
         public const string SettingsAlwaysOnTop = "SettingsAlwaysOnTop";
+        public const string SettingsAlwaysOnTopTooltip = "SettingsAlwaysOnTopTooltip";
         public const string SettingsAutoScrollToHero = "SettingsAutoScrollToHero";
+        public const string SettingsAutoScrollToHeroTooltip = "SettingsAutoScrollToHeroTooltip";
         public const string SettingsSwapMonitor = "SettingsSwapMonitor";
         public const string SettingsZoom = "SettingsZoom";
         public const string SettingsWindowSize = "SettingsWindowSize";

--- a/PitHero/WindowManager.cs
+++ b/PitHero/WindowManager.cs
@@ -291,6 +291,72 @@ namespace PitHero
         }
 
         /// <summary>
+        /// Clears dock tracking so later shrink/restore anchor to the window's current position
+        /// instead of snapping back to a dock (used by free-move mode).
+        /// </summary>
+        public static void ClearDockMode()
+        {
+            _currentDockMode = DockMode.None;
+            _currentDockYOffset = 0;
+        }
+
+        /// <summary>
+        /// Gets the window's position and size in global desktop coordinates. False if the SDL handle is unavailable.
+        /// </summary>
+        public static bool TryGetWindowRect(Game game, out int x, out int y, out int w, out int h)
+        {
+            x = y = w = h = 0;
+            IntPtr sdlWindow = game.Window.Handle;
+            if (sdlWindow == IntPtr.Zero)
+                return false;
+
+            SDL.SDL_GetWindowPosition(sdlWindow, out x, out y);
+            SDL.SDL_GetWindowSize(sdlWindow, out w, out h);
+            return true;
+        }
+
+        /// <summary>
+        /// Reads the global desktop mouse position. Returns true while the left button is held.
+        /// </summary>
+        public static bool GetGlobalMouseLeftDown(out float x, out float y)
+        {
+            return (SDL.SDL_GetGlobalMouseState(out x, out y) & SDL.SDL_MouseButtonFlags.SDL_BUTTON_LMASK) != 0;
+        }
+
+        /// <summary>
+        /// Moves the window to (x, y) clamped inside the current display's bounds. Supports negative desktop coordinates.
+        /// </summary>
+        public static void MoveWindowClampedToCurrentDisplay(Game game, int x, int y)
+        {
+            IntPtr sdlWindow = game.Window.Handle;
+            if (sdlWindow == IntPtr.Zero)
+                return;
+            EnsureCurrentDisplay(sdlWindow);
+
+            SDL.SDL_GetWindowSize(sdlWindow, out int winW, out int winH);
+            ClampRectToBounds(ref x, ref y, winW, winH,
+                _currentDisplayBounds.x, _currentDisplayBounds.y, _currentDisplayBounds.w, _currentDisplayBounds.h);
+            SDL.SDL_SetWindowPosition(sdlWindow, x, y);
+        }
+
+        /// <summary>
+        /// Clamps a window rect into display bounds. A window as wide/tall as the bounds pins to the
+        /// bounds origin on that axis, so full-display-width windows can only move vertically.
+        /// </summary>
+        public static void ClampRectToBounds(ref int x, ref int y, int winW, int winH, int bx, int by, int bw, int bh)
+        {
+            int maxX = bx + bw - winW;
+            if (maxX < bx) maxX = bx;
+            int maxY = by + bh - winH;
+            if (maxY < by) maxY = by;
+
+            if (x < bx) x = bx;
+            else if (x > maxX) x = maxX;
+            if (y < by) y = by;
+            else if (y > maxY) y = maxY;
+        }
+
+        /// <summary>
         /// Docks the window to the top of the screen with optional Y offset for fine-tuning.
         /// </summary>
         public static void DockTop(Game game, int yOffset = 0)

--- a/PitHero/WindowManager.cs
+++ b/PitHero/WindowManager.cs
@@ -86,7 +86,6 @@ namespace PitHero
 
             // Default horizontal behavior: center relative to previous
             int newX = prevX + (prevW - newWidth) / 2;
-            if (newX < 0) newX = 0;
 
             // Determine Y based on docking mode (fix: keep top-docked windows at top when shrinking)
             int newY;
@@ -119,9 +118,12 @@ namespace PitHero
                     // legacy behavior: anchor bottom edge as before
                     int bottomY = prevY + prevH; // previous bottom pixel
                     newY = bottomY - newHeight;
-                    if (newY < 0) newY = 0;
                     break;
             }
+
+            // Clamp inside display bounds (display-origin aware for secondary monitors)
+            ClampRectToBounds(ref newX, ref newY, newWidth, newHeight,
+                _currentDisplayBounds.x, _currentDisplayBounds.y, _currentDisplayBounds.w, _currentDisplayBounds.h);
 
             SDL.SDL_SetWindowSize(sdlWindow, newWidth, newHeight);
             SDL.SDL_SetWindowPosition(sdlWindow, newX, newY);
@@ -146,7 +148,6 @@ namespace PitHero
             SDL.SDL_GetWindowPosition(sdlWindow, out int prevX, out int prevY);
 
             int newX = prevX - (_originalWindowWidth - prevW) / 2;
-            if (newX < 0) newX = 0;
 
             int newY;
             switch (_currentDockMode)
@@ -168,10 +169,10 @@ namespace PitHero
                     break;
             }
 
-            // Clamp inside display bounds
-            if (newY < _currentDisplayBounds.y) newY = _currentDisplayBounds.y;
-            if (newY + _originalWindowHeight > _currentDisplayBounds.y + _currentDisplayBounds.h)
-                newY = _currentDisplayBounds.y + _currentDisplayBounds.h - _originalWindowHeight;
+            // Clamp inside display bounds (a full-display-width window pins X to the display edge,
+            // so restoring from an off-center half-size window can't hang past the right edge)
+            ClampRectToBounds(ref newX, ref newY, _originalWindowWidth, _originalWindowHeight,
+                _currentDisplayBounds.x, _currentDisplayBounds.y, _currentDisplayBounds.w, _currentDisplayBounds.h);
 
             SDL.SDL_SetWindowSize(sdlWindow, _originalWindowWidth, _originalWindowHeight);
             SDL.SDL_SetWindowPosition(sdlWindow, newX, newY);

--- a/PitHero/WindowManager.cs
+++ b/PitHero/WindowManager.cs
@@ -501,8 +501,23 @@ namespace PitHero
                     break;
             }
 
-            SDL.SDL_SetWindowSize(sdlWindow, targetWidth, targetHeight);
+            // Move first, then resize: a resize issued while the window is still on the old monitor
+            // gets processed in that monitor's context (DPI/resolution) and comes out wrong after
+            // the move. Re-assert the position afterwards since resizing can shift the window, and
+            // sync between operations (SDL3 window ops are asynchronous).
             SDL.SDL_SetWindowPosition(sdlWindow, targetX, targetY);
+            SDL.SDL_SyncWindow(sdlWindow);
+            SDL.SDL_SetWindowSize(sdlWindow, targetWidth, targetHeight);
+            SDL.SDL_SyncWindow(sdlWindow);
+            SDL.SDL_SetWindowPosition(sdlWindow, targetX, targetY);
+            SDL.SDL_SyncWindow(sdlWindow);
+
+            // The Normal-size strip now belongs to the new monitor; keep shrink/restore consistent
+            if (_storedOriginalSize)
+            {
+                _originalWindowWidth = targetWidth;
+                _originalWindowHeight = targetHeight;
+            }
 
             SetCurrentDisplay(nextDisplayID, nextBounds);
 


### PR DESCRIPTION
Closes #364

## Summary
Adds a **Free Move Window** button to the Settings UI Window tab. Clicking it hides the settings window and lets the player click-and-drag anywhere in the game window to move the OS window, confined to the current monitor. A centered **Exit Free Move** button (rendered bright above the darkened overlay) or Escape exits the mode and brings the Settings UI back. The game stays paused with the darkened overlay throughout.

- **Full size**: the window is a full-display-width strip, so dragging moves it up/down only, clamped to the monitor.
- **Half size**: entering the mode shrinks the window to the persistent Half size for the drag; it clamps on all four monitor edges. Exiting restores Normal size anchored at the dragged position (settings reappears, mirroring the usual temp-restore).

## Implementation notes
- `WindowManager` (sole SDL toucher) gains `ClearDockMode`, `TryGetWindowRect`, `GetGlobalMouseLeftDown`, `MoveWindowClampedToCurrentDisplay`, and pure `ClampRectToBounds`. The clamp is display-origin aware (works on negative-coordinate secondary monitors, unlike the legacy `SetPosition`). A full-width window pins X automatically via the degenerate-max guard.
- Drag math uses `SDL_GetGlobalMouseState` polled per frame — client-relative coords shift as the window moves under the cursor. Releasing the button (or losing focus mid-drag) ends the drag.
- The mode keeps settings *logically* open: `_settingsWindow.SetVisible(false)` only, so `PauseService` stays paused and the `UIWindowManager` open-window refcount is untouched (no double Half-restore on the real close later).
- Dock mode is cleared at entry so the exit-time size restore anchors to the dragged position instead of snapping back to the old dock.
- A full-screen `FreeMoveInputBlocker` element swallows every click, blocks the camera controller and world interactions via `stage.Hit`, and draws the pause dim itself; the engine pause overlay (layer 999, above UI) is suppressed during the mode so the Exit button stays bright and obviously clickable.
- `IsFreeMoveModeActive` added to `MainGameScene.BuildingInteractionsBlocked()` per the established mode-flag pattern.

## Testing
- `dotnet build PitHero.sln` clean.
- `dotnet test`: 1804 passed, 0 failed (baseline maintained), including new `WindowClampTests` covering full-width pinning, four-edge clamping, negative-origin monitors, and oversized windows.
- Manual verification recommended for: Normal-size vertical-only drag, Half-size two-axis drag + restore anchoring, Escape exit, repeated enter/exit (refcount), and multi-monitor clamping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)