### PR TITLE
Various fixes for issue #371

### DIFF
--- a/PitHero.Tests/MercenaryPitEdgeOffsetTests.cs
+++ b/PitHero.Tests/MercenaryPitEdgeOffsetTests.cs
@@ -44,5 +44,23 @@ namespace PitHero.Tests
                     $"Merc {mercIndex} edge row {tile.Y} must be within interior rows {InteriorRowMin}..{InteriorRowMax}");
             }
         }
+
+        [TestMethod]
+        public void PartyPitEdgeTiles_AvoidBlockedRimRows()
+        {
+            // The map's rim column pattern (PitHero.tmx Collision layer, stamped at every pit
+            // width by PitWidthManager) has collision tiles at rows 5 and 7 — only rows 4, 6
+            // and 8 are open within the interior span. Offsets that target 5 or 7 dead-end the
+            // merc's walk-to-edge plan and strand the party (issue #371 regression).
+            const int edgeX = 13;
+            for (int mercIndex = 0; mercIndex < 2; mercIndex++)
+            {
+                var tile = WalkToPitEdgeAction.CalculatePitEdgeTileForPartyIndex(edgeX, mercIndex);
+                Assert.AreNotEqual(GameConfig.PitCenterTileY - 1, tile.Y,
+                    $"Merc {mercIndex} must not target blocked rim row {GameConfig.PitCenterTileY - 1}");
+                Assert.AreNotEqual(GameConfig.PitCenterTileY + 1, tile.Y,
+                    $"Merc {mercIndex} must not target blocked rim row {GameConfig.PitCenterTileY + 1}");
+            }
+        }
     }
 }

--- a/PitHero.Tests/MercenaryPitEdgeOffsetTests.cs
+++ b/PitHero.Tests/MercenaryPitEdgeOffsetTests.cs
@@ -2,6 +2,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Xna.Framework;
 using PitHero.AI;
 
+// Also covers WalkToPitEdgeAction.PartyMemberBlocksStep (anti-overlap yield rule)
+
 namespace PitHero.Tests
 {
     [TestClass]
@@ -61,6 +63,49 @@ namespace PitHero.Tests
                 Assert.AreNotEqual(GameConfig.PitCenterTileY + 1, tile.Y,
                     $"Merc {mercIndex} must not target blocked rim row {GameConfig.PitCenterTileY + 1}");
             }
+        }
+
+        // ── Anti-overlap yield rule ──────────────────────────────────────────────
+
+        private static Vector2 TileCenter(int tileX, int tileY) => new Vector2(
+            tileX * GameConfig.TileSize + GameConfig.TileSize / 2,
+            tileY * GameConfig.TileSize + GameConfig.TileSize / 2);
+
+        [TestMethod]
+        public void PartyMemberBlocksStep_OverlappingBoundingBoxes_Blocks()
+        {
+            // Same tile — fully overlapped
+            Assert.IsTrue(WalkToPitEdgeAction.PartyMemberBlocksStep(
+                TileCenter(50, 6), TileCenter(50, 6), new Point(49, 6)));
+
+            // Partially overlapped (other is mid-move, half a tile ahead)
+            var halfTile = TileCenter(50, 6) + new Vector2(GameConfig.TileSize / 2f, 0);
+            Assert.IsTrue(WalkToPitEdgeAction.PartyMemberBlocksStep(
+                halfTile, TileCenter(50, 6), new Point(49, 6)));
+        }
+
+        [TestMethod]
+        public void PartyMemberBlocksStep_NextTileOccupied_Blocks()
+        {
+            // Other stands two tiles away but on the step destination
+            Assert.IsTrue(WalkToPitEdgeAction.PartyMemberBlocksStep(
+                TileCenter(48, 6), TileCenter(50, 6), new Point(48, 6)));
+        }
+
+        [TestMethod]
+        public void PartyMemberBlocksStep_AdjacentGridAligned_AllowsSingleFile()
+        {
+            // Grid-aligned actors on adjacent tiles are exactly TileSize apart — trailing
+            // single-file must not be blocked, or the party could never walk in a line.
+            Assert.IsFalse(WalkToPitEdgeAction.PartyMemberBlocksStep(
+                TileCenter(49, 6), TileCenter(50, 6), new Point(51, 6)));
+        }
+
+        [TestMethod]
+        public void PartyMemberBlocksStep_FarAway_DoesNotBlock()
+        {
+            Assert.IsFalse(WalkToPitEdgeAction.PartyMemberBlocksStep(
+                TileCenter(10, 4), TileCenter(50, 6), new Point(49, 6)));
         }
     }
 }

--- a/PitHero.Tests/MercenaryPitEdgeOffsetTests.cs
+++ b/PitHero.Tests/MercenaryPitEdgeOffsetTests.cs
@@ -1,0 +1,48 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Xna.Framework;
+using PitHero.AI;
+
+namespace PitHero.Tests
+{
+    [TestClass]
+    public class MercenaryPitEdgeOffsetTests
+    {
+        // Pit interior rows span PitRectY+1 .. PitRectY+PitRectHeight-2; a merc's jump lands at
+        // (edgeX - 2, edgeY), so every offset rim tile must keep its row inside that span.
+        private const int InteriorRowMin = GameConfig.PitRectY + 1;
+        private const int InteriorRowMax = GameConfig.PitRectY + GameConfig.PitRectHeight - 2;
+
+        [TestMethod]
+        public void PartyPitEdgeTiles_AreDistinctPerMercAndFromHero()
+        {
+            const int edgeX = 13;
+            var heroTile = new Point(edgeX, GameConfig.PitCenterTileY);
+            var merc0Tile = WalkToPitEdgeAction.CalculatePitEdgeTileForPartyIndex(edgeX, 0);
+            var merc1Tile = WalkToPitEdgeAction.CalculatePitEdgeTileForPartyIndex(edgeX, 1);
+
+            Assert.AreNotEqual(heroTile, merc0Tile, "Merc 0 must not share the hero's pit-edge tile");
+            Assert.AreNotEqual(heroTile, merc1Tile, "Merc 1 must not share the hero's pit-edge tile");
+            Assert.AreNotEqual(merc0Tile, merc1Tile, "Mercs must not share a pit-edge tile");
+        }
+
+        [TestMethod]
+        public void PartyPitEdgeTiles_StayOnEdgeColumn()
+        {
+            const int edgeX = 13;
+            Assert.AreEqual(edgeX, WalkToPitEdgeAction.CalculatePitEdgeTileForPartyIndex(edgeX, 0).X);
+            Assert.AreEqual(edgeX, WalkToPitEdgeAction.CalculatePitEdgeTileForPartyIndex(edgeX, 1).X);
+        }
+
+        [TestMethod]
+        public void PartyPitEdgeTiles_KeepJumpLandingRowsInsidePitInterior()
+        {
+            const int edgeX = 13;
+            for (int mercIndex = 0; mercIndex < 2; mercIndex++)
+            {
+                var tile = WalkToPitEdgeAction.CalculatePitEdgeTileForPartyIndex(edgeX, mercIndex);
+                Assert.IsTrue(tile.Y >= InteriorRowMin && tile.Y <= InteriorRowMax,
+                    $"Merc {mercIndex} edge row {tile.Y} must be within interior rows {InteriorRowMin}..{InteriorRowMax}");
+            }
+        }
+    }
+}

--- a/PitHero.Tests/PitResetOnHeroDeathTests.cs
+++ b/PitHero.Tests/PitResetOnHeroDeathTests.cs
@@ -79,9 +79,25 @@ namespace PitHero.Tests
         // ── Tier state ────────────────────────────────────────────────────────────
 
         [TestMethod]
-        public void TierAndBaseLevel_SurviveSetPitLevel1()
+        public void ResetTierForNewCycle_ResetsTierAndBaseLevel()
         {
-            // Tier and base level must NOT reset when the pit resets to level 1 on hero death.
+            // Hero death resets the whole pit cycle: tier and base level go back to 1.
+            var pitManager = CreatePitManager();
+            pitManager.Initialize();
+            pitManager.SetPitTier(3);
+            pitManager.SetTierBaseLevel(20);
+
+            pitManager.ResetTierForNewCycle();
+
+            Assert.AreEqual(1, pitManager.CurrentPitTier, "PitTier must reset to 1 on death");
+            Assert.AreEqual(1, pitManager.TierBaseLevel, "TierBaseLevel must reset to 1 on death");
+        }
+
+        [TestMethod]
+        public void SetPitLevel1_AloneDoesNotTouchTier()
+        {
+            // The tier reset is an explicit death-path call (ResetTierForNewCycle),
+            // not a side effect of SetPitLevel(1) — normal tier rollover also passes through level 1.
             var pitManager = CreatePitManager();
             pitManager.Initialize();
             pitManager.SetPitTier(3);
@@ -89,8 +105,8 @@ namespace PitHero.Tests
 
             pitManager.SetPitLevel(1);
 
-            Assert.AreEqual(3, pitManager.CurrentPitTier, "PitTier must survive death reset");
-            Assert.AreEqual(20, pitManager.TierBaseLevel, "TierBaseLevel must survive death reset");
+            Assert.AreEqual(3, pitManager.CurrentPitTier, "SetPitLevel must not change tier");
+            Assert.AreEqual(20, pitManager.TierBaseLevel, "SetPitLevel must not change base level");
             Assert.AreEqual(1, pitManager.CurrentPitLevel, "PitLevel should be 1 after reset");
         }
 
