### PR TITLE
Crystal shop improvements and UI dismissal overhaul

### DIFF
--- a/PitHero.Tests/HeroCrystalBuyBackPriceTests.cs
+++ b/PitHero.Tests/HeroCrystalBuyBackPriceTests.cs
@@ -1,0 +1,104 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RolePlayingFramework.Heroes;
+using RolePlayingFramework.Jobs;
+using RolePlayingFramework.Jobs.Primary;
+using RolePlayingFramework.Stats;
+
+namespace PitHero.Tests
+{
+    [TestClass]
+    public class HeroCrystalBuyBackPriceTests
+    {
+        private static HeroCrystal CreateCrystal(IJob job, int level)
+        {
+            var baseStats = new StatBlock(strength: 5, agility: 3, vitality: 5, magic: 1);
+            return new HeroCrystal("Test Crystal", job, level, baseStats);
+        }
+
+        [TestMethod]
+        public void BuyBackPrice_NoSkills_IsFlatBasePricePerLevel()
+        {
+            var crystal = CreateCrystal(new Knight(), 1);
+
+            Assert.AreEqual(GameConfig.CrystalBuyBackBasePrice, crystal.CalculateBuyBackPrice());
+        }
+
+        [TestMethod]
+        public void BuyBackPrice_NoSkills_ScalesWithLevel()
+        {
+            var crystal = CreateCrystal(new Mage(), 10);
+
+            Assert.AreEqual(10 * GameConfig.CrystalBuyBackBasePrice, crystal.CalculateBuyBackPrice());
+        }
+
+        [TestMethod]
+        public void BuyBackPrice_LearnedJobSkill_AddsJPAnchoredPremium()
+        {
+            var knight = new Knight();
+            // High level so the cap does not engage
+            var crystal = CreateCrystal(knight, 50);
+            var skill = knight.Skills[0];
+            crystal.AddLearnedSkill(skill.Id);
+
+            int basePrice = 50 * GameConfig.CrystalBuyBackBasePrice;
+            int expectedPremium = (int)(skill.JPCost * GameConfig.CrystalJPToGoldRate);
+            Assert.AreEqual(basePrice + expectedPremium, crystal.CalculateBuyBackPrice());
+        }
+
+        [TestMethod]
+        public void BuyBackPrice_LearnedSynergySkill_AddsFlatFee()
+        {
+            var crystal = CreateCrystal(new Priest(), 50);
+            crystal.LearnSynergySkill("synergy.test_skill");
+
+            int basePrice = 50 * GameConfig.CrystalBuyBackBasePrice;
+            Assert.AreEqual(basePrice + GameConfig.CrystalSynergySkillFee, crystal.CalculateBuyBackPrice());
+        }
+
+        [TestMethod]
+        public void BuyBackPrice_PremiumIsCappedAtBasePrice()
+        {
+            var knight = new Knight();
+            // Level 1: base 100g, so a mastered crystal must cost exactly double the base
+            var crystal = CreateCrystal(knight, 1);
+            for (int i = 0; i < knight.Skills.Count; i++)
+                crystal.AddLearnedSkill(knight.Skills[i].Id);
+            crystal.LearnSynergySkill("synergy.test_skill");
+
+            int totalJP = 0;
+            for (int i = 0; i < knight.Skills.Count; i++)
+                totalJP += knight.Skills[i].JPCost;
+            int uncappedPremium = (int)(totalJP * GameConfig.CrystalJPToGoldRate) + GameConfig.CrystalSynergySkillFee;
+            Assert.IsTrue(uncappedPremium > GameConfig.CrystalBuyBackBasePrice,
+                "Test requires the uncapped premium to exceed the level-1 base price");
+
+            Assert.AreEqual(2 * GameConfig.CrystalBuyBackBasePrice, crystal.CalculateBuyBackPrice());
+        }
+
+        [TestMethod]
+        public void BuyBackPrice_SkillIdNotInJob_AddsNoPremium()
+        {
+            var crystal = CreateCrystal(new Knight(), 5);
+            crystal.AddLearnedSkill("mage.fire");
+
+            Assert.AreEqual(5 * GameConfig.CrystalBuyBackBasePrice, crystal.CalculateBuyBackPrice());
+        }
+
+        [TestMethod]
+        public void BuyBackPrice_CompositeJob_CountsSkillsFromBothJobs()
+        {
+            var knight = new Knight();
+            var mage = new Mage();
+            var composite = new CompositeJob(knight, mage);
+            var crystal = CreateCrystal(composite, 50);
+            var knightSkill = knight.Skills[0];
+            var mageSkill = mage.Skills[0];
+            crystal.AddLearnedSkill(knightSkill.Id);
+            crystal.AddLearnedSkill(mageSkill.Id);
+
+            int basePrice = 50 * GameConfig.CrystalBuyBackBasePrice;
+            int expectedPremium = (int)((knightSkill.JPCost + mageSkill.JPCost) * GameConfig.CrystalJPToGoldRate);
+            Assert.AreEqual(basePrice + expectedPremium, crystal.CalculateBuyBackPrice());
+        }
+    }
+}

--- a/PitHero/ECS/Components/HeroDeathComponent.cs
+++ b/PitHero/ECS/Components/HeroDeathComponent.cs
@@ -222,7 +222,7 @@ namespace PitHero.ECS.Components
             if (vault != null)
             {
                 vault.AddCrystal(crystal);
-                Debug.Log($"[HeroDeathComponent] Added crystal to vault. Crystal sell value: {crystal.CalculateSellValue()} gold");
+                Debug.Log($"[HeroDeathComponent] Added crystal to vault. Buy-back price: {crystal.CalculateBuyBackPrice()} gold");
             }
             else
             {

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -106,6 +106,8 @@ namespace PitHero
         public static int GetInnCostForMember(int level)
             => InnCostBaseGoldPerMember + InnCostGoldPerTenLevels * (level / 10);
         public const int CrystalBuyBackBasePrice = 100; // Base gold cost per crystal level for Second Chance Shop
+        public const float CrystalJPToGoldRate = 0.5f;  // Gold per JP invested in learned job skills (buy-back premium)
+        public const int CrystalSynergySkillFee = 150;  // Flat gold per learned synergy skill (buy-back premium)
 
         // Tavern seat configuration (for Stop Adventuring)
         public const int TavernHeroSeatTileX = 93;

--- a/PitHero/RolePlayingFramework/Heroes/Hero.cs
+++ b/PitHero/RolePlayingFramework/Heroes/Hero.cs
@@ -94,6 +94,22 @@ namespace RolePlayingFramework.Heroes
                     if (fromCrystal.HasSkill(s.Id))
                         _learnedSkills[s.Id] = s;
                 }
+
+                // preload synergy skills permanently bound to the crystal
+                foreach (var synergySkillId in fromCrystal.LearnedSynergySkillIds)
+                {
+                    if (_learnedSkills.ContainsKey(synergySkillId)) continue;
+                    var patterns = SynergyPatternRegistry.All;
+                    for (int i = 0; i < patterns.Count; i++)
+                    {
+                        var unlocked = patterns[i].UnlockedSkill;
+                        if (unlocked != null && unlocked.Id == synergySkillId)
+                        {
+                            _learnedSkills[synergySkillId] = unlocked;
+                            break;
+                        }
+                    }
+                }
             }
             ApplyPassiveSkills();
             RecalculateDerived();

--- a/PitHero/RolePlayingFramework/Heroes/HeroCrystal.cs
+++ b/PitHero/RolePlayingFramework/Heroes/HeroCrystal.cs
@@ -215,6 +215,30 @@ namespace RolePlayingFramework.Heroes
             return (int)(BaseValuePerLevel * Level * tierMultiplier);
         }
 
