### PR TITLE
Rename executable to FeedTheHero and derive analytics folder from exe…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "dotnet: build (Debug)",
-            "program": "${workspaceFolder}/PitHero/bin/Debug/PitHero.dll",
+            "program": "${workspaceFolder}/PitHero/bin/Debug/FeedTheHero.dll",
             "args": [],
             "cwd": "${workspaceFolder}/PitHero",
             "stopAtEntry": false,
@@ -21,7 +21,7 @@
             "name": ".NET: Launch Without Building",
             "type": "coreclr",
             "request": "launch",
-            "program": "${workspaceFolder}/PitHero/bin/Debug/PitHero.dll",
+            "program": "${workspaceFolder}/PitHero/bin/Debug/FeedTheHero.dll",
             "args": [],
             "cwd": "${workspaceFolder}/PitHero",
             "stopAtEntry": false,
@@ -38,7 +38,7 @@
             "name": "Launch (Mac)",
             "type": "mono",
             "request": "launch",
-            "program": "${workspaceFolder}/PitHero/bin/Debug/PitHero.exe",
+            "program": "${workspaceFolder}/PitHero/bin/Debug/FeedTheHero.exe",
             "cwd": "${workspaceFolder}/PitHero",
             "preLaunchTask": "Build (Debug)",
             "osx":{
@@ -52,7 +52,7 @@
             "name": "Launch Without Building (Mac)",
             "type": "mono",
             "request": "launch",
-            "program": "${workspaceFolder}/PitHero/bin/Debug/PitHero.exe",
+            "program": "${workspaceFolder}/PitHero/bin/Debug/FeedTheHero.exe",
             "cwd": "${workspaceFolder}",
             "osx":{
                 "env": {
@@ -65,7 +65,7 @@
             "name": "Launch (Windows)",
             "type": "clr",
             "request": "launch",
-            "program": "${workspaceFolder}/PitHero/bin/Debug/PitHero.exe",
+            "program": "${workspaceFolder}/PitHero/bin/Debug/FeedTheHero.exe",
             "cwd": "${workspaceFolder}/PitHero",
             "preLaunchTask": "Build (Debug)"
         },
@@ -74,7 +74,7 @@
             "name": "Launch Without Building (Windows)",
             "type": "clr",
             "request": "launch",
-            "program": "${workspaceFolder}/PitHero/bin/Debug/PitHero.exe",
+            "program": "${workspaceFolder}/PitHero/bin/Debug/FeedTheHero.exe",
             "cwd": "${workspaceFolder}"
         },
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -149,12 +149,12 @@
             "type": "shell",
             "group": "build",
             "osx":{
-                "command": "DYLD_LIBRARY_PATH=${workspaceFolder}/PitHero/bin/Debug/osx/ mono ${workspaceFolder}/PitHero/bin/Debug/PitHero.exe"
+                "command": "DYLD_LIBRARY_PATH=${workspaceFolder}/PitHero/bin/Debug/osx/ mono ${workspaceFolder}/PitHero/bin/Debug/FeedTheHero.exe"
             },
             "windows":{
                 "command": "start",
                 "args": [
-                    "${workspaceFolder}/PitHero/bin/Debug/PitHero.exe"
+                    "${workspaceFolder}/PitHero/bin/Debug/FeedTheHero.exe"
                 ]
             },
             "dependsOn": "Build (Debug)",
@@ -166,12 +166,12 @@
             "type": "shell",
             "group": "build",
             "osx":{
-                "command": "DYLD_LIBRARY_PATH=${workspaceFolder}/PitHero/bin/Release/osx/ mono ${workspaceFolder}/PitHero/bin/Release/PitHero.exe"
+                "command": "DYLD_LIBRARY_PATH=${workspaceFolder}/PitHero/bin/Release/osx/ mono ${workspaceFolder}/PitHero/bin/Release/FeedTheHero.exe"
             },
             "windows":{
                 "command": "start",
                 "args": [
-                    "${workspaceFolder}/PitHero/bin/Release/PitHero.exe"
+                    "${workspaceFolder}/PitHero/bin/Release/FeedTheHero.exe"
                 ]
             },
             "dependsOn": "Build (Release)",

--- a/PitHero/Game1.cs
+++ b/PitHero/Game1.cs
@@ -11,7 +11,7 @@ namespace PitHero
 {
     class Game1 : Core
     {
-        public Game1() : base(GameConfig.VirtualWidth, GameConfig.VirtualHeight, false, "PitHero")
+        public Game1() : base(GameConfig.VirtualWidth, GameConfig.VirtualHeight, false, "Feed the Hero")
         {
             // Set up for pixel-perfect rendering - uncomment for scaled pixel art
             System.Environment.SetEnvironmentVariable("FNA_OPENGL_BACKBUFFER_SCALE_NEAREST", "1");

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -90,7 +90,7 @@ namespace PitHero
         public const bool AnalyticsEnabled = true; // Master switch for analytics logging in debug builds
         public const float AnalyticsFlushIntervalSeconds = 15f; // How often buffered analytics events are written to disk
         public const int AnalyticsFlushThresholdChars = 65536; // Buffer size that forces an immediate analytics flush
-        public const string AnalyticsDirectoryName = "analytics"; // Subfolder under %LOCALAPPDATA%\PitHero for analytics logs
+        public const string AnalyticsDirectoryName = "analytics"; // Subfolder under the exe-named %LOCALAPPDATA% folder (same root as save files)
 
         // Inn configuration
         public const int InnkeeperTileX = 69; // Innkeeper stands at (69, 3)

--- a/PitHero/PitHero.csproj
+++ b/PitHero/PitHero.csproj
@@ -5,7 +5,7 @@
                 <TargetFramework>net8.0</TargetFramework>
                 <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
                 <PlatformTarget>AnyCPU</PlatformTarget>
-        <AssemblyName>PitHero</AssemblyName>
+        <AssemblyName>FeedTheHero</AssemblyName>
         <MonoGamePlatform>DesktopGL</MonoGamePlatform>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
                 <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/PitHero/Services/Analytics/AnalyticsService.cs
+++ b/PitHero/Services/Analytics/AnalyticsService.cs
@@ -45,12 +45,14 @@ namespace PitHero.Services.Analytics
 #endif
         }
 
-        /// <summary>Initializes analytics using the default output directory (%LOCALAPPDATA%\PitHero\analytics).</summary>
+        /// <summary>Initializes analytics using the default output directory (%LOCALAPPDATA%\&lt;exeName&gt;\analytics, alongside FileDataStore saves).</summary>
         [Conditional("DEBUG")]
         public static void Initialize()
         {
 #if DEBUG
-            var baseDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "PitHero");
+            // Same derivation Nez's FileDataStore uses so analytics always co-locates with save files
+            var exeName = Path.GetFileNameWithoutExtension(AppDomain.CurrentDomain.FriendlyName);
+            var baseDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), exeName);
             Initialize(Path.Combine(baseDir, GameConfig.AnalyticsDirectoryName));
 #endif
         }