@@ -138,6 +154,7 @@ namespace PitHero.Tests
         [TestMethod]
         public void SetTierBaseLevel_IsMonotonicNonDecreasing()
         {
+            // ResetTierForNewCycle is the only sanctioned way to lower the base level.
             var pitManager = CreatePitManager();
             pitManager.Initialize();
             pitManager.SetTierBaseLevel(50);
@@ -150,6 +167,11 @@ namespace PitHero.Tests
             // Higher value is accepted.
             pitManager.SetTierBaseLevel(60);
             Assert.AreEqual(60, pitManager.TierBaseLevel);
+
+            // After a cycle reset, the monotonic guard restarts from 1.
+            pitManager.ResetTierForNewCycle();
+            pitManager.SetTierBaseLevel(5);
+            Assert.AreEqual(5, pitManager.TierBaseLevel, "Base level should be settable again after reset");
         }
 
         [TestMethod]

--- a/PitHero/AI/HeroStateMachine.cs
+++ b/PitHero/AI/HeroStateMachine.cs
@@ -873,6 +873,11 @@ namespace PitHero.AI
         /// </summary>
         private Point? CalculateBedLocation()
         {
+            // Night-time load spawned the hero already in bed — target the bed so GoTo is a
+            // no-op and the FSM proceeds straight to the sleep action.
+            if (_hero != null && _hero.SpawnedAsleepPending)
+                return new Point(GameConfig.InnHeroBedTileX, GameConfig.InnHeroBedTileY);
+
             // Return the payment tile position (67, 3) instead of bed position (73, 3)
             // This ensures hero walks to innkeeper first to pay before sleeping
             return new Point(GameConfig.InnPaymentTileX, GameConfig.InnPaymentTileY);

--- a/PitHero/AI/Interfaces/IPitWidthManager.cs
+++ b/PitHero/AI/Interfaces/IPitWidthManager.cs
@@ -13,12 +13,13 @@ namespace PitHero.AI.Interfaces
         int CurrentPitLevel { get; }
 
         /// <summary>
-        /// Current pit tier (1–99, permanent, never decreases).
+        /// Current pit tier (1–99, resets to 1 when the hero dies).
         /// </summary>
         int CurrentPitTier { get; }
 
         /// <summary>
         /// Hero level recorded when the tier first incremented; respawned heroes start here.
+        /// Resets to 1 when the hero dies.
         /// </summary>
         int TierBaseLevel { get; }
 

--- a/PitHero/AI/MercenaryStateMachine.cs
+++ b/PitHero/AI/MercenaryStateMachine.cs
@@ -344,7 +344,14 @@ namespace PitHero.AI
         {
             var currentTile = GetCurrentTile();
             var pitEdgeTile = FindPitEdge();
-            return currentTile == pitEdgeTile;
+            if (pitEdgeTile == Point.Zero)
+                return false;
+            if (currentTile == pitEdgeTile)
+                return true;
+
+            // WalkToPitEdgeAction falls back to the shared center rim tile when this merc's
+            // offset tile is unreachable — standing there counts as at-edge too.
+            return currentTile == new Point(pitEdgeTile.X, GameConfig.PitCenterTileY);
         }
 
         private Point FindPitEdge()
@@ -357,7 +364,17 @@ namespace PitHero.AI
             var pitWidth = pitWidthManager.CurrentPitRectWidthTiles;
             var pitRight = pitLeft + pitWidth - 1;
 
-            return new Point(pitRight, GameConfig.PitCenterTileY);
+            // Same per-merc offset WalkToPitEdgeAction targets, keyed by hire order
+            int mercIndex = 0;
+            var mercenaryManager = Core.Services.GetService<MercenaryManager>();
+            if (mercenaryManager != null)
+            {
+                var index = mercenaryManager.GetHiredMercenaries().IndexOf(Entity);
+                if (index >= 0)
+                    mercIndex = index;
+            }
+
+            return WalkToPitEdgeAction.CalculatePitEdgeTileForPartyIndex(pitRight, mercIndex);
         }
 
         private Point GetCurrentTile()

--- a/PitHero/AI/SleepInBedAction.cs
+++ b/PitHero/AI/SleepInBedAction.cs
@@ -112,6 +112,21 @@ namespace PitHero.AI
             var animComps = entity.GetComponents<HeroAnimationComponent>();
             for (int i = 0; i < animComps.Count; i++)
                 animComps[i].ForceSleepPose(dir);
+
+            SetSleepRenderOffset(entity, true);
+        }
+
+        /// <summary>
+        /// Shifts the actor's composited sprite down into the bed while asleep (render-only —
+        /// entity position, tile coordinates and pathfinding are untouched). Idempotent.
+        /// </summary>
+        private static void SetSleepRenderOffset(Entity entity, bool asleep)
+        {
+            var compositor = entity.GetComponent<MultiSpriteAnimator>();
+            if (compositor != null)
+                compositor.SetLocalOffset(new Vector2(
+                    compositor.LocalOffset.X,
+                    asleep ? GameConfig.SleepInBedSpriteOffsetY : 0f));
         }
 
         /// <summary>Unpauses every animation layer on the hero and all hired mercenaries.</summary>
@@ -121,12 +136,15 @@ namespace PitHero.AI
             for (int i = 0; i < heroAnims.Count; i++)
                 heroAnims[i].UnpauseAnimation();
 
+            SetSleepRenderOffset(heroEntity, false);
+
             var hired = Core.Services.GetService<MercenaryManager>()?.GetHiredMercenaries();
             for (int i = 0; hired != null && i < hired.Count; i++)
             {
                 var mercAnims = hired[i].GetComponents<HeroAnimationComponent>();
                 for (int j = 0; j < mercAnims.Count; j++)
                     mercAnims[j].UnpauseAnimation();
+                SetSleepRenderOffset(hired[i], false);
             }
         }
 
@@ -493,6 +511,7 @@ namespace PitHero.AI
                     heroAnimComps[i].PlaySleepAnimationForDirection(heroSleepDir);
                 for (int i = 0; i < heroAnimComps.Count; i++)
                     heroAnimComps[i].PauseAnimation();
+                SetSleepRenderOffset(heroEntity, true);
 
                 // Play sleep animations then pause all mercenary animation layers
                 for (int i = 0; i < hiredMercenaries.Count && i < 2; i++)
@@ -503,6 +522,7 @@ namespace PitHero.AI
                         mercAnimComps[j].PlaySleepAnimationForDirection(mercSleepDir);
                     for (int j = 0; j < mercAnimComps.Count; j++)
                         mercAnimComps[j].PauseAnimation();
+                    SetSleepRenderOffset(hiredMercenaries[i], true);
                 }
             }
 
@@ -623,6 +643,7 @@ namespace PitHero.AI
                     var mercAnimCompsWake = merc.GetComponents<HeroAnimationComponent>();
                     for (int j = 0; j < mercAnimCompsWake.Count; j++)
                         mercAnimCompsWake[j].UnpauseAnimation();
+                    SetSleepRenderOffset(merc, false);
 
                     Debug.Log($"[SleepInBedAction] Re-enabled following for mercenary {i + 1}");
                 }
@@ -641,6 +662,7 @@ namespace PitHero.AI
             var heroAnimCompsWake = heroEntity.GetComponents<HeroAnimationComponent>();
             for (int i = 0; i < heroAnimCompsWake.Count; i++)
                 heroAnimCompsWake[i].UnpauseAnimation();
+            SetSleepRenderOffset(heroEntity, false);
 
             // Step 5: Walk hero out of bed to exit tile (71, 3) - between payment tile and bed
             var exitTile = new Point(GameConfig.InnExitTileX, GameConfig.InnExitTileY);

--- a/PitHero/AI/SleepInBedAction.cs
+++ b/PitHero/AI/SleepInBedAction.cs
@@ -95,6 +95,42 @@ namespace PitHero.AI
         }
 
         /// <summary>
+        /// Instantly poses an actor asleep in bed: random sleep facing, closed-eye sleep
+        /// animation, paused. Used by the night-load spawn path so the party never renders
+        /// awake (open eyes, walk-cycle bobbing) while waiting for the sleep plan to start.
+        /// </summary>
+        public static void ApplySleepPose(Entity entity)
+        {
+            var dir = SleepFacingDirections[Nez.Random.Range(0, 4)];
+            var facing = entity.GetComponent<ActorFacingComponent>();
+            if (facing != null)
+            {
+                facing.SetFacing(dir);
+                facing.ConsumeDirtyFlag();
+            }
+
+            var animComps = entity.GetComponents<HeroAnimationComponent>();
+            for (int i = 0; i < animComps.Count; i++)
+                animComps[i].ForceSleepPose(dir);
+        }
+
+        /// <summary>Unpauses every animation layer on the hero and all hired mercenaries.</summary>
+        private static void UnpausePartyAnimations(Entity heroEntity)
+        {
+            var heroAnims = heroEntity.GetComponents<HeroAnimationComponent>();
+            for (int i = 0; i < heroAnims.Count; i++)
+                heroAnims[i].UnpauseAnimation();
+
+            var hired = Core.Services.GetService<MercenaryManager>()?.GetHiredMercenaries();
+            for (int i = 0; hired != null && i < hired.Count; i++)
+            {
+                var mercAnims = hired[i].GetComponents<HeroAnimationComponent>();
+                for (int j = 0; j < mercAnims.Count; j++)
+                    mercAnims[j].UnpauseAnimation();
+            }
+        }
+
+        /// <summary>
         /// Execute the sleep action - walk to payment tile, pay innkeeper (if not night sleep), then sleep and restore HP/MP
         /// NOTE: Gold check happens here since we can't add dynamic preconditions
         /// </summary>