+        /// <summary>
+        /// Calculates the Second Chance buy-back price: base gold per level plus a premium for
+        /// learned skills, anchored to the JP invested in them. The premium is capped at the base
+        /// price so recovering a mastered crystal never costs more than double the flat price.
+        /// </summary>
+        public int CalculateBuyBackPrice()
+        {
+            int basePrice = Level * PitHero.GameConfig.CrystalBuyBackBasePrice;
+
+            int jpInvested = 0;
+            var jobSkills = Job.Skills;
+            for (int i = 0; i < jobSkills.Count; i++)
+            {
+                if (_learnedSkillIds.Contains(jobSkills[i].Id))
+                    jpInvested += jobSkills[i].JPCost;
+            }
+
+            int premium = (int)(jpInvested * PitHero.GameConfig.CrystalJPToGoldRate)
+                + _learnedSynergySkillIds.Count * PitHero.GameConfig.CrystalSynergySkillFee;
+            if (premium > basePrice) premium = basePrice;
+
+            return basePrice + premium;
+        }
+
         /// <summary>Combines two crystals by averaging level, summing base stats, unioning skills and composing jobs.</summary>
         public static HeroCrystal Combine(string combinedName, HeroCrystal a, HeroCrystal b)
         {

--- a/PitHero/UI/AutoSellCropTypesDialog.cs
+++ b/PitHero/UI/AutoSellCropTypesDialog.cs
@@ -25,6 +25,7 @@ namespace PitHero.UI
         private readonly CheckBox[] _cropChecks = new CheckBox[CropTypeInfo.Count];
 
         private Window _window;
+        private uint _shownFrame;
         private HoverableLabel _keepStacksLabel;
         private EnhancedSlider _keepStacksSlider;
         private TextService _textService;
@@ -136,12 +137,20 @@ namespace PitHero.UI
                 (_stage.GetHeight() - _window.GetHeight()) / 2f);
             _window.SetVisible(true);
             _window.ToFront();
+            _shownFrame = Time.FrameCount;
         }
 
         /// <summary>Hides the window.</summary>
         public void Hide()
         {
             _window?.SetVisible(false);
+        }
+
+        /// <summary>Hides the dialog when a click lands outside it without consuming the click. Call once per frame.</summary>
+        public void Update()
+        {
+            if (OutsideClickDismissal.ShouldDismiss(_window, _stage, _shownFrame))
+                Hide();
         }
 
         /// <summary>

--- a/PitHero/UI/AutoSellCropTypesDialog.cs
+++ b/PitHero/UI/AutoSellCropTypesDialog.cs
@@ -146,6 +146,9 @@ namespace PitHero.UI
             _window?.SetVisible(false);
         }
 
+        /// <summary>True while the dialog window is visible.</summary>
+        public bool IsVisible() => _window != null && _window.IsVisible();
+
         /// <summary>Hides the dialog when a click lands outside it without consuming the click. Call once per frame.</summary>
         public void Update()
         {

--- a/PitHero/UI/ConfirmationDialog.cs
+++ b/PitHero/UI/ConfirmationDialog.cs
@@ -10,8 +10,50 @@ namespace PitHero.UI
         public TextButton YesButton { get; }
         public TextButton NoButton { get; }
 
+        private readonly System.Action _onNo;
+
+        // Shown dialogs, tracked so window-level outside-click/Escape handling can defer to an open
+        // confirmation. Self-pruning: entries removed from the stage drop out on the next query.
+        private static readonly System.Collections.Generic.List<ConfirmationDialog> _shown = new System.Collections.Generic.List<ConfirmationDialog>();
+
+        /// <summary>True while any confirmation dialog is on a stage and visible.</summary>
+        public static bool AnyVisible
+        {
+            get
+            {
+                Prune();
+                return _shown.Count > 0;
+            }
+        }
+
+        /// <summary>
+        /// Cancels the most recently shown visible dialog as if its No button were clicked.
+        /// Returns true if a dialog was cancelled (used by Escape handling).
+        /// </summary>
+        public static bool TryCancelTopMost()
+        {
+            Prune();
+            if (_shown.Count == 0) return false;
+            var dialog = _shown[_shown.Count - 1];
+            _shown.RemoveAt(_shown.Count - 1);
+            dialog._onNo?.Invoke();
+            dialog.Remove();
+            return true;
+        }
+
+        private static void Prune()
+        {
+            for (int i = _shown.Count - 1; i >= 0; i--)
+            {
+                var d = _shown[i];
+                if (d.GetParent() == null || !d.IsVisible())
+                    _shown.RemoveAt(i);
+            }
+        }
+
         public ConfirmationDialog(string title, string message, Skin skin, System.Action onYes, System.Action onNo = null) : base(title, skin)
         {
+            _onNo = onNo;
             var textService = Core.Services.GetService<TextService>();
             
             SetSize(350, 180);
@@ -65,6 +107,8 @@ namespace PitHero.UI
 
             stage.AddElement(this);
             SetVisible(true);
+            if (!_shown.Contains(this))
+                _shown.Add(this);
         }
     }
 }

--- a/PitHero/UI/ConsumablePurchaseOptionsDialog.cs
+++ b/PitHero/UI/ConsumablePurchaseOptionsDialog.cs
@@ -167,6 +167,9 @@ namespace PitHero.UI
             _window?.SetVisible(false);
         }
 
+        /// <summary>True while the dialog window is visible.</summary>
+        public bool IsVisible() => _window != null && _window.IsVisible();
+
         /// <summary>Hides the dialog when a click lands outside it without consuming the click. Call once per frame.</summary>
         public void Update()
         {

--- a/PitHero/UI/ConsumablePurchaseOptionsDialog.cs
+++ b/PitHero/UI/ConsumablePurchaseOptionsDialog.cs
@@ -29,6 +29,7 @@ namespace PitHero.UI
         private readonly EnhancedSlider[] _stackSliders = new EnhancedSlider[ConsumableCatalog.Count];
 
         private Window _window;
+        private uint _shownFrame;
         private TextService _textService;
 
         public ConsumablePurchaseOptionsDialog(Stage stage)
@@ -157,12 +158,20 @@ namespace PitHero.UI
                 (_stage.GetHeight() - _window.GetHeight()) / 2f);
             _window.SetVisible(true);
             _window.ToFront();
+            _shownFrame = Time.FrameCount;
         }
 
         /// <summary>Hides the window.</summary>
         public void Hide()
         {
             _window?.SetVisible(false);
+        }
+
+        /// <summary>Hides the dialog when a click lands outside it without consuming the click. Call once per frame.</summary>
+        public void Update()
+        {
+            if (OutsideClickDismissal.ShouldDismiss(_window, _stage, _shownFrame))
+                Hide();
         }
 
         /// <summary>

--- a/PitHero/UI/ConsumableSellOptionsDialog.cs
+++ b/PitHero/UI/ConsumableSellOptionsDialog.cs
@@ -165,6 +165,9 @@ namespace PitHero.UI
             _window?.SetVisible(false);
         }
 
+        /// <summary>True while the dialog window is visible.</summary>
+        public bool IsVisible() => _window != null && _window.IsVisible();
+
         /// <summary>Hides the dialog when a click lands outside it without consuming the click. Call once per frame.</summary>
         public void Update()
         {

--- a/PitHero/UI/ConsumableSellOptionsDialog.cs
+++ b/PitHero/UI/ConsumableSellOptionsDialog.cs
@@ -30,6 +30,7 @@ namespace PitHero.UI
         private readonly EnhancedSlider[] _stackSliders = new EnhancedSlider[ConsumableCatalog.Count];
 
         private Window _window;
+        private uint _shownFrame;
         private TextService _textService;
 
         public ConsumableSellOptionsDialog(Stage stage)
@@ -155,12 +156,20 @@ namespace PitHero.UI
                 (_stage.GetHeight() - _window.GetHeight()) / 2f);
             _window.SetVisible(true);
             _window.ToFront();
+            _shownFrame = Time.FrameCount;
         }
 
         /// <summary>Hides the window.</summary>
         public void Hide()
         {
             _window?.SetVisible(false);
+        }
+
+        /// <summary>Hides the dialog when a click lands outside it without consuming the click. Call once per frame.</summary>
+        public void Update()
+        {
+            if (OutsideClickDismissal.ShouldDismiss(_window, _stage, _shownFrame))
+                Hide();
         }
 
         /// <summary>

