### PR TITLE
Stopped party sleeps at night and hero-led tavern dining

### DIFF
--- a/PitHero/AI/HeroStateMachine.cs
+++ b/PitHero/AI/HeroStateMachine.cs
@@ -218,6 +218,8 @@ namespace PitHero.AI
                         EmitInnRestEvent();
                         _innRestEmitted = true;
                     }
+
+                    StandUpForNightSleepIfSeated();
                 }
                 else
                 {
@@ -282,6 +284,8 @@ namespace PitHero.AI
                                 EmitInnRestEvent();
                                 _innRestEmitted = true;
                             }
+
+                            StandUpForNightSleepIfSeated();
                         }
                         else
                         {
@@ -954,6 +958,23 @@ namespace PitHero.AI
                 if (actions[i] is SleepInBedAction)
                     return true;
             return false;
+        }
+
+        /// <summary>
+        /// A stopped party adopting a night-sleep plan leaves the table: clearing SeatedInTavern
+        /// stops the kitchen from taking party orders during the walk to the inn, and the dining
+        /// service settles outstanding tickets. Mercenaries get up and follow the hero to the inn
+        /// (the sleep coroutine re-disables following when it puts them to bed). StoppedAdventure
+        /// stays true, so the party walks back to the table after waking.
+        /// </summary>
+        private void StandUpForNightSleepIfSeated()
+        {
+            if (_hero.StoppedAdventure && _hero.SeatedInTavern)
+            {
+                _hero.SeatedInTavern = false;
+                WalkToTavernForStopAction.ReenableMercenaryFollowing();
+                Core.Services.GetService<PartyDiningService>()?.OnNightSleepDeparture();
+            }
         }
 
         /// <summary>Emits the inn-rest console event, using night-specific text when it's nighttime.</summary>

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -284,6 +284,8 @@ ConsoleHeroRespawn,{0} walks to the hero statue for his next chance
 ConsoleCrystalPromotion,{0} ventures forth as a {1}!
 ConsoleInnRest,Visiting inn to rest
 ConsoleNightSleep,Turning in for the night
+ConsoleBreakfastSkipped,The party skips breakfast - no ingredients for {0}
+ConsoleBreakfastSkippedGold,The party skips breakfast - not enough gold for {0}
 ConsoleMercenaryHired,{0} {1} was hired
 ConsoleMonsterAttack,{0} attacks {1} for {2} damage!
 ConsoleItemFound,{0} found {1}.

--- a/PitHero/ECS/Components/HeroComponent.cs
+++ b/PitHero/ECS/Components/HeroComponent.cs
@@ -958,8 +958,18 @@ namespace PitHero.ECS.Components
             // HIGHEST PRIORITY: Player stopped adventuring — go to tavern and stay there.
             // When SeatedInTavern is already true the goal is already satisfied, so the
             // planner returns no actions and the hero stays idle until Continue is pressed.
+            // Night sleep still preempts the seat: at 10 PM the party leaves the table,
+            // sleeps at the inn, and returns to the table after waking because
+            // StoppedAdventure stays true throughout.
             if (StoppedAdventure)
             {
+                var stopTimeService = Core.Services.GetService<InGameTimeService>();
+                if (stopTimeService?.IsNighttime == true)
+                {
+                    goalState.Set(GoapConstants.IsNighttime, false);
+                    return;
+                }
+
                 goalState.Set(GoapConstants.SeatedInTavern, true);
                 return;
             }

--- a/PitHero/Services/PartyDiningService.cs
+++ b/PitHero/Services/PartyDiningService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Xna.Framework;
 using Nez;
 using PitHero.Dining;
 using PitHero.ECS.Components;
@@ -31,8 +32,9 @@ namespace PitHero.Services
         /// <summary>The hero's favorite dish chosen in the Food tab.</summary>
         public int FavoriteDishId = (int)DishType.RoastedOnionSkewers;
 
-        /// <summary>When true, the party auto-dines at the tavern after waking each morning.</summary>
-        public bool EatAtTavern;
+        /// <summary>When true, the party auto-dines at the tavern after waking each morning. On by
+        /// default so new players see the dining system in action; saves restore the player's choice.</summary>
+        public bool EatAtTavern = true;
 
         private readonly MemberDining[] _slots = new MemberDining[PartySlots];
         private readonly KitchenTicket[] _tickets = new KitchenTicket[PartySlots];