@@ -128,8 +164,9 @@ namespace PitHero.AI
             if (spawnAsleep && !isNightSleep)
             {
                 // Clock crossed 6 AM between load and the first plan — undo the spawn-asleep
-                // staging and behave like a normal (paid) inn visit.
+                // staging (including the paused sleep poses) and behave like a normal (paid) inn visit.
                 hero.IsSleeping = false;
+                UnpausePartyAnimations(hero.Entity);
                 WalkToTavernForStopAction.ReenableMercenaryFollowing();
                 spawnAsleep = false;
             }
@@ -432,36 +469,41 @@ namespace PitHero.AI
                 }
             }
 
-            // Set random facing direction for sleep
-            Direction heroSleepDir = SleepFacingDirections[Nez.Random.Range(0, 4)];
-            if (facingComponent != null)
-                facingComponent.SetFacing(heroSleepDir);
-
-            for (int i = 0; i < hiredMercenaries.Count && i < 2; i++)
+            // Set random facing and freeze everyone into their sleep pose. Skipped when the
+            // party spawned asleep — the night-load path already posed them (ApplySleepPose),
+            // and re-randomizing here would visibly flip facings mid-sleep.
+            if (!spawnAsleep)
             {
-                var mercFacing = hiredMercenaries[i].GetComponent<ActorFacingComponent>();
-                mercFacing?.SetFacing(SleepFacingDirections[Nez.Random.Range(0, 4)]);
-            }
+                Direction heroSleepDir = SleepFacingDirections[Nez.Random.Range(0, 4)];
+                if (facingComponent != null)
+                    facingComponent.SetFacing(heroSleepDir);
 
-            // Wait one frame so HeroAnimationComponent.Update() picks up new facing direction before freeze
-            yield return null;
+                for (int i = 0; i < hiredMercenaries.Count && i < 2; i++)
+                {
+                    var mercFacing = hiredMercenaries[i].GetComponent<ActorFacingComponent>();
+                    mercFacing?.SetFacing(SleepFacingDirections[Nez.Random.Range(0, 4)]);
+                }
 
-            // Play sleep animations then pause all hero animation layers so hero looks still while sleeping
-            var heroAnimComps = heroEntity.GetComponents<HeroAnimationComponent>();
-            for (int i = 0; i < heroAnimComps.Count; i++)
-                heroAnimComps[i].PlaySleepAnimationForDirection(heroSleepDir);
-            for (int i = 0; i < heroAnimComps.Count; i++)
-                heroAnimComps[i].PauseAnimation();
+                // Wait one frame so HeroAnimationComponent.Update() picks up new facing direction before freeze
+                yield return null;
 
-            // Play sleep animations then pause all mercenary animation layers
-            for (int i = 0; i < hiredMercenaries.Count && i < 2; i++)
-            {
-                Direction mercSleepDir = hiredMercenaries[i].GetComponent<ActorFacingComponent>()?.Facing ?? Direction.Down;
-                var mercAnimComps = hiredMercenaries[i].GetComponents<HeroAnimationComponent>();
-                for (int j = 0; j < mercAnimComps.Count; j++)
-                    mercAnimComps[j].PlaySleepAnimationForDirection(mercSleepDir);
-                for (int j = 0; j < mercAnimComps.Count; j++)
-                    mercAnimComps[j].PauseAnimation();
+                // Play sleep animations then pause all hero animation layers so hero looks still while sleeping
+                var heroAnimComps = heroEntity.GetComponents<HeroAnimationComponent>();
+                for (int i = 0; i < heroAnimComps.Count; i++)
+                    heroAnimComps[i].PlaySleepAnimationForDirection(heroSleepDir);
+                for (int i = 0; i < heroAnimComps.Count; i++)
+                    heroAnimComps[i].PauseAnimation();
+
+                // Play sleep animations then pause all mercenary animation layers
+                for (int i = 0; i < hiredMercenaries.Count && i < 2; i++)
+                {
+                    Direction mercSleepDir = hiredMercenaries[i].GetComponent<ActorFacingComponent>()?.Facing ?? Direction.Down;
+                    var mercAnimComps = hiredMercenaries[i].GetComponents<HeroAnimationComponent>();
+                    for (int j = 0; j < mercAnimComps.Count; j++)
+                        mercAnimComps[j].PlaySleepAnimationForDirection(mercSleepDir);
+                    for (int j = 0; j < mercAnimComps.Count; j++)
+                        mercAnimComps[j].PauseAnimation();
+                }
             }
 
             // Night sleep: wait until 6 AM; healing sleep: wait 10 seconds

--- a/PitHero/AI/SleepInBedAction.cs
+++ b/PitHero/AI/SleepInBedAction.cs
@@ -122,6 +122,18 @@ namespace PitHero.AI
             var timeService = Core.Services.GetService<InGameTimeService>();
             bool isNightSleep = timeService?.IsNighttime == true;
 
+            // Night-time load spawned the party already in bed — skip the walk/pay steps.
+            bool spawnAsleep = hero.SpawnedAsleepPending;
+            hero.SpawnedAsleepPending = false;
+            if (spawnAsleep && !isNightSleep)
+            {
+                // Clock crossed 6 AM between load and the first plan — undo the spawn-asleep
+                // staging and behave like a normal (paid) inn visit.
+                hero.IsSleeping = false;
+                WalkToTavernForStopAction.ReenableMercenaryFollowing();
+                spawnAsleep = false;
+            }
+
             // Night sleep is free — skip gold check
             if (!isNightSleep)
             {
@@ -135,17 +147,18 @@ namespace PitHero.AI
             }
 
             // Start the sleep coroutine
-            Debug.Log($"[SleepInBedAction] Starting sleep action (isNightSleep={isNightSleep})");
+            Debug.Log($"[SleepInBedAction] Starting sleep action (isNightSleep={isNightSleep}, spawnAsleep={spawnAsleep})");
             _isSleeping = true;
             hero.IsSleeping = true;
-            _sleepCoroutine = Core.StartCoroutine(SleepCoroutine(hero, isNightSleep));
+            _sleepCoroutine = Core.StartCoroutine(SleepCoroutine(hero, isNightSleep, spawnAsleep));
             return false; // Not complete yet
         }
 
         /// <summary>
-        /// Coroutine that walks to payment tile, optionally pays innkeeper (free for night sleep), then sleeps and heals the hero and hired mercenaries
+        /// Coroutine that walks to payment tile, optionally pays innkeeper (free for night sleep), then sleeps and heals the hero and hired mercenaries.
+        /// When spawnAsleep is set (night-time load placed the party in the beds already), the innkeeper walk/pay steps are skipped.
         /// </summary>
-        private IEnumerator SleepCoroutine(HeroComponent hero, bool isNightSleep)
+        private IEnumerator SleepCoroutine(HeroComponent hero, bool isNightSleep, bool spawnAsleep)
         {
             var heroEntity = hero.Entity;
             var tileMover = heroEntity.GetComponent<TileByTileMover>();
@@ -166,8 +179,9 @@ namespace PitHero.AI
 
             Debug.Log($"[SleepInBedAction] Starting sleep action at ({currentTile.X},{currentTile.Y})");
 
-            // If not at payment tile, walk there directly (shouldn't normally happen)
-            if (currentTile != paymentTile)
+            // If not at payment tile, walk there directly (shouldn't normally happen).
+            // Skipped entirely when the party spawned asleep — they're already in the beds.
+            if (!spawnAsleep && currentTile != paymentTile)
             {
                 Debug.Warn($"[SleepInBedAction] Hero not at payment tile, walking from ({currentTile.X},{currentTile.Y}) to ({paymentTile.X},{paymentTile.Y})");
                 
@@ -239,15 +253,16 @@ namespace PitHero.AI
 
             _hasReachedPaymentTile = true;
 
-            // Step 2: Face right (towards innkeeper)
-            if (facingComponent != null)
+            // Step 2: Face right (towards innkeeper) — skipped when already in bed
+            if (!spawnAsleep && facingComponent != null)
             {
                 facingComponent.SetFacing(Direction.Right);
                 Debug.Log("[SleepInBedAction] Hero facing right towards innkeeper");
             }
 
             // Wait a brief moment (payment animation would go here)
-            yield return Coroutine.WaitForSeconds(0.5f);
+            if (!spawnAsleep)
+                yield return Coroutine.WaitForSeconds(0.5f);
 
             // Step 3: Pay the innkeeper (skipped for free night sleep)
             if (!isNightSleep)
@@ -273,7 +288,7 @@ namespace PitHero.AI
                     yield break;
                 }
             }
-            else
+            else if (!spawnAsleep) // save-restore of an in-progress night sleep isn't a new inn stay
             {
                 Debug.Log("[SleepInBedAction] Night sleep — innkeeper stay is free");
 
@@ -282,7 +297,7 @@ namespace PitHero.AI
             }
 
             // Step 4: Walk to bed (73, 3)
-            var bedTile = new Point(73, 3);
+            var bedTile = new Point(GameConfig.InnHeroBedTileX, GameConfig.InnHeroBedTileY);
             currentTile = tileMover.GetCurrentTileCoordinates();
 
             Debug.Log($"[SleepInBedAction] Walking to bed ({bedTile.X},{bedTile.Y}) from ({currentTile.X},{currentTile.Y})");