--- a/PitHero/UI/CrystalsTab.cs
+++ b/PitHero/UI/CrystalsTab.cs
@@ -375,16 +375,7 @@ namespace PitHero.UI
         /// </summary>
         private void DismissCrystalCardOnOutsideClick()
         {
-            if (_crystalCard == null || !_crystalCard.IsVisible()) return;
-            if (!Input.LeftMouseButtonPressed && !Input.RightMouseButtonPressed) return;
-            if (Time.FrameCount == _cardShownFrame) return;
-
-            var mousePos = _stage.GetMousePosition();
-            bool insideCard = mousePos.X >= _crystalCard.GetX()
-                && mousePos.X <= _crystalCard.GetX() + _crystalCard.GetWidth()
-                && mousePos.Y >= _crystalCard.GetY()
-                && mousePos.Y <= _crystalCard.GetY() + _crystalCard.GetHeight();
-            if (!insideCard)
+            if (OutsideClickDismissal.ShouldDismiss(_crystalCard, _stage, _cardShownFrame))
                 HideCrystalCard();
         }
 

--- a/PitHero/UI/CrystalsTab.cs
+++ b/PitHero/UI/CrystalsTab.cs
@@ -45,8 +45,8 @@ namespace PitHero.UI
         private CrystalSlotElement _dragHoveredSlot;
         private int _hoverCheckFrame;
 
-        // Full-screen dismiss layer for the crystal card (hides card when clicking outside it)
-        private Element _cardDismissLayer;
+        // Frame on which the crystal card was last shown (guards the outside-click dismiss poll)
+        private uint _cardShownFrame;
 
         /// <summary>Creates and returns the tab content table.</summary>
         public Table CreateContent(Skin skin, Stage stage, Window heroWindow)
@@ -358,36 +358,42 @@ namespace PitHero.UI
             _crystalCard.ShowCrystal(crystal);
             _crystalCard.Pack();
             _crystalCard.PositionAtWindowRight(_heroWindow);
-
-            // Ensure card dismiss layer exists and is wired up
-            if (_cardDismissLayer == null)
-            {
-                _cardDismissLayer = new DismissLayer(() => HideCrystalCard());
-                _stage.AddElement(_cardDismissLayer);
-            }
-            _cardDismissLayer.SetSize(_stage.GetWidth(), _stage.GetHeight());
-            _cardDismissLayer.SetVisible(true);
-            // Bring hero window above the dismiss layer so its crystal-slot children receive
-            // native click/hover events.  Set ChildrenOnly touchable so empty areas in the
-            // window background are NOT hit by the window, letting those clicks fall through
-            // to the dismiss layer behind it.  The card sits at the very front.
-            _heroWindow?.ToFront();
-            _heroWindow?.SetTouchable(Touchable.ChildrenOnly);
             _crystalCard.ToFront();
+            // Stamp the frame so the same click that opened the card can't also dismiss it
+            _cardShownFrame = Time.FrameCount;
         }
 
         private void HideCrystalCard()
         {
             _crystalCard?.Hide();
-            if (_cardDismissLayer != null)
-                _cardDismissLayer.SetVisible(false);
-            _heroWindow?.SetTouchable(Touchable.Enabled);
+        }
+
+        /// <summary>
+        /// Dismisses the crystal card on any click outside it. Polls global mouse state instead of
+        /// using a click-consuming overlay so the same click still reaches whatever was under it
+        /// (top bar buttons, tabs, other windows).
+        /// </summary>
+        private void DismissCrystalCardOnOutsideClick()
+        {
+            if (_crystalCard == null || !_crystalCard.IsVisible()) return;
+            if (!Input.LeftMouseButtonPressed && !Input.RightMouseButtonPressed) return;
+            if (Time.FrameCount == _cardShownFrame) return;
+
+            var mousePos = _stage.GetMousePosition();
+            bool insideCard = mousePos.X >= _crystalCard.GetX()
+                && mousePos.X <= _crystalCard.GetX() + _crystalCard.GetWidth()
+                && mousePos.Y >= _crystalCard.GetY()
+                && mousePos.Y <= _crystalCard.GetY() + _crystalCard.GetHeight();
+            if (!insideCard)
+                HideCrystalCard();
         }
 
         /// <summary>Called every frame by HeroUI to run periodic hover checks and keep tooltip visible.</summary>
         public void Update()
         {
             if (_stage == null) return;
+
+            DismissCrystalCardOnOutsideClick();
 
             _hoverCheckFrame++;
             if (_hoverCheckFrame % 5 != 0) return;

--- a/PitHero/UI/CrystalsTab.cs
+++ b/PitHero/UI/CrystalsTab.cs
@@ -448,6 +448,9 @@ namespace PitHero.UI
             }
         }
 
+        /// <summary>The crystal info card element, for parent-window bounds checks (may be null).</summary>
+        public Element CrystalCardElement => _crystalCard;
+
         /// <summary>Hides any open crystal card. Called when the parent Hero UI window closes.</summary>
         public void Cleanup()
         {

--- a/PitHero/UI/GearFilterOptionsDialog.cs
+++ b/PitHero/UI/GearFilterOptionsDialog.cs
@@ -165,6 +165,9 @@ namespace PitHero.UI
             _window?.SetVisible(false);
         }
 
+        /// <summary>True while the dialog window is visible.</summary>
+        public bool IsVisible() => _window != null && _window.IsVisible();
+
         /// <summary>Hides the dialog when a click lands outside it without consuming the click. Call once per frame.</summary>
         public void Update()
         {

--- a/PitHero/UI/GearFilterOptionsDialog.cs
+++ b/PitHero/UI/GearFilterOptionsDialog.cs
@@ -35,6 +35,7 @@ namespace PitHero.UI
         private readonly CheckBox[] _typeChecks = new CheckBox[GearCategoryUtils.Count];
 
         private Window _window;
+        private uint _shownFrame;
         private TextService _textService;
 
         /// <summary>
@@ -155,12 +156,20 @@ namespace PitHero.UI
                 (_stage.GetHeight() - _window.GetHeight()) / 2f);
             _window.SetVisible(true);
             _window.ToFront();
+            _shownFrame = Time.FrameCount;
         }
 
         /// <summary>Hides the window.</summary>
         public void Hide()
         {
             _window?.SetVisible(false);
+        }
+
+        /// <summary>Hides the dialog when a click lands outside it without consuming the click. Call once per frame.</summary>
+        public void Update()
+        {
+            if (OutsideClickDismissal.ShouldDismiss(_window, _stage, _shownFrame))
+                Hide();
         }
 
         /// <summary>