@@ -154,13 +156,22 @@ namespace PitHero.Services
 
         /// <summary>
         /// Morning auto-dine (called from SleepInBedAction after night sleep). Enters Stop mode
-        /// and walks the party to the tavern for breakfast — skipped entirely when no member
-        /// could actually order (gold, storage coverage, or the kitchen can't serve).
+        /// and walks the party to the tavern for breakfast — skipped entirely when the hero,
+        /// who leads the meal, can't order (gold, storage coverage, or the kitchen can't serve).
         /// </summary>
         public void BeginAutoDine()
         {
             if (!EatAtTavern)
                 return;
+
+            var heroComponent = GetHeroComponent();
+            if (heroComponent != null && heroComponent.StoppedAdventure)
+            {
+                // A player-stopped party returns to the table on its own (SeatedInTavern goal)
+                // and orders once seated; arming auto-resume here would cancel the player's stop.
+                Debug.Log("[PartyDiningService] Skipping breakfast trip — party already stopped");
+                return;
+            }
 
             var coordinator = Core.Services.GetService<KitchenTaskCoordinator>();
             if (coordinator == null || !coordinator.IsKitchenOpen)
@@ -169,9 +180,29 @@ namespace PitHero.Services
                 return;
             }
 
-            if (!AnyMemberCanDine(coordinator))
+            // The hero leads the meal — mercs eat free but only when he eats — so the trip
+            // hinges entirely on his favorite dish being makeable and affordable.
+            if (_slots[0].HasEatenToday || GetCombatant(0) == null)
             {
-                Debug.Log("[PartyDiningService] Skipping breakfast trip — no party member can order");
+                Debug.Log("[PartyDiningService] Skipping breakfast trip — hero already ate");
+                return;
+            }
+
+            var favorite = FavoriteDishId >= 0 && FavoriteDishId < DishTypeInfo.Count
+                ? (DishType)FavoriteDishId
+                : DishType.RoastedOnionSkewers;
+            if (!coordinator.CanCoverRecipe(favorite))
+            {
+                EmitBreakfastSkipped(UITextKey.ConsoleBreakfastSkipped, favorite);
+                Debug.Log("[PartyDiningService] Skipping breakfast trip — no ingredients for favorite dish");
+                return;
+            }
+
+            var gameState = Core.Services.GetService<GameStateService>();
+            if (gameState == null || gameState.Funds < DishConfig.GetPrice(favorite))
+            {
+                EmitBreakfastSkipped(UITextKey.ConsoleBreakfastSkippedGold, favorite);
+                Debug.Log("[PartyDiningService] Skipping breakfast trip — not enough gold for favorite dish");
                 return;
             }
 