@@ -365,7 +380,11 @@ namespace PitHero.AI
             
             Debug.Log($"[SleepInBedAction] Found {hiredMercenaries.Count} hired mercenaries to teleport to beds");
             
-            var mercBedPositions = new Point[] { new Point(76, 3), new Point(73, 7) };
+            var mercBedPositions = new Point[]
+            {
+                new Point(GameConfig.InnMercBed1TileX, GameConfig.InnMercBed1TileY),
+                new Point(GameConfig.InnMercBed2TileX, GameConfig.InnMercBed2TileY)
+            };
             
             for (int i = 0; i < hiredMercenaries.Count && i < 2; i++)
             {
@@ -582,7 +601,7 @@ namespace PitHero.AI
                 heroAnimCompsWake[i].UnpauseAnimation();
 
             // Step 5: Walk hero out of bed to exit tile (71, 3) - between payment tile and bed
-            var exitTile = new Point(71, 3);
+            var exitTile = new Point(GameConfig.InnExitTileX, GameConfig.InnExitTileY);
             currentTile = tileMover.GetCurrentTileCoordinates();
 
             Debug.Log($"[SleepInBedAction] Waking up - walking to exit tile ({exitTile.X},{exitTile.Y}) from ({currentTile.X},{currentTile.Y})");

--- a/PitHero/AI/WalkToPitEdgeAction.cs
+++ b/PitHero/AI/WalkToPitEdgeAction.cs
@@ -29,7 +29,7 @@ namespace PitHero.AI
         {
             if (!_pathCalculated)
             {
-                _pitEdgeTile = FindNearestPitEdge();
+                _pitEdgeTile = FindNearestPitEdge(mercenary);
                 _pathCalculated = true;
             }
 
@@ -99,7 +99,7 @@ namespace PitHero.AI
             );
         }
 
-        private Point FindNearestPitEdge()
+        private Point FindNearestPitEdge(MercenaryComponent mercenary)
         {
             var pitWidthManager = Core.Services.GetService<PitWidthManager>();
             if (pitWidthManager == null)
@@ -108,10 +108,27 @@ namespace PitHero.AI
             var pitLeft = GameConfig.PitRectX;
             var pitWidth = pitWidthManager.CurrentPitRectWidthTiles;
             var pitRight = pitLeft + pitWidth - 1;
-            var pitEdgeX = pitRight;
-            var pitEdgeY = GameConfig.PitCenterTileY;
 
-            return new Point(pitEdgeX, pitEdgeY);
+            int mercIndex = 0;
+            var mercenaryManager = Core.Services.GetService<MercenaryManager>();
+            if (mercenaryManager != null)
+            {
+                var index = mercenaryManager.GetHiredMercenaries().IndexOf(mercenary.Entity);
+                if (index >= 0)
+                    mercIndex = index;
+            }
+
+            return CalculatePitEdgeTileForPartyIndex(pitRight, mercIndex);
+        }
+
+        /// <summary>
+        /// The hero targets (edgeX, PitCenterTileY); mercs offset vertically by hire order so the
+        /// party never converges on one tile — and their subsequent jump landings stay distinct too.
+        /// </summary>
+        public static Point CalculatePitEdgeTileForPartyIndex(int pitEdgeX, int mercIndex)
+        {
+            int yOffset = mercIndex == 0 ? -1 : 1;
+            return new Point(pitEdgeX, GameConfig.PitCenterTileY + yOffset);
         }
 
         private Direction? GetDirectionToTile(Point current, Point target)