--- a/PitHero/UI/HeroCrystalCard.cs
+++ b/PitHero/UI/HeroCrystalCard.cs
@@ -138,7 +138,8 @@ namespace PitHero.UI
             for (int i = 0; i < jobSkills.Count; i++)
             {
                 var skill = jobSkills[i];
-                var btn = new SkillIconButton(skill, false);
+                bool isLearned = _crystal.HasSkill(skill.Id);
+                var btn = new SkillIconButton(skill, isLearned, false);
                 btn.OnHover += OnSkillHover;
                 btn.OnUnhover += OnSkillUnhover;
                 _skillButtons.Add(btn);
@@ -165,17 +166,21 @@ namespace PitHero.UI
             var discoveredSynergyIds = _crystal.DiscoveredSynergyIds;
             // Cast to ICollection<string> to access Contains without LINQ
             var learnedSynergyIds = _crystal.LearnedSynergySkillIds as ICollection<string>;
+            var processedSkillIds = new HashSet<string>();
 
             int synergyCount = 0;
             // IReadOnlyCollection has no indexer, use GetEnumerator manually (UI-only code path)
             var discoveredEnumerator = discoveredSynergyIds.GetEnumerator();
             while (discoveredEnumerator.MoveNext())
             {
-                var pattern = SynergyDetector.GetPatternById(discoveredEnumerator.Current);
+                var synergyId = discoveredEnumerator.Current;
+                var pattern = SynergyPatternRegistry.GetById(synergyId);
                 if (pattern?.UnlockedSkill == null) continue;
                 var skill = pattern.UnlockedSkill;
-                if (learnedSynergyIds == null || !learnedSynergyIds.Contains(skill.Id)) continue;
-                var btn = new SkillIconButton(skill, true);
+                if (!processedSkillIds.Add(skill.Id)) continue;
+                bool isLearned = learnedSynergyIds != null && learnedSynergyIds.Contains(skill.Id);
+                var btn = new SkillIconButton(skill, isLearned, true,
+                    _crystal.GetSynergyPoints(synergyId), pattern.SynergyPointsRequired);
                 btn.OnHover += OnSkillHover;
                 btn.OnUnhover += OnSkillUnhover;
                 _skillButtons.Add(btn);
@@ -203,10 +208,10 @@ namespace PitHero.UI
             _contentTable.Row();
         }
 
-        private void OnSkillHover(ISkill skill)
+        private void OnSkillHover(ISkill skill, bool isLearned, bool isSynergy, int synergyCurrentPoints, int synergyRequiredPoints)
         {
             if (_stage == null) return;
-            _skillTooltip.ShowSkill(skill, false, null, false, 0, 0, showCostAndStatus: false);
+            _skillTooltip.ShowSkill(skill, isLearned, null, isSynergy, synergyCurrentPoints, synergyRequiredPoints);
             if (_skillTooltip.GetContainer().GetParent() == null)
                 _stage.AddElement(_skillTooltip.GetContainer());
             _skillTooltip.PositionWithinBounds(_stage.GetMousePosition(), _stage);
@@ -223,23 +228,33 @@ namespace PitHero.UI
         private class SkillIconButton : Element, IInputListener
         {
             private readonly ISkill _skill;
+            private readonly bool _isLearned;
+            private readonly bool _isSynergy;
+            private readonly int _synergyCurrentPoints;
+            private readonly int _synergyRequiredPoints;
             private SpriteDrawable _iconDrawable;
             private SpriteDrawable _highlightBoxDrawable;
             private bool _isHovered;
 
-            public event Action<ISkill> OnHover;
+            public event Action<ISkill, bool, bool, int, int> OnHover;
             public event Action OnUnhover;
 
-            public SkillIconButton(ISkill skill, bool isSynergy)
+            public SkillIconButton(ISkill skill, bool isLearned, bool isSynergy,
+                int synergyCurrentPoints = 0, int synergyRequiredPoints = 0)
             {
                 _skill = skill;
+                _isLearned = isLearned;
+                _isSynergy = isSynergy;
+                _synergyCurrentPoints = synergyCurrentPoints;
+                _synergyRequiredPoints = synergyRequiredPoints;
                 if (Core.Content != null)
                 {
                     var skillsAtlas = Core.Content.LoadSpriteAtlas("Content/Atlases/SkillsStencils.atlas");
                     var uiAtlas = Core.Content.LoadSpriteAtlas("Content/Atlases/UI.atlas");
                     var icon = skillsAtlas.GetSprite(skill.Id) ?? uiAtlas.GetSprite("SkillIcon1");
                     _iconDrawable = new SpriteDrawable(icon);
-                    if (!isSynergy) _iconDrawable.TintColor = Color.White;
+                    // Unlearned skills draw faded, matching HeroCrystalTab
+                    _iconDrawable.TintColor = isLearned ? Color.White : new Color(128, 128, 128, 200);
                     var hl = uiAtlas.GetSprite("HighlightBox");
                     if (hl != null) _highlightBoxDrawable = new SpriteDrawable(hl);
                 }
@@ -255,7 +270,7 @@ namespace PitHero.UI
                     _highlightBoxDrawable.Draw(batcher, GetX(), GetY(), GetWidth(), GetHeight(), Color.White);
             }
 
-            void IInputListener.OnMouseEnter()  { _isHovered = true;  OnHover?.Invoke(_skill); }
+            void IInputListener.OnMouseEnter()  { _isHovered = true;  OnHover?.Invoke(_skill, _isLearned, _isSynergy, _synergyCurrentPoints, _synergyRequiredPoints); }
             void IInputListener.OnMouseExit()   { _isHovered = false; OnUnhover?.Invoke(); }
             void IInputListener.OnMouseMoved(Vector2 _) { }
             bool IInputListener.OnLeftMousePressed(Vector2 _)  => true;

--- a/PitHero/UI/HeroUI.cs
+++ b/PitHero/UI/HeroUI.cs
@@ -421,16 +421,7 @@ namespace PitHero.UI
         /// </summary>
         private void DismissStencilPanelOnOutsideClick()
         {
-            if (_stencilLibraryPanel == null || !_stencilLibraryPanel.IsVisible()) return;
-            if (!Input.LeftMouseButtonPressed && !Input.RightMouseButtonPressed) return;
-            if (Time.FrameCount == _stencilPanelShownFrame) return;
-
-            var mousePos = _stage.GetMousePosition();
-            bool insidePanel = mousePos.X >= _stencilLibraryPanel.GetX()
-                && mousePos.X <= _stencilLibraryPanel.GetX() + _stencilLibraryPanel.GetWidth()
-                && mousePos.Y >= _stencilLibraryPanel.GetY()
-                && mousePos.Y <= _stencilLibraryPanel.GetY() + _stencilLibraryPanel.GetHeight();
-            if (!insidePanel)
+            if (OutsideClickDismissal.ShouldDismiss(_stencilLibraryPanel, _stage, _stencilPanelShownFrame))
                 _stencilLibraryPanel.SetVisible(false);
         }
 

--- a/PitHero/UI/HeroUI.cs
+++ b/PitHero/UI/HeroUI.cs
@@ -47,6 +47,7 @@ namespace PitHero.UI
 
         // Stencil system
         private StencilLibraryPanel _stencilLibraryPanel;
+        private uint _stencilPanelShownFrame;
         private List<RolePlayingFramework.Synergies.SynergyPattern> _allSynergyPatterns;
 
         // Item card for selection only (hover uses tooltip)
@@ -229,6 +230,8 @@ namespace PitHero.UI
         {
             if (_heroWindow == null) return;
 
+            _stencilLibraryPanel?.SetVisible(false);
+
             float newWidth;
             if (selectedTab == _inventoryTab)
             {
@@ -405,7 +408,30 @@ namespace PitHero.UI
                 _stencilLibraryPanel.SetPosition(panelX, panelY);
                 _stage.AddElement(_stencilLibraryPanel);
                 _stencilLibraryPanel.SetVisible(true);
+                // Stamp the frame so the same click that opened the panel can't also dismiss it
+                _stencilPanelShownFrame = Time.FrameCount;
             }
+        }
+
+        /// <summary>
+        /// Dismisses the stencil library panel on any click outside it. Polls global mouse state
+        /// instead of using a click-consuming overlay so the same click still reaches whatever was
+        /// under it (top bar buttons, tabs, other windows). Clicking View Stencils while the panel
+        /// is open closes it via this path, making the button an effective toggle.
+        /// </summary>
+        private void DismissStencilPanelOnOutsideClick()
+        {
+            if (_stencilLibraryPanel == null || !_stencilLibraryPanel.IsVisible()) return;
+            if (!Input.LeftMouseButtonPressed && !Input.RightMouseButtonPressed) return;
+            if (Time.FrameCount == _stencilPanelShownFrame) return;
+
+            var mousePos = _stage.GetMousePosition();
+            bool insidePanel = mousePos.X >= _stencilLibraryPanel.GetX()
+                && mousePos.X <= _stencilLibraryPanel.GetX() + _stencilLibraryPanel.GetWidth()
+                && mousePos.Y >= _stencilLibraryPanel.GetY()
+                && mousePos.Y <= _stencilLibraryPanel.GetY() + _stencilLibraryPanel.GetHeight();
+            if (!insidePanel)
+                _stencilLibraryPanel.SetVisible(false);
         }
 
         private void HandleMoveStencilsClicked(Button button)
@@ -1111,6 +1137,9 @@ namespace PitHero.UI
 
                 // Update crystals collection tab hover check
                 _crystalsTabComponent?.Update();
+
+                // Dismiss stencil library panel on outside click
+                DismissStencilPanelOnOutsideClick();
 
                 // Periodic hover check — safety net for missed hover events
                 _hoverCheckFrame++;

--- a/PitHero/UI/HeroUI.cs
+++ b/PitHero/UI/HeroUI.cs
@@ -48,6 +48,8 @@ namespace PitHero.UI
         // Stencil system
         private StencilLibraryPanel _stencilLibraryPanel;
         private uint _stencilPanelShownFrame;
+        private uint _windowShownFrame;
+        private List<Element> _windowBoundsElements;
         private List<RolePlayingFramework.Synergies.SynergyPattern> _allSynergyPatterns;
 
         // Item card for selection only (hover uses tooltip)
@@ -882,6 +884,8 @@ namespace PitHero.UI
                 _heroWindow.ToFront();
                 var pauseService = Core.Services.GetService<PauseService>();
                 if (pauseService != null) pauseService.IsPaused = true;
+                // Stamp the frame so the click that opened the window can't also dismiss it
+                _windowShownFrame = Time.FrameCount;
                 Debug.Log("Hero window opened and game paused");
             }
             else
@@ -1132,11 +1136,55 @@ namespace PitHero.UI
                 // Dismiss stencil library panel on outside click
                 DismissStencilPanelOnOutsideClick();
 
+                HandleWindowDismissInput();
+
                 // Periodic hover check — safety net for missed hover events
                 _hoverCheckFrame++;
                 if (_hoverCheckFrame % 5 == 0)
                     PerformPeriodicHoverCheck();
             }
+        }
+
+        /// <summary>
+        /// Closes the hero window on Escape or on a click outside its window envelope (window,
+        /// stencil panel, item card, crystal card). Escape peels one layer at a time: confirmation
+        /// dialog, then panel/cards, then the window. Defers mid-drag.
+        /// </summary>
+        private void HandleWindowDismissInput()
+        {
+            if (InventoryDragManager.IsDragging) return;
+
+            bool escPressed = Input.IsKeyPressed(Microsoft.Xna.Framework.Input.Keys.Escape)
+                && _stage.GetKeyboardFocus() == null;
+            if (escPressed)
+            {
+                if (ConfirmationDialog.TryCancelTopMost()) return;
+                if (_stencilLibraryPanel != null && _stencilLibraryPanel.IsVisible()) { _stencilLibraryPanel.SetVisible(false); return; }
+                var crystalCard = _crystalsTabComponent?.CrystalCardElement;
+                if (crystalCard != null && crystalCard.IsVisible()) { _crystalsTabComponent.Cleanup(); return; }
+                if (_selectedItemCard != null && _selectedItemCard.IsVisible()) { _selectedItemCard.Hide(); return; }
+                ToggleHeroWindow();
+                return;
+            }
+
+            if (ConfirmationDialog.AnyVisible) return;
+            // Clicks on the window's own top-bar button are the toggle handler's job, not ours
+            if (OutsideClickDismissal.IsMouseInside(_heroButton, _stage)) return;
+            if (OutsideClickDismissal.ShouldDismiss(GetWindowBoundsElements(), _stage, _windowShownFrame))
+                ToggleHeroWindow();
+        }
+
+        /// <summary>All elements whose bounding envelope counts as "inside the hero UI" for outside-click dismissal.</summary>
+        private List<Element> GetWindowBoundsElements()
+        {
+            if (_windowBoundsElements == null)
+                _windowBoundsElements = new List<Element>(4);
+            _windowBoundsElements.Clear();
+            _windowBoundsElements.Add(_heroWindow);
+            _windowBoundsElements.Add(_stencilLibraryPanel);
+            _windowBoundsElements.Add(_selectedItemCard);
+            _windowBoundsElements.Add(_crystalsTabComponent?.CrystalCardElement);
+            return _windowBoundsElements;
         }
 
         /// <summary>Periodic safety-net hover check: ensures the item tooltip appears if the mouse is