--- a/PitHero/docs/AnalyticsSchema.md
+++ b/PitHero/docs/AnalyticsSchema.md
@@ -6,7 +6,8 @@ interpretation caveats that are not obvious from the raw data.
 
 ## Where the data lives
 
-- **Path:** `%LOCALAPPDATA%\PitHero\analytics\session_yyyyMMdd_HHmmss.jsonl`
+- **Path:** `%LOCALAPPDATA%\FeedTheHero\analytics\session_yyyyMMdd_HHmmss.jsonl`
+  (the folder is derived from the executable name at runtime, so it always matches the save-file root)
 - **Format:** JSONL — one JSON object per line, one line per event.
 - **Rotation:** a new file per session. Returning to the title screen and starting/loading
   another game rotates to a new file within the same process.


### PR DESCRIPTION
… name

- AssemblyName PitHero -> FeedTheHero (namespaces and project files unchanged)
- Window title is now "Feed the Hero"
- Analytics logs derive their %LOCALAPPDATA% folder from the running exe name (same derivation as Nez FileDataStore) instead of hardcoding "PitHero", so analytics always co-locates with save files
- Update .vscode launch/tasks paths to the renamed exe/dll
- Align GameConfig comment and AnalyticsSchema.md with the new path

Existing saves in %LOCALAPPDATA%\PitHero are migrated manually by copying save_slot_*.bin to %LOCALAPPDATA%\FeedTheHero.