--- a/PitHero/AI/WalkToPitEdgeAction.cs
+++ b/PitHero/AI/WalkToPitEdgeAction.cs
@@ -14,6 +14,7 @@ namespace PitHero.AI
     {
         private Point _pitEdgeTile;
         private bool _pathCalculated = false;
+        private float _yieldTimer;
 
         public WalkToPitEdgeAction() : base(GoapConstants.WalkToPitEdgeAction, 1)
         {
@@ -39,6 +40,7 @@ namespace PitHero.AI
             {
                 Debug.Log($"[WalkToPitEdge] {mercenary.Entity.Name} reached pit edge at ({_pitEdgeTile.X},{_pitEdgeTile.Y})");
                 _pathCalculated = false;
+                _yieldTimer = 0f;
                 return true;
             }
 
@@ -98,6 +100,20 @@ namespace PitHero.AI
             if (path.Count > 0)
             {
                 var nextTile = path[0];
+
+                // Anti-overlap: while walking independently, never walk inside a party member
+                // ahead in priority (hero > merc 1 > merc 2) — wait for them to move clear so the
+                // party doesn't render as one person. Priority ordering makes the yield one-way,
+                // so two mercs can never deadlock waiting on each other; the timer is a safety
+                // valve in case the member ahead parks on this merc's only route.
+                if (ShouldYieldToPartyAhead(mercenary, nextTile))
+                {
+                    _yieldTimer += Time.DeltaTime;
+                    if (_yieldTimer < GameConfig.MovementStuckTimeoutSeconds)
+                        return false;
+                }
+                _yieldTimer = 0f;
+
                 var direction = GetDirectionToTile(currentTile, nextTile);
                 if (direction.HasValue && tileMover != null)
                 {
@@ -106,6 +122,53 @@ namespace PitHero.AI
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// True when a higher-priority party member (the hero, or a merc hired earlier) is
+        /// currently overlapping this merc's bounding box or standing on the tile it would step
+        /// onto next.
+        /// </summary>
+        private bool ShouldYieldToPartyAhead(MercenaryComponent mercenary, Point nextTile)
+        {
+            var selfEntity = mercenary.Entity;
+            var selfPos = selfEntity.Transform.Position;
+
+            var heroEntity = selfEntity.Scene?.FindEntity("hero");
+            if (heroEntity != null && PartyMemberBlocksStep(heroEntity.Transform.Position, selfPos, nextTile))
+                return true;
+
+            var mercenaryManager = Core.Services.GetService<MercenaryManager>();
+            var hired = mercenaryManager?.GetHiredMercenaries();
+            if (hired == null)
+                return false;
+
+            var myIndex = hired.IndexOf(selfEntity);
+            for (int i = 0; i < myIndex; i++)
+            {
+                if (PartyMemberBlocksStep(hired[i].Transform.Position, selfPos, nextTile))
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// A step is blocked when the other member's tile-sized bounding box overlaps this one's,
+        /// or when the other member currently occupies the step's destination tile. Grid-aligned
+        /// actors on adjacent tiles are exactly TileSize apart, so single-file trailing is allowed.
+        /// </summary>
+        public static bool PartyMemberBlocksStep(Vector2 otherPos, Vector2 selfPos, Point nextTile)
+        {
+            if (System.Math.Abs(otherPos.X - selfPos.X) < GameConfig.TileSize &&
+                System.Math.Abs(otherPos.Y - selfPos.Y) < GameConfig.TileSize)
+                return true;
+
+            var otherTile = new Point(
+                (int)(otherPos.X / GameConfig.TileSize),
+                (int)(otherPos.Y / GameConfig.TileSize)
+            );
+            return otherTile == nextTile;
         }
 
         private Point GetCurrentTile(MercenaryComponent mercenary)

--- a/PitHero/AI/WalkToPitEdgeAction.cs
+++ b/PitHero/AI/WalkToPitEdgeAction.cs
@@ -57,6 +57,24 @@ namespace PitHero.AI
             var path = pathfinding.CalculatePath(currentTile, _pitEdgeTile);
             if (path == null || path.Count == 0)
             {
+                // The per-merc offset tile may be unreachable (map decor, runtime obstacles) —
+                // fall back to the shared center rim tile rather than dead-ending the plan.
+                // Overlapping at the edge beats a merc that never leaves for the pit at all.
+                var centerEdgeTile = new Point(_pitEdgeTile.X, GameConfig.PitCenterTileY);
+                if (_pitEdgeTile != centerEdgeTile)
+                {
+                    var fallbackPath = pathfinding.CalculatePath(currentTile, centerEdgeTile);
+                    if (fallbackPath != null && fallbackPath.Count > 0)
+                    {
+                        Debug.Warn($"[WalkToPitEdge] {mercenary.Entity.Name} cannot reach offset edge tile ({_pitEdgeTile.X},{_pitEdgeTile.Y}), falling back to center ({centerEdgeTile.X},{centerEdgeTile.Y})");
+                        _pitEdgeTile = centerEdgeTile;
+                        path = fallbackPath;
+                    }
+                }
+            }
+
+            if (path == null || path.Count == 0)
+            {
                 // Never cache the edge tile across attempts — the pit can widen between them
                 _pathCalculated = false;
 
@@ -124,10 +142,12 @@ namespace PitHero.AI
         /// <summary>
         /// The hero targets (edgeX, PitCenterTileY); mercs offset vertically by hire order so the
         /// party never converges on one tile — and their subsequent jump landings stay distinct too.
+        /// The rim rows directly adjacent to center (5 and 7) are collision tiles in the map's rim
+        /// column pattern, so the offsets must be ±2 to land on the open rows (4 and 8).
         /// </summary>
         public static Point CalculatePitEdgeTileForPartyIndex(int pitEdgeX, int mercIndex)
         {
-            int yOffset = mercIndex == 0 ? -1 : 1;
+            int yOffset = mercIndex == 0 ? -2 : 2;
             return new Point(pitEdgeX, GameConfig.PitCenterTileY + yOffset);
         }
 

--- a/PitHero/AI/WalkToTavernForStopAction.cs
+++ b/PitHero/AI/WalkToTavernForStopAction.cs
@@ -300,6 +300,9 @@ namespace PitHero.AI
                 var followComponent = mercEntity.GetComponent<MercenaryFollowComponent>();
                 if (followComponent != null)
                 {
+                    // Clear paths and stuck timers left over from before the party was seated —
+                    // stale state here triggers immediate stuck-warps onto the follow target.
+                    followComponent.ResetPathfinding();
                     followComponent.Enabled = true;
                     Debug.Log($"[WalkToTavernForStop] Re-enabled following for mercenary {i + 1}");
                 }

--- a/PitHero/Config/BiomeProgressionConfig.cs
+++ b/PitHero/Config/BiomeProgressionConfig.cs
@@ -3,7 +3,7 @@ namespace PitHero.Config
     /// <summary>
     /// Biome progression rules for pit tier rollover and effective cumulative depth calculations.
     /// The pit loops back to level 1 when it would exceed MaxBiomeLevel; each loop increments
-    /// the pit tier (1–99, permanent, survives hero death).
+    /// the pit tier (1–99). Hero death resets the tier to 1 along with the pit level.
     /// </summary>
     public static class BiomeProgressionConfig
     {
@@ -12,7 +12,7 @@ namespace PitHero.Config
         /// </summary>
         public static int MaxBiomeLevel => CaveBiomeConfig.CaveEndLevel;
 
-        /// <summary>Maximum pit tier. Tier is permanent and never decreases.</summary>
+        /// <summary>Maximum pit tier. Tier only decreases when hero death resets the cycle.</summary>
         public const int MaxPitTier = 99;
 
         /// <summary>

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -221,6 +221,7 @@ SkillProgress,Progress: {0} / {1} SP
 SkillJpCost,Cost: {0} JP
 SkillOwnerFormat,{0} ({1})
 SkillActiveMultiplier,Active: {0}x (Multiplier: {1:F2}x)
+SkillGrantsSynergySkill,Grants Synergy Skill!
 EquipPreviewChanges,Changes
 TabCrystals,Crystals
 CrystalForgeTitle,Crystal Forge

--- a/PitHero/ECS/Components/HeroAnimationComponent.cs
+++ b/PitHero/ECS/Components/HeroAnimationComponent.cs
@@ -206,6 +206,18 @@ namespace PitHero.ECS.Components
             }
         }
 
+        /// <summary>
+        /// Instantly freezes this layer in its sleep pose for the given direction. Syncs the
+        /// direction cache so the next Update doesn't re-play the walk animation over the pose;
+        /// callers must also consume the facing component's dirty flag.
+        /// </summary>
+        public void ForceSleepPose(Direction direction)
+        {
+            _lastDirection = direction;
+            PlaySleepAnimationForDirection(direction);
+            PauseAnimation();
+        }
+
         /// <summary>Updates the jump animation flip state (called during jump updates)</summary>
         public void UpdateJumpAnimationFlip(Direction direction)
         {

--- a/PitHero/ECS/Components/HeroComponent.cs
+++ b/PitHero/ECS/Components/HeroComponent.cs
@@ -327,6 +327,12 @@ namespace PitHero.ECS.Components
         /// </summary>
         public bool IsSleeping { get; set; }
 
+        /// <summary>
+        /// Set when a night-time load spawns the party directly in the inn beds; consumed by
+        /// SleepInBedAction to skip the walk-to-innkeeper/payment steps on its first execution.
+        /// </summary>
+        public bool SpawnedAsleepPending { get; set; }
+
         // Replenish override tracking - per-character flags set when Replenish button is pressed
         private bool _replenishHPOverrideHero;
         private bool _replenishMPOverrideHero;

--- a/PitHero/ECS/Components/MercenaryFollowComponent.cs
+++ b/PitHero/ECS/Components/MercenaryFollowComponent.cs
@@ -160,15 +160,16 @@ namespace PitHero.ECS.Components
                     return;
                 }
 
-                Debug.Warn($"[MercenaryFollowComponent] {Entity.Name} stuck at ({myTile.X},{myTile.Y}) for {_stuckTimer:F1}s, warping near target ({targetTile.X},{targetTile.Y})");
-                _tileMover.WarpToTile(targetTile);
+                var warpTile = PickWarpTile(targetTile, myTile);
+                Debug.Warn($"[MercenaryFollowComponent] {Entity.Name} stuck at ({myTile.X},{myTile.Y}) for {_stuckTimer:F1}s, warping to ({warpTile.X},{warpTile.Y}) near target ({targetTile.X},{targetTile.Y})");
+                _tileMover.WarpToTile(warpTile);
                 _pathfinding.RefreshPathfindingWithObstacles();
 
                 _currentPath = null;
                 _pathIndex = 0;
                 _stuckTimer = 0f;
-                _lastStuckCheckTile = targetTile;
-                _mercComponent.LastTilePosition = targetTile;
+                _lastStuckCheckTile = warpTile;
+                _mercComponent.LastTilePosition = warpTile;
                 return;
             }
 
@@ -226,6 +227,72 @@ namespace PitHero.ECS.Components
             if (_stateMachine == null)
                 _stateMachine = Entity.GetComponent<AI.MercenaryStateMachine>();
             return _stateMachine;
+        }
+
+        /// <summary>
+        /// Picks a free tile orthogonally adjacent to the follow target for a stuck-warp so the
+        /// merc never lands on top of the target or another party member. Falls back to the
+        /// target tile itself if every neighbor is walled, across the pit boundary, or occupied.
+        /// </summary>
+        private Point PickWarpTile(Point targetTile, Point myTile)
+        {
+            var candidates = new Point[]
+            {
+                new Point(targetTile.X - 1, targetTile.Y),
+                new Point(targetTile.X + 1, targetTile.Y),
+                new Point(targetTile.X, targetTile.Y - 1),
+                new Point(targetTile.X, targetTile.Y + 1),
+            };
+
+            // Nearest to the merc first so the warp covers the least distance
+            System.Array.Sort(candidates, (a, b) =>
+                (System.Math.Abs(a.X - myTile.X) + System.Math.Abs(a.Y - myTile.Y))
+                    .CompareTo(System.Math.Abs(b.X - myTile.X) + System.Math.Abs(b.Y - myTile.Y)));
+
+            var pitWidthManager = Core.Services.GetService<PitWidthManager>();
+            for (int i = 0; i < candidates.Length; i++)
+            {
+                var candidate = candidates[i];
+                if (_pathfinding.PathfindingGraph?.Walls?.Contains(candidate) == true)
+                    continue;
+                if (pitWidthManager != null && pitWidthManager.IsTileInsidePitInterior(candidate) != _mercComponent.InsidePit)
+                    continue;
+                if (IsTileOccupiedByPartyMember(candidate))
+                    continue;
+                return candidate;
+            }
+
+            return targetTile;
+        }
+
+        /// <summary>True when the hero or another hired mercenary currently stands on the tile.</summary>
+        private bool IsTileOccupiedByPartyMember(Point tile)
+        {
+            var hero = GetHeroComponent();
+            if (hero?.Entity != null && GetEntityTile(hero.Entity) == tile)
+                return true;
+
+            var mercenaryManager = Core.Services.GetService<MercenaryManager>();
+            if (mercenaryManager != null)
+            {
+                var hired = mercenaryManager.GetHiredMercenaries();
+                for (int i = 0; i < hired.Count; i++)
+                {
+                    if (hired[i] != Entity && GetEntityTile(hired[i]) == tile)
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static Point GetEntityTile(Entity entity)
+        {
+            var pos = entity.Transform.Position;
+            return new Point(
+                (int)(pos.X / GameConfig.TileSize),
+                (int)(pos.Y / GameConfig.TileSize)
+            );
         }
 
         /// <summary>

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -1394,7 +1394,38 @@ namespace PitHero.ECS.Scenes
                 followComp.Enabled = false;
             }
 
+            // Freeze everyone into their sleep pose (closed eyes, paused animation) right away —
+            // without this the party stands in the beds playing the open-eyed walk cycle until
+            // the GOAP sleep action's coroutine catches up.
+            Core.StartCoroutine(ApplySpawnSleepPoses(heroEntity, heroComp));
+
             Debug.Log("[MainGameScene] Night load — party spawned asleep in the inn beds");
+        }
+
+        /// <summary>
+        /// Waits for the party's animation layers to initialize (the atlas loads in
+        /// OnAddedToEntity, which can run after the load restore), then poses the hero and
+        /// hired mercenaries asleep in their beds. Bails if the party already woke up
+        /// (degenerate load right as the clock crosses 6 AM).
+        /// </summary>
+        private System.Collections.IEnumerator ApplySpawnSleepPoses(Entity heroEntity, HeroComponent heroComp)
+        {
+            for (int frame = 0; frame < 10; frame++)
+            {
+                yield return null;
+                var anim = heroEntity.GetComponent<HeroAnimationComponent>();
+                if (anim != null && anim.Animations != null && anim.Animations.Count > 0)
+                    break;
+            }
+
+            if (!heroComp.IsSleeping)
+                yield break;
+
+            AI.SleepInBedAction.ApplySleepPose(heroEntity);
+
+            var hiredMercenaries = Core.Services.GetService<MercenaryManager>()?.GetHiredMercenaries();
+            for (int i = 0; hiredMercenaries != null && i < hiredMercenaries.Count && i < 2; i++)
+                AI.SleepInBedAction.ApplySleepPose(hiredMercenaries[i]);
         }
 
         /// <summary>

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -868,6 +868,15 @@ namespace PitHero.ECS.Scenes
                 Debug.Log("[MainGameScene] Restored " + pendingData.HiredMercenaries.Count + " hired mercenaries");
             }
 
+            // Loading during sleeping hours: spawn the party directly in the inn beds instead of
+            // making them walk to the innkeeper first. Must run after the mercenaries are spawned
+            // (their default spawn positions derive from the hero's). SleepInBedAction consumes
+            // SpawnedAsleepPending and takes over from the in-bed state.
+            if (Core.Services.GetService<InGameTimeService>()?.IsNighttime == true)
+            {
+                PositionPartyInBedsForNightLoad(heroEntity, heroComp);
+            }
+
             // Restore party dining state (issue #319) — after hero + hired mercs exist so
             // active meal buffs can be re-registered against their combatants
             Core.Services.GetService<Services.PartyDiningService>()?.RestoreFromSave(pendingData);
@@ -1339,6 +1348,56 @@ namespace PitHero.ECS.Scenes
         }
 
         /// <summary>
+        /// Places the hero and hired mercenaries directly into the inn beds after a night-time
+        /// load, so they wake through the normal SleepInBedAction path instead of walking to the
+        /// innkeeper first (issue #371).
+        /// </summary>
+        private void PositionPartyInBedsForNightLoad(Entity heroEntity, HeroComponent heroComp)
+        {
+            heroEntity.Transform.Position = new Vector2(
+                GameConfig.InnHeroBedTileX * GameConfig.TileSize + GameConfig.TileSize / 2,
+                GameConfig.InnHeroBedTileY * GameConfig.TileSize + GameConfig.TileSize / 2);
+            heroEntity.GetComponent<TileByTileMover>()?.SnapToTileGrid();
+            heroComp.IsSleeping = true;
+            heroComp.SpawnedAsleepPending = true;
+
+            var mercBedTiles = new Point[]
+            {
+                new Point(GameConfig.InnMercBed1TileX, GameConfig.InnMercBed1TileY),
+                new Point(GameConfig.InnMercBed2TileX, GameConfig.InnMercBed2TileY),
+            };
+
+            var hiredMercenaries = Core.Services.GetService<MercenaryManager>()?.GetHiredMercenaries();
+            for (int i = 0; hiredMercenaries != null && i < hiredMercenaries.Count && i < 2; i++)
+            {
+                var merc = hiredMercenaries[i];
+                var bedTile = mercBedTiles[i];
+                merc.Transform.Position = new Vector2(
+                    bedTile.X * GameConfig.TileSize + GameConfig.TileSize / 2,
+                    bedTile.Y * GameConfig.TileSize + GameConfig.TileSize / 2);
+                merc.GetComponent<TileByTileMover>()?.SnapToTileGrid();
+
+                var mercComp = merc.GetComponent<MercenaryComponent>();
+                if (mercComp != null)
+                {
+                    mercComp.LastTilePosition = bedTile;
+                    mercComp.InsidePit = false;
+                    merc.GetComponent<PathfindingActorComponent>()?.RefreshPathfindingWithObstacles();
+                }
+
+                // Pre-add the follow component disabled so the merc stays in bed until the sleep
+                // action's wake path re-enables it (FollowTargetAction only adds-if-missing and
+                // never forces Enabled back on).
+                var followComp = merc.GetComponent<MercenaryFollowComponent>();
+                if (followComp == null)
+                    followComp = merc.AddComponent(new MercenaryFollowComponent());
+                followComp.Enabled = false;
+            }
+
+            Debug.Log("[MainGameScene] Night load — party spawned asleep in the inn beds");
+        }
+
+        /// <summary>
         /// Creates a hero entity at the specified tile coordinates using HeroDesign for appearance.
         /// When needsCrystal is true, the hero spawns without a crystal and waits for the promotion ceremony.
         /// </summary>
@@ -1489,6 +1548,10 @@ namespace PitHero.ECS.Scenes
         /// </summary>
         private void RespawnHero()
         {
+            // Reset the pit cycle before the crystal ceremony so the new hero's spawn level
+            // is computed from a fresh TierBaseLevel, not the dead run's progression.
+            Core.Services.GetService<PitWidthManager>()?.ResetTierForNewCycle();
+
             CreateHeroEntity(34, 6, needsCrystal: true);
 
             // Disable save while hero walks to statue — saving in this transitional state puts the game in an odd state
@@ -1552,7 +1615,8 @@ namespace PitHero.ECS.Scenes
                 return;
             }
 
-            Debug.Log($"[MainGameScene] Resetting pit from level {pitManager.CurrentPitLevel} to level 1 after hero death.");
+            Debug.Log($"[MainGameScene] Resetting pit from level {pitManager.CurrentPitLevel} (tier {pitManager.CurrentPitTier}) to level 1, tier 1 after hero death.");
+            pitManager.ResetTierForNewCycle();
             pitManager.SetPitLevel(1);
         }
 
@@ -2601,11 +2665,11 @@ namespace PitHero.ECS.Scenes
             
             Entity newHoveredMercenary = null;
 
-            // Suppress hover entirely while the cursor is outside the game window so the SelectBox
-            // doesn't latch onto a mercenary the user isn't actually pointing at.
-            bool mouseInWindow = Util.MouseUtils.IsMouseInsideWindow();
+            // Suppress hover while the cursor is outside the game window or over open UI so the
+            // SelectBox doesn't latch onto a mercenary the user isn't actually pointing at.
+            bool interactable = !MercenaryInteractionsBlocked();
 
-            for (int i = 0; mouseInWindow && i < mercenaries.Count; i++)
+            for (int i = 0; interactable && i < mercenaries.Count; i++)
             {
                 var mercEntity = mercenaries[i];
                 var mercComponent = mercEntity.GetComponent<MercenaryComponent>();
@@ -2723,12 +2787,7 @@ namespace PitHero.ECS.Scenes
             if (!Input.LeftMouseButtonPressed)
                 return;
 
-            // Ignore clicks made while the cursor is outside the game window (e.g. on a second monitor).
-            if (!Util.MouseUtils.IsMouseInsideWindow())
-                return;
-
-            // Don't process clicks if dialog is already open
-            if (_mercenaryHireDialog?.IsDialogVisible == true)
+            if (MercenaryInteractionsBlocked())
                 return;
 
             var mercenaryManager = Core.Services.GetService<MercenaryManager>();
@@ -2766,6 +2825,22 @@ namespace PitHero.ECS.Scenes
                     break;
                 }
             }
+        }
+
+        /// <summary>
+        /// True when tavern-mercenary hover/click interactions should be suppressed — while the
+        /// cursor is outside the game window, while the hire dialog is already open, or when the
+        /// pointer is over UI (so mercs behind an open window can't be clicked through it).
+        /// </summary>
+        private bool MercenaryInteractionsBlocked()
+        {
+            if (!Util.MouseUtils.IsMouseInsideWindow())
+                return true;
+            if (_mercenaryHireDialog?.IsDialogVisible == true)
+                return true;
+            if (_uiStage != null && _uiStage.Hit(_uiStage.GetMousePosition()) != null)
+                return true;
+            return false;
         }
 
         /// <summary>

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -97,6 +97,14 @@ namespace PitHero
         public const int InnkeeperTileY = 3;
         public const int InnPaymentTileX = 67; // Hero pays at (67, 3) facing right
         public const int InnPaymentTileY = 3;