--- a/PitHero/UI/MonsterUI.cs
+++ b/PitHero/UI/MonsterUI.cs
@@ -15,6 +15,7 @@ namespace PitHero.UI
         private HoverableImageButton _monsterButton;
         private Window _monsterWindow;
         private bool _windowVisible = false;
+        private uint _windowShownFrame;
         private ImageButtonStyle _monsterNormalStyle;
         private ImageButtonStyle _monsterHalfStyle;
         private bool _styleChanged = false;
@@ -199,6 +200,8 @@ namespace PitHero.UI
                 var pauseService = Core.Services.GetService<PauseService>();
                 if (pauseService != null)
                     pauseService.IsPaused = true;
+                // Stamp the frame so the click that opened the window can't also dismiss it
+                _windowShownFrame = Time.FrameCount;
             }
             else
             {
@@ -575,7 +578,33 @@ namespace PitHero.UI
         public void Update()
         {
             UpdateButtonStyleIfNeeded();
-            if (_windowVisible) PositionWindow();
+            if (_windowVisible)
+            {
+                PositionWindow();
+                HandleWindowDismissInput();
+            }
+        }
+
+        /// <summary>
+        /// Closes the monster window on Escape or on a click outside it. Defers to any open
+        /// confirmation dialog.
+        /// </summary>
+        private void HandleWindowDismissInput()
+        {
+            bool escPressed = Input.IsKeyPressed(Microsoft.Xna.Framework.Input.Keys.Escape)
+                && _stage.GetKeyboardFocus() == null;
+            if (escPressed)
+            {
+                if (!ConfirmationDialog.TryCancelTopMost())
+                    ToggleMonsterWindow();
+                return;
+            }
+
+            if (ConfirmationDialog.AnyVisible) return;
+            // Clicks on the window's own top-bar button are the toggle handler's job, not ours
+            if (OutsideClickDismissal.IsMouseInside(_monsterButton, _stage)) return;
+            if (OutsideClickDismissal.ShouldDismiss(_monsterWindow, _stage, _windowShownFrame))
+                ToggleMonsterWindow();
         }
     }
 }

--- a/PitHero/UI/OutsideClickDismissal.cs
+++ b/PitHero/UI/OutsideClickDismissal.cs
@@ -1,0 +1,27 @@
+using Nez;
+using Nez.UI;
+
+namespace PitHero.UI
+{
+    /// <summary>
+    /// Outside-click dismissal for non-modal popups (info cards, designation dialogs). Polls global
+    /// mouse state instead of using a click-consuming overlay so the same click still reaches
+    /// whatever was under it (top bar buttons, tabs, other windows). Callers stamp Time.FrameCount
+    /// when showing the popup so the click that opened it can't also dismiss it.
+    /// </summary>
+    public static class OutsideClickDismissal
+    {
+        /// <summary>Returns true when a visible popup should hide: a click occurred this frame outside its bounds.</summary>
+        public static bool ShouldDismiss(Element popup, Stage stage, uint shownFrame)
+        {
+            if (popup == null || stage == null || !popup.IsVisible()) return false;
+            if (!Input.LeftMouseButtonPressed && !Input.RightMouseButtonPressed) return false;
+            if (Time.FrameCount == shownFrame) return false;
+
+            var mousePos = stage.GetMousePosition();
+            bool inside = mousePos.X >= popup.GetX() && mousePos.X <= popup.GetX() + popup.GetWidth()
+                && mousePos.Y >= popup.GetY() && mousePos.Y <= popup.GetY() + popup.GetHeight();
+            return !inside;
+        }
+    }
+}

--- a/PitHero/UI/OutsideClickDismissal.cs
+++ b/PitHero/UI/OutsideClickDismissal.cs
@@ -1,13 +1,15 @@
+using Microsoft.Xna.Framework;
 using Nez;
 using Nez.UI;