@@ -199,6 +230,21 @@ namespace PitHero.Services
         public void OnResumed()
         {
             _autoResumeWhenDone = false;
+            CancelOrFastTrackOutstandingOrders();
+        }
+
+        /// <summary>
+        /// Called when the party leaves the table for night sleep while Stop mode persists
+        /// (10 PM). Outstanding orders are settled like a resume, but AutoResumeWhenDone is
+        /// deliberately untouched so a manual stop survives the night.
+        /// </summary>
+        public void OnNightSleepDeparture()
+        {
+            CancelOrFastTrackOutstandingOrders();
+        }
+
+        private void CancelOrFastTrackOutstandingOrders()
+        {
             var coordinator = Core.Services.GetService<KitchenTaskCoordinator>();
             var gameState = Core.Services.GetService<GameStateService>();
 
@@ -284,13 +330,23 @@ namespace PitHero.Services
         // ── IPartyOrderSource ───────────────────────────────────────────────────
 
         /// <summary>
-        /// Next seated party member wanting to order, gold-gated hero-first. Members whose
-        /// favorite can't be covered by storage are skipped without substitution.
+        /// Next seated party member wanting to order. The hero leads the meal: he orders his
+        /// favorite dish only and pays for it; if it can't be made or afforded, the servers
+        /// skip the entire party — mercenaries never eat unless the hero eats. Mercenary meals
+        /// are free (job favorite, then the job's cheap fallbacks, ingredient-gated only).
+        /// Skips are re-evaluated on every poll, so the party is still served if ingredients
+        /// or gold appear while they remain seated.
         /// </summary>
         public bool TryGetNextPartyOrder(out int partySlot, out DishType dish)
         {
             partySlot = -1;
             dish = default;
+
+            // Eat-at-tavern off: the party may sit at the table, but servers ignore them and
+            // focus on walk-in patrons. Toggling it back on while seated (and not yet fed
+            // today) makes them orderable again on the next poll.
+            if (!EatAtTavern)
+                return false;
 
             var hero = GetHeroComponent();
             if (hero == null || !hero.StoppedAdventure || !hero.SeatedInTavern)
@@ -301,9 +357,29 @@ namespace PitHero.Services
             if (coordinator == null || gameState == null)
                 return false;
 
-            for (int slot = 0; slot < PartySlots; slot++)
+            bool heroLeads = _slots[0].OrderedDishId >= 0 || _slots[0].HasEatenToday;
+            if (!heroLeads)
             {
-                if (_slots[slot].OrderedDishId >= 0 || _skippedThisSeating[slot])
+                var heroCombatant = GetCombatant(0);
+                if (heroCombatant == null || !TryGetFavorite(0, out var heroFavorite))
+                    return false;
+
+                if (!coordinator.CanCoverRecipe(heroFavorite)
+                    || gameState.Funds < DishConfig.GetPrice(heroFavorite))
+                {
+                    MarkPartySkippedByHero(coordinator, heroFavorite, heroCombatant.Name);
+                    return false;
+                }
+
+                _skippedThisSeating[0] = false;
+                partySlot = 0;
+                dish = heroFavorite;
+                return true;
+            }
+
+            for (int slot = 1; slot < PartySlots; slot++)
+            {
+                if (_slots[slot].OrderedDishId >= 0)
                     continue;
                 var combatant = GetCombatant(slot);
                 if (combatant == null)
@@ -313,22 +389,27 @@ namespace PitHero.Services
 
                 if (_slots[slot].HasEatenToday)
                 {
-                    _skippedThisSeating[slot] = true;
-                    Analytics.AnalyticsService.LogPartyDineSkipped(slot, combatant.Name,
-                        favorite.ToString(), "already_ate");
+                    if (!_skippedThisSeating[slot])
+                    {
+                        _skippedThisSeating[slot] = true;
+                        Analytics.AnalyticsService.LogPartyDineSkipped(slot, combatant.Name,
+                            favorite.ToString(), "already_ate");
+                    }
                     continue;
                 }
 
-                // Favorite first, then the job class's two cheap fallbacks
-                if (!TryPickOrderableDish(slot, favorite, coordinator, gameState, out var chosen))
+                if (!TryPickMercDish(slot, favorite, coordinator, out var chosen))
                 {
-                    _skippedThisSeating[slot] = true;
-                    string reason = !coordinator.CanCoverRecipe(favorite) ? "no_ingredients" : "no_gold";
-                    Analytics.AnalyticsService.LogPartyDineSkipped(slot, combatant.Name,
-                        favorite.ToString(), reason);
+                    if (!_skippedThisSeating[slot])
+                    {
+                        _skippedThisSeating[slot] = true;
+                        Analytics.AnalyticsService.LogPartyDineSkipped(slot, combatant.Name,
+                            favorite.ToString(), "no_ingredients");
+                    }
                     continue;
                 }
 
+                _skippedThisSeating[slot] = false;
                 partySlot = slot;
                 dish = chosen;
                 return true;
@@ -336,18 +417,24 @@ namespace PitHero.Services
             return false;
         }
 
-        /// <summary>Party pays at order time (unlike walk-in patrons).</summary>
+        /// <summary>
+        /// The hero pays for his own meal at order time (unlike walk-in patrons, who pay when
+        /// they finish). Mercenary meals are free — no gold moves in either direction.
+        /// </summary>
         public void OnPartyOrderTaken(int partySlot, KitchenTicket ticket)
         {
-            var gameState = Core.Services.GetService<GameStateService>();
-            if (gameState != null)
+            if (partySlot == 0)
             {
-                gameState.Funds -= DishConfig.GetPrice(ticket.Dish);
-                PlaySoundAtHero(SoundEffectType.PayGold);
+                var gameState = Core.Services.GetService<GameStateService>();
+                if (gameState != null)
+                {
+                    gameState.Funds -= DishConfig.GetPrice(ticket.Dish);
+                    PlaySoundAtHero(SoundEffectType.PayGold);
+                }
             }
 
             _slots[partySlot].OrderedDishId = (int)ticket.Dish;
-            _slots[partySlot].HasPaid = true;
+            _slots[partySlot].HasPaid = partySlot == 0;
             _tickets[partySlot] = ticket;
         }
 
@@ -406,11 +493,16 @@ namespace PitHero.Services
             }
 
             // Still waiting on anything? (open order, eating, or an un-skipped eligible member)
+            // Eligible members only hold the trip while they can actually be served: if the
+            // player disabled EatAtTavern mid-trip or the kitchen lost its staff, they can
+            // never order, so only in-flight meals keep the party seated.
+            bool canStillServe = EatAtTavern
+                && Core.Services.GetService<KitchenTaskCoordinator>()?.IsKitchenOpen == true;
             for (int slot = 0; slot < PartySlots; slot++)
             {
                 if (_tickets[slot] != null || _eating[slot])
                     return;
-                if (!_slots[slot].HasEatenToday && !_skippedThisSeating[slot]
+                if (canStillServe && !_slots[slot].HasEatenToday && !_skippedThisSeating[slot]
                     && GetCombatant(slot) != null && TryGetFavorite(slot, out _))
                     return;
             }
@@ -423,30 +515,46 @@ namespace PitHero.Services
 
         // ── Helpers ─────────────────────────────────────────────────────────────
 
-        private bool AnyMemberCanDine(KitchenTaskCoordinator coordinator)
+        /// <summary>Session-log line explaining why the wake-up breakfast trip was skipped.</summary>
+        private void EmitBreakfastSkipped(string textKey, DishType favorite)
         {
-            var gameState = Core.Services.GetService<GameStateService>();
-            if (gameState == null)
-                return false;
-
-            for (int slot = 0; slot < PartySlots; slot++)
-            {
-                if (_slots[slot].HasEatenToday || GetCombatant(slot) == null)
-                    continue;
-                if (!TryGetFavorite(slot, out var favorite))
-                    continue;
-                if (TryPickOrderableDish(slot, favorite, coordinator, gameState, out _))
-                    return true;
-            }
-            return false;
+            var events = Core.Services.GetService<GameEventService>();
+            if (events == null)
+                return;
+            string dishName = events.LocalizeUI(DishConfig.GetDefinition(favorite).NameKey);
+            events.EmitLocalized(textKey, (dishName, Color.Green));
         }
 
         /// <summary>
-        /// Picks the dish this member would order right now: their favorite, or — when it can't
-        /// be made or afforded — the job class's two cheap fallback dishes, in order.
+        /// The hero can't order (ingredients or gold), so nobody eats this poll. Marks every
+        /// un-fed, order-free slot skipped so CheckAllDone can end a breakfast trip instead of
+        /// waiting forever; flags don't block later polls, so the party is still served if
+        /// supplies appear while seated.
         /// </summary>
-        private bool TryPickOrderableDish(int slot, DishType favorite,
-            KitchenTaskCoordinator coordinator, GameStateService gameState, out DishType dish)
+        private void MarkPartySkippedByHero(KitchenTaskCoordinator coordinator,
+            DishType heroFavorite, string heroName)
+        {
+            if (!_skippedThisSeating[0])
+            {
+                string reason = !coordinator.CanCoverRecipe(heroFavorite) ? "no_ingredients" : "no_gold";
+                Analytics.AnalyticsService.LogPartyDineSkipped(0, heroName,
+                    heroFavorite.ToString(), reason);
+            }
+
+            for (int slot = 0; slot < PartySlots; slot++)
+            {
+                if (_slots[slot].OrderedDishId < 0 && !_slots[slot].HasEatenToday)
+                    _skippedThisSeating[slot] = true;
+            }
+        }
+
+        /// <summary>
+        /// Picks the free dish a mercenary would order right now: their job favorite, or — when
+        /// it can't be made — the job class's two cheap fallback dishes, in order. Ingredient-
+        /// gated only; mercenary meals never touch gold.
+        /// </summary>
+        private bool TryPickMercDish(int slot, DishType favorite,
+            KitchenTaskCoordinator coordinator, out DishType dish)
         {
             string jobName = GetJobName(slot);
             for (int c = 0; c < 3; c++)
@@ -455,8 +563,6 @@ namespace PitHero.Services
                 if (c > 0 && candidate == favorite)
                     continue; // favorite already failed — don't re-check it
                 if (!coordinator.CanCoverRecipe(candidate))
-                    continue;
-                if (gameState.Funds < DishConfig.GetPrice(candidate))
                     continue;
                 dish = candidate;
                 return true;

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -295,6 +295,8 @@ namespace PitHero
         public const string ConsoleCrystalPromotion = "ConsoleCrystalPromotion";
         public const string ConsoleInnRest = "ConsoleInnRest";
         public const string ConsoleNightSleep = "ConsoleNightSleep";
+        public const string ConsoleBreakfastSkipped = "ConsoleBreakfastSkipped";
+        public const string ConsoleBreakfastSkippedGold = "ConsoleBreakfastSkippedGold";
         public const string ConsoleMercenaryHired = "ConsoleMercenaryHired";
         public const string ConsoleMonsterAttack = "ConsoleMonsterAttack";
         public const string ConsoleItemFound = "ConsoleItemFound";

--- a/PitHero/docs/TavernDiningSystem.md
+++ b/PitHero/docs/TavernDiningSystem.md
@@ -207,24 +207,36 @@ after eating they linger 5 min. On delivery the patron faces their table
 Rides **Stop mode** — no new GOAP surface. Entry paths:
 
 - **Manual**: player hits Stop; hero (and hired mercs) walk to the tavern and sit
-  (`WalkToTavernForStopAction`, `HeroComponent.StoppedAdventure && SeatedInTavern`).
+  (`WalkToTavernForStopAction`, `HeroComponent.StoppedAdventure && SeatedInTavern`). The party
+  sits regardless of the "Eat at tavern" checkbox; when it's off, servers ignore them entirely
+  and focus on walk-in patrons.
 - **Morning auto-dine**: `SleepInBedAction` calls `BeginAutoDine()` after waking if the
-  Food-tab "Eat at tavern" checkbox is on, the kitchen is open, and at least one member can
-  dine; it force-stops, and `CheckAllDone()` auto-resumes when everyone finishes.
+  Food-tab "Eat at tavern" checkbox is on (default **on** for new games), the kitchen is open,
+  and the hero can order (favorite makeable + affordable — an ingredient or gold shortfall
+  skips the trip with a session-console line); it force-stops, and `CheckAllDone()`
+  auto-resumes when everyone finishes. `BeginAutoDine` no-ops when the party is already
+  player-stopped so it can't cancel a manual stop. At 10 PM a stopped party leaves the table
+  for night sleep (`OnNightSleepDeparture` settles tickets like a resume) and returns after
+  waking — `StoppedAdventure` stays true throughout.
 
 `PartyDiningService` implements `IPartyOrderSource`; the coordinator polls
-`TryGetNextPartyOrder` (hero first — slot 0, then hired mercs 1/2). Dish choice: hero uses the
-Food-tab favorite (`FavoriteDishId`); mercs use `DishConfig.GetFavoriteForJob(job)`, falling
-back through two job-specific cheap dishes. A member whose candidates are all uncoverable or
-unaffordable is **skipped for that seating, with no substitution** (`party_dine_skipped`
-analytics with reason `already_ate` / `no_ingredients` / `no_gold`). One meal per member per
-day (`HasEatenToday`, reset at the 6 AM daily tick along with `MealBuffService.ClearAll()`).
+`TryGetNextPartyOrder`. **The hero leads the meal**: he orders only the Food-tab favorite
+(`FavoriteDishId`) and pays for it; if it can't be made or afforded, the servers skip the
+whole party — mercenaries never eat unless the hero eats. Mercenary meals are **free** (no
+gold in or out): job favorite via `DishConfig.GetFavoriteForJob(job)`, falling back through
+two job-specific cheap dishes, ingredient-gated only. Skips log `party_dine_skipped`
+analytics once (reason `already_ate` / `no_ingredients` / `no_gold`) but are **re-evaluated
+every poll**, so a seated party is still served when ingredients/gold appear later. One meal
+per member per day (`HasEatenToday`, reset at the 6 AM daily tick along with
+`MealBuffService.ClearAll()`).
 
-**Party pays at order time** (`OnPartyOrderTaken`), unlike patrons who pay after eating.
+**The hero pays at order time** (`OnPartyOrderTaken`), unlike patrons who pay after eating.
 Eating runs on `GetEatSeconds` (5/7/10s by class); `FinishMember` applies the meal buff, logs
 `dish_served` (party=true, tip=0), and notifies the coordinator. Resuming play mid-meal
-cancels outstanding tickets (refunding gold only while `CropsRefundable`), but a `Delivered`
-dish is fast-tracked — buffs still granted.
+cancels outstanding tickets (refunding gold only while `CropsRefundable` and `HasPaid`), but
+a `Delivered` dish is fast-tracked — buffs still granted. `CheckAllDone` holds the trip open
+for un-fed members only while they can actually be served (EatAtTavern on + kitchen staffed);
+otherwise in-flight meals finish and the party resumes — no endless sitting.
 
 ## Meal buffs
 


### PR DESCRIPTION
## Summary

A party stopped at the tavern table no longer sits there forever — at 10:00 PM they get up, sleep at the inn, and return to the table at 6 AM, still stopped. Alongside that, tavern dining becomes hero-led: the hero orders and pays for his favorite dish only, and mercenaries eat free.

### Night sleep while stopped
- The nighttime sleep goal now preempts the `SeatedInTavern` goal inside the `StoppedAdventure` branch of `HeroComponent.SetGoalState`, while `StoppedAdventure` stays true throughout — so the party walks back and re-seats after waking.
- When the sleep plan is adopted, the hero stands up (`SeatedInTavern` cleared), mercenaries re-enable following and walk behind him to the inn (no more chair-to-bed teleports), and `PartyDiningService.OnNightSleepDeparture()` settles outstanding tickets (delivered food fast-tracked, uncooked refunded) without touching auto-resume.
- `BeginAutoDine` bails when the party is already player-stopped, so the morning breakfast flow can no longer silently cancel a manual stop.

### Dining changes
- **Eat at tavern defaults ON** for new games (saves keep the player's choice). When off, servers ignore the seated party and focus on walk-in patrons; toggling it on while seated makes un-fed members orderable again.
- **Hero-led meals**: the hero orders only his Food-tab favorite and is the sole payer. If it can't be made or afforded, the servers skip the whole party — mercs never eat unless the hero eats. Mercenary meals are free and gold-neutral (job favorite → job fallbacks, ingredient-gated only).
- Skips are re-evaluated on every server poll, so a seated party is served as soon as ingredients or gold appear; analytics still logs each skip once.
- The wake-up breakfast trip is skipped up front with a session-console line when the hero's favorite lacks ingredients (`ConsoleBreakfastSkipped`) or gold (`ConsoleBreakfastSkippedGold`).
- Soft-lock protection: if the hero can't order once seated, all un-fed slots are marked skipped so `CheckAllDone` resumes the trip; `CheckAllDone` also only waits on members who can actually be served (EatAtTavern on + kitchen staffed).

Docs updated in `PitHero/docs/TavernDiningSystem.md`.

## Testing

- `dotnet build` clean; `dotnet test` — 1811 passed, 0 failed (baseline 0).
- These paths have no headless coverage; manual playtest script (night departure with tickets in flight, merc follow-to-inn, EatAtTavern default/toggle, gold/ingredient skip paths) is in the plan and should be run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)