+        public const int InnHeroBedTileX = 73; // Hero sleeps at (73, 3)
+        public const int InnHeroBedTileY = 3;
+        public const int InnMercBed1TileX = 76; // First hired merc sleeps at (76, 3)
+        public const int InnMercBed1TileY = 3;
+        public const int InnMercBed2TileX = 73; // Second hired merc sleeps at (73, 7)
+        public const int InnMercBed2TileY = 7;
+        public const int InnExitTileX = 71; // Hero walks here after waking, between payment tile and bed
+        public const int InnExitTileY = 3;
         // Inn nap cost scales with the party: each member costs the base fee plus a surcharge
         // per full 10 levels (level 30 -> 10 + 30 = 40g). Night sleep stays free.
         public const int InnCostBaseGoldPerMember = 10;
@@ -257,7 +265,7 @@ namespace PitHero
         public const float CameraKeyboardPanAccelSeconds = 1.5f; // seconds of continuous key-hold to ramp pan speed from starting to top
         public const float CameraFollowLerpSpeed = 5f; // speed at which camera lerps to hero position
         public const float CameraManualControlTimeout = 7f; // seconds of inactivity before auto-following resumes (paused when player interacts with selectables)
-        public const bool CameraAutoScrollToHeroDefault = true; // default value for auto-scroll to hero setting
+        public const bool CameraAutoScrollToHeroDefault = false; // default value for auto-scroll to hero setting
         public const int MapQuadrantCount = 4; // horizontal map quadrants reachable via keys 1-4
 
         // World Bounds

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -105,6 +105,9 @@ namespace PitHero
         public const int InnMercBed2TileY = 7;
         public const int InnExitTileX = 71; // Hero walks here after waking, between payment tile and bed
         public const int InnExitTileY = 3;
+        // Render-only Y offset applied to a sleeping actor's composite sprite so they nestle
+        // into the bed instead of standing on top of it
+        public const float SleepInBedSpriteOffsetY = 8f;
         // Inn nap cost scales with the party: each member costs the base fee plus a surcharge
         // per full 10 levels (level 30 -> 10 + 30 = 40g). Night sleep stays free.
         public const int InnCostBaseGoldPerMember = 10;