+using System.Collections.Generic;
 
 namespace PitHero.UI
 {
     /// <summary>
-    /// Outside-click dismissal for non-modal popups (info cards, designation dialogs). Polls global
-    /// mouse state instead of using a click-consuming overlay so the same click still reaches
-    /// whatever was under it (top bar buttons, tabs, other windows). Callers stamp Time.FrameCount
-    /// when showing the popup so the click that opened it can't also dismiss it.
+    /// Outside-click dismissal for non-modal popups (info cards, designation dialogs) and paused-game
+    /// UI windows. Polls global mouse state instead of using a click-consuming overlay so the same
+    /// click still reaches whatever was under it (top bar buttons, tabs, other windows). Callers
+    /// stamp Time.FrameCount when showing the popup so the click that opened it can't also dismiss it.
     /// </summary>
     public static class OutsideClickDismissal
     {
@@ -18,10 +20,58 @@ namespace PitHero.UI
             if (!Input.LeftMouseButtonPressed && !Input.RightMouseButtonPressed) return false;
             if (Time.FrameCount == shownFrame) return false;
 
+            return !IsInside(popup, stage.GetMousePosition());
+        }
+
+        /// <summary>
+        /// Multi-window variant for UIs composed of several windows/cards (e.g. the shop's paired
+        /// panels): returns true when a click this frame landed outside the bounding envelope of all
+        /// visible elements in the list. Using the envelope (not the strict union) means clicks in
+        /// the gap BETWEEN two windows of the same UI do not dismiss it — a mis-click between the
+        /// shop panels mid-session must not close the shop. Null or hidden entries are skipped, so
+        /// the list can safely contain lazily created popups.
+        /// </summary>
+        public static bool ShouldDismiss(List<Element> insideAny, Stage stage, uint shownFrame)
+        {
+            if (insideAny == null || stage == null) return false;
+            if (!Input.LeftMouseButtonPressed && !Input.RightMouseButtonPressed) return false;
+            if (Time.FrameCount == shownFrame) return false;
+
+            float minX = float.MaxValue, minY = float.MaxValue;
+            float maxX = float.MinValue, maxY = float.MinValue;
+            bool anyVisible = false;
+            for (int i = 0; i < insideAny.Count; i++)
+            {
+                var element = insideAny[i];
+                if (element == null || !element.IsVisible()) continue;
+                anyVisible = true;
+                if (element.GetX() < minX) minX = element.GetX();
+                if (element.GetY() < minY) minY = element.GetY();
+                if (element.GetX() + element.GetWidth() > maxX) maxX = element.GetX() + element.GetWidth();
+                if (element.GetY() + element.GetHeight() > maxY) maxY = element.GetY() + element.GetHeight();
+            }
+            if (!anyVisible) return false;
+
             var mousePos = stage.GetMousePosition();
-            bool inside = mousePos.X >= popup.GetX() && mousePos.X <= popup.GetX() + popup.GetWidth()
-                && mousePos.Y >= popup.GetY() && mousePos.Y <= popup.GetY() + popup.GetHeight();
-            return !inside;
+            return mousePos.X < minX || mousePos.X > maxX || mousePos.Y < minY || mousePos.Y > maxY;
+        }
+
+        /// <summary>
+        /// True when the mouse is currently over the given visible element. Used to exempt a UI's
+        /// own top-bar toggle button from outside-click dismissal: the dismissal poll runs before
+        /// stage input, so without the exemption the poll closes the window and the button's toggle
+        /// handler immediately reopens it — the window appears stuck open.
+        /// </summary>
+        public static bool IsMouseInside(Element element, Stage stage)
+        {
+            if (element == null || stage == null || !element.IsVisible()) return false;
+            return IsInside(element, stage.GetMousePosition());
+        }
+
+        private static bool IsInside(Element element, Vector2 stagePos)
+        {
+            return stagePos.X >= element.GetX() && stagePos.X <= element.GetX() + element.GetWidth()
+                && stagePos.Y >= element.GetY() && stagePos.Y <= element.GetY() + element.GetHeight();
         }
     }
 }

--- a/PitHero/UI/SecondChanceHeroCrystalPanel.cs
+++ b/PitHero/UI/SecondChanceHeroCrystalPanel.cs
@@ -310,7 +310,10 @@ namespace PitHero.UI
         {
             if (slot.Crystal == null || _hoverTooltip == null || _stage == null) return;
             var crystal = slot.Crystal;
-            _hoverLabel.SetText(crystal.Name + " (Lv." + crystal.Level + ")");
+            string skillsText = crystal.IsJobMastered()
+                ? "Mastered"
+                : crystal.JobLevel + "/" + crystal.Job.Skills.Count + " skills";
+            _hoverLabel.SetText(crystal.Name + " (" + skillsText + ")");
             _hoverTooltip.Pack();
             if (_hoverTooltip.GetParent() == null)
                 _stage.AddElement(_hoverTooltip);

--- a/PitHero/UI/SecondChanceShopUI.cs
+++ b/PitHero/UI/SecondChanceShopUI.cs
@@ -58,7 +58,7 @@ namespace PitHero.UI
         private VaultCrystalGrid _vaultCrystalGrid;
         private SecondChanceHeroCrystalPanel _heroCrystalPanel;
         private HeroCrystalCard _vaultCrystalCard;
-        private VaultCrystalCardDismissLayer _vaultCrystalCardDismissLayer;
+        private uint _cardShownFrame;
 
         // Which tab is currently active (0=Items, 1=Crystals)
         private int _activeTabIndex = 0;
@@ -400,6 +400,7 @@ namespace PitHero.UI
         private void HandleTabChanged(int tabIndex)
         {
             _activeTabIndex = tabIndex;
+            HideVaultCrystalCard();
             if (!_windowVisible) return;
 
             if (tabIndex == 0) // Items tab
@@ -584,6 +585,7 @@ namespace PitHero.UI
             UpdatePromotionVisibilityIfNeeded();
             UpdateButtonStyleIfNeeded();
             UpdateHeroInventoryTooltipPosition();
+            DismissVaultCrystalCardOnOutsideClick();
 
             if (_windowVisible && _stage != null)
             {
@@ -1066,7 +1068,7 @@ namespace PitHero.UI
                 return;
             }
 
-            int price = crystal.Level * GameConfig.CrystalBuyBackBasePrice;
+            int price = crystal.CalculateBuyBackPrice();
             string promptText = string.Format(GetText(TextType.UI, UITextKey.SecondChanceBuyPrompt), price);
 
             var dialog = new ConfirmationDialog(
@@ -1177,30 +1179,34 @@ namespace PitHero.UI
             _vaultCrystalCard.ShowCrystal(crystal);
             _vaultCrystalCard.Pack();
             _vaultCrystalCard.PositionAtWindowLeft(_shopWindow);
-
-            if (_vaultCrystalCardDismissLayer == null)
-                _vaultCrystalCardDismissLayer = new VaultCrystalCardDismissLayer(HideVaultCrystalCard);
-            if (_vaultCrystalCardDismissLayer.GetParent() == null)
-                _stage.AddElement(_vaultCrystalCardDismissLayer);
-            _vaultCrystalCardDismissLayer.SetSize(_stage.GetWidth(), _stage.GetHeight());
-            _vaultCrystalCardDismissLayer.SetVisible(true);
-            // Bring shop and hero-crystal windows above the dismiss layer so their
-            // crystal-slot children receive native click/hover events. Set ChildrenOnly
-            // touchable on both so empty background areas fall through to the dismiss layer.
-            _shopWindow?.ToFront();
-            _shopWindow?.SetTouchable(Touchable.ChildrenOnly);
-            _heroCrystalWindow?.ToFront();
-            _heroCrystalWindow?.SetTouchable(Touchable.ChildrenOnly);
             _vaultCrystalCard.ToFront();
+            // Stamp the frame so the same click that opened the card can't also dismiss it
+            _cardShownFrame = Time.FrameCount;
         }
 
         private void HideVaultCrystalCard()
         {
             _vaultCrystalCard?.Hide();
-            if (_vaultCrystalCardDismissLayer != null)
-                _vaultCrystalCardDismissLayer.SetVisible(false);
-            _shopWindow?.SetTouchable(Touchable.Enabled);
-            _heroCrystalWindow?.SetTouchable(Touchable.Enabled);
+        }
+
+        /// <summary>
+        /// Dismisses the crystal card on any click outside it. Polls global mouse state instead of
+        /// using a click-consuming overlay so the same click still reaches whatever was under it
+        /// (top bar buttons, shop tabs, other windows).
+        /// </summary>
+        private void DismissVaultCrystalCardOnOutsideClick()
+        {
+            if (_vaultCrystalCard == null || !_vaultCrystalCard.IsVisible()) return;
+            if (!Input.LeftMouseButtonPressed && !Input.RightMouseButtonPressed) return;
+            if (Time.FrameCount == _cardShownFrame) return;
+
+            var mousePos = _stage.GetMousePosition();
+            bool insideCard = mousePos.X >= _vaultCrystalCard.GetX()
+                && mousePos.X <= _vaultCrystalCard.GetX() + _vaultCrystalCard.GetWidth()
+                && mousePos.Y >= _vaultCrystalCard.GetY()
+                && mousePos.Y <= _vaultCrystalCard.GetY() + _vaultCrystalCard.GetHeight();
+            if (!insideCard)
+                HideVaultCrystalCard();
         }
 
         // ──────────────────────────────────────────────────────────────────────────
@@ -1396,25 +1402,5 @@ namespace PitHero.UI
 
         /// <summary>Full-stage transparent overlay that dismisses the vault crystal card on any click.
         /// Crystal-slot clicks are handled by the slots themselves (windows use ChildrenOnly touchable).</summary>
-        private class VaultCrystalCardDismissLayer : Element, IInputListener
-        {
-            private readonly System.Action _onDismiss;
-
-            public VaultCrystalCardDismissLayer(System.Action onDismiss)
-            {
-                _onDismiss = onDismiss;
-                SetTouchable(Touchable.Enabled);
-                SetVisible(false);
-            }
-
-            bool IInputListener.OnLeftMousePressed(Vector2 mousePos)  { _onDismiss?.Invoke(); return true; }
-            bool IInputListener.OnRightMousePressed(Vector2 mousePos) { _onDismiss?.Invoke(); return true; }
-            void IInputListener.OnMouseEnter()  { }
-            void IInputListener.OnMouseExit()   { }
-            void IInputListener.OnMouseMoved(Vector2 mousePos) { }
-            void IInputListener.OnLeftMouseUp(Vector2 mousePos)  { }
-            void IInputListener.OnRightMouseUp(Vector2 mousePos) { }
-            bool IInputListener.OnMouseScrolled(int mouseWheelDelta) => false;
-        }
     }
 }

--- a/PitHero/UI/SecondChanceShopUI.cs
+++ b/PitHero/UI/SecondChanceShopUI.cs
@@ -59,6 +59,8 @@ namespace PitHero.UI
         private SecondChanceHeroCrystalPanel _heroCrystalPanel;
         private HeroCrystalCard _vaultCrystalCard;
         private uint _cardShownFrame;
+        private uint _windowShownFrame;
+        private List<Nez.UI.Element> _windowBoundsElements;
 
         // Which tab is currently active (0=Items, 1=Crystals)
         private int _activeTabIndex = 0;
@@ -481,6 +483,9 @@ namespace PitHero.UI
 
                 if (_pauseService != null)
                     _pauseService.IsPaused = true;
+
+                // Stamp the frame so the click that opened the shop can't also dismiss it
+                _windowShownFrame = Time.FrameCount;
             }
             else
             {
@@ -601,7 +606,48 @@ namespace PitHero.UI
                     _heroCrystalPanel?.Update(mousePos);
                 }
                 // Seeds tab (index 2): no per-frame grid update needed
+
+                HandleWindowDismissInput();
             }
+        }
+
+        /// <summary>
+        /// Closes the shop on Escape or on a click outside its window envelope. Defers to any open
+        /// confirmation dialog and stays put mid-drag.
+        /// </summary>
+        private void HandleWindowDismissInput()
+        {
+            if (InventoryDragManager.IsDragging) return;
+
+            bool escPressed = Input.IsKeyPressed(Microsoft.Xna.Framework.Input.Keys.Escape)
+                && _stage.GetKeyboardFocus() == null;
+            if (escPressed)
+            {
+                if (ConfirmationDialog.TryCancelTopMost()) return;
+                if (_vaultCrystalCard != null && _vaultCrystalCard.IsVisible()) { HideVaultCrystalCard(); return; }
+                ToggleShopWindow();
+                return;
+            }
+
+            if (ConfirmationDialog.AnyVisible) return;
+            // Clicks on the window's own top-bar button are the toggle handler's job, not ours
+            if (OutsideClickDismissal.IsMouseInside(_shopButton, _stage)) return;
+            if (OutsideClickDismissal.ShouldDismiss(GetWindowBoundsElements(), _stage, _windowShownFrame))
+                ToggleShopWindow();
+        }
+
+        /// <summary>All elements whose bounding envelope counts as "inside the shop" for outside-click dismissal.</summary>
+        private List<Nez.UI.Element> GetWindowBoundsElements()
+        {
+            if (_windowBoundsElements == null)
+                _windowBoundsElements = new List<Nez.UI.Element>(5);
+            _windowBoundsElements.Clear();
+            _windowBoundsElements.Add(_shopWindow);
+            _windowBoundsElements.Add(_merchantSprite);
+            _windowBoundsElements.Add(_heroInventoryWindow);
+            _windowBoundsElements.Add(_heroCrystalWindow);
+            _windowBoundsElements.Add(_vaultCrystalCard);
+            return _windowBoundsElements;
         }
 
         /// <summary>Periodic safety-net hover check for the hero inventory tooltip in the shop.</summary>

--- a/PitHero/UI/SecondChanceShopUI.cs
+++ b/PitHero/UI/SecondChanceShopUI.cs
@@ -1196,16 +1196,7 @@ namespace PitHero.UI
         /// </summary>
         private void DismissVaultCrystalCardOnOutsideClick()
         {
-            if (_vaultCrystalCard == null || !_vaultCrystalCard.IsVisible()) return;
-            if (!Input.LeftMouseButtonPressed && !Input.RightMouseButtonPressed) return;
-            if (Time.FrameCount == _cardShownFrame) return;
-
-            var mousePos = _stage.GetMousePosition();
-            bool insideCard = mousePos.X >= _vaultCrystalCard.GetX()
-                && mousePos.X <= _vaultCrystalCard.GetX() + _vaultCrystalCard.GetWidth()
-                && mousePos.Y >= _vaultCrystalCard.GetY()
-                && mousePos.Y <= _vaultCrystalCard.GetY() + _vaultCrystalCard.GetHeight();
-            if (!insideCard)
+            if (OutsideClickDismissal.ShouldDismiss(_vaultCrystalCard, _stage, _cardShownFrame))
                 HideVaultCrystalCard();
         }
 

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -551,6 +551,10 @@ namespace PitHero.UI
             _tabPane.AddTab(_buttonsTab);
             _tabPane.AddTab(_automationTab);
 
+            // Switching settings tabs dismisses any open automation dialog
+            for (int i = 0; i < _tabPane.TabButtons.Count; i++)
+                _tabPane.TabButtons[i].OnClick += HideAutomationDialogs;
+
             // Add TabPane to settings window
             _settingsWindow.Add(_tabPane).Expand().Fill().Pad(0); // No cell padding - tabs flush with window edges
 
@@ -1937,6 +1941,7 @@ namespace PitHero.UI
                 // Hide any open confirmation dialogs
                 HideConfirmationDialog(_exitConfirmationDialog);
                 HideConfirmationDialog(_quitToTitleConfirmationDialog);