--- a/PitHero/PitWidthManager.cs
+++ b/PitHero/PitWidthManager.cs
@@ -258,6 +258,17 @@ namespace PitHero
         }
 
         /// <summary>
+        /// Resets tier progression to the first cycle after permadeath. Bypasses the monotonic
+        /// guard in SetTierBaseLevel, which stays monotonic for normal progression.
+        /// </summary>
+        public void ResetTierForNewCycle()
+        {
+            _currentPitTier = 1;
+            _tierBaseLevel = 1;
+            Debug.Log("[PitWidthManager] Tier reset to 1 for new cycle (hero death)");
+        }
+
+        /// <summary>
         /// Increments the pit tier by 1 (clamped at MaxPitTier) and records the hero level as the new tier base level.
         /// Called when the pit level wraps from MaxBiomeLevel back to 1.
         /// </summary>

--- a/PitHero/UI/HeroUI.cs
+++ b/PitHero/UI/HeroUI.cs
@@ -1133,6 +1133,9 @@ namespace PitHero.UI
                 // Update crystals collection tab hover check
                 _crystalsTabComponent?.Update();
 
+                // Keep the stencil library hover card glued to the cursor
+                _stencilLibraryPanel?.UpdateHoverTooltip();
+
                 // Dismiss stencil library panel on outside click
                 DismissStencilPanelOnOutsideClick();
 

--- a/PitHero/UI/SkillTooltip.cs
+++ b/PitHero/UI/SkillTooltip.cs
@@ -156,10 +156,10 @@ namespace PitHero.UI
         /// </summary>
         public void ShowSynergyPattern(SynergyPattern pattern)
         {
-            BuildSynergyCard(pattern, null);
+            BuildSynergyCard(pattern, null, showGrantsSkillNote: pattern.UnlockedSkill != null);
         }
 