+                HideAutomationDialogs();
             }
 
             _isVisible = willShow;
@@ -1954,6 +1959,16 @@ namespace PitHero.UI
                 Core.Services.GetService<AutoHireMercenaryService>()?.TryHirePass();
         }
 
+        /// <summary>Hides all Automation tab option dialogs (designation, gear/consumable filters).</summary>
+        private void HideAutomationDialogs()
+        {
+            _autoSellCropTypesDialog?.Hide();
+            _gearSellOptionsDialog?.Hide();
+            _consumableSellOptionsDialog?.Hide();
+            _gearPurchaseOptionsDialog?.Hide();
+            _consumablePurchaseOptionsDialog?.Hide();
+        }
+
         /// <summary>
         /// Force closes the settings window and updates internal state.
         /// Called by other UIs (HeroUI, MonsterUI) when enforcing the single window policy.
@@ -1966,6 +1981,7 @@ namespace PitHero.UI
                 UIWindowManager.OnUIWindowClosing();
                 HideConfirmationDialog(_exitConfirmationDialog);
                 HideConfirmationDialog(_quitToTitleConfirmationDialog);
+                HideAutomationDialogs();
                 _settingsWindow.SetVisible(false);
                 var pauseService = Core.Services.GetService<PauseService>();
                 if (pauseService != null)
@@ -2117,6 +2133,13 @@ namespace PitHero.UI
                 UpdateFreeMoveMode();
                 return;
             }
+
+            // Dismiss automation option dialogs on outside click (without consuming the click)
+            _autoSellCropTypesDialog?.Update();
+            _gearSellOptionsDialog?.Update();
+            _consumableSellOptionsDialog?.Update();
+            _gearPurchaseOptionsDialog?.Update();
+            _consumablePurchaseOptionsDialog?.Update();
 
             // OnClicked (mouse-up) already ran in base.Update() before this method is called.
             // If till mode is now active but wasn't at the end of last frame, the click that activated
@@ -2285,6 +2308,7 @@ namespace PitHero.UI
             // Hide settings WITHOUT the close path: no OnUIWindowClosing, no unpause, _isVisible stays true
             HideConfirmationDialog(_exitConfirmationDialog);
             HideConfirmationDialog(_quitToTitleConfirmationDialog);
+            HideAutomationDialogs();
             _settingsWindow.SetVisible(false);
 
             // Forget docking so the exit-time shrink/restore anchors to the dragged position

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -1959,6 +1959,16 @@ namespace PitHero.UI
                 Core.Services.GetService<AutoHireMercenaryService>()?.TryHirePass();
         }
 
+        /// <summary>True while any Automation tab option dialog is visible.</summary>
+        private bool AnyAutomationDialogVisible()
+        {
+            return (_autoSellCropTypesDialog != null && _autoSellCropTypesDialog.IsVisible())
+                || (_gearSellOptionsDialog != null && _gearSellOptionsDialog.IsVisible())
+                || (_consumableSellOptionsDialog != null && _consumableSellOptionsDialog.IsVisible())
+                || (_gearPurchaseOptionsDialog != null && _gearPurchaseOptionsDialog.IsVisible())
+                || (_consumablePurchaseOptionsDialog != null && _consumablePurchaseOptionsDialog.IsVisible());
+        }
+
         /// <summary>Hides all Automation tab option dialogs (designation, gear/consumable filters).</summary>
         private void HideAutomationDialogs()
         {
@@ -2140,6 +2150,22 @@ namespace PitHero.UI
             _consumableSellOptionsDialog?.Update();
             _gearPurchaseOptionsDialog?.Update();
             _consumablePurchaseOptionsDialog?.Update();
+
+            // Escape peels one layer at a time: confirmation dialog, then automation dialogs, then
+            // the settings window itself. Settings deliberately has no outside-click dismissal —
+            // it's the window where an accidental close costs the most re-navigation.
+            if (_isVisible && Input.IsKeyPressed(Microsoft.Xna.Framework.Input.Keys.Escape)
+                && _stage.GetKeyboardFocus() == null)
+            {
+                if (_exitConfirmationDialog != null && _exitConfirmationDialog.IsVisible())
+                    HideConfirmationDialog(_exitConfirmationDialog);
+                else if (_quitToTitleConfirmationDialog != null && _quitToTitleConfirmationDialog.IsVisible())
+                    HideConfirmationDialog(_quitToTitleConfirmationDialog);
+                else if (AnyAutomationDialogVisible())
+                    HideAutomationDialogs();
+                else
+                    ToggleSettingsVisibility();
+            }
 
             // OnClicked (mouse-up) already ran in base.Update() before this method is called.
             // If till mode is now active but wasn't at the end of last frame, the click that activated

--- a/PitHero/UI/VaultCrystalGrid.cs
+++ b/PitHero/UI/VaultCrystalGrid.cs
@@ -173,7 +173,10 @@ namespace PitHero.UI
         {
             if (slot.Crystal == null || _hoverTooltip == null || _tooltipStage == null) return;
             var crystal = slot.Crystal;
-            _hoverLabel.SetText(crystal.Job.Name + " (Lv." + crystal.Level + ") - " + (GameConfig.CrystalBuyBackBasePrice * crystal.Level) + "g");
+            string skillsText = crystal.IsJobMastered()
+                ? "Mastered"
+                : crystal.JobLevel + "/" + crystal.Job.Skills.Count + " skills";
+            _hoverLabel.SetText(crystal.Job.Name + " (" + skillsText + ") - " + crystal.CalculateBuyBackPrice() + "g");
             // Add to stage first so Pack()/GetHeight() returns correct dimensions
             if (_hoverTooltip.GetParent() == null)
                 _tooltipStage.AddElement(_hoverTooltip);


### PR DESCRIPTION
## Summary

### Crystal system
- **Synergy skills persist through respawn** — the `Hero` constructor now re-adds learned synergy skills from the crystal via `SynergyPatternRegistry`, making the crystal the permanent home for synergy skills (matching job skills).
- **Crystal card shows learned vs. unlearned** — job skills fade when unlearned; discovered synergy skills appear faded with point progress in the tooltip (intentional shop-value signal: an almost-learned skill makes a crystal more attractive).
- **Buy-back pricing reflects skills** — `HeroCrystal.CalculateBuyBackPrice()`: level base (100g/level) + 0.5g per JP invested in learned job skills + 150g per learned synergy skill, with the premium hard-capped at the base price so recovery never costs more than 2× the flat price. Banked-but-unlearned synergy points add no premium.
- **Tooltips show mastery instead of the vestigial crystal level** — `Knight (5/8 skills)` / `(Mastered)` replaces `Lv.1`, which was a constant in practice (crystals are only ever created at level 1, and forging averages levels).

### UI dismissal overhaul
- New shared `OutsideClickDismissal` helper: popups dismiss on outside click via per-frame polling instead of click-consuming overlays, so a single click both dismisses and activates whatever was under it (top bar buttons, tabs, other windows).
- Applied to: shop/hero crystal cards, stencil library panel (also hides on Hero UI tab change; View Stencils now toggles), and the five Automation-tab option dialogs (which also hide on settings tab switch and every settings close path — previously they floated after settings closed).
- **Windows close on outside click + Escape** — Hero, Shop, and Monster windows dismiss on clicks outside their bounding envelope (gap clicks between paired shop panels are safe) and on Escape, which peels one layer at a time: confirmation dialog → cards/panels → window. Settings is Escape-only by design. Dismissal defers mid-drag and while a `ConfirmationDialog` is open; each window's own top-bar button is exempt so its toggle handler owns that click.

## Test plan
- Full suite: 1811 passed, 0 failed (7 new `HeroCrystalBuyBackPriceTests` covering flat pricing, JP premium, synergy fee, cap engagement, foreign skill ids, composite jobs).
- Playtested: crystal card display in shop and Crystals tab, buy-back price surfaces, tab/top-bar/outside-click/Escape dismissal across Hero, Shop, Monster, Settings, and the automation dialogs, top-bar button toggle behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)