-        private void BuildSynergyCard(SynergyPattern pattern, string multiplierLine)
+        private void BuildSynergyCard(SynergyPattern pattern, string multiplierLine, bool showGrantsSkillNote = false)
         {
             _contentTable.Clear();
 
@@ -209,6 +209,13 @@ namespace PitHero.UI
             var noteLabel = new Label(GetText(TextType.UI, UITextKey.SkillActivePatternNote), new LabelStyle { Font = Graphics.Instance.BitmapFont, FontColor = SynergyOrange });
             _contentTable.Add(noteLabel).Left().SetPadTop(5f);
             _contentTable.Row();
+
+            if (showGrantsSkillNote)
+            {
+                var grantsLabel = new Label(GetText(TextType.UI, UITextKey.SkillGrantsSynergySkill), new LabelStyle { Font = Graphics.Instance.BitmapFont, FontColor = SynergyGreen });
+                _contentTable.Add(grantsLabel).Left().SetPadTop(5f);
+                _contentTable.Row();
+            }
 
             _container.SetVisible(true);
             _container.Pack();

--- a/PitHero/UI/SkillTooltip.cs
+++ b/PitHero/UI/SkillTooltip.cs
@@ -143,6 +143,24 @@ namespace PitHero.UI
 
         public void ShowSynergyEffect(SynergyPattern pattern, int instanceCount, float multiplier)
         {
+            // Instance count and multiplier, truncated (not rounded) to 2 decimals so the
+            // display never overstates the bonus (e.g. 1.9375 shows as 1.93, not 1.94)
+            var truncatedMultiplier = System.MathF.Truncate(multiplier * 100f) / 100f;
+            var instanceText = string.Format(GetText(TextType.UI, UITextKey.SkillActiveMultiplier), instanceCount, truncatedMultiplier);
+            BuildSynergyCard(pattern, instanceText);
+        }
+
+        /// <summary>
+        /// Shows the synergy card for a pattern without any active-instance multiplier info —
+        /// used by the stencil library, where the pattern isn't tied to a hero's active synergies.
+        /// </summary>
+        public void ShowSynergyPattern(SynergyPattern pattern)
+        {
+            BuildSynergyCard(pattern, null);
+        }
+
+        private void BuildSynergyCard(SynergyPattern pattern, string multiplierLine)
+        {
             _contentTable.Clear();
 
             // Pattern name
@@ -150,13 +168,12 @@ namespace PitHero.UI
             _contentTable.Add(nameLabel).Left();
             _contentTable.Row();
 
-            // Instance count and multiplier, truncated (not rounded) to 2 decimals so the
-            // display never overstates the bonus (e.g. 1.9375 shows as 1.93, not 1.94)
-            var truncatedMultiplier = System.MathF.Truncate(multiplier * 100f) / 100f;
-            var instanceText = string.Format(GetText(TextType.UI, UITextKey.SkillActiveMultiplier), instanceCount, truncatedMultiplier);
-            var instanceLabel = new Label(SanitizeText(instanceText), new LabelStyle { Font = Graphics.Instance.BitmapFont, FontColor = SynergyGreen });
-            _contentTable.Add(instanceLabel).Left();
-            _contentTable.Row();
+            if (multiplierLine != null)
+            {
+                var instanceLabel = new Label(SanitizeText(multiplierLine), new LabelStyle { Font = Graphics.Instance.BitmapFont, FontColor = SynergyGreen });
+                _contentTable.Add(instanceLabel).Left();
+                _contentTable.Row();
+            }
 
             // Description
             if (!string.IsNullOrEmpty(pattern.Description))

--- a/PitHero/UI/StencilLibraryPanel.cs
+++ b/PitHero/UI/StencilLibraryPanel.cs
@@ -26,6 +26,7 @@ namespace PitHero.UI
         private TextButton _closeButton;
         private SynergyPattern _selectedPattern;
         private TextService _textService;
+        private SkillTooltip _hoverTooltip;
 
         public event System.Action<SynergyPattern> OnStencilActivated;
 
@@ -37,6 +38,7 @@ namespace PitHero.UI
             SetResizable(false);
 
             GetTitleLabel().SetText(GetText(TextType.UI, UITextKey.StencilSynergyStencils));
+            _hoverTooltip = new SkillTooltip(this, skin);
             BuildUI(skin);
 
             // Size the window to exactly fit its rows — the stage is only ~360 tall,
@@ -75,6 +77,8 @@ namespace PitHero.UI
             {
                 var slot = new StencilSlot(i, skin);
                 slot.OnSlotClicked += HandleSlotClicked;
+                slot.OnSlotHoverStart += HandleSlotHoverStart;
+                slot.OnSlotHoverEnd += HandleSlotHoverEnd;
                 _slots[i] = slot;
 
                 _gridTable.Add(slot).Size(SLOT_SIZE, SLOT_SIZE).Pad(SLOT_PADDING);
@@ -201,6 +205,7 @@ namespace PitHero.UI
             {
                 OnStencilActivated?.Invoke(_selectedPattern);
                 ResetSelection();
+                HandleSlotHoverEnd();
                 SetVisible(false);
             }
         }
@@ -208,7 +213,52 @@ namespace PitHero.UI
         private void HandleCloseClicked(Button button)
         {
             ResetSelection();
+            HandleSlotHoverEnd();
             SetVisible(false);
+        }
+
+        private void HandleSlotHoverStart(SynergyPattern pattern)
+        {
+            var stage = GetStage();
+            if (stage == null)
+                return;
+
+            _hoverTooltip.ShowSynergyPattern(pattern);
+            if (_hoverTooltip.GetContainer().GetParent() == null)
+            {
+                stage.AddElement(_hoverTooltip.GetContainer());
+            }
+
+            _hoverTooltip.PositionWithinBounds(stage.GetMousePosition(), stage);
+            _hoverTooltip.GetContainer().ToFront();
+        }
+
+        private void HandleSlotHoverEnd()
+        {
+            _hoverTooltip.GetContainer().Remove();
+        }
+
+        /// <summary>
+        /// Repositions the hover card at the cursor each frame and removes it when the panel is
+        /// hidden without a mouse-exit event (outside-click dismissal sets visibility directly).
+        /// </summary>
+        public void UpdateHoverTooltip()
+        {
+            var container = _hoverTooltip?.GetContainer();
+            if (container == null || !container.HasParent())
+                return;
+
+            if (!IsVisible())
+            {
+                container.Remove();
+                return;
+            }
+
+            var stage = GetStage();
+            if (stage != null)
+            {
+                _hoverTooltip.PositionWithinBounds(stage.GetMousePosition(), stage);
+            }
         }
 
         /// <summary>Individual slot in the stencil library grid.</summary>
@@ -224,10 +274,10 @@ namespace PitHero.UI
             private SynergyPattern _pattern;
             private bool _isDiscovered;
             private bool _isHovered;
-            private Tooltip _tooltip;
-            private Skin _skin;
 
             public event System.Action<int> OnSlotClicked;
+            public event System.Action<SynergyPattern> OnSlotHoverStart;
+            public event System.Action OnSlotHoverEnd;
 
             public SynergyPattern Pattern { get; private set; }
             public bool IsSelected { get; set; }
@@ -235,7 +285,6 @@ namespace PitHero.UI
             public StencilSlot(int index, Skin skin)
             {
                 _index = index;
-                _skin = skin;
                 IsSelected = false;
 
                 var itemsAtlas = Core.Content.LoadSpriteAtlas("Content/Atlases/Items.atlas");
@@ -261,21 +310,6 @@ namespace PitHero.UI
                 _pattern = pattern;
                 Pattern = pattern;
                 _isDiscovered = discovered;
-
-                // Update tooltip
-                if (_tooltip != null && _skin != null)
-                {
-                    _tooltip = null;
-                }
-
-                if (_isDiscovered && _pattern != null)
-                {
-                    var tooltipStyle = new TextTooltipStyle
-                    {
-                        LabelStyle = new LabelStyle { Font = Graphics.Instance.BitmapFont, FontColor = Color.White }
-                    };
-                    _tooltip = new TextTooltip(_pattern.Name, this, tooltipStyle);
-                }
             }
 
             public override void Draw(Batcher batcher, float parentAlpha)
@@ -416,27 +450,20 @@ namespace PitHero.UI
             void IInputListener.OnMouseEnter()
             {
                 _isHovered = true;
-                if (_tooltip != null && _isDiscovered)
+                if (_isDiscovered && _pattern != null)
                 {
-                    _tooltip.Hit(Nez.Input.MousePosition);
+                    OnSlotHoverStart?.Invoke(_pattern);
                 }
             }
 
             void IInputListener.OnMouseExit()
             {
                 _isHovered = false;
-                if (_tooltip != null)
-                {
-                    _tooltip.Hit(new Vector2(-10000f, -10000f));
-                }
+                OnSlotHoverEnd?.Invoke();
             }
 
             void IInputListener.OnMouseMoved(Vector2 mousePos)
             {
-                if (_tooltip != null && _isDiscovered)
-                {
-                    _tooltip.Hit(Nez.Input.MousePosition);
-                }
             }
 
             bool IInputListener.OnLeftMousePressed(Vector2 mousePos)

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -239,6 +239,7 @@ namespace PitHero
         public const string SkillJpCost = "SkillJpCost";
         public const string SkillOwnerFormat = "SkillOwnerFormat";
         public const string SkillActiveMultiplier = "SkillActiveMultiplier";
+        public const string SkillGrantsSynergySkill = "SkillGrantsSynergySkill";
         public const string EquipPreviewChanges = "EquipPreviewChanges";
         public const string TabCrystals = "TabCrystals";
         public const string CrystalForgeTitle = "CrystalForgeTitle";

--- a/PitHero/VirtualGame/VirtualPitWidthManager.cs
+++ b/PitHero/VirtualGame/VirtualPitWidthManager.cs
@@ -154,6 +154,17 @@ namespace PitHero.VirtualGame
         }
 
         /// <summary>
+        /// Resets tier progression to the first cycle after permadeath. Bypasses the monotonic
+        /// guard in SetTierBaseLevel, which stays monotonic for normal progression.
+        /// </summary>
+        public void ResetTierForNewCycle()
+        {
+            _currentPitTier = 1;
+            _tierBaseLevel = 1;
+            Console.WriteLine("[VirtualPitWidthManager] Tier reset to 1 for new cycle (hero death)");
+        }
+
+        /// <summary>
         /// Increments the pit tier by 1 (clamped at MaxPitTier) and records the hero level as the new tier base level.
         /// </summary>
         public void IncrementPitTier(int heroLevelAtEntry)

--- a/PitHero/docs/CrystalCeremony.md
+++ b/PitHero/docs/CrystalCeremony.md
@@ -8,13 +8,13 @@ When a hero dies (see [Permadeath.md](Permadeath.md) for the death animation and
 ## Flow
 
 1. **Hero death** — `HeroDeathComponent` plays the death animation and moves the hero's crystal to the vault (see Permadeath.md). `MainGameScene.RespawnHeroAfterDelay` → `RespawnHero()` runs afterward.
-2. **Respawn** — `RespawnHero()` calls `CreateHeroEntity(34, 6, needsCrystal: true)`. The hero spawns with `HeroComponent.NeedsCrystal = true` and no `LinkedHero`. Saving is disabled during this transitional state. Hired mercenaries are unfrozen and reassigned to follow the new hero; the pit resets to level 1 once all mercenaries have exited (or a safety timeout elapses).
+2. **Respawn** — `RespawnHero()` calls `CreateHeroEntity(34, 6, needsCrystal: true)`. The hero spawns with `HeroComponent.NeedsCrystal = true` and no `LinkedHero`. Saving is disabled during this transitional state. Hired mercenaries are unfrozen and reassigned to follow the new hero; the pit tier resets to 1 immediately (`PitWidthManager.ResetTierForNewCycle`), and the pit resets to level 1 once all mercenaries have exited (or a safety timeout elapses).
 3. **Walk to statue** — the GOAP action `WalkToStatueForCrystalAction` (`PitHero/AI/WalkToStatueForCrystalAction.cs`) paths the hero to the statue and sets `HeroComponent.HasArrivedAtStatueForCrystal = true`. GOAP states: `GoapConstants.NeedsCrystal`, `GoapConstants.HasArrivedAtStatueForCrystal`.
 4. **Ceremony** — `HeroPromotionService.CheckAndPromoteHeroIfNeeded()` (called every frame from `MainGameScene.Update()`) detects `NeedsCrystal && HasArrivedAtStatueForCrystal` and starts `ExecuteHeroCrystalCeremony`:
    - Movement and AI are disabled; the hero faces the statue (`Direction.Up`) for 1 second
    - The "LightningStrike" animation from Actors.atlas plays (`PlayLightningStrikeAtHero`)
    - `GetNextCrystalForHero()` selects the crystal: dequeue from `CrystalCollectionService`, else `GenerateRandomHeroCrystal()` (random primary job, level 1, random 2–5 base stats)
-   - A new `Hero` is created with the chosen crystal. Spawn level is `max(crystal level, TierBaseLevel)` so tier ≥ 2 heroes respawn at the recorded tier base level
+   - A new `Hero` is created with the chosen crystal. Spawn level is `max(crystal level, TierBaseLevel)`; since hero death resets the pit cycle (`ResetTierForNewCycle` sets `TierBaseLevel` back to 1), this is effectively the crystal level
    - `NeedsCrystal`/`HasArrivedAtStatueForCrystal` are cleared, movement/AI re-enabled
    - `ReconnectUIToHero()` reconnects the ShortcutBar and InventoryGrid to the new hero (these reconnects are idempotent — the underlying events are static, see `ShortcutBar.ConnectToDragManager`)
    - The Save button is re-enabled


### PR DESCRIPTION
Closes #371. Six independent fixes:

## Mercs walking on top of each other (independent movement)
- `WalkToPitEdgeAction` now offsets each merc's pit-edge target by hire order (merc 0 one tile above the hero's center-row tile, merc 1 one tile below), which also makes their jump landings distinct. Helper `CalculatePitEdgeTileForPartyIndex` is pure and unit-tested (`MercenaryPitEdgeOffsetTests`).
- `MercenaryFollowComponent` stuck-warp now picks a free orthogonally-adjacent tile (not walled, same pit side, not occupied by hero/other merc) instead of warping onto the follow target's tile.
- `WalkToTavernForStopAction.ReenableMercenaryFollowing()` now resets follow pathfinding before re-enabling, so stale paths/stuck timers from before dining don't trigger immediate warps.

## Auto-scroll to Hero defaults OFF
- `GameConfig.CameraAutoScrollToHeroDefault` flipped to `false`. Setting isn't persisted, so this takes effect for everyone with no migration.

## Night-time load spawns the party asleep in beds
- When a save is loaded during sleeping hours (22:00–06:00), `MainGameScene.PositionPartyInBedsForNightLoad` places the hero and mercs directly in the inn beds, sets `IsSleeping`, and disables merc following.
- New `HeroComponent.SpawnedAsleepPending` flag: GOAP plans night sleep normally, and `SleepInBedAction` consumes the flag to skip the walk-to-innkeeper/facing/payment steps. The normal wake path (heal at 6 AM, re-enable mercs, walk to exit, auto-dine) runs unchanged. Degenerate case (clock crosses 6 AM between load and first plan) unwinds the staging and behaves like a normal inn visit.
- Inn bed/exit tiles extracted to `GameConfig` constants.

## Hero death resets the pit cycle (tier)
- New `PitWidthManager.ResetTierForNewCycle()` (mirrored in `VirtualPitWidthManager`) resets `CurrentPitTier` and `TierBaseLevel` to 1, bypassing the monotonic base-level guard (which stays monotonic for normal progression).
- Called from `RespawnHero()` (before the crystal ceremony so the new hero's spawn level uses the reset base) and `ResetPitToLevelOne()`. Effective depth `(tier-1)*25 + level` now truly restarts, so a fresh hero no longer faces late-cycle monsters.
- Tests updated: death-path tier reset covered; `SetPitLevel(1)` alone still doesn't touch tier.

## Tavern mercs not clickable behind UI windows
- New `MercenaryInteractionsBlocked()` guard (mouse outside window, hire dialog open, or pointer over UI via `_uiStage.Hit`) applied to both `HandleMercenaryClicks` and `HandleMercenaryHover` — same idiom as the existing building-interaction guard, so the SelectBox/name label also no longer render behind windows.

## Stencil hover card in View Stencils
- `SkillTooltip.ShowSynergyPattern(pattern)` renders the synergy card (name, description, effects, active-pattern note) without the multiplier line; `ShowSynergyEffect` shares the same builder.
- `StencilLibraryPanel` slots now raise hover events (discovered stencils only) that drive the shared card, replacing the old name-only `TextTooltip`; the card follows the cursor per frame and is removed on close/activate/outside-click dismissal.

## Testing
- `dotnet build`: 0 errors
- `dotnet test`: 1815 passed, 0 failed (baseline maintained), including new `MercenaryPitEdgeOffsetTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)