### PR TITLE
Backpressure scaling on jobs (#375)

### DIFF
--- a/PitHero.Tests/AutoJobAssignmentServiceTests.cs
+++ b/PitHero.Tests/AutoJobAssignmentServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PitHero;
 using PitHero.Dining;
@@ -138,10 +139,10 @@ namespace PitHero.Tests
             var service = CreateHeadlessService(roster);
 
             service.TickCadence(0f, isNighttime: false);
-            service.TickCadence(30f, isNighttime: true);
+            service.TickCadence(GameConfig.AutoJobReassessIntervalSeconds / 3f, isNighttime: true);
 
             Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[0].Job,
-                "Day→night boundary reassesses immediately, well before the 60-minute cadence");
+                "Day→night boundary reassesses immediately, well before the reassess cadence");
         }
 
         [TestMethod]
@@ -150,17 +151,18 @@ namespace PitHero.Tests
             var roster = new AlliedMonsterManager();
             var service = CreateHeadlessService(roster);
 
+            float interval = GameConfig.AutoJobReassessIntervalSeconds;
             service.TickCadence(0f, isNighttime: false);
-            service.TickCadence(50f, isNighttime: true);   // boundary reassess at t=50
+            service.TickCadence(interval - 5f, isNighttime: true);   // boundary reassess before the cadence
 
-            // Now give the monster a job and verify the next cadence fire is 60s after the
-            // boundary (t=110), not 60s after the original init (t=60).
+            // Now give the monster a job and verify the next cadence fire is one interval after
+            // the boundary reassess, not one interval after the original init.
             roster.AddAlliedMonster(Monster("Bob", 1, 5, 1, MonsterJob.Farming));
-            service.TickCadence(65f, isNighttime: true);
+            service.TickCadence(interval - 5f + interval - 1f, isNighttime: true);
             Assert.AreEqual(MonsterJob.Farming, roster.AlliedMonsters[0].Job,
-                "Boundary reassess restarted the interval — t=65 is too early");
+                "Boundary reassess restarted the interval — one second early must not fire");
 
-            service.TickCadence(50f + GameConfig.AutoJobReassessIntervalSeconds, isNighttime: true);
+            service.TickCadence(interval - 5f + interval, isNighttime: true);
             Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[0].Job,
                 "Cadence fires one full interval after the boundary reassess");
         }
@@ -248,35 +250,33 @@ namespace PitHero.Tests
         }
 
         [TestMethod]
-        public void ReassessNow_TwoMonstersWithFarmWorkload_BothFarm()
+        public void ReassessNow_TwoMonstersWithPlansOnly_OneCaretakerOneHome()
         {
-            // The reported bug: with only 2 workers and farm work outstanding, both used to be
-            // sunk into a dead-end kitchen. Farming now takes priority and the kitchen (which
-            // can't field its 3-monster crew anyway) stands down.
+            // Issue #375 honest farm demand: placed plans with no outstanding tasks keep exactly
+            // one caretaker on the field. The other monster goes home rather than staffing a
+            // kitchen that can't field its 3-monster crew.
             var roster = new AlliedMonsterManager();
             roster.AddAlliedMonster(Monster("A", 1, 5, 5));
             roster.AddAlliedMonster(Monster("B", 1, 5, 5));
-            var service = CreateServiceWithFarmWorkload(roster,
-                planCount: GameConfig.AutoJobFarmCropsPerWorkerBaseline + 1);   // farming desired = 2
+            var service = CreateServiceWithFarmWorkload(roster, planCount: 13);
 
             service.ReassessNow();
 
-            Assert.AreEqual(MonsterJob.Farming, roster.AlliedMonsters[0].Job, "Both workers farm");
-            Assert.AreEqual(MonsterJob.Farming, roster.AlliedMonsters[1].Job, "Both workers farm");
+            Assert.AreEqual(MonsterJob.Farming, roster.AlliedMonsters[0].Job, "One caretaker farms");
+            Assert.AreEqual(MonsterJob.None, roster.AlliedMonsters[1].Job,
+                "No idle second farmer, and the kitchen can't field a functional crew of 2");
         }
 
         [TestMethod]
         public void ReassessNow_FourMonsters_OneFarmerThreeKitchen()
         {
-            // With 4 monsters the kitchen's full crew fits alongside the guaranteed farmer:
-            // 1 farms (even though farming wants 2), 3 staff the kitchen.
+            // With 4 monsters the kitchen's full crew fits alongside the guaranteed caretaker.
             var roster = new AlliedMonsterManager();
             roster.AddAlliedMonster(Monster("A", 1, 5, 5));
             roster.AddAlliedMonster(Monster("B", 1, 5, 5));
             roster.AddAlliedMonster(Monster("C", 1, 5, 5));
             roster.AddAlliedMonster(Monster("D", 1, 5, 5));
-            var service = CreateServiceWithFarmWorkload(roster,
-                planCount: GameConfig.AutoJobFarmCropsPerWorkerBaseline + 1);   // farming desired = 2
+            var service = CreateServiceWithFarmWorkload(roster, planCount: 13);
 
             service.ReassessNow();
 
@@ -365,6 +365,8 @@ namespace PitHero.Tests
                 => _entry = new JobDemandEntry { Job = job, MinWorkers = min, DesiredWorkers = desired, Sticky = false };
             public MonsterJob Job => _entry.Job;
             public JobDemandEntry EvaluateDemand(int rosterSize, int availableWorkers) => _entry;
+            public void SamplePressure(float nowSeconds) { }
+            public void ResetPressure(float nowSeconds) { }
         }
 
         // ── Farming demand math ──────────────────────────────────────────────
@@ -372,52 +374,64 @@ namespace PitHero.Tests
         [TestMethod]
         public void FarmingDemand_ZeroWorkload_WantsNoWorkers()
         {
-            var d = FarmingJobDemandEvaluator.ComputeDemand(0, 0, availableWorkers: 10);
+            var d = FarmingJobDemandEvaluator.ComputeDemand(0, 0, grantedWorkers: 0, availableWorkers: 10);
             Assert.AreEqual(0, d.DesiredWorkers);
             Assert.AreEqual(0, d.MinWorkers);
             Assert.IsFalse(d.Sticky, "Farming is not sticky — farmers are released during lulls");
         }
 
         [TestMethod]
-        public void FarmingDemand_BaselineScalesByCeilingDivision()
+        public void FarmingDemand_CareLoadAlone_KeepsOneCaretaker()
         {
-            int per = GameConfig.AutoJobFarmCropsPerWorkerBaseline;
-            Assert.AreEqual(1, FarmingJobDemandEvaluator.ComputeDemand(0, 1, 10).DesiredWorkers);
-            Assert.AreEqual(1, FarmingJobDemandEvaluator.ComputeDemand(0, per, 10).DesiredWorkers);
-            Assert.AreEqual(2, FarmingJobDemandEvaluator.ComputeDemand(0, per + 1, 10).DesiredWorkers);
+            // Issue #375: crops growing but nothing to do right now = exactly one caretaker for
+            // the coming watering wave. The old baseline staffed careLoad/12 farmers who wandered.
+            var d = FarmingJobDemandEvaluator.ComputeDemand(0, careLoad: 40,
+                grantedWorkers: 0, availableWorkers: 10);
+            Assert.AreEqual(1, d.DesiredWorkers, "Idle care load never staffs more than the caretaker");
+            Assert.AreEqual(1, d.MinWorkers);
         }
 
         [TestMethod]
-        public void FarmingDemand_BurstOutranksBaseline()
+        public void FarmingDemand_BurstScalesWithOutstandingTasks()
         {
-            // A watering/harvest wave (many outstanding tasks) demands more workers than the
-            // baseline care load alone would.
             int tasksPer = GameConfig.AutoJobFarmTasksPerWorker;
-            var d = FarmingJobDemandEvaluator.ComputeDemand(tasksPer * 3, careLoad: 1, availableWorkers: 10);
-            Assert.AreEqual(3, d.DesiredWorkers, "Burst signal should win when larger than baseline");
+            var d = FarmingJobDemandEvaluator.ComputeDemand(tasksPer * 3, careLoad: 1,
+                grantedWorkers: 0, availableWorkers: 10);
+            Assert.AreEqual(3, d.DesiredWorkers, "A watering/harvest wave staffs up instantly");
             Assert.AreEqual(1, d.MinWorkers, "At least one farmer whenever any workload exists");
+        }
+
+        [TestMethod]
+        public void FarmingDemand_GrantedWorkersHoldAfterBurstClears()
+        {
+            // The tracker's drain-limited grant keeps recent-wave farmers on the field for a
+            // while after the outstanding tasks hit zero, so staffing ramps down instead of
+            // collapsing between waves.
+            var d = FarmingJobDemandEvaluator.ComputeDemand(0, careLoad: 5,
+                grantedWorkers: 3, availableWorkers: 10);
+            Assert.AreEqual(3, d.DesiredWorkers, "Granted workers outrank the live lull");
         }
 
         [TestMethod]
         public void FarmingDemand_ClampsToAvailableWorkers()
         {
-            var d = FarmingJobDemandEvaluator.ComputeDemand(1000, 1000, availableWorkers: 4);
+            var d = FarmingJobDemandEvaluator.ComputeDemand(1000, 1000, grantedWorkers: 0, availableWorkers: 4);
             Assert.AreEqual(4, d.DesiredWorkers, "Demand can never exceed the available workers");
         }
 
         [TestMethod]
-        public void FarmingEvaluator_CountsPlansFromCropPlantingService()
+        public void FarmingEvaluator_PlansAloneKeepACaretaker()
         {
             var planting = new CropPlantingService();
             var growth = new CropGrowthService(planting);
-            int per = GameConfig.AutoJobFarmCropsPerWorkerBaseline;
-            for (int i = 0; i < per + 1; i++)
+            for (int i = 0; i < 13; i++)
                 planting.AddPlan(new PlacedCropPlan { Type = CropType.Wheat, TileX = i, TileY = 0 });
             var evaluator = new FarmingJobDemandEvaluator(null, growth, planting);
 
             var d = evaluator.EvaluateDemand(rosterSize: 10, availableWorkers: 10);
 
-            Assert.AreEqual(2, d.DesiredWorkers, "Placed plans count toward the baseline care load");
+            Assert.AreEqual(1, d.DesiredWorkers,
+                "Placed plans with no outstanding tasks staff exactly the caretaker");
         }
 
         // ── Kitchen demand math ──────────────────────────────────────────────
@@ -425,12 +439,12 @@ namespace PitHero.Tests
         [TestMethod]
         public void KitchenDemand_ZeroBacklog_StillWantsBaseCrew()
         {
-            var d = KitchenJobDemandEvaluator.ComputeDemand(0, rosterSize: 10, availableWorkers: 10);
+            var d = KitchenJobDemandEvaluator.ComputeDemand(0, 0, rosterSize: 10, availableWorkers: 10);
             Assert.AreEqual(GameConfig.AutoJobKitchenBaseStaff, d.DesiredWorkers,
                 "Kitchen keeps a cook + server + runner crew even with no orders");
             Assert.AreEqual(GameConfig.AutoJobKitchenBaseStaff, d.MinWorkers,
                 "Base crew is a firm minimum so it fills before farming's desired extras");
-            Assert.IsTrue(d.Sticky, "Kitchen workers must never be pulled away");
+            Assert.IsTrue(d.Sticky, "Kitchen workers only leave via the trim or starvation passes");
         }
 
         [TestMethod]
@@ -438,7 +452,7 @@ namespace PitHero.Tests
         {
             // Available equals the full roster (no farming reservation), so a partial crew is
             // still fielded on tiny rosters, exactly as before the farming-priority change.
-            var d = KitchenJobDemandEvaluator.ComputeDemand(0, rosterSize: 2, availableWorkers: 2);
+            var d = KitchenJobDemandEvaluator.ComputeDemand(0, 0, rosterSize: 2, availableWorkers: 2);
             Assert.AreEqual(2, d.DesiredWorkers);
         }
 
@@ -447,7 +461,7 @@ namespace PitHero.Tests
         {
             // Farming reserved a worker and fewer than cook+server+runner remain: a partial
             // kitchen has no runner and is pointless, so the kitchen cedes the shortage entirely.
-            var d = KitchenJobDemandEvaluator.ComputeDemand(0, rosterSize: 3, availableWorkers: 2);
+            var d = KitchenJobDemandEvaluator.ComputeDemand(0, 0, rosterSize: 3, availableWorkers: 2);
             Assert.AreEqual(0, d.DesiredWorkers, "All-or-nothing when competing with farming");
             Assert.AreEqual(0, d.MinWorkers);
         }
@@ -456,15 +470,34 @@ namespace PitHero.Tests
         public void KitchenDemand_BacklogAddsExtraWorkers()
         {
             int per = GameConfig.AutoJobKitchenBacklogPerExtraWorker;
-            var d = KitchenJobDemandEvaluator.ComputeDemand(per * 2, rosterSize: 10, availableWorkers: 10);
+            var d = KitchenJobDemandEvaluator.ComputeDemand(per * 2, 0, rosterSize: 10, availableWorkers: 10);
             Assert.AreEqual(GameConfig.AutoJobKitchenBaseStaff + 2, d.DesiredWorkers);
             Assert.AreEqual(GameConfig.AutoJobKitchenBaseStaff, d.MinWorkers);
         }
 
         [TestMethod]
+        public void KitchenDemand_HighPatronWait_AddsAWorker()
+        {
+            // A patron waiting a long time proves the pipeline is behind even when the raw
+            // backlog count looks modest.
+            var d = KitchenJobDemandEvaluator.ComputeDemand(0, 0, rosterSize: 10, availableWorkers: 10,
+                anyDishOrderable: true, patronWaitHigh: true);
+            Assert.AreEqual(GameConfig.AutoJobKitchenBaseStaff + 1, d.DesiredWorkers);
+        }
+
+        [TestMethod]
+        public void KitchenDemand_GrantedExtrasHoldAfterBacklogClears()
+        {
+            // The rush just ended: live backlog is zero but the tracker still grants two extras,
+            // draining one per interval instead of dumping the whole crew at once.
+            var d = KitchenJobDemandEvaluator.ComputeDemand(0, 2, rosterSize: 10, availableWorkers: 10);
+            Assert.AreEqual(GameConfig.AutoJobKitchenBaseStaff + 2, d.DesiredWorkers);
+        }
+
+        [TestMethod]
         public void KitchenDemand_CapsAtMaxWorkers()
         {
-            var d = KitchenJobDemandEvaluator.ComputeDemand(1000, rosterSize: 20, availableWorkers: 20);
+            var d = KitchenJobDemandEvaluator.ComputeDemand(1000, 0, rosterSize: 20, availableWorkers: 20);
             Assert.AreEqual(GameConfig.AutoJobKitchenMaxWorkers, d.DesiredWorkers,
                 "Kitchen demand is capped at the coordinator's worker limit");
         }
@@ -474,12 +507,12 @@ namespace PitHero.Tests
         {
             // No coverable dish means servers can never take an order, so no ticket can ever
             // exist — staffing the kitchen would be dead weight.
-            var d = KitchenJobDemandEvaluator.ComputeDemand(0, rosterSize: 10, availableWorkers: 10,
+            var d = KitchenJobDemandEvaluator.ComputeDemand(0, 0, rosterSize: 10, availableWorkers: 10,
                 anyDishOrderable: false);
             Assert.AreEqual(0, d.DesiredWorkers);
             Assert.AreEqual(0, d.MinWorkers);
             Assert.IsTrue(d.Sticky,
-                "Workers already in the kitchen stay put when the larder runs dry mid-day");
+                "Workers already in the kitchen drain out one per solve when the larder runs dry");
         }
 
         // ── Kitchen evaluator: empty-larder gate ─────────────────────────────
@@ -526,6 +559,86 @@ namespace PitHero.Tests
 
             Assert.AreEqual(GameConfig.AutoJobKitchenBaseStaff, d.DesiredWorkers,
                 "One coverable dish is enough to staff the kitchen");
+        }
+
+        // ── End-to-end backpressure scaling (issue #375) ─────────────────────
+
+        private static int CountJobs(AlliedMonsterManager roster, MonsterJob job)
+        {
+            int count = 0;
+            for (int i = 0; i < roster.AlliedMonsters.Count; i++)
+                if (roster.AlliedMonsters[i].Job == job)
+                    count++;
+            return count;
+        }
+
+        [TestMethod]
+        public void EndToEnd_KitchenScalesPastBaseCrewUnderBacklog_ThenDrainsStepwise()
+        {
+            // The previously untested seam: a packed ticket board must staff the kitchen ABOVE
+            // its base crew through the real sampler + evaluator + solver, even while farming has
+            // its own workload — and once the rush ends, the crew drains back one worker per
+            // drain interval, never in one layoff.
+            var coordinator = CreateHeadlessKitchen(out _, out var storage);
+            var def = DishConfig.GetDefinition((DishType)0);
+            const int backlogTickets = 9;
+            // One serving beyond the backlog: ticket creation physically withdraws crops, and the
+            // kitchen only staffs while at least one dish remains orderable.
+            for (int i = 0; i < def.Recipe.Length; i++)
+                Assert.IsTrue(storage.TryDeposit(1, def.Recipe[i].Crop, def.Recipe[i].Qty * (backlogTickets + 1)));
+            var tickets = new List<KitchenTicket>();
+            for (int i = 0; i < backlogTickets; i++)
+            {
+                var t = coordinator.CreateTicket((DishType)0, false, -1, null,
+                    new Microsoft.Xna.Framework.Point(96, 7));
+                Assert.IsNotNull(t, $"Ticket {i} must be coverable from the stocked storage");
+                tickets.Add(t);
+            }
+
+            var planting = new CropPlantingService();
+            var growth = new CropGrowthService(planting);
+            for (int i = 0; i < 13; i++)
+                planting.AddPlan(new PlacedCropPlan { Type = CropType.Wheat, TileX = i, TileY = 0 });
+
+            var roster = new AlliedMonsterManager();
+            for (int i = 0; i < 12; i++)
+                roster.AddAlliedMonster(Monster($"M{i}", 1, 5, 5));
+            var service = new AutoJobAssignmentService(roster,
+                new KitchenJobDemandEvaluator(coordinator, null, null),
+                new FarmingJobDemandEvaluator(null, growth, planting));
+
+            float sample = GameConfig.AutoJobPressureSampleIntervalSeconds;
+            service.TickCadence(0f, isNighttime: false);       // init
+            service.TickCadence(sample, isNighttime: false);   // first pressure sample sees the rush
+            service.ReassessNow();
+
+            int extras = backlogTickets / GameConfig.AutoJobKitchenBacklogPerExtraWorker;
+            Assert.AreEqual(GameConfig.AutoJobKitchenBaseStaff + extras,
+                CountJobs(roster, MonsterJob.Cooking),
+                "The rush staffs the kitchen past its base crew despite farming being listed first");
+            Assert.AreEqual(1, CountJobs(roster, MonsterJob.Farming),
+                "Farming keeps its caretaker alongside the scaled-up kitchen");
+
+            // The rush ends all at once.
+            for (int i = 0; i < tickets.Count; i++)
+                coordinator.CancelTicket(tickets[i]);
+            Assert.AreEqual(0, coordinator.ActiveTicketCount);
+
+            // Let the real cadence run: samples decay the pressure, grants drain one worker per
+            // drain interval, and each reassessment releases at most one cook.
+            int cooks = CountJobs(roster, MonsterJob.Cooking);
+            for (float t = sample * 2f; t <= GameConfig.AutoJobScaleDownDrainIntervalSeconds * 4f; t += sample)
+            {
+                service.TickCadence(t, isNighttime: false);
+                int now = CountJobs(roster, MonsterJob.Cooking);
+                Assert.IsTrue(cooks - now <= 1,
+                    $"Scale-down must be a slow drain: went {cooks}→{now} in one tick at t={t}");
+                Assert.IsTrue(now >= GameConfig.AutoJobKitchenBaseStaff,
+                    "The kitchen never drops below its base crew while dishes are orderable");
+                cooks = now;
+            }
+            Assert.AreEqual(GameConfig.AutoJobKitchenBaseStaff, cooks,
+                "After the drain intervals elapse the kitchen is back to cook + server + runner");
         }
 
         [TestMethod]

--- a/PitHero.Tests/AutoJobAssignmentServiceTests.cs
+++ b/PitHero.Tests/AutoJobAssignmentServiceTests.cs
@@ -625,9 +625,12 @@ namespace PitHero.Tests
             Assert.AreEqual(0, coordinator.ActiveTicketCount);
 
             // Let the real cadence run: samples decay the pressure, grants drain one worker per
-            // drain interval, and each reassessment releases at most one cook.
+            // KITCHEN drain interval (slower than farming's — service-area departures are highly
+            // visible), and each reassessment releases at most one cook.
             int cooks = CountJobs(roster, MonsterJob.Cooking);
-            for (float t = sample * 2f; t <= GameConfig.AutoJobScaleDownDrainIntervalSeconds * 4f; t += sample)
+            float drainWindow = GameConfig.AutoJobKitchenScaleDownDrainIntervalSeconds * 3f
+                + GameConfig.AutoJobReassessIntervalSeconds + sample;
+            for (float t = sample * 2f; t <= drainWindow; t += sample)
             {
                 service.TickCadence(t, isNighttime: false);
                 int now = CountJobs(roster, MonsterJob.Cooking);

--- a/PitHero.Tests/BackpressureTrackerTests.cs
+++ b/PitHero.Tests/BackpressureTrackerTests.cs
@@ -1,0 +1,107 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero;
+using PitHero.Services.AutoJob;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Tests for the BackpressureTracker smoother (issue #375): rising pressure is granted
+    /// instantly, falling pressure decays through the EMA, and grants drain at most one worker
+    /// per drain interval.
+    /// </summary>
+    [TestClass]
+    public class BackpressureTrackerTests
+    {
+        [TestMethod]
+        public void Sample_RisingPressure_GrantsInstantly()
+        {
+            var tracker = new BackpressureTracker();
+            tracker.Sample(3f, nowSeconds: 0f);
+            Assert.AreEqual(3, tracker.GrantedWorkers, "A pressure spike is granted on the very next sample");
+        }
+
+        [TestMethod]
+        public void Sample_FractionalPressure_RoundsUp()
+        {
+            var tracker = new BackpressureTracker();
+            tracker.Sample(1.4f, nowSeconds: 0f);
+            Assert.AreEqual(2, tracker.GrantedWorkers, "Workers are whole monsters — pressure rounds up");
+        }
+
+        [TestMethod]
+        public void Sample_FallingPressure_DecaysThroughEma()
+        {
+            var tracker = new BackpressureTracker();
+            tracker.Sample(4f, 0f);
+            tracker.Sample(0f, 5f);
+            Assert.IsTrue(tracker.SmoothedPressure > 0f && tracker.SmoothedPressure < 4f,
+                "One low sample only decays smoothed pressure part-way");
+        }
+
+        [TestMethod]
+        public void Sample_NoDrainBeforeInterval()
+        {
+            var tracker = new BackpressureTracker();
+            tracker.Sample(2f, 0f);
+            float justBefore = GameConfig.AutoJobScaleDownDrainIntervalSeconds - 1f;
+            for (float t = 5f; t <= justBefore; t += 5f)
+                tracker.Sample(0f, t);
+            Assert.AreEqual(2, tracker.GrantedWorkers,
+                "Grants must hold until a full drain interval has elapsed");
+        }
+
+        [TestMethod]
+        public void Sample_DrainsExactlyOneWorkerPerInterval()
+        {
+            var tracker = new BackpressureTracker();
+            tracker.Sample(3f, 0f);
+            Assert.AreEqual(3, tracker.GrantedWorkers);
+
+            // Hold raw pressure at zero across two full drain intervals: one worker released per
+            // interval, never a jump straight to zero.
+            float interval = GameConfig.AutoJobScaleDownDrainIntervalSeconds;
+            for (float t = 5f; t <= interval * 2f + 5f; t += 5f)
+            {
+                int before = tracker.GrantedWorkers;
+                tracker.Sample(0f, t);
+                Assert.IsTrue(before - tracker.GrantedWorkers <= 1,
+                    "A single sample may release at most one worker");
+            }
+            Assert.AreEqual(1, tracker.GrantedWorkers,
+                "Two elapsed drain intervals release exactly two workers");
+        }
+
+        [TestMethod]
+        public void Sample_ReboundDuringDrain_RestoresGrantInstantly()
+        {
+            var tracker = new BackpressureTracker();
+            tracker.Sample(3f, 0f);
+            float interval = GameConfig.AutoJobScaleDownDrainIntervalSeconds;
+            for (float t = 5f; t <= interval + 5f; t += 5f)
+                tracker.Sample(0f, t);
+            Assert.AreEqual(2, tracker.GrantedWorkers, "One worker drained");
+
+            tracker.Sample(3f, interval + 10f);
+            Assert.AreEqual(3, tracker.GrantedWorkers, "The rush came back — regrant instantly");
+        }
+
+        [TestMethod]
+        public void Reset_ClearsSmoothedPressureAndGrants()
+        {
+            var tracker = new BackpressureTracker();
+            tracker.Sample(5f, 100f);
+            tracker.Reset(0f);
+            Assert.AreEqual(0, tracker.GrantedWorkers);
+            Assert.AreEqual(0f, tracker.SmoothedPressure);
+        }
+
+        [TestMethod]
+        public void Sample_NegativeRawClampsToZero()
+        {
+            var tracker = new BackpressureTracker();
+            tracker.Sample(-2f, 0f);
+            Assert.AreEqual(0, tracker.GrantedWorkers);
+            Assert.AreEqual(0f, tracker.SmoothedPressure);
+        }
+    }
+}

--- a/PitHero.Tests/JobAssignmentSolverTests.cs
+++ b/PitHero.Tests/JobAssignmentSolverTests.cs
@@ -6,9 +6,10 @@ using RolePlayingFramework.AlliedMonsters;
 namespace PitHero.Tests
 {
     /// <summary>
-    /// Tests for the pure JobAssignmentSolver: sticky/min/desired fill order, proficiency selection
-    /// with deterministic tie-breaks, surplus demotion, the starvation release pass (the one
-    /// exception to stickiness), and the strict-double-improvement swap pass.
+    /// Tests for the pure JobAssignmentSolver: sticky/min fill order, the round-robin desired
+    /// fill, proficiency selection with deterministic tie-breaks, the one-per-solve sticky trim
+    /// (issue #375 slow-drain scale-down), the starvation release pass, and the
+    /// strict-double-improvement swap pass.
     /// </summary>
     [TestClass]
     public class JobAssignmentSolverTests
@@ -136,8 +137,10 @@ namespace PitHero.Tests
         }
 
         [TestMethod]
-        public void Solve_StickyCookingWorkers_KeptEvenAboveDesired()
+        public void Solve_StickyExcess_TrimsOneWorstWorkerPerSolve()
         {
+            // Issue #375 scale-down: three sticky cooks but the kitchen only wants one. Exactly
+            // ONE worker (the worst cook) is released per solve — a slow drain, never a layoff.
             var monsters = new List<MonsterJobSnapshot>
             {
                 Monster(0, MonsterJob.Cooking, 1, 4),
@@ -151,9 +154,50 @@ namespace PitHero.Tests
 
             JobAssignmentSolver.Solve(monsters, demands, _result);
 
-            Assert.AreEqual(MonsterJob.Cooking, _result[0], "Sticky worker is never demoted");
-            Assert.AreEqual(MonsterJob.Cooking, _result[1], "Sticky worker is never demoted");
-            Assert.AreEqual(MonsterJob.Cooking, _result[2], "Sticky worker is never demoted");
+            Assert.AreEqual(MonsterJob.None, _result[0], "Worst cook is released first");
+            Assert.AreEqual(MonsterJob.Cooking, _result[1], "Only one worker is trimmed per solve");
+            Assert.AreEqual(MonsterJob.Cooking, _result[2], "Best cook is never the one trimmed");
+        }
+
+        [TestMethod]
+        public void Solve_StickyAtDesired_NothingTrimmed()
+        {
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.Cooking, 1, 4),
+                Monster(1, MonsterJob.Cooking, 1, 6),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Cooking, 0, 2, sticky: true),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            Assert.AreEqual(MonsterJob.Cooking, _result[0], "Held workers within desired are untouched");
+            Assert.AreEqual(MonsterJob.Cooking, _result[1], "Held workers within desired are untouched");
+        }
+
+        [TestMethod]
+        public void Solve_TrimmedWorker_ReassignedToNeedyJobSameSolve()
+        {
+            // The trim runs before the fill passes, so the released cook lands on the farm in the
+            // SAME solve instead of walking home first.
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.Cooking, 7, 3),
+                Monster(1, MonsterJob.Cooking, 2, 9),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Farming, 1, 1, sticky: false),
+                Demand(MonsterJob.Cooking, 0, 1, sticky: true),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            Assert.AreEqual(MonsterJob.Farming, _result[0], "Trimmed worst cook is picked up by farming immediately");
+            Assert.AreEqual(MonsterJob.Cooking, _result[1], "Best cook keeps the kitchen");
         }
 
         [TestMethod]
@@ -264,10 +308,11 @@ namespace PitHero.Tests
         // ── Starvation release: the one exception to kitchen stickiness ──────
 
         [TestMethod]
-        public void Solve_StarvedFarming_PullsStickyKitchenWorker()
+        public void Solve_StarvedFarming_PullsStickyKitchenWorkersStepwise()
         {
-            // Every monster is sticky-locked in the kitchen while farming demands workers:
-            // with no kitchen floor (min 0), farming pulls as many as it needs.
+            // Every monster is sticky-locked in a kitchen that wants nobody while farming demands
+            // workers. The drain is stepwise: each solve trims one cook for the farm, so farming
+            // reaches its desired count over successive solves rather than in one layoff.
             var monsters = new List<MonsterJobSnapshot>
             {
                 Monster(0, MonsterJob.Cooking, 5, 5),
@@ -280,9 +325,18 @@ namespace PitHero.Tests
             };
 
             JobAssignmentSolver.Solve(monsters, demands, _result);
+            Assert.AreEqual(MonsterJob.Farming, _result[0], "First solve releases one cook to the farm");
+            Assert.AreEqual(MonsterJob.Cooking, _result[1], "The second cook drains on a later solve, not this one");
 
-            Assert.AreEqual(MonsterJob.Farming, _result[0], "Sticky cook is released when farming has zero workers");
-            Assert.AreEqual(MonsterJob.Farming, _result[1], "Farming pulls up to its desired count");
+            for (int i = 0; i < monsters.Count; i++)
+            {
+                var m = monsters[i];
+                m.CurrentJob = _result[i];
+                monsters[i] = m;
+            }
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+            Assert.AreEqual(MonsterJob.Farming, _result[0]);
+            Assert.AreEqual(MonsterJob.Farming, _result[1], "Second solve drains the remaining cook");
         }
 
         [TestMethod]
@@ -364,6 +418,8 @@ namespace PitHero.Tests
         [TestMethod]
         public void Solve_StarvedDemand_NeverRaidsHigherPriorityStickyJob()
         {
+            // Kitchen still wants both its workers (desired 2, so no trim), and starved farming
+            // sits BELOW it in the demand list: the release pass only raids lower-priority jobs.
             var monsters = new List<MonsterJobSnapshot>
             {
                 Monster(0, MonsterJob.Cooking, 5, 5),
@@ -371,7 +427,7 @@ namespace PitHero.Tests
             };
             var demands = new List<JobDemandEntry>
             {
-                Demand(MonsterJob.Cooking, 0, 0, sticky: true),
+                Demand(MonsterJob.Cooking, 0, 2, sticky: true),
                 Demand(MonsterJob.Farming, 1, 2, sticky: false),
             };
 
@@ -379,6 +435,65 @@ namespace PitHero.Tests
 
             Assert.AreEqual(MonsterJob.Cooking, _result[0], "A starved demand only raids lower-priority jobs");
             Assert.AreEqual(MonsterJob.Cooking, _result[1], "A starved demand only raids lower-priority jobs");
+        }
+
+        // ── Round-robin desired fill (issue #375) ────────────────────────────
+
+        [TestMethod]
+        public void Solve_DesiredExtras_SplitRoundRobinAcrossDemands()
+        {
+            // The original bug: farming's desired extras consumed every spare monster before the
+            // kitchen's desired pass ran, freezing the kitchen at its minimum. Desired slots now
+            // fill one per demand per cycle, so both jobs grow together.
+            var monsters = new List<MonsterJobSnapshot>();
+            for (int i = 0; i < 10; i++)
+                monsters.Add(Monster(i, MonsterJob.None, 5, 5));
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Farming, 1, 8, sticky: false),
+                Demand(MonsterJob.Cooking, 3, 6, sticky: true),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            int farmers = 0, cooks = 0;
+            for (int i = 0; i < _result.Count; i++)
+            {
+                if (_result[i] == MonsterJob.Farming) farmers++;
+                if (_result[i] == MonsterJob.Cooking) cooks++;
+            }
+            // Mins take 1 + 3; the 6 spares alternate farming/cooking (farming first per cycle)
+            // until the kitchen hits its desired 6, leaving farming the rest.
+            Assert.AreEqual(6, cooks, "Kitchen reaches its full desired count despite farming being listed first");
+            Assert.AreEqual(4, farmers, "Farming grows with the remaining spares instead of monopolizing all six");
+        }
+
+        [TestMethod]
+        public void Solve_DesiredRoundRobin_ListOrderBreaksTheTie()
+        {
+            // One spare after mins: the first-listed demand wins each cycle's first slot.
+            var monsters = new List<MonsterJobSnapshot>
+            {
+                Monster(0, MonsterJob.None, 5, 5),
+                Monster(1, MonsterJob.None, 5, 5),
+                Monster(2, MonsterJob.None, 5, 5),
+            };
+            var demands = new List<JobDemandEntry>
+            {
+                Demand(MonsterJob.Farming, 1, 3, sticky: false),
+                Demand(MonsterJob.Cooking, 1, 3, sticky: true),
+            };
+
+            JobAssignmentSolver.Solve(monsters, demands, _result);
+
+            int farmers = 0, cooks = 0;
+            for (int i = 0; i < _result.Count; i++)
+            {
+                if (_result[i] == MonsterJob.Farming) farmers++;
+                if (_result[i] == MonsterJob.Cooking) cooks++;
+            }
+            Assert.AreEqual(2, farmers, "First-listed farming takes the lone contested spare");
+            Assert.AreEqual(1, cooks);
         }
 
         [TestMethod]

--- a/PitHero.Tests/KitchenServiceLoopTests.cs
+++ b/PitHero.Tests/KitchenServiceLoopTests.cs
@@ -542,6 +542,84 @@ namespace PitHero.Tests
             CollectionAssert.AreEqual(first, second);
         }
 
+        // ── Role retention (issue #375 follow-up: no cook-leaves-cook-arrives shuffles) ──
+
+        private static System.Collections.Generic.List<KitchenRole> Retained(
+            KitchenRole[] mix, int[] currentRoles)
+        {
+            var mixList = new System.Collections.Generic.List<KitchenRole>(mix);
+            var currentList = new System.Collections.Generic.List<int>(currentRoles);
+            var into = new System.Collections.Generic.List<KitchenRole>();
+            KitchenTaskCoordinator.AssignRolesWithRetention(mixList, currentList, into);
+            return into;
+        }
+
+        private const int NoWorker = -1;
+        private const int C = (int)KitchenRole.Cook;
+        private const int S = (int)KitchenRole.Server;
+        private const int R = (int)KitchenRole.Runner;
+
+        [TestMethod]
+        public void Retention_SameCounts_NobodyChangesRole()
+        {
+            // The mix pattern flipped positions (C,S,R,C,R → recompute) but the COUNTS are the
+            // same — every live worker keeps its current role, zero churn.
+            var roles = Retained(
+                new[] { KitchenRole.Cook, KitchenRole.Server, KitchenRole.Runner, KitchenRole.Cook, KitchenRole.Runner },
+                new[] { R, C, S, R, C });
+            CollectionAssert.AreEqual(
+                new[] { KitchenRole.Runner, KitchenRole.Cook, KitchenRole.Server, KitchenRole.Runner, KitchenRole.Cook },
+                roles);
+        }
+
+        [TestMethod]
+        public void Retention_RoleShrinks_OnlyWorstHolderReassigned()
+        {
+            // Three cooks on shift but the mix now wants one: quota is consumed in post order
+            // (best proficiency first), so the two lower posts are the ones reassigned.
+            var roles = Retained(
+                new[] { KitchenRole.Cook, KitchenRole.Server, KitchenRole.Runner },
+                new[] { C, C, C });
+            CollectionAssert.AreEqual(
+                new[] { KitchenRole.Cook, KitchenRole.Server, KitchenRole.Runner }, roles);
+        }
+
+        [TestMethod]
+        public void Retention_NewJoiner_TakesOnlyTheNewPost()
+        {
+            // Crew of three grows to four: the incumbents keep their roles, the joiner takes
+            // exactly the added quota.
+            var roles = Retained(
+                new[] { KitchenRole.Cook, KitchenRole.Server, KitchenRole.Runner, KitchenRole.Runner },
+                new[] { S, C, R, NoWorker });
+            CollectionAssert.AreEqual(
+                new[] { KitchenRole.Server, KitchenRole.Cook, KitchenRole.Runner, KitchenRole.Runner },
+                roles);
+        }
+
+        [TestMethod]
+        public void Retention_FreshSpawn_AssignsBaseRolesInOrder()
+        {
+            var roles = Retained(
+                new[] { KitchenRole.Cook, KitchenRole.Server, KitchenRole.Runner },
+                new[] { NoWorker, NoWorker, NoWorker });
+            CollectionAssert.AreEqual(
+                new[] { KitchenRole.Cook, KitchenRole.Server, KitchenRole.Runner }, roles);
+        }
+
+        [TestMethod]
+        public void Retention_AlwaysPreservesTheMixRoleCounts()
+        {
+            // Whatever the current holders look like, the output multiset is exactly the mix's —
+            // the kitchen-open guarantees (≥1 cook, ≥1 server) ride on the counts.
+            var roles = Retained(
+                new[] { KitchenRole.Cook, KitchenRole.Server, KitchenRole.Runner, KitchenRole.Cook },
+                new[] { R, R, R, R });
+            Assert.AreEqual(2, roles.FindAll(r => r == KitchenRole.Cook).Count);
+            Assert.AreEqual(1, roles.FindAll(r => r == KitchenRole.Server).Count);
+            Assert.AreEqual(1, roles.FindAll(r => r == KitchenRole.Runner).Count);
+        }
+
         // ── Bus queue (issue #327: runners own plate clearing) ──
 
         private static KitchenTaskCoordinator.BusJob MakeBusJob(Vector2 pos, float enqueuedTime)

--- a/PitHero.Tests/KitchenServiceLoopTests.cs
+++ b/PitHero.Tests/KitchenServiceLoopTests.cs
@@ -466,6 +466,82 @@ namespace PitHero.Tests
                 "the auto-job cap must mirror the coordinator's post cap");
         }
 
+        // ── Demand-weighted role mix (issue #375) ──
+
+        private static System.Collections.Generic.List<KitchenRole> WeightedRoleMix(
+            int postCount, int cookPressure, int serverPressure, int runnerPressure)
+        {
+            var roles = new System.Collections.Generic.List<KitchenRole>();
+            KitchenTaskCoordinator.FillRoleMix(postCount, cookPressure, serverPressure,
+                runnerPressure, roles);
+            return roles;
+        }
+
+        [TestMethod]
+        public void WeightedRoleMix_BaseCrewInvariantUnderAllWeights()
+        {
+            // Whatever the pressure skew, posts 0-2 stay Cook, Server, Runner — the crew that
+            // opens the kitchen and keeps it fed and cleared.
+            var roles = WeightedRoleMix(3, 0, 0, 99);
+            CollectionAssert.AreEqual(
+                new[] { KitchenRole.Cook, KitchenRole.Server, KitchenRole.Runner }, roles);
+        }
+
+        [TestMethod]
+        public void WeightedRoleMix_HeavyRunnerPressure_FillsRunnersFirst()
+        {
+            // A backlog of ingredient fetches and dirty plates: posts 3+ go to runners until
+            // their cap, then fall back to the neutral cycle.
+            var roles = WeightedRoleMix(5, 0, 0, 10);
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    KitchenRole.Cook, KitchenRole.Server, KitchenRole.Runner,
+                    KitchenRole.Runner, KitchenRole.Runner,
+                }, roles);
+        }
+
+        [TestMethod]
+        public void WeightedRoleMix_ServerPressure_CapsAtTwoServers()
+        {
+            // Server zoning only supports 2 servers (ServerZone design limit); pressure past the
+            // cap spills into the neutral cycle.
+            var roles = WeightedRoleMix(8, 0, 50, 0);
+            Assert.AreEqual(GameConfig.MaxKitchenServers,
+                roles.FindAll(r => r == KitchenRole.Server).Count);
+        }
+
+        [TestMethod]
+        public void WeightedRoleMix_SplitsProportionallyByPressurePerWorker()
+        {
+            // D'Hondt greedy: cook pressure 6 vs server 3 vs runner 2 — the second and third
+            // extra posts still favor cooks (6/2 then 6/3 beat 3/2 and 2/2) before the server.
+            var roles = WeightedRoleMix(6, 6, 3, 2);
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    KitchenRole.Cook, KitchenRole.Server, KitchenRole.Runner,
+                    KitchenRole.Cook, KitchenRole.Cook, KitchenRole.Server,
+                }, roles);
+        }
+
+        [TestMethod]
+        public void WeightedRoleMix_ZeroPressures_MatchesNeutralCycle()
+        {
+            var neutral = RoleMix(KitchenTaskCoordinator.MaxWorkerPosts);
+            var weighted = WeightedRoleMix(KitchenTaskCoordinator.MaxWorkerPosts, 0, 0, 0);
+            CollectionAssert.AreEqual(neutral, weighted,
+                "The weighted mix with no pressure is exactly the legacy Cook→Server→Runner cycle");
+        }
+
+        [TestMethod]
+        public void WeightedRoleMix_IsDeterministic()
+        {
+            var first = WeightedRoleMix(8, 4, 4, 4);
+            var second = WeightedRoleMix(8, 4, 4, 4);
+            CollectionAssert.AreEqual(first, second);
+        }
+
         // ── Bus queue (issue #327: runners own plate clearing) ──
 
         private static KitchenTaskCoordinator.BusJob MakeBusJob(Vector2 pos, float enqueuedTime)

--- a/PitHero/Dining/KitchenTicket.cs
+++ b/PitHero/Dining/KitchenTicket.cs
@@ -34,6 +34,9 @@ namespace PitHero.Dining
         public int TicketId;
         public DishType Dish;
 
+        /// <summary>Time.TotalTime when the order was created; drives backpressure age metrics. Not persisted.</summary>
+        public float CreatedTime;
+
         /// <summary>True for hero/hired-merc orders; they get cook priority.</summary>
         public bool IsPartyTicket;
 

--- a/PitHero/ECS/Components/TavernPatronComponent.cs
+++ b/PitHero/ECS/Components/TavernPatronComponent.cs
@@ -37,6 +37,9 @@ namespace PitHero.ECS.Components
         /// <summary>The ticket assigned to this patron's order; null until ordered.</summary>
         public KitchenTicket ActiveTicket { get; set; }
 
+        /// <summary>Seconds spent in the current state (resets on each transition) — the patron's live wait time.</summary>
+        public float StateElapsedSeconds => _elapsed;
+
         /// <summary>Seat tile this patron occupies; used to derive the table plate position.</summary>
         public Point SeatTile { get; set; }
 

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -247,13 +247,17 @@ namespace PitHero
         public const float DishTipMinPercent = 0.05f;           // tip is 5-15% of dish price, rounded up
         public const float DishTipMaxPercent = 0.15f;
 
-        // Automated monster job assignment (issue #321)
-        public const float AutoJobReassessIntervalSeconds = 60f;   // scaled seconds between reassessments (60 in-game minutes)
+        // Automated monster job assignment (issue #321, backpressure scaling issue #375)
+        public const float AutoJobReassessIntervalSeconds = 15f;   // scaled seconds between solve/apply passes (15 in-game minutes)
+        public const float AutoJobPressureSampleIntervalSeconds = 5f;  // scaled seconds between backpressure signal samples
+        public const float AutoJobScaleDownDrainIntervalSeconds = 60f; // min scaled seconds between releasing successive workers per job
+        public const float AutoJobPressureDecayAlpha = 0.15f;      // per-sample EMA decay on falling pressure (rising pressure is instant)
+        public const float AutoJobKitchenHighWaitSeconds = 60f;    // a patron waiting this long (1 in-game hour) adds a worker of pressure
         public const int AutoJobFarmTasksPerWorker = 6;            // burst demand: outstanding farm tasks each farmer can absorb
-        public const int AutoJobFarmCropsPerWorkerBaseline = 12;   // quiet-period demand: crops + plans each farmer can tend
         public const int AutoJobKitchenBaseStaff = 3;              // cook + server + runner minimum (no runner -> fridge runs dry)
         public const int AutoJobKitchenBacklogPerExtraWorker = 3;  // tickets/patrons per extra kitchen worker beyond base staff
         public const int AutoJobKitchenMaxWorkers = 8;             // mirrors KitchenTaskCoordinator.MaxWorkerPosts (3 cooks + 2 servers + 3 runners)
+        public const float KitchenRoleMixDwellSeconds = 45f;       // min scaled seconds between demand-weighted role-mix recomputes (anti-thrash)
 
         // Camera Configuration
         public const float CameraDefaultZoom = 1f; // default zoom level

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -259,6 +259,8 @@ namespace PitHero
         public const int AutoJobKitchenBacklogPerExtraWorker = 3;  // tickets/patrons per extra kitchen worker beyond base staff
         public const int AutoJobKitchenMaxWorkers = 8;             // mirrors KitchenTaskCoordinator.MaxWorkerPosts (3 cooks + 2 servers + 3 runners)
         public const float KitchenRoleMixDwellSeconds = 45f;       // min scaled seconds between demand-weighted role-mix recomputes (anti-thrash)
+        public const float KitchenRolePressureSampleIntervalSeconds = 5f; // scaled seconds between per-role pressure samples
+        public const float KitchenRolePressureEmaAlpha = 0.1f;     // per-sample EMA weight; ~50 scaled-sec time constant spans a full service cycle
 
         // Camera Configuration
         public const float CameraDefaultZoom = 1f; // default zoom level

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -251,7 +251,7 @@ namespace PitHero
         public const float AutoJobReassessIntervalSeconds = 15f;   // scaled seconds between solve/apply passes (15 in-game minutes)
         public const float AutoJobPressureSampleIntervalSeconds = 5f;  // scaled seconds between backpressure signal samples
         public const float AutoJobScaleDownDrainIntervalSeconds = 60f; // min scaled seconds between releasing successive workers per job (farming)
-        public const float AutoJobKitchenScaleDownDrainIntervalSeconds = 180f; // kitchen drains slower — departures are highly visible in a service area
+        public const float AutoJobKitchenScaleDownDrainIntervalSeconds = 360f; // kitchen drains slower — departures are highly visible in a service area
         public const float AutoJobPressureDecayAlpha = 0.15f;      // per-sample EMA decay on falling pressure (rising pressure is instant)
         public const float AutoJobKitchenHighWaitSeconds = 60f;    // a patron waiting this long (1 in-game hour) adds a worker of pressure
         public const int AutoJobFarmTasksPerWorker = 6;            // burst demand: outstanding farm tasks each farmer can absorb

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -250,7 +250,8 @@ namespace PitHero
         // Automated monster job assignment (issue #321, backpressure scaling issue #375)
         public const float AutoJobReassessIntervalSeconds = 15f;   // scaled seconds between solve/apply passes (15 in-game minutes)
         public const float AutoJobPressureSampleIntervalSeconds = 5f;  // scaled seconds between backpressure signal samples
-        public const float AutoJobScaleDownDrainIntervalSeconds = 60f; // min scaled seconds between releasing successive workers per job
+        public const float AutoJobScaleDownDrainIntervalSeconds = 60f; // min scaled seconds between releasing successive workers per job (farming)
+        public const float AutoJobKitchenScaleDownDrainIntervalSeconds = 180f; // kitchen drains slower — departures are highly visible in a service area
         public const float AutoJobPressureDecayAlpha = 0.15f;      // per-sample EMA decay on falling pressure (rising pressure is instant)
         public const float AutoJobKitchenHighWaitSeconds = 60f;    // a patron waiting this long (1 in-game hour) adds a worker of pressure
         public const int AutoJobFarmTasksPerWorker = 6;            // burst demand: outstanding farm tasks each farmer can absorb

--- a/PitHero/Services/Analytics/AnalyticsService.cs
+++ b/PitHero/Services/Analytics/AnalyticsService.cs
@@ -887,6 +887,43 @@ namespace PitHero.Services.Analytics
 #endif
         }
 
+        /// <summary>Logs an allied monster leaving one MonsterJob for another (issue #375 staffing analysis).</summary>
+        [Conditional("DEBUG")]
+        public static void LogMonsterJobChanged(string monster, string monsterType,
+            string fromJob, string toJob, string trigger)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("monster_job_changed"))
+                return;
+            _json.Field("monster", monster);
+            _json.Field("monsterType", monsterType);
+            _json.Field("fromJob", fromJob);
+            _json.Field("toJob", toJob);
+            _json.Field("trigger", trigger);
+            EndEvent();
+#endif
+        }
+
+        /// <summary>Logs a kitchen worker being sent home to respawn in a different role (issue #375 churn analysis).</summary>
+        [Conditional("DEBUG")]
+        public static void LogKitchenRoleChanged(string monster, string monsterType,
+            string fromRole, string toRole)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("kitchen_role_changed"))
+                return;
+            _json.Field("monster", monster);
+            _json.Field("monsterType", monsterType);
+            _json.Field("fromRole", fromRole);
+            _json.Field("toRole", toRole);
+            EndEvent();
+#endif
+        }
+
 #if DEBUG
         /// <summary>Opens a new event object with timestamp, in-game time and event type. Returns false if output is unavailable.</summary>
         private static bool BeginEvent(string eventType)

--- a/PitHero/Services/AutoJob/BackpressureTracker.cs
+++ b/PitHero/Services/AutoJob/BackpressureTracker.cs
@@ -12,9 +12,16 @@ namespace PitHero.Services.AutoJob
     /// </summary>
     public sealed class BackpressureTracker
     {
+        private readonly float _drainIntervalSeconds;
         private float _smoothed;
         private int _granted;
         private float _lastChangeSeconds;
+
+        /// <summary>drainIntervalSeconds: min scaled seconds between releasing successive workers.</summary>
+        public BackpressureTracker(float drainIntervalSeconds = GameConfig.AutoJobScaleDownDrainIntervalSeconds)
+        {
+            _drainIntervalSeconds = drainIntervalSeconds;
+        }
 
         /// <summary>Smoothed pressure in workers-worth units (instant attack, EMA decay).</summary>
         public float SmoothedPressure => _smoothed;
@@ -54,7 +61,7 @@ namespace PitHero.Services.AutoJob
                 _lastChangeSeconds = nowSeconds;
             }
             else if (_granted > 0 && _smoothed <= _granted - 0.5f
-                && nowSeconds - _lastChangeSeconds >= GameConfig.AutoJobScaleDownDrainIntervalSeconds)
+                && nowSeconds - _lastChangeSeconds >= _drainIntervalSeconds)
             {
                 // Scale down one worker per drain interval, never more. The half-worker margin is
                 // the release hysteresis: pressure hovering just under the grant keeps the crew,

--- a/PitHero/Services/AutoJob/BackpressureTracker.cs
+++ b/PitHero/Services/AutoJob/BackpressureTracker.cs
@@ -1,0 +1,67 @@
+namespace PitHero.Services.AutoJob
+{
+    /// <summary>
+    /// Asymmetric backpressure smoother for one job (issue #375). Raw pressure is sampled in
+    /// workers-worth units on the sampling cadence; rising pressure is adopted instantly (a dinner
+    /// rush staffs up on the next solve) while falling pressure decays through an EMA, so demand
+    /// must stay low for several samples before the recommendation drops. The granted worker count
+    /// additionally drains at most one worker per drain interval — the issue's "slow drain, not
+    /// sudden" scale-down. All times are scaled seconds (InGameTimeService.AccumulatedSeconds),
+    /// so pausing freezes the tracker. State is transient: never persisted, rebuilt within a few
+    /// samples after load.
+    /// </summary>
+    public sealed class BackpressureTracker
+    {
+        private float _smoothed;
+        private int _granted;
+        private float _lastChangeSeconds;
+
+        /// <summary>Smoothed pressure in workers-worth units (instant attack, EMA decay).</summary>
+        public float SmoothedPressure => _smoothed;
+
+        /// <summary>Current drain-limited worker recommendation.</summary>
+        public int GrantedWorkers => _granted;
+
+        /// <summary>Clears smoothing and drain state. Call when the clock rewinds (save load).</summary>
+        public void Reset(float nowSeconds)
+        {
+            _smoothed = 0f;
+            _granted = 0;
+            _lastChangeSeconds = nowSeconds;
+        }
+
+        /// <summary>Feeds one raw pressure sample and advances the grant toward it.</summary>
+        public void Sample(float rawWorkersNeeded, float nowSeconds)
+        {
+            if (rawWorkersNeeded < 0f)
+                rawWorkersNeeded = 0f;
+
+            if (rawWorkersNeeded >= _smoothed)
+                _smoothed = rawWorkersNeeded;
+            else
+                _smoothed += (rawWorkersNeeded - _smoothed) * GameConfig.AutoJobPressureDecayAlpha;
+
+            // Scale-up keys off the RAW signal (small epsilon for float noise): the decaying EMA
+            // tail must never re-grant a worker the live signal no longer justifies.
+            int target = (int)System.Math.Ceiling(rawWorkersNeeded - 0.001f);
+            if (target < 0)
+                target = 0;
+
+            if (target > _granted)
+            {
+                // Scale up instantly: backpressure means diners are waiting right now.
+                _granted = target;
+                _lastChangeSeconds = nowSeconds;
+            }
+            else if (_granted > 0 && _smoothed <= _granted - 0.5f
+                && nowSeconds - _lastChangeSeconds >= GameConfig.AutoJobScaleDownDrainIntervalSeconds)
+            {
+                // Scale down one worker per drain interval, never more. The half-worker margin is
+                // the release hysteresis: pressure hovering just under the grant keeps the crew,
+                // and the EMA's asymptotic tail can't strand the final worker forever.
+                _granted--;
+                _lastChangeSeconds = nowSeconds;
+            }
+        }
+    }
+}

--- a/PitHero/Services/AutoJob/FarmingJobDemandEvaluator.cs
+++ b/PitHero/Services/AutoJob/FarmingJobDemandEvaluator.cs
@@ -3,15 +3,20 @@ using RolePlayingFramework.AlliedMonsters;
 namespace PitHero.Services.AutoJob
 {
     /// <summary>
-    /// Farming demand: the larger of a burst signal (outstanding till/plant/water/harvest tasks — spikes
-    /// during watering and harvest waves) and a baseline signal (crops + plans under care — keeps a
-    /// skeleton crew during quiet growth periods).
+    /// Farming demand, driven by real outstanding work (issue #375): the burst signal (outstanding
+    /// till/plant/water/harvest tasks) staffs up instantly during watering and harvest waves, and
+    /// the backpressure tracker holds that headcount briefly so a momentary dip between waves
+    /// doesn't send everyone home — then drains it one worker at a time. While crops or plans
+    /// exist at all, one caretaker stays on the field for the next wave; idle surplus farmers are
+    /// released instead of wandering (the pre-#375 baseline term kept them staffed with nothing
+    /// to do).
     /// </summary>
     public sealed class FarmingJobDemandEvaluator : IJobDemandEvaluator
     {
         private readonly FarmTaskCoordinator _coordinator;
         private readonly CropGrowthService _cropGrowth;
         private readonly CropPlantingService _cropPlanting;
+        private readonly BackpressureTracker _tracker = new BackpressureTracker();
 
         /// <summary>All dependencies are optional so the evaluator can run headless in tests.</summary>
         public FarmingJobDemandEvaluator(FarmTaskCoordinator coordinator,
@@ -26,27 +31,45 @@ namespace PitHero.Services.AutoJob
         public MonsterJob Job => MonsterJob.Farming;
 
         /// <inheritdoc/>
+        public void SamplePressure(float nowSeconds)
+        {
+            int outstanding = _coordinator != null ? _coordinator.OutstandingTaskCount : 0;
+            _tracker.Sample(outstanding / (float)GameConfig.AutoJobFarmTasksPerWorker, nowSeconds);
+        }
+
+        /// <inheritdoc/>
+        public void ResetPressure(float nowSeconds) => _tracker.Reset(nowSeconds);
+
+        /// <inheritdoc/>
         public JobDemandEntry EvaluateDemand(int rosterSize, int availableWorkers)
         {
             int outstanding = _coordinator != null ? _coordinator.OutstandingTaskCount : 0;
             int careLoad = (_cropGrowth != null ? _cropGrowth.CropCount : 0)
                 + (_cropPlanting != null ? _cropPlanting.PlanCount : 0);
-            return ComputeDemand(outstanding, careLoad, availableWorkers);
+            return ComputeDemand(outstanding, careLoad, _tracker.GrantedWorkers, availableWorkers);
         }
 
-        /// <summary>Pure demand math: max of the burst and baseline worker counts, clamped to the available workers.</summary>
-        public static JobDemandEntry ComputeDemand(int outstandingTasks, int careLoad, int availableWorkers)
+        /// <summary>
+        /// Pure demand math. The live burst gives instant scale-up even between samples; the
+        /// tracker's granted count (which only falls one worker per drain interval) gives the
+        /// slow scale-down. One caretaker minimum while anything is planted or planned.
+        /// </summary>
+        public static JobDemandEntry ComputeDemand(int outstandingTasks, int careLoad,
+            int grantedWorkers, int availableWorkers)
         {
             int burst = CeilDiv(outstandingTasks, GameConfig.AutoJobFarmTasksPerWorker);
-            int baseline = CeilDiv(careLoad, GameConfig.AutoJobFarmCropsPerWorkerBaseline);
-            int desired = burst > baseline ? burst : baseline;
+            int min = (outstandingTasks > 0 || careLoad > 0) ? 1 : 0;
+
+            int desired = burst > grantedWorkers ? burst : grantedWorkers;
+            if (desired < min)
+                desired = min;
             if (desired > availableWorkers)
                 desired = availableWorkers;
 
             return new JobDemandEntry
             {
                 Job = MonsterJob.Farming,
-                MinWorkers = desired > 0 ? 1 : 0,
+                MinWorkers = min < desired ? min : desired,
                 DesiredWorkers = desired,
                 Sticky = false,
             };

--- a/PitHero/Services/AutoJob/IJobDemandEvaluator.cs
+++ b/PitHero/Services/AutoJob/IJobDemandEvaluator.cs
@@ -14,5 +14,15 @@ namespace PitHero.Services.AutoJob
         /// evaluators (registration order = priority), so lower-priority jobs only claim what's left.
         /// </summary>
         JobDemandEntry EvaluateDemand(int rosterSize, int availableWorkers);
+
+        /// <summary>
+        /// Samples the live workload into the evaluator's backpressure tracker (issue #375).
+        /// Called once per sampling interval (scaled seconds) — never from EvaluateDemand, which
+        /// runs twice per reassessment (once per shift) and would double-sample.
+        /// </summary>
+        void SamplePressure(float nowSeconds);
+
+        /// <summary>Clears smoothing/drain state. Called when the clock rewinds (save load).</summary>
+        void ResetPressure(float nowSeconds);
     }
 }

--- a/PitHero/Services/AutoJob/JobAssignmentSolver.cs
+++ b/PitHero/Services/AutoJob/JobAssignmentSolver.cs
@@ -40,10 +40,12 @@ namespace PitHero.Services.AutoJob
 
     /// <summary>
     /// Pure, deterministic assignment solver: fills each job's minimum staffing first (by proficiency),
-    /// then desired staffing, honoring sticky jobs whose workers are never demoted — except that a
-    /// higher-priority job left with zero workers may pull sticky workers from lower-priority jobs
-    /// (StarvationReleasePass). Monsters left unassigned get MonsterJob.None so the coordinators
-    /// send them home.
+    /// then desired staffing round-robin across jobs so no single job's extras monopolize the spare
+    /// workers (issue #375). Sticky jobs keep their workers between solves, but a sticky job holding
+    /// more workers than it wants sheds exactly one per solve (StickyTrimPass — the slow-drain
+    /// scale-down), and a higher-priority job left with zero workers may pull sticky workers from
+    /// lower-priority jobs (StarvationReleasePass). Monsters left unassigned get MonsterJob.None so
+    /// the coordinators send them home.
     /// </summary>
     public static class JobAssignmentSolver
     {
@@ -87,42 +89,116 @@ namespace PitHero.Services.AutoJob
                 }
             }
 
-            FillPass(monsters, demands, resultJobs, true);
-            FillPass(monsters, demands, resultJobs, false);
+            StickyTrimPass(monsters, demands, resultJobs);
+            MinFillPass(monsters, demands, resultJobs);
+            DesiredFillRoundRobin(monsters, demands, resultJobs);
             StarvationReleasePass(monsters, demands, resultJobs);
             SwapPass(monsters, demands, resultJobs);
         }
 
-        /// <summary>Fills each demand up to MinWorkers (minPass) or DesiredWorkers by best proficiency.</summary>
-        private static void FillPass(List<MonsterJobSnapshot> monsters, List<JobDemandEntry> demands,
-            List<MonsterJob> resultJobs, bool minPass)
+        /// <summary>
+        /// Scale-down path (issue #375), deliberately replacing the original "sticky workers are
+        /// never demoted, even above desired" rule: a sticky demand holding more workers than
+        /// max(MinWorkers, DesiredWorkers) releases its LOWEST-proficiency worker — at most ONE per
+        /// solve per demand, so downscaling is a slow drain rather than a mass layoff even if a
+        /// demand gate suddenly zeroes out. Runs before the fill passes so the freed monster is
+        /// immediately claimable by whichever job needs it in this same solve.
+        /// </summary>
+        private static void StickyTrimPass(List<MonsterJobSnapshot> monsters,
+            List<JobDemandEntry> demands, List<MonsterJob> resultJobs)
         {
             for (int d = 0; d < demands.Count; d++)
             {
                 var demand = demands[d];
-                int target = minPass ? demand.MinWorkers : demand.DesiredWorkers;
-                int assigned = CountAssigned(resultJobs, demand.Job);
-                while (assigned < target)
+                if (!demand.Sticky)
+                    continue;
+                int wanted = demand.MinWorkers > demand.DesiredWorkers
+                    ? demand.MinWorkers : demand.DesiredWorkers;
+                if (CountAssigned(resultJobs, demand.Job) <= wanted)
+                    continue;
+
+                int worst = -1;
+                int worstProficiency = int.MaxValue;
+                for (int i = 0; i < monsters.Count; i++)
                 {
-                    int best = -1;
-                    int bestProficiency = -1;
-                    for (int i = 0; i < monsters.Count; i++)
+                    if (resultJobs[i] != demand.Job || monsters[i].CurrentJob != demand.Job)
+                        continue;
+                    int proficiency = GetProficiency(monsters[i], demand.Job);
+                    if (proficiency < worstProficiency)
                     {
-                        if (resultJobs[i] != MonsterJob.None)
-                            continue;
-                        int proficiency = GetProficiency(monsters[i], demand.Job);
-                        if (proficiency > bestProficiency)
-                        {
-                            best = i;
-                            bestProficiency = proficiency;
-                        }
+                        worst = i;
+                        worstProficiency = proficiency;
                     }
+                }
+                if (worst >= 0)
+                    resultJobs[worst] = MonsterJob.None;
+            }
+        }
+
+        /// <summary>Fills each demand up to MinWorkers by best proficiency, in demand-list order.</summary>
+        private static void MinFillPass(List<MonsterJobSnapshot> monsters, List<JobDemandEntry> demands,
+            List<MonsterJob> resultJobs)
+        {
+            for (int d = 0; d < demands.Count; d++)
+            {
+                var demand = demands[d];
+                int assigned = CountAssigned(resultJobs, demand.Job);
+                while (assigned < demand.MinWorkers)
+                {
+                    int best = SelectBestFree(monsters, resultJobs, demand.Job);
                     if (best < 0)
                         break;
                     resultJobs[best] = demand.Job;
                     assigned++;
                 }
             }
+        }
+
+        /// <summary>
+        /// Fills desired staffing one worker per demand per cycle instead of whole-demand-at-a-time,
+        /// so an early-listed job's extras can't monopolize every spare monster before later jobs
+        /// see any (the issue #375 "kitchen frozen at its minimum" bug). List order still decides
+        /// who gets each cycle's first spare, making priority a tiebreak rather than a monopoly.
+        /// </summary>
+        private static void DesiredFillRoundRobin(List<MonsterJobSnapshot> monsters,
+            List<JobDemandEntry> demands, List<MonsterJob> resultJobs)
+        {
+            bool assignedAny = true;
+            while (assignedAny)
+            {
+                assignedAny = false;
+                for (int d = 0; d < demands.Count; d++)
+                {
+                    var demand = demands[d];
+                    if (CountAssigned(resultJobs, demand.Job) >= demand.DesiredWorkers)
+                        continue;
+                    int best = SelectBestFree(monsters, resultJobs, demand.Job);
+                    if (best < 0)
+                        continue;
+                    resultJobs[best] = demand.Job;
+                    assignedAny = true;
+                }
+            }
+        }
+
+        /// <summary>Unassigned monster with the best proficiency for the job; ties break to lowest index. -1 if none.</summary>
+        private static int SelectBestFree(List<MonsterJobSnapshot> monsters, List<MonsterJob> resultJobs,
+            MonsterJob job)
+        {
+            int best = -1;
+            int bestProficiency = -1;
+            for (int i = 0; i < monsters.Count; i++)
+            {
+                if (resultJobs[i] != MonsterJob.None)
+                    continue;
+                int proficiency = GetProficiency(monsters[i], job);
+                if (proficiency > bestProficiency)
+                {
+                    best = i;
+                    bestProficiency = proficiency;
+                }
+            }
+            return best;
         }
 
         /// <summary>
@@ -175,8 +251,11 @@ namespace PitHero.Services.AutoJob
         }
 
         /// <summary>
-        /// One deterministic improvement pass: a sticky worker swaps jobs with a non-sticky worker only
-        /// when BOTH jobs strictly gain proficiency, so assignments never oscillate between solves.
+        /// One deterministic improvement pass: a sticky worker swaps jobs with a non-sticky worker
+        /// only when the other job strictly gains proficiency and the sticky job doesn't lose any.
+        /// Every swap strictly raises total proficiency, so the reverse swap can never qualify and
+        /// assignments never oscillate between solves. (The zero-loss case matters after a trim:
+        /// equal cooks but one is the far better farmer — the farm should get that one.)
         /// </summary>
         private static void SwapPass(List<MonsterJobSnapshot> monsters, List<JobDemandEntry> demands,
             List<MonsterJob> resultJobs)
@@ -201,7 +280,7 @@ namespace PitHero.Services.AutoJob
                             continue;
                         int stickyGain = GetProficiency(monsters[f], stickyJob) - GetProficiency(monsters[w], stickyJob);
                         int otherGain = GetProficiency(monsters[w], otherJob) - GetProficiency(monsters[f], otherJob);
-                        if (stickyGain <= 0 || otherGain <= 0)
+                        if (stickyGain < 0 || otherGain <= 0)
                             continue;
                         if (stickyGain + otherGain > bestGain)
                         {

--- a/PitHero/Services/AutoJob/KitchenJobDemandEvaluator.cs
+++ b/PitHero/Services/AutoJob/KitchenJobDemandEvaluator.cs
@@ -21,7 +21,10 @@ namespace PitHero.Services.AutoJob
         private readonly KitchenTaskCoordinator _coordinator;
         private readonly MercenaryManager _mercenaryManager;
         private readonly PartyDiningService _partyDining;
-        private readonly BackpressureTracker _tracker = new BackpressureTracker();
+        // Kitchen crews drain on their own slower interval: a worker walking out of a service
+        // area mid-rush is far more noticeable than a farmer leaving a field.
+        private readonly BackpressureTracker _tracker =
+            new BackpressureTracker(GameConfig.AutoJobKitchenScaleDownDrainIntervalSeconds);
 
         /// <summary>All dependencies are optional so the evaluator can run headless in tests.</summary>
         public KitchenJobDemandEvaluator(KitchenTaskCoordinator coordinator,

--- a/PitHero/Services/AutoJob/KitchenJobDemandEvaluator.cs
+++ b/PitHero/Services/AutoJob/KitchenJobDemandEvaluator.cs
@@ -3,20 +3,25 @@ using RolePlayingFramework.AlliedMonsters;
 namespace PitHero.Services.AutoJob
 {
     /// <summary>
-    /// Kitchen demand: a base crew of cook + server + runner, plus extra workers as the order backlog
-    /// grows, capped at the coordinator's worker limit. The base crew is all-or-nothing when competing
-    /// with farming: if higher-priority reservations leave fewer than the base crew available, the
-    /// kitchen fields no one (a partial kitchen has no runner and the fridge runs dry — and without
-    /// farm workers there'd be no ingredients anyway). The kitchen also fields no one while no dish
-    /// is coverable from fridge + storage: servers refuse orders they can't cover, so staff would be
-    /// dead weight until crops exist (e.g. a new game before any harvest). Sticky: kitchen workers
-    /// are never pulled away by the solver except when farming would otherwise have zero workers.
+    /// Kitchen demand: a base crew of cook + server + runner, plus extra workers as backpressure
+    /// grows (issue #375) — one per backlog block of tickets/patrons, plus one more when a patron
+    /// has been waiting a long time (a long wait means the pipeline is behind even if the raw
+    /// counts look modest). Extras scale up instantly with the live backlog and drain down one
+    /// worker per drain interval through the backpressure tracker. The base crew is all-or-nothing
+    /// when competing with farming: if higher-priority reservations leave fewer than the base crew
+    /// available, the kitchen fields no one (a partial kitchen has no runner and the fridge runs
+    /// dry — and without farm workers there'd be no ingredients anyway). The kitchen also fields
+    /// no one while no dish is coverable from fridge + storage: servers refuse orders they can't
+    /// cover, so staff would be dead weight until crops exist (e.g. a new game before any harvest).
+    /// Sticky: kitchen workers are not reshuffled arbitrarily between solves — they leave only
+    /// through the solver's one-per-solve trim or the starvation release.
     /// </summary>
     public sealed class KitchenJobDemandEvaluator : IJobDemandEvaluator
     {
         private readonly KitchenTaskCoordinator _coordinator;
         private readonly MercenaryManager _mercenaryManager;
         private readonly PartyDiningService _partyDining;
+        private readonly BackpressureTracker _tracker = new BackpressureTracker();
 
         /// <summary>All dependencies are optional so the evaluator can run headless in tests.</summary>
         public KitchenJobDemandEvaluator(KitchenTaskCoordinator coordinator,
@@ -30,19 +35,44 @@ namespace PitHero.Services.AutoJob
         /// <inheritdoc/>
         public MonsterJob Job => MonsterJob.Cooking;
 
+        private int LiveBacklog =>
+            (_coordinator != null ? _coordinator.ActiveTicketCount : 0)
+            + (_mercenaryManager != null ? _mercenaryManager.CountSeatedPatrons() : 0)
+            + (_partyDining != null ? _partyDining.CountPendingPartyDiners() : 0);
+
+        private bool PatronWaitHigh =>
+            _mercenaryManager != null
+            && _mercenaryManager.MaxPatronWaitSeconds() >= GameConfig.AutoJobKitchenHighWaitSeconds;
+
+        /// <inheritdoc/>
+        public void SamplePressure(float nowSeconds)
+        {
+            // Integer block division, matching the live math in ComputeDemand, so the tracker's
+            // granted extras and the live extras agree for the same backlog.
+            int raw = LiveBacklog / GameConfig.AutoJobKitchenBacklogPerExtraWorker;
+            if (PatronWaitHigh)
+                raw++;
+            _tracker.Sample(raw, nowSeconds);
+        }
+
+        /// <inheritdoc/>
+        public void ResetPressure(float nowSeconds) => _tracker.Reset(nowSeconds);
+
         /// <inheritdoc/>
         public JobDemandEntry EvaluateDemand(int rosterSize, int availableWorkers)
         {
-            int backlog = (_coordinator != null ? _coordinator.ActiveTicketCount : 0)
-                + (_mercenaryManager != null ? _mercenaryManager.CountSeatedPatrons() : 0)
-                + (_partyDining != null ? _partyDining.CountPendingPartyDiners() : 0);
             bool anyDishOrderable = _coordinator == null || _coordinator.HasAnyOrderableDish();
-            return ComputeDemand(backlog, rosterSize, availableWorkers, anyDishOrderable);
+            return ComputeDemand(LiveBacklog, _tracker.GrantedWorkers, rosterSize, availableWorkers,
+                anyDishOrderable, PatronWaitHigh);
         }
 
-        /// <summary>Pure demand math: base crew plus one extra worker per backlog block, capped.</summary>
-        public static JobDemandEntry ComputeDemand(int backlog, int rosterSize, int availableWorkers,
-            bool anyDishOrderable = true)
+        /// <summary>
+        /// Pure demand math: base crew plus extra workers, capped. Extras are the larger of the
+        /// live signal (instant scale-up: one per backlog block, +1 on a long patron wait) and
+        /// the tracker's granted count (slow scale-down memory of the recent rush).
+        /// </summary>
+        public static JobDemandEntry ComputeDemand(int backlog, int grantedExtras, int rosterSize,
+            int availableWorkers, bool anyDishOrderable = true, bool patronWaitHigh = false)
         {
             int baseStaff = GameConfig.AutoJobKitchenBaseStaff;
 
@@ -76,12 +106,17 @@ namespace PitHero.Services.AutoJob
             if (baseStaff > availableWorkers)
                 baseStaff = availableWorkers;
 
-            int desired = baseStaff + backlog / GameConfig.AutoJobKitchenBacklogPerExtraWorker;
+            int liveExtras = backlog / GameConfig.AutoJobKitchenBacklogPerExtraWorker;
+            if (patronWaitHigh)
+                liveExtras++;
+            int extras = liveExtras > grantedExtras ? liveExtras : grantedExtras;
+
+            int desired = baseStaff + extras;
             if (desired > GameConfig.AutoJobKitchenMaxWorkers)
                 desired = GameConfig.AutoJobKitchenMaxWorkers;
 
             // A firm minimum keeps the base crew staffed ahead of farming's desired extras, and doubles
-            // as the floor the StarvationReleasePass won't raid below.
+            // as the floor neither the trim pass nor the StarvationReleasePass drops below.
             return new JobDemandEntry
             {
                 Job = MonsterJob.Cooking,

--- a/PitHero/Services/AutoJobAssignmentService.cs
+++ b/PitHero/Services/AutoJobAssignmentService.cs
@@ -7,9 +7,10 @@ using RolePlayingFramework.AlliedMonsters;
 namespace PitHero.Services
 {
     /// <summary>
-    /// Automates allied-monster job assignment (issue #321). When enabled, reassesses per-job worker
-    /// demand every GameConfig.AutoJobReassessIntervalSeconds of in-game time (60 in-game minutes)
-    /// and reassigns monsters via JobAssignmentSolver. Day and nocturnal monsters are disjoint
+    /// Automates allied-monster job assignment (issue #321; backpressure scaling issue #375).
+    /// When enabled, samples each job's backpressure every AutoJobPressureSampleIntervalSeconds
+    /// and reassesses worker demand every AutoJobReassessIntervalSeconds of in-game time,
+    /// reassigning monsters via JobAssignmentSolver. Day and nocturnal monsters are disjoint
     /// workforces (MonsterScheduleConfig: 6AM–10PM vs 10PM–6AM), so each shift is solved separately
     /// and every job gets both a day crew and a night crew. The coordinators reconcile worker
     /// entities off AlliedMonster.Job every frame, so writing the job field is the entire
@@ -26,6 +27,7 @@ namespace PitHero.Services
         private readonly List<MonsterJob> _resultJobs = new List<MonsterJob>(64);
 
         private float _lastAssessSeconds = -1f;
+        private float _lastSampleSeconds = -1f;
         private bool _wasNighttime;
 
         /// <summary>Whether automatic job assignment is active.</summary>
@@ -79,10 +81,24 @@ namespace PitHero.Services
         {
             if (_lastAssessSeconds < 0f || nowSeconds < _lastAssessSeconds)
             {
-                // First tick after enable/load, or time rewound by a load — restart the interval.
+                // First tick after enable/load, or time rewound by a load — restart the interval
+                // and clear the backpressure trackers (their timestamps are from the old clock).
                 _lastAssessSeconds = nowSeconds;
+                _lastSampleSeconds = nowSeconds;
                 _wasNighttime = isNighttime;
+                for (int i = 0; i < _evaluators.Count; i++)
+                    _evaluators[i].ResetPressure(nowSeconds);
                 return;
+            }
+
+            // Backpressure sampling runs on its own faster cadence so trackers see rushes start
+            // and end between reassessments. Sampled before any reassess below so a solve always
+            // works from fresh grants.
+            if (nowSeconds - _lastSampleSeconds >= GameConfig.AutoJobPressureSampleIntervalSeconds)
+            {
+                _lastSampleSeconds = nowSeconds;
+                for (int i = 0; i < _evaluators.Count; i++)
+                    _evaluators[i].SamplePressure(nowSeconds);
             }
 
             if (isNighttime != _wasNighttime)

--- a/PitHero/Services/AutoJobAssignmentService.cs
+++ b/PitHero/Services/AutoJobAssignmentService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Nez;
 using PitHero.Config;
+using PitHero.Services.Analytics;
 using PitHero.Services.AutoJob;
 using RolePlayingFramework.AlliedMonsters;
 
@@ -174,7 +175,11 @@ namespace PitHero.Services
             {
                 var monster = roster[_snapshots[i].RosterIndex];
                 if (monster.Job != _resultJobs[i])
+                {
+                    AnalyticsService.LogMonsterJobChanged(monster.Name, monster.MonsterTypeName,
+                        monster.Job.ToString(), _resultJobs[i].ToString(), "auto");
                     monster.Job = _resultJobs[i];
+                }
             }
         }
     }

--- a/PitHero/Services/KitchenTaskCoordinator.cs
+++ b/PitHero/Services/KitchenTaskCoordinator.cs
@@ -55,6 +55,15 @@ namespace PitHero.Services
         private DroppedCropService _droppedCrops;
         private DishEntityService _dishService;
         private GameStateService _gameState;
+        private MercenaryManager _mercenaryManager;
+
+        // ── Role-mix dwell (issue #375) ─────────────────────────────────────────
+        // A role change sends the worker home to respawn, so the demand-weighted mix is
+        // recomputed at most once per dwell period (head-count changes recompute immediately —
+        // spawns/despawns are happening anyway).
+        private readonly List<KitchenRole> _cachedRoles = new List<KitchenRole>(8);
+        private int _cachedPostCount = -1;
+        private float _roleMixElapsed = GameConfig.KitchenRoleMixDwellSeconds;
 
         // ── Workers ─────────────────────────────────────────────────────────────
         private readonly List<ActiveWorker> _workers = new List<ActiveWorker>(8);
@@ -112,21 +121,64 @@ namespace PitHero.Services
             GameConfig.MaxKitchenCooks + GameConfig.MaxKitchenServers + GameConfig.MaxKitchenRunners;
 
         /// <summary>
-        /// Fills <paramref name="into"/> with the role for each of the first postCount posts by
-        /// cycling Cook → Server → Runner and skipping roles that are already full, which yields
-        /// cook1, server1, runner1, cook2, server2, runner2, cook3, runner3. Ordering is what
-        /// makes the crew grow sensibly: a two-monster kitchen is a cook and a server (the pair
-        /// that opens it), the third is the runner that keeps the fridge stocked and the tables
-        /// clear. Stations and zones are then claimed dynamically by the FSMs.
+        /// Neutral role mix (no pressure signals): cycles Cook → Server → Runner, yielding
+        /// cook1, server1, runner1, cook2, server2, runner2, cook3, runner3.
         /// </summary>
         public static void FillRoleMix(int postCount, List<KitchenRole> into)
+            => FillRoleMix(postCount, 0, 0, 0, into);
+
+        /// <summary>
+        /// Fills <paramref name="into"/> with the role for each of the first postCount posts.
+        /// Posts 0–2 are always Cook, Server, Runner — the base crew: a two-monster kitchen is a
+        /// cook and a server (the pair that opens it), the third is the runner that keeps the
+        /// fridge stocked and the tables clear. Posts beyond the base crew go to the role with
+        /// the highest pressure per worker already assigned to it (D'Hondt greedy, issue #375),
+        /// honoring the per-role caps; roles with zero pressure fall back to the neutral
+        /// Cook → Server → Runner cycle. Stations and zones are then claimed dynamically by
+        /// the FSMs.
+        /// </summary>
+        public static void FillRoleMix(int postCount, int cookPressure, int serverPressure,
+            int runnerPressure, List<KitchenRole> into)
         {
             if (postCount > MaxWorkerPosts)
                 postCount = MaxWorkerPosts;
-            int cooks = 0, servers = 0, runners = 0, cursor = 0;
-            for (int i = 0; i < postCount; i++)
+            int cooks = 0, servers = 0, runners = 0;
+
+            if (postCount >= 1) { cooks++; into.Add(KitchenRole.Cook); }
+            if (postCount >= 2) { servers++; into.Add(KitchenRole.Server); }
+            if (postCount >= 3) { runners++; into.Add(KitchenRole.Runner); }
+
+            int cursor = 0;
+            for (int i = 3; i < postCount; i++)
             {
-                // postCount never exceeds the sum of the per-role caps, so this always resolves
+                // Highest pressure/(count+1) among roles under cap, compared by integer
+                // cross-multiplication; strict > breaks ties toward Cook, then Server, then Runner.
+                int bestRole = -1, bestNum = 0, bestDen = 1;
+                if (cooks < GameConfig.MaxKitchenCooks)
+                {
+                    bestRole = 0; bestNum = cookPressure; bestDen = cooks + 1;
+                }
+                if (servers < GameConfig.MaxKitchenServers
+                    && (bestRole < 0 || serverPressure * bestDen > bestNum * (servers + 1)))
+                {
+                    bestRole = 1; bestNum = serverPressure; bestDen = servers + 1;
+                }
+                if (runners < GameConfig.MaxKitchenRunners
+                    && (bestRole < 0 || runnerPressure * bestDen > bestNum * (runners + 1)))
+                {
+                    bestRole = 2; bestNum = runnerPressure; bestDen = runners + 1;
+                }
+
+                if (bestRole >= 0 && bestNum > 0)
+                {
+                    if (bestRole == 0) { cooks++; into.Add(KitchenRole.Cook); }
+                    else if (bestRole == 1) { servers++; into.Add(KitchenRole.Server); }
+                    else { runners++; into.Add(KitchenRole.Runner); }
+                    continue;
+                }
+
+                // No pressured role can take the post — continue the neutral cycle. postCount
+                // never exceeds the sum of the per-role caps, so this always resolves.
                 while (true)
                 {
                     int slot = cursor % 3;
@@ -149,6 +201,72 @@ namespace PitHero.Services
 
         /// <summary>Number of open kitchen tickets (any state) — the order backlog.</summary>
         public int ActiveTicketCount => _tickets.Count;
+
+        // ── Per-role backpressure signals (issue #375) ──────────────────────────
+        // Each counter isolates the pipeline stage one role is responsible for, so the role mix
+        // can put extra posts where the actual bottleneck is.
+
+        /// <summary>Tickets stalled until a runner delivers their storage shortfall — runner pressure.</summary>
+        public int AwaitingIngredientsTicketCount
+        {
+            get
+            {
+                int count = 0;
+                for (int i = 0; i < _tickets.Count; i++)
+                    if (_tickets[i].State == TicketState.AwaitingIngredients)
+                        count++;
+                return count;
+            }
+        }
+
+        /// <summary>Posted tickets no cook has picked up yet — cook pressure.</summary>
+        public int ReadyToCookUnclaimedCount
+        {
+            get
+            {
+                int count = 0;
+                for (int i = 0; i < _tickets.Count; i++)
+                {
+                    var t = _tickets[i];
+                    if (t.PostedToBoard && !t.CookClaimed
+                        && (t.State == TicketState.ReadyToCook || t.State == TicketState.AwaitingIngredients))
+                        count++;
+                }
+                return count;
+            }
+        }
+
+        /// <summary>Cooked dishes sitting on serving tables waiting for a server — server pressure.</summary>
+        public int PlatedAwaitingPickupCount
+        {
+            get
+            {
+                int count = 0;
+                for (int i = 0; i < _tickets.Count; i++)
+                    if (_tickets[i].State == TicketState.Plated)
+                        count++;
+                return count;
+            }
+        }
+
+        /// <summary>Tickets queued for a runner's storage→fridge trip — runner pressure.</summary>
+        public int FetchQueueDepth => _fetchQueue.Count;
+
+        /// <summary>Empty plates queued for bussing — runner pressure.</summary>
+        public int BusJobCount => _busJobs.Count;
+
+        /// <summary>Age in seconds of the oldest open ticket, or 0 with an empty board.</summary>
+        public float OldestOpenTicketAgeSeconds(float nowTotalTime)
+        {
+            float oldest = 0f;
+            for (int i = 0; i < _tickets.Count; i++)
+            {
+                float age = nowTotalTime - _tickets[i].CreatedTime;
+                if (age > oldest)
+                    oldest = age;
+            }
+            return oldest;
+        }
 
         /// <summary>True while the ticket board has room for another order.</summary>
         public bool HasTicketCapacity => _tickets.Count < MaxOpenTickets;
@@ -266,7 +384,24 @@ namespace PitHero.Services
 
             int postCount = _wantedAssignments.Count < MaxWorkerPosts
                 ? _wantedAssignments.Count : MaxWorkerPosts;
-            FillRoleMix(postCount, _wantedRoles);
+
+            _roleMixElapsed += Time.DeltaTime;
+            if (postCount != _cachedPostCount || _roleMixElapsed >= GameConfig.KitchenRoleMixDwellSeconds)
+            {
+                _roleMixElapsed = 0f;
+                _cachedPostCount = postCount;
+                _cachedRoles.Clear();
+                EnsureServices();
+                // AwaitingIngredients tickets already cover the queued fetch jobs, so the fetch
+                // queue isn't added again on top of them.
+                int runnerPressure = AwaitingIngredientsTicketCount + BusJobCount;
+                int cookPressure = ReadyToCookUnclaimedCount;
+                int serverPressure = PlatedAwaitingPickupCount
+                    + (_mercenaryManager != null ? _mercenaryManager.CountPatronsWaitingToOrder() : 0);
+                FillRoleMix(postCount, cookPressure, serverPressure, runnerPressure, _cachedRoles);
+            }
+            for (int i = 0; i < _cachedRoles.Count; i++)
+                _wantedRoles.Add(_cachedRoles[i]);
 
             // SpawnWorker appends to _workers mid-pass, so snapshot the count and never index past it.
             int existingWorkerCount = _workers.Count;
@@ -547,6 +682,7 @@ namespace PitHero.Services
             var ticket = new KitchenTicket
             {
                 TicketId = ++_nextTicketId,
+                CreatedTime = Time.TotalTime,
                 Dish = dish,
                 IsPartyTicket = isParty,
                 PartySlot = partySlot,
@@ -588,6 +724,7 @@ namespace PitHero.Services
             var ticket = new KitchenTicket
             {
                 TicketId = ++_nextTicketId,
+                CreatedTime = Time.TotalTime,
                 Dish = dish,
                 IsPartyTicket = true,
                 PartySlot = partySlot,
@@ -1402,6 +1539,8 @@ namespace PitHero.Services
                 _dishService = Core.Services.GetService<DishEntityService>();
             if (_gameState == null)
                 _gameState = Core.Services.GetService<GameStateService>();
+            if (_mercenaryManager == null)
+                _mercenaryManager = Core.Services.GetService<MercenaryManager>();
         }
 
         /// <summary>

--- a/PitHero/Services/KitchenTaskCoordinator.cs
+++ b/PitHero/Services/KitchenTaskCoordinator.cs
@@ -67,6 +67,16 @@ namespace PitHero.Services
         private int _cachedPostCount = -1;
         private float _roleMixElapsed = GameConfig.KitchenRoleMixDwellSeconds;
 
+        // Per-role pressures seesaw within a single service cycle (orders just taken → runner
+        // work spikes; dishes plated → server work spikes), so an instantaneous reading at
+        // recompute time hands the marginal post to whichever side of the seesaw got sampled —
+        // and back again at the next dwell. EMA-smoothed pressures see the cycle's AVERAGE, so
+        // the marginal post only moves on a sustained shift in where the bottleneck really is.
+        private float _rolePressureSampleElapsed = GameConfig.KitchenRolePressureSampleIntervalSeconds;
+        private float _smoothedCookPressure;
+        private float _smoothedServerPressure;
+        private float _smoothedRunnerPressure;
+
         // ── Workers ─────────────────────────────────────────────────────────────
         private readonly List<ActiveWorker> _workers = new List<ActiveWorker>(8);
         private readonly List<IMonsterWorkerHost> _peers = new List<IMonsterWorkerHost>(2);
@@ -440,20 +450,33 @@ namespace PitHero.Services
             int postCount = _wantedAssignments.Count < MaxWorkerPosts
                 ? _wantedAssignments.Count : MaxWorkerPosts;
 
+            _rolePressureSampleElapsed += Time.DeltaTime;
+            if (_rolePressureSampleElapsed >= GameConfig.KitchenRolePressureSampleIntervalSeconds)
+            {
+                _rolePressureSampleElapsed = 0f;
+                EnsureServices();
+                // AwaitingIngredients tickets already cover the queued fetch jobs, so the fetch
+                // queue isn't added again on top of them.
+                int rawRunner = AwaitingIngredientsTicketCount + BusJobCount;
+                int rawCook = ReadyToCookUnclaimedCount;
+                int rawServer = PlatedAwaitingPickupCount
+                    + (_mercenaryManager != null ? _mercenaryManager.CountPatronsWaitingToOrder() : 0);
+                float alpha = GameConfig.KitchenRolePressureEmaAlpha;
+                _smoothedCookPressure += (rawCook - _smoothedCookPressure) * alpha;
+                _smoothedServerPressure += (rawServer - _smoothedServerPressure) * alpha;
+                _smoothedRunnerPressure += (rawRunner - _smoothedRunnerPressure) * alpha;
+            }
+
             _roleMixElapsed += Time.DeltaTime;
             if (postCount != _cachedPostCount || _roleMixElapsed >= GameConfig.KitchenRoleMixDwellSeconds)
             {
                 _roleMixElapsed = 0f;
                 _cachedPostCount = postCount;
                 _cachedRoles.Clear();
-                EnsureServices();
-                // AwaitingIngredients tickets already cover the queued fetch jobs, so the fetch
-                // queue isn't added again on top of them.
-                int runnerPressure = AwaitingIngredientsTicketCount + BusJobCount;
-                int cookPressure = ReadyToCookUnclaimedCount;
-                int serverPressure = PlatedAwaitingPickupCount
-                    + (_mercenaryManager != null ? _mercenaryManager.CountPatronsWaitingToOrder() : 0);
-                FillRoleMix(postCount, cookPressure, serverPressure, runnerPressure, _cachedRoles);
+                FillRoleMix(postCount,
+                    (int)(_smoothedCookPressure + 0.5f),
+                    (int)(_smoothedServerPressure + 0.5f),
+                    (int)(_smoothedRunnerPressure + 0.5f), _cachedRoles);
             }
 
             // Map the mix's role COUNTS onto posts so live workers keep their roles wherever the

--- a/PitHero/Services/KitchenTaskCoordinator.cs
+++ b/PitHero/Services/KitchenTaskCoordinator.cs
@@ -5,6 +5,7 @@ using PitHero.Config;
 using PitHero.Dining;
 using PitHero.ECS.Components;
 using PitHero.Farming;
+using PitHero.Services.Analytics;
 using PitHero.Util;
 using RolePlayingFramework.AlliedMonsters;
 
@@ -500,7 +501,13 @@ namespace PitHero.Services
                 }
                 else
                 {
-                    // Role changed — send home; will be respawned next reconcile
+                    // Role changed — send home; will be respawned next reconcile. Log only on the
+                    // transition (this branch repeats every frame until the worker despawns).
+                    if (!w.Fsm.IsReturningHome)
+                    {
+                        AnalyticsService.LogKitchenRoleChanged(w.Monster.Name, w.Monster.MonsterTypeName,
+                            w.Role.ToString(), _wantedRoles[wantedIdx].ToString());
+                    }
                     w.Fsm.RequestReturnHome();
                 }
             }

--- a/PitHero/Services/KitchenTaskCoordinator.cs
+++ b/PitHero/Services/KitchenTaskCoordinator.cs
@@ -62,6 +62,7 @@ namespace PitHero.Services
         // recomputed at most once per dwell period (head-count changes recompute immediately —
         // spawns/despawns are happening anyway).
         private readonly List<KitchenRole> _cachedRoles = new List<KitchenRole>(8);
+        private readonly List<int> _currentRoleByPost = new List<int>(8);
         private int _cachedPostCount = -1;
         private float _roleMixElapsed = GameConfig.KitchenRoleMixDwellSeconds;
 
@@ -196,6 +197,59 @@ namespace PitHero.Services
                         runners++; into.Add(KitchenRole.Runner); break;
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Maps the role mix onto the actual posts with minimum churn (issue #375 follow-up): the
+        /// mix is treated as a multiset of role COUNTS, and a live worker keeps its current role
+        /// as long as that role still has quota — quota is consumed in post order (= proficiency
+        /// order), so when a role shrinks, the best holders keep it and only the worst is
+        /// reassigned. Remaining quota goes to unmatched posts in Cook → Server → Runner order.
+        /// Without this, roles were tied to sorted-list positions, and any recompute could flip
+        /// two positions' roles — sending BOTH workers home to respawn in each other's role, a
+        /// pure-waste "cook leaves, different cook walks in" shuffle.
+        /// currentRoleByPost[j] = (int)KitchenRole of post j's live worker, or -1 if none.
+        /// </summary>
+        public static void AssignRolesWithRetention(List<KitchenRole> mix,
+            List<int> currentRoleByPost, List<KitchenRole> into)
+        {
+            int cooks = 0, servers = 0, runners = 0;
+            for (int j = 0; j < mix.Count; j++)
+            {
+                if (mix[j] == KitchenRole.Cook) cooks++;
+                else if (mix[j] == KitchenRole.Server) servers++;
+                else runners++;
+            }
+
+            // Pass 1: retention. keptMask bit j = post j kept its current role (mix.Count ≤ 8).
+            int keptMask = 0;
+            for (int j = 0; j < mix.Count; j++)
+            {
+                into.Add(KitchenRole.Cook);   // placeholder; every post is overwritten below
+                int current = currentRoleByPost[j];
+                if (current == (int)KitchenRole.Cook && cooks > 0)
+                {
+                    cooks--; into[j] = KitchenRole.Cook; keptMask |= 1 << j;
+                }
+                else if (current == (int)KitchenRole.Server && servers > 0)
+                {
+                    servers--; into[j] = KitchenRole.Server; keptMask |= 1 << j;
+                }
+                else if (current == (int)KitchenRole.Runner && runners > 0)
+                {
+                    runners--; into[j] = KitchenRole.Runner; keptMask |= 1 << j;
+                }
+            }
+
+            // Pass 2: remaining quota to unmatched posts, best proficiency toward Cook first.
+            for (int j = 0; j < mix.Count; j++)
+            {
+                if ((keptMask & (1 << j)) != 0)
+                    continue;
+                if (cooks > 0) { cooks--; into[j] = KitchenRole.Cook; }
+                else if (servers > 0) { servers--; into[j] = KitchenRole.Server; }
+                else { runners--; into[j] = KitchenRole.Runner; }
             }
         }
 
@@ -400,8 +454,25 @@ namespace PitHero.Services
                     + (_mercenaryManager != null ? _mercenaryManager.CountPatronsWaitingToOrder() : 0);
                 FillRoleMix(postCount, cookPressure, serverPressure, runnerPressure, _cachedRoles);
             }
-            for (int i = 0; i < _cachedRoles.Count; i++)
-                _wantedRoles.Add(_cachedRoles[i]);
+
+            // Map the mix's role COUNTS onto posts so live workers keep their roles wherever the
+            // quota allows — only genuine count changes cause a walk-home/respawn.
+            _currentRoleByPost.Clear();
+            for (int j = 0; j < postCount; j++)
+            {
+                int currentRole = -1;
+                for (int wi = 0; wi < _workers.Count; wi++)
+                {
+                    if (ReferenceEquals(_workers[wi].Monster, _wantedAssignments[j])
+                        && !_workers[wi].Entity.IsDestroyed)
+                    {
+                        currentRole = (int)_workers[wi].Role;
+                        break;
+                    }
+                }
+                _currentRoleByPost.Add(currentRole);
+            }
+            AssignRolesWithRetention(_cachedRoles, _currentRoleByPost, _wantedRoles);
 
             // SpawnWorker appends to _workers mid-pass, so snapshot the count and never index past it.
             int existingWorkerCount = _workers.Count;

--- a/PitHero/Services/MercenaryManager.cs
+++ b/PitHero/Services/MercenaryManager.cs
@@ -754,6 +754,53 @@ namespace PitHero.Services
             return count;
         }
 
+        /// <summary>Seated patrons still waiting for a server to take their order — server pressure (issue #375).</summary>
+        public int CountPatronsWaitingToOrder()
+        {
+            int count = 0;
+            for (int i = 0; i < _mercenaryEntities.Count; i++)
+            {
+                var entity = _mercenaryEntities[i];
+                if (entity == null)
+                    continue;
+                var comp = entity.GetComponent<MercenaryComponent>();
+                if (comp == null || comp.IsHired)
+                    continue;
+                var patron = entity.GetComponent<ECS.Components.TavernPatronComponent>();
+                if (patron != null && patron.State == ECS.Components.PatronState.WaitingToOrder)
+                    count++;
+            }
+            return count;
+        }
+
+        /// <summary>
+        /// Longest current wait among patrons who haven't been served yet (waiting to order, or
+        /// ordered and waiting for food). 0 when nobody is waiting. Backpressure signal: a long
+        /// wait means the kitchen is understaffed even if the raw backlog count looks modest.
+        /// </summary>
+        public float MaxPatronWaitSeconds()
+        {
+            float max = 0f;
+            for (int i = 0; i < _mercenaryEntities.Count; i++)
+            {
+                var entity = _mercenaryEntities[i];
+                if (entity == null)
+                    continue;
+                var comp = entity.GetComponent<MercenaryComponent>();
+                if (comp == null || comp.IsHired)
+                    continue;
+                var patron = entity.GetComponent<ECS.Components.TavernPatronComponent>();
+                if (patron == null)
+                    continue;
+                if (patron.State != ECS.Components.PatronState.WaitingToOrder
+                    && patron.State != ECS.Components.PatronState.Ordered)
+                    continue;
+                if (patron.StateElapsedSeconds > max)
+                    max = patron.StateElapsedSeconds;
+            }
+            return max;
+        }
+
         /// <summary>
         /// Gets an available tavern position, preferring one whose table is already cleared —
         /// a seat with an un-bussed plate would park the arriving patron at the door.

--- a/PitHero/UI/MonsterUI.cs
+++ b/PitHero/UI/MonsterUI.cs
@@ -3,6 +3,7 @@ using Nez;
 using Nez.UI;
 using PitHero.Config;
 using PitHero.Services;
+using PitHero.Services.Analytics;
 using PitHero.Util;
 using RolePlayingFramework.AlliedMonsters;
 
@@ -456,6 +457,12 @@ namespace PitHero.UI
                             var closuredJob = jobValue;
                             jobBtn.OnClicked += (_) =>
                             {
+                                if (closuredMonster.Job != closuredJob)
+                                {
+                                    AnalyticsService.LogMonsterJobChanged(closuredMonster.Name,
+                                        closuredMonster.MonsterTypeName, closuredMonster.Job.ToString(),
+                                        closuredJob.ToString(), "manual");
+                                }
                                 closuredMonster.Job = closuredJob;
                                 RefreshMonsterList();
                             };

--- a/PitHero/docs/AnalyticsSchema.md
+++ b/PitHero/docs/AnalyticsSchema.md
@@ -108,6 +108,17 @@ All farming work is performed by allied monsters; `monster` is the worker's disp
 | `dish_served` | `dish`, `price`, `tip`, `isParty`, `deluxe` | One line per finished meal. `dish` is the `DishType` enum name. Patron meals (`isParty:false`) pair with `gold_gained (source:"dish_sale")` and, when `tip > 0`, `gold_gained (source:"dish_tip")`. Party meals (`isParty:true`) never tip and paid at order time (spend not logged — infer from `currentGold` deltas). A patron who leaves after cooking started (patience expiry or hired mid-dining) still pays via `gold_gained (source:"dish_sale")` but logs no `dish_served`. |
 | `party_dine_skipped` | `slot`, `member`, `dish`, `reason` | A party member was passed over during a tavern seating — no order, no charge. `slot`: 0 = hero, 1/2 = hired mercs. `dish` is the favorite that would have been ordered. `reason`: `no_ingredients` (fridge + storage can't cover the favorite's recipe — no substitution by design), `no_gold` (funds below the dish price), or `already_ate` (member already dined today; normal after breakfast if the party stops again). At most one line per member per seating. |
 
+### Monster job staffing (issue #375)
+
+For analyzing auto-assignment scaling and kitchen churn. `monster` is the allied monster's
+display name and `monsterType` its species key (nocturnal/day schedule is derivable from the
+type via `MonsterScheduleConfig`).
+
+| `e` | Fields | Notes |
+|---|---|---|
+| `monster_job_changed` | `monster`, `monsterType`, `fromJob`, `toJob`, `trigger` | An allied monster's `MonsterJob` changed. Jobs are the `MonsterJob` enum names (`None`, `Farming`, `Cooking`, `Fishing`); `toJob:"None"` means sent home, `fromJob:"None"` means newly staffed. `trigger`: `"auto"` (AutoJobAssignmentService reassessment — fires per shift solve, so a burst of lines at one timestamp is one reassessment) or `"manual"` (job button in the Monsters window; only possible while automation is off). Save restore never logs. |
+| `kitchen_role_changed` | `monster`, `monsterType`, `fromRole`, `toRole` | A live kitchen worker was sent home to respawn in a different role (`Cook`/`Server`/`Runner`). Logged once at the send-home decision; `toRole` is the role wanted at that moment and can in rare cases differ from the role actually taken after the walk-home/respawn round trip (the mix may shift meanwhile). Workers leaving the kitchen entirely log `monster_job_changed` instead, not this. With role retention this should be RARE — a sustained stream of these lines means the role mix is thrashing and `KitchenRoleMixDwellSeconds` needs raising. |
+
 ## Interpretation caveats
 
 - **Names are text keys, not display names.** Monsters log localization keys

--- a/PitHero/docs/AutoJobAssignmentSystem.md
+++ b/PitHero/docs/AutoJobAssignmentSystem.md
@@ -56,9 +56,11 @@ Tunables live in `GameConfig` under the `AutoJob*` prefix.
 - **Decay is smoothed**: falling raw decays through an EMA (`AutoJobPressureDecayAlpha`), so
   pressure must stay low across several samples before a grant becomes releasable.
 - **Drain is rate-limited**: a grant level is released only when smoothed pressure sits below
-  `granted − 0.5` (half-worker release hysteresis) AND a full
-  `AutoJobScaleDownDrainIntervalSeconds` (60 scaled seconds) has passed since the last change —
-  one worker per interval, never more.
+  `granted − 0.5` (half-worker release hysteresis) AND a full drain interval has passed since the
+  last change — one worker per interval, never more. The interval is per-job (tracker constructor
+  param): farming uses `AutoJobScaleDownDrainIntervalSeconds` (60 scaled seconds); the kitchen
+  uses `AutoJobKitchenScaleDownDrainIntervalSeconds` (180) because a worker walking out of a
+  service area mid-rush is far more noticeable than a farmer leaving a field.
 
 Tracker state is transient (never persisted); it rebuilds within a few samples after a load.
 
@@ -182,6 +184,15 @@ Per-role pressure signals, computed in the coordinator's `Update()`:
 weighted mix is recomputed at most once per `GameConfig.KitchenRoleMixDwellSeconds` (45 scaled
 seconds) — except when the post count itself changes, which recomputes immediately (spawns and
 despawns are happening anyway).
+
+**Role retention:** the mix is applied as a multiset of role *counts*
+(`AssignRolesWithRetention`), not position-by-position: a live worker keeps its current role as
+long as that role still has quota, with quota consumed in proficiency order so a shrinking role
+sheds its worst holder first; only leftover quota is assigned to unmatched posts (Cook → Server →
+Runner). A recompute whose counts don't change therefore causes **zero** churn. Before this,
+roles were tied to sorted-list positions and a recompute could flip two positions — sending both
+workers home to respawn in each other's roles (the visible "one cook leaves and another cook
+immediately replaces it" shuffle).
 
 Workload getters: `FarmTaskCoordinator.OutstandingTaskCount`,
 `KitchenTaskCoordinator.ActiveTicketCount` / `AwaitingIngredientsTicketCount` /

--- a/PitHero/docs/AutoJobAssignmentSystem.md
+++ b/PitHero/docs/AutoJobAssignmentSystem.md
@@ -172,13 +172,22 @@ per-role caps (3 cooks / 2 servers / 3 runners; 2 servers is a hard `ServerZone`
 Zero-pressure roles fall back to the legacy Cook → Server → Runner cycle, and the zero-pressure
 overload *is* the legacy cycle.
 
-Per-role pressure signals, computed in the coordinator's `Update()`:
+Per-role pressure signals, sampled in the coordinator's `Update()`:
 
 - **Runner**: `AwaitingIngredientsTicketCount` (tickets stalled on a storage fetch — this already
   covers the queued fetch jobs) + `BusJobCount` (dirty plates).
 - **Cook**: `ReadyToCookUnclaimedCount` (posted tickets no cook has picked up).
 - **Server**: `PlatedAwaitingPickupCount` (dishes cooling on serving tables) +
   `MercenaryManager.CountPatronsWaitingToOrder()`.
+
+**Pressure smoothing:** these counts seesaw within a single service cycle — orders just taken
+spike runner work, plated dishes spike server work — so an instantaneous reading at recompute
+time would hand the marginal post to whichever side of the seesaw got sampled, then hand it
+back at the next dwell (observed in playtesting as a worker ping-ponging Runner↔Server at
+exactly the dwell cadence). The mix therefore reads EMA-smoothed pressures, sampled every
+`KitchenRolePressureSampleIntervalSeconds` (5 scaled seconds) with weight
+`KitchenRolePressureEmaAlpha` (0.1 ≈ 50 scaled-second time constant, spanning a full cycle),
+rounded to the nearest worker — the marginal post only moves on a sustained bottleneck shift.
 
 **Anti-thrash dwell:** a role change sends the worker home to despawn and respawn, so the
 weighted mix is recomputed at most once per `GameConfig.KitchenRoleMixDwellSeconds` (45 scaled

--- a/PitHero/docs/AutoJobAssignmentSystem.md
+++ b/PitHero/docs/AutoJobAssignmentSystem.md
@@ -1,11 +1,15 @@
-# Auto Job Assignment System (issue #321)
+# Auto Job Assignment System (issue #321; backpressure scaling issue #375)
 
 Automates allied-monster job assignment. When the player enables **Settings → Automation →
-"Automate monster jobs"**, `AutoJobAssignmentService` periodically measures per-job workload
-("demand") and rewrites each monster's `AlliedMonster.Job`. That field write is the *entire*
-assignment action: `FarmTaskCoordinator.Update()` and `KitchenTaskCoordinator.Update()` reconcile
-worker entities against `Job` + awake state every frame, so no entity or FSM code is involved in
-assignment.
+"Automate monster jobs"**, `AutoJobAssignmentService` continuously samples per-job backpressure,
+periodically measures per-job workload ("demand"), and rewrites each monster's
+`AlliedMonster.Job`. That field write is the *entire* assignment action:
+`FarmTaskCoordinator.Update()` and `KitchenTaskCoordinator.Update()` reconcile worker entities
+against `Job` + awake state every frame, so no entity or FSM code is involved in assignment.
+
+Scaling is asymmetric by design (issue #375): jobs staff **up instantly** when they fall behind
+and drain **down slowly** (one worker per drain interval per job) when pressure subsides, so a
+dinner rush is met immediately but its crew isn't dumped the moment the last plate lands.
 
 The coordinators are peered via `IMonsterWorkerHost` (`MainGameScene` wires `AddPeer` both ways):
 on a mid-shift job change the monster's old-job worker entity must walk home and despawn before
@@ -18,7 +22,8 @@ The same gate covers kitchen role changes (the replacement waits for the old wor
 |---|---|---|
 | `AutoJobAssignmentService` | `PitHero/Services/AutoJobAssignmentService.cs` | Cadence + snapshot + apply loop. Registered/ticked/unloaded in `MainGameScene` (`Begin`, `Update` unpaused block, `Unload`). |
 | `JobAssignmentSolver` | `PitHero/Services/AutoJob/JobAssignmentSolver.cs` | Pure static solver. No service or ECS dependencies — fully unit-testable. |
-| `IJobDemandEvaluator` | `PitHero/Services/AutoJob/IJobDemandEvaluator.cs` | One per automatable job: reports how many workers the job wants right now. |
+| `IJobDemandEvaluator` | `PitHero/Services/AutoJob/IJobDemandEvaluator.cs` | One per automatable job: reports how many workers the job wants right now (`EvaluateDemand`) and feeds its backpressure tracker (`SamplePressure`/`ResetPressure`). |
+| `BackpressureTracker` | `PitHero/Services/AutoJob/BackpressureTracker.cs` | Per-job smoother: instant attack, EMA decay, one-worker-per-interval drain. Owned by each evaluator. |
 | `FarmingJobDemandEvaluator` | `PitHero/Services/AutoJob/FarmingJobDemandEvaluator.cs` | Farming demand (non-sticky). |
 | `KitchenJobDemandEvaluator` | `PitHero/Services/AutoJob/KitchenJobDemandEvaluator.cs` | Kitchen demand (sticky). |
 | UI gating | `PitHero/UI/SettingsUI.cs` (checkbox), `PitHero/UI/MonsterUI.cs` (job buttons non-clickable while enabled) | |
@@ -26,16 +31,36 @@ The same gate covers kitchen role changes (the replacement waits for the old wor
 
 Tunables live in `GameConfig` under the `AutoJob*` prefix.
 
-## When reassessment runs
+## When sampling and reassessment run
 
-`Update()` (per unpaused frame) calls `TickCadence(nowSeconds, isNighttime)`, which fires
-`ReassessNow()`:
+`Update()` (per unpaused frame) calls `TickCadence(nowSeconds, isNighttime)`, measured on
+`InGameTimeService.AccumulatedSeconds` so pausing never advances either timer. Two cadences:
 
-1. Every `GameConfig.AutoJobReassessIntervalSeconds` (60 scaled seconds = 60 in-game minutes),
-   measured on `InGameTimeService.AccumulatedSeconds` so pausing never advances the timer. A
-   `now < last` guard restarts the interval after a load rewinds time.
-2. Immediately when `IsNighttime` flips (6AM / 10PM shift change), restarting the interval.
-3. Immediately when the player first checks the checkbox (`SettingsUI` calls `ReassessNow()`).
+- **Pressure sampling** — every `GameConfig.AutoJobPressureSampleIntervalSeconds` (5 scaled
+  seconds) each evaluator's `SamplePressure` feeds live workload into its `BackpressureTracker`.
+  Sampling always runs before any reassess in the same tick, so a solve works from fresh grants.
+- **Reassessment** — `ReassessNow()` fires:
+  1. Every `GameConfig.AutoJobReassessIntervalSeconds` (15 scaled seconds = 15 in-game minutes).
+     A `now < last` guard restarts the interval after a load rewinds time — and also calls
+     `ResetPressure` on every evaluator, since tracker timestamps came from the old clock.
+  2. Immediately when `IsNighttime` flips (6AM / 10PM shift change), restarting the interval.
+  3. Immediately when the player first checks the checkbox (`SettingsUI` calls `ReassessNow()`).
+
+### The backpressure tracker
+
+`BackpressureTracker.Sample(raw, now)` holds pressure in workers-worth units:
+
+- **Attack is instant**: raw ≥ smoothed replaces smoothed outright, and the granted worker count
+  jumps straight to `ceil(raw)` — a rush staffs up on the very next solve. (Scale-up keys off the
+  raw signal, never the smoothed one, so the EMA tail can't re-grant workers.)
+- **Decay is smoothed**: falling raw decays through an EMA (`AutoJobPressureDecayAlpha`), so
+  pressure must stay low across several samples before a grant becomes releasable.
+- **Drain is rate-limited**: a grant level is released only when smoothed pressure sits below
+  `granted − 0.5` (half-worker release hysteresis) AND a full
+  `AutoJobScaleDownDrainIntervalSeconds` (60 scaled seconds) has passed since the last change —
+  one worker per interval, never more.
+
+Tracker state is transient (never persisted); it rebuilds within a few samples after a load.
 
 ## Day/night shifts are solved independently
 
@@ -52,20 +77,37 @@ assigned normally — the coordinators keep them home until their work window.
 `RosterIndex`), allocation-free, all `for` loops:
 
 1. **Sticky pass** — monsters whose `CurrentJob` matches a demand entry with `Sticky = true` keep
-   that job unconditionally, even above `DesiredWorkers` (kitchen workers are never demoted).
-2. **Min pass** — each demand, in list order, fills up to `MinWorkers` from unassigned monsters by
+   that job (stickiness = "not reshuffled arbitrarily between solves"; workers leave only through
+   the next pass or the starvation release).
+2. **Sticky trim pass** (issue #375, deliberately replacing the original "never demoted, even
+   above desired" rule) — a sticky demand holding more workers than
+   `max(MinWorkers, DesiredWorkers)` releases its **lowest-proficiency** worker, at most **one per
+   solve per demand**. This is the sanctioned scale-down path: even if a demand gate suddenly
+   zeroes desired (larder ran dry), the crew drains one worker per reassessment, never in one
+   layoff. Running before the fill passes means the freed monster is claimable by whichever job
+   needs it in the *same* solve.
+3. **Min pass** — each demand, in list order, fills up to `MinWorkers` from unassigned monsters by
    highest proficiency for that job.
-3. **Desired pass** — same, up to `DesiredWorkers`.
-4. **Starvation release pass** — the one exception to stickiness. A demand with `MinWorkers > 0`
+4. **Desired round-robin pass** (issue #375, replacing the whole-demand-at-a-time desired fill) —
+   repeated cycles over the demand list; each demand still under `DesiredWorkers` claims exactly
+   **one** free monster per cycle. List order decides who gets each cycle's first spare, making
+   priority a tiebreak instead of a monopoly. (The old pass let farming's desired extras absorb
+   every spare monster before the kitchen's desired pass ran — the "kitchen frozen at 3 during a
+   packed dinner rush" bug.)
+5. **Starvation release pass** — a demand with `MinWorkers > 0`
    that ends the fill passes with **zero** workers (proof that every candidate is sticky-locked
    elsewhere — fill exhausts free monsters first) pulls sticky-held workers from **lower-priority**
    demands only, up to its `DesiredWorkers`, never dropping a raided job below its own
    `MinWorkers`. In practice: farm tasks with no farmer at all release kitchen workers to the farm
    (kitchen work is pointless with nothing being grown), but the kitchen is never raided below its
-   base crew when the shift is big enough to field one.
-5. **Swap pass** — a sticky worker swaps with a non-sticky assignee only when **both** jobs
-   strictly gain proficiency (prevents oscillation between reassessments).
-6. Everyone unassigned gets `MonsterJob.None` → the coordinators send them home.
+   base crew when the shift is big enough to field one. (The trim pass never drops a job below its
+   own `MinWorkers`, so a trimmed kitchen can't trigger its own starvation.)
+6. **Swap pass** — a sticky worker swaps with a non-sticky assignee only when the other job
+   **strictly** gains proficiency and the sticky job **doesn't lose** any. Every swap strictly
+   raises total proficiency, so the reverse swap can never qualify and assignments never
+   oscillate between reassessments. (The zero-loss case matters after a trim: equal cooks, but
+   one is the far better farmer — the farm gets that one.)
+7. Everyone unassigned gets `MonsterJob.None` → the coordinators send them home.
 
 A monster holding a job with **no demand entry** is non-sticky by definition and gets pooled and
 reassigned — this is the extensibility guarantee (a Fishing-assigned monster before a fishing
@@ -78,40 +120,77 @@ demand is covered before the kitchen staffs). Each evaluator receives the shift'
 `availableWorkers` = roster minus the `MinWorkers` already reserved by higher-priority evaluators,
 so a lower-priority job only claims workers its betters don't need.
 
-- **Farming** (`Sticky = false`, listed first): `max(burst, baseline)` where burst =
-  `FarmTaskCoordinator.OutstandingTaskCount / AutoJobFarmTasksPerWorker` (catches watering/harvest
-  waves) and baseline = `(CropCount + PlanCount) / AutoJobFarmCropsPerWorkerBaseline` (quiet
-  growth periods), ceil-divided, clamped to available workers. `MinWorkers` = 1 whenever any
-  workload exists — the ≥1-farmer guarantee. Released farmers become the pool that staffs the
-  kitchen or goes home.
+- **Farming** (`Sticky = false`, listed first): honest, work-driven demand (issue #375). Desired =
+  `max(burst, granted, min)` clamped to available workers, where burst =
+  `OutstandingTaskCount / AutoJobFarmTasksPerWorker` ceil-divided (instant scale-up for
+  watering/harvest waves), granted = the tracker's drain-limited memory of recent waves (so
+  staffing ramps down between waves instead of collapsing), and `MinWorkers` = 1 whenever any
+  crops or plans exist — one caretaker for the next wave. The pre-#375 baseline term
+  (`careLoad / 12`) is gone: it staffed farmers who had literally nothing to claim, and they
+  ping-ponged Idle↔Wander around the field. Surplus farmers now drain off to the kitchen or home.
 - **Kitchen** (`Sticky = true`): base crew `AutoJobKitchenBaseStaff` = 3 — **cook + server +
   runner; never less, a runner-less kitchen runs the fridge dry and leaves dirty plates on the
-  tables** — plus one worker per `AutoJobKitchenBacklogPerExtraWorker` backlog items (open tickets
-  + seated patrons + pending party diners), capped at `AutoJobKitchenMaxWorkers` (must mirror
-  `KitchenTaskCoordinator.MaxWorkerPosts` = 3 cooks + 2 servers + 3 runners = 8; asserted by
-  `KitchenServiceLoopTests.RoleMix_RespectsPerRoleCapsAndNeverExceedsMaxPosts`).
+  tables** — plus extra workers `max(liveExtras, grantedExtras)`, capped at
+  `AutoJobKitchenMaxWorkers` (must mirror `KitchenTaskCoordinator.MaxWorkerPosts` = 3 cooks +
+  2 servers + 3 runners = 8; asserted by
+  `KitchenServiceLoopTests.RoleMix_RespectsPerRoleCapsAndNeverExceedsMaxPosts`). Live extras =
+  one worker per `AutoJobKitchenBacklogPerExtraWorker` backlog items (open tickets + seated
+  patrons + pending party diners), **plus one more when any patron has waited
+  `AutoJobKitchenHighWaitSeconds` (an in-game hour) to order or be served** — a long wait proves
+  the pipeline is behind even when raw counts look modest. Granted extras come from the tracker
+  (slow drain after the rush).
   `MinWorkers` = the base crew (firm, so it fills ahead of farming's desired extras and doubles as
-  the floor the starvation release pass won't raid below). **All-or-nothing when competing with
-  farming:** if farming's reservation leaves fewer than the base crew available
-  (`availableWorkers < baseStaff && availableWorkers < rosterSize`), the kitchen fields no one — a
-  partial kitchen has no runner, and with no farm workers there'd be no ingredients anyway. On
-  tiny rosters with no farm workload, the base crew still clamps down to the roster as before.
+  the floor neither the trim pass nor the starvation release pass drops below). **All-or-nothing
+  when competing with farming:** if farming's reservation leaves fewer than the base crew
+  available (`availableWorkers < baseStaff && availableWorkers < rosterSize`), the kitchen fields
+  no one — a partial kitchen has no runner, and with no farm workers there'd be no ingredients
+  anyway. On tiny rosters with no farm workload, the base crew still clamps down to the roster as
+  before.
   **Empty-larder gate:** demand is also zero while no dish is coverable from fridge + storage
   (`KitchenTaskCoordinator.HasAnyOrderableDish`) — servers refuse orders they can't cover, so
   staff would be dead weight (a new game's lone monster stays home instead of taking the chef
-  hat). Workers already in the kitchen stay (sticky) if the larder runs dry mid-day; the gate
-  only blocks fresh staffing until the next cadence tick after crops land in storage.
+  hat). Workers already in the kitchen drain out one per solve (trim pass) if the larder runs dry
+  mid-day; the gate blocks fresh staffing until the next cadence tick after crops land in storage.
 
   The demand model's granularity is `MonsterJob`, not `KitchenRole` — it asks for *N kitchen
-  workers* and the coordinator decides the cook/server/runner split (`FillRoleMix`).
+  workers* and the coordinator decides the cook/server/runner split (`FillRoleMix`, below).
 
-Worked examples (farm workload present): 2 monsters → both farm, no kitchen. Exactly 4 → 1 farmer
-+ 3 kitchen (even if farming wants more). 6 with light farm work → 1 farmer + 3 kitchen + 2 home.
+Worked examples (farm plans present, no outstanding tasks): 2 monsters → 1 caretaker farms, 1
+home (kitchen can't field a functional crew of 2). Exactly 4 → 1 farmer + 3 kitchen. 12 with a
+9-ticket dinner rush → 1 farmer + 6 kitchen + 5 home, draining back to 1 + 3 + 8 after the rush.
 
-Workload getters added for this system: `FarmTaskCoordinator.OutstandingTaskCount`,
-`KitchenTaskCoordinator.ActiveTicketCount`, `CropGrowthService.CropCount`,
-`CropPlantingService.PlanCount`, `MercenaryManager.CountSeatedPatrons()`,
-`PartyDiningService.CountPendingPartyDiners()`.
+## Kitchen role mix under pressure
+
+`KitchenTaskCoordinator.FillRoleMix(postCount, cookPressure, serverPressure, runnerPressure,
+into)` decides the cook/server/runner split. Posts 0–2 are always Cook, Server, Runner (the crew
+that opens the kitchen and keeps it fed and cleared — `IsKitchenOpen` needs posts 0 and 1). Posts
+beyond the base crew go to the role with the highest **pressure per already-assigned worker**
+(D'Hondt greedy, integer cross-multiplication, ties toward Cook → Server → Runner), honoring the
+per-role caps (3 cooks / 2 servers / 3 runners; 2 servers is a hard `ServerZone` design limit).
+Zero-pressure roles fall back to the legacy Cook → Server → Runner cycle, and the zero-pressure
+overload *is* the legacy cycle.
+
+Per-role pressure signals, computed in the coordinator's `Update()`:
+
+- **Runner**: `AwaitingIngredientsTicketCount` (tickets stalled on a storage fetch — this already
+  covers the queued fetch jobs) + `BusJobCount` (dirty plates).
+- **Cook**: `ReadyToCookUnclaimedCount` (posted tickets no cook has picked up).
+- **Server**: `PlatedAwaitingPickupCount` (dishes cooling on serving tables) +
+  `MercenaryManager.CountPatronsWaitingToOrder()`.
+
+**Anti-thrash dwell:** a role change sends the worker home to despawn and respawn, so the
+weighted mix is recomputed at most once per `GameConfig.KitchenRoleMixDwellSeconds` (45 scaled
+seconds) — except when the post count itself changes, which recomputes immediately (spawns and
+despawns are happening anyway).
+
+Workload getters: `FarmTaskCoordinator.OutstandingTaskCount`,
+`KitchenTaskCoordinator.ActiveTicketCount` / `AwaitingIngredientsTicketCount` /
+`ReadyToCookUnclaimedCount` / `PlatedAwaitingPickupCount` / `FetchQueueDepth` / `BusJobCount` /
+`OldestOpenTicketAgeSeconds`, `CropGrowthService.CropCount`, `CropPlantingService.PlanCount`,
+`MercenaryManager.CountSeatedPatrons()` / `CountPatronsWaitingToOrder()` /
+`MaxPatronWaitSeconds()`, `TavernPatronComponent.StateElapsedSeconds`,
+`PartyDiningService.CountPendingPartyDiners()`. `KitchenTicket.CreatedTime` stamps ticket
+creation (`Time.TotalTime`, mirroring `BusJob.EnqueuedTime`; not persisted).
 
 ## Adding a new job (e.g. Fishing)
 
@@ -125,7 +204,10 @@ The solver never changes. Steps:
    whatever workload signal fits (keep the arithmetic in a `public static ComputeDemand(...)` so
    it's unit-testable headless, like the existing evaluators; take service dependencies as
    nullable constructor params). `EvaluateDemand(rosterSize, availableWorkers)` — clamp to
-   `availableWorkers`, the workers left after higher-priority evaluators' minimums.
+   `availableWorkers`, the workers left after higher-priority evaluators' minimums. Own a
+   `BackpressureTracker`, feed it in `SamplePressure` (never in `EvaluateDemand`, which runs
+   twice per reassess — once per shift), clear it in `ResetPressure`, and fold
+   `tracker.GrantedWorkers` into desired via `max(liveSignal, granted)` for slow scale-down.
 3. Decide `Sticky`: true only if pulling workers off the job mid-shift is harmful (kitchen-style
    continuity); false if workers can be freely rebalanced (farming-style).
 4. Register it in `MainGameScene.Begin()` via `autoJobAssignmentService.AddEvaluator(...)` —

--- a/PitHero/docs/AutoJobAssignmentSystem.md
+++ b/PitHero/docs/AutoJobAssignmentSystem.md
@@ -29,7 +29,26 @@ The same gate covers kitchen role changes (the replacement waits for the old wor
 | UI gating | `PitHero/UI/SettingsUI.cs` (checkbox), `PitHero/UI/MonsterUI.cs` (job buttons non-clickable while enabled) | |
 | Persistence | `SaveData.AutomateMonsterJobs` (v19, section 34) → `AutoJobAssignmentService.Enabled` | Loading never forces a reshuffle; persisted jobs stand until the next cadence tick. |
 
-Tunables live in `GameConfig` under the `AutoJob*` prefix.
+## Tunables
+
+All in `GameConfig` (`AutoJob*` prefix for headcount scaling, `KitchenRole*` for the role mix).
+Times are scaled seconds (1 scaled second = 1 in-game minute; pause freezes them all).
+
+| Constant | Value | What it does / when to change it |
+|---|---|---|
+| `AutoJobReassessIntervalSeconds` | 15 | Solve/apply cadence. Raise if assignments visibly change too often overall; lower for snappier reaction to demand. |
+| `AutoJobPressureSampleIntervalSeconds` | 5 | Headcount backpressure sampling cadence. Rarely needs touching. |
+| `AutoJobScaleDownDrainIntervalSeconds` | 60 | Min gap between releasing successive FARM workers. Raise if farmers leave/return too often between waves. |
+| `AutoJobKitchenScaleDownDrainIntervalSeconds` | 180 | Min gap between releasing successive KITCHEN workers. Raise if kitchen departures look churny; lower if surplus staff linger too long. |
+| `AutoJobPressureDecayAlpha` | 0.15 | EMA decay on falling headcount pressure. Lower = grants hold longer after a rush. |
+| `AutoJobKitchenHighWaitSeconds` | 60 | Patron wait (to order or be served) that adds +1 worker of kitchen pressure. Lower to react to unhappy patrons sooner. |
+| `AutoJobFarmTasksPerWorker` | 6 | Outstanding farm tasks each farmer absorbs. Lower = more farmers per wave. |
+| `AutoJobKitchenBaseStaff` | 3 | Cook + server + runner floor. Do not lower — a runner-less kitchen runs the fridge dry. |
+| `AutoJobKitchenBacklogPerExtraWorker` | 3 | Backlog items per extra kitchen worker. Lower = kitchen scales up harder during rushes. |
+| `AutoJobKitchenMaxWorkers` | 8 | Kitchen headcount cap. Must equal `KitchenTaskCoordinator.MaxWorkerPosts` (test-asserted). |
+| `KitchenRoleMixDwellSeconds` | 45 | Min gap between role-mix recomputes. Raise if `kitchen_role_changed` events stream (see Diagnosing below). |
+| `KitchenRolePressureSampleIntervalSeconds` | 5 | Per-role pressure sampling cadence. |
+| `KitchenRolePressureEmaAlpha` | 0.1 | Per-role pressure smoothing (~50s time constant). Lower if the marginal role post still flips on service-cycle noise. |
 
 ## When sampling and reassessment run
 
@@ -212,6 +231,49 @@ Workload getters: `FarmTaskCoordinator.OutstandingTaskCount`,
 `PartyDiningService.CountPendingPartyDiners()`. `KitchenTicket.CreatedTime` stamps ticket
 creation (`Time.TotalTime`, mirroring `BusJob.EnqueuedTime`; not persisted).
 
+## Diagnosing staffing behavior
+
+Staffing decisions are observable in the debug-build analytics JSONL
+(`%LOCALAPPDATA%\<exeName>\analytics\session_*.jsonl`; schema in
+`PitHero/docs/AnalyticsSchema.md` → "Monster job staffing"). Grep for `monster_job_changed`
+(headcount) and `kitchen_role_changed` (role mix), read `gt` for in-game time, and compare
+against these signatures:
+
+- **Healthy**: rush scale-ups arrive as a burst of `toJob:"Cooking"` lines at one timestamp;
+  scale-downs release exactly one worker per drain interval (e.g. one farmer `toJob:"None"` per
+  hour through the afternoon); `kitchen_role_changed` is rare and coincides with crew-size
+  changes.
+- **Role-mix thrash**: the same monster flips A→B→A→B in `kitchen_role_changed` at intervals
+  matching `KitchenRoleMixDwellSeconds`. Every role change is a walk-home/despawn/respawn round
+  trip, so this is highly visible in-game. First check `KitchenRolePressureEmaAlpha` (smoothing
+  too reactive), then the dwell.
+- **Headcount churn**: a monster leaves a job and returns within an hour or two
+  (`monster_job_changed` pairs). Distinguish real demand cycles (see Known behaviors) from
+  boundary oscillation — a backlog hovering at a multiple of
+  `AutoJobKitchenBacklogPerExtraWorker` flips desired by ±1; the drain interval bounds the cycle
+  to one departure per interval.
+
+This exact workflow (previous session vs. new session event counts + per-monster timelines) is
+how the role-retention and pressure-smoothing fixes were validated.
+
+## Known behaviors (intended — do not "fix" without a design decision)
+
+- **The noon bounce**: the backlog dips between breakfast and lunch, so the kitchen trims a
+  worker around midday and re-staffs them about an hour later when the lunch rush hits. That's
+  demand-following working as designed; the cost is one walk-home/return round trip per day for
+  the marginal worker. Softening it further means longer drain intervals (slower response
+  everywhere), not a bug fix.
+- **Small-crew night wobble**: on a small night shift a single marginal post covers the whole
+  crew, and smoothed role pressures near a rounding boundary (~half a worker) can occasionally
+  flip it (observed: one Runner↔Cook reversal pair per session). Accepted; if it worsens, lower
+  `KitchenRolePressureEmaAlpha` or add an incumbent-bias margin to the D'Hondt comparison.
+- **Suboptimal-but-stable role holders**: role retention deliberately keeps a worker in its
+  current role even when a higher-proficiency colleague would ideally hold it — stability beats
+  marginal cook-speed. Fresh optimal assignments happen naturally at shift changes and respawns.
+- **05:37 pre-dawn send-home**: outstanding farm work often hits zero just before dawn, so the
+  whole day crew drains right before the 6AM shift-change reassess re-staffs it. Harmless — the
+  monsters are asleep/home anyway.
+
 ## Adding a new job (e.g. Fishing)
 
 The solver never changes. Steps:
@@ -243,9 +305,18 @@ The solver never changes. Steps:
 
 ## Testing
 
-- `PitHero.Tests/JobAssignmentSolverTests.cs` — solver passes, tie-breaks, stickiness, swaps,
-  extensibility.
+- `PitHero.Tests/JobAssignmentSolverTests.cs` — solver passes, tie-breaks, round-robin desired
+  fairness, one-per-solve sticky trim, starvation release, swaps, extensibility.
+- `PitHero.Tests/BackpressureTrackerTests.cs` — instant attack, EMA decay, one drain per
+  interval, rebound regrant, reset.
 - `PitHero.Tests/AutoJobAssignmentServiceTests.cs` — service wiring, cadence/shift-boundary
   triggers (`TickCadence` is public precisely so tests can drive it without `Core.Services`),
-  per-shift segregation, evaluator math. Construct everything directly (no `Core.Services`);
-  evaluators accept null dependencies for headless runs.
+  per-shift segregation, evaluator math, and the end-to-end
+  `EndToEnd_KitchenScalesPastBaseCrewUnderBacklog_ThenDrainsStepwise` (a real ticket rush staffs
+  the kitchen past 3 while farming keeps its caretaker, then drains back one worker at a time —
+  note ticket creation withdraws crops, so the test stocks backlog+1 servings to keep
+  `HasAnyOrderableDish` true). Construct everything directly (no `Core.Services`); evaluators
+  accept null dependencies for headless runs.
+- `PitHero.Tests/KitchenServiceLoopTests.cs` — `RoleMix_*` (neutral cycle, pinned base-crew
+  posts, caps), `WeightedRoleMix_*` (D'Hondt splits), `Retention_*` (no churn on count-neutral
+  recomputes, worst-holder-first shrink, count preservation).

--- a/PitHero/docs/TavernDiningSystem.md
+++ b/PitHero/docs/TavernDiningSystem.md
@@ -119,11 +119,16 @@ the sink by the carrier's FSM when it sees `Canceled`.
 
 **Staffing** (coordinator `Update`, per frame): candidates = allied monsters with
 `Job == Cooking` that are awake per `MonsterScheduleConfig.IsAsleep` (in-game time = the shift
-system), sorted by `CookingProficiency` descending. `FillRoleMix` cycles Cook → Server → Runner
-skipping full roles, giving **cook1, server1, runner1, cook2, server2, runner2, cook3, runner3**
-(`MaxWorkerPosts` = 8 = 3 cooks + 2 servers + 3 runners). Change a `GameConfig.MaxKitchen*`
-constant and the order re-derives — but keep `AutoJobKitchenMaxWorkers` in sync (a test asserts
-it). Workers whose role/slot disappears get `RequestReturnHome()` (finish current task,
+system), sorted by `CookingProficiency` descending. `FillRoleMix` fixes posts 0–2 as Cook,
+Server, Runner, then gives posts 3+ to the role with the highest backpressure per assigned
+worker (issue #375: stalled-fetch tickets + dirty plates → runners, unclaimed board tickets →
+cooks, plated dishes + patrons waiting to order → servers; D'Hondt greedy). With no pressure it
+falls back to the legacy Cook → Server → Runner cycle — **cook1, server1, runner1, cook2,
+server2, runner2, cook3, runner3** (`MaxWorkerPosts` = 8 = 3 cooks + 2 servers + 3 runners). The
+weighted mix is recomputed at most once per `KitchenRoleMixDwellSeconds` (role changes are
+expensive walk-home/respawn round trips), except immediately on head-count changes. Change a
+`GameConfig.MaxKitchen*` constant and the order re-derives — but keep `AutoJobKitchenMaxWorkers`
+in sync (a test asserts it). Workers whose role/slot disappears get `RequestReturnHome()` (finish current task,
 walk into the house, despawn); a restored assignment calls `CancelReturnHome()`. Spawn is at
 their Monster House door (anchor +2 south); no collider/TAG_MONSTER, so workers never trigger
 battles. A 5s sweep calls `EnsureHat()` — `KitchenHatService` pools 7 hat entities

--- a/PitHero/docs/TavernDiningSystem.md
+++ b/PitHero/docs/TavernDiningSystem.md
@@ -122,7 +122,8 @@ the sink by the carrier's FSM when it sees `Canceled`.
 system), sorted by `CookingProficiency` descending. `FillRoleMix` fixes posts 0–2 as Cook,
 Server, Runner, then gives posts 3+ to the role with the highest backpressure per assigned
 worker (issue #375: stalled-fetch tickets + dirty plates → runners, unclaimed board tickets →
-cooks, plated dishes + patrons waiting to order → servers; D'Hondt greedy). With no pressure it
+cooks, plated dishes + patrons waiting to order → servers; D'Hondt greedy over EMA-smoothed
+pressures so a single service cycle's seesaw can't flip the marginal post). With no pressure it
 falls back to the legacy Cook → Server → Runner cycle — **cook1, server1, runner1, cook2,
 server2, runner2, cook3, runner3** (`MaxWorkerPosts` = 8 = 3 cooks + 2 servers + 3 runners). The
 weighted mix is recomputed at most once per `KitchenRoleMixDwellSeconds` (role changes are

--- a/PitHero/docs/TavernDiningSystem.md
+++ b/PitHero/docs/TavernDiningSystem.md
@@ -126,9 +126,11 @@ cooks, plated dishes + patrons waiting to order → servers; D'Hondt greedy). Wi
 falls back to the legacy Cook → Server → Runner cycle — **cook1, server1, runner1, cook2,
 server2, runner2, cook3, runner3** (`MaxWorkerPosts` = 8 = 3 cooks + 2 servers + 3 runners). The
 weighted mix is recomputed at most once per `KitchenRoleMixDwellSeconds` (role changes are
-expensive walk-home/respawn round trips), except immediately on head-count changes. Change a
-`GameConfig.MaxKitchen*` constant and the order re-derives — but keep `AutoJobKitchenMaxWorkers`
-in sync (a test asserts it). Workers whose role/slot disappears get `RequestReturnHome()` (finish current task,
+expensive walk-home/respawn round trips), except immediately on head-count changes. The mix is
+applied as role *counts* with retention (`AssignRolesWithRetention`): live workers keep their
+current role while quota remains, so a recompute with unchanged counts never reshuffles anyone.
+Change a `GameConfig.MaxKitchen*` constant and the order re-derives — but keep
+`AutoJobKitchenMaxWorkers` in sync (a test asserts it). Workers whose role/slot disappears get `RequestReturnHome()` (finish current task,
 walk into the house, despawn); a restored assignment calls `CancelReturnHome()`. Spawn is at
 their Monster House door (anchor +2 south); no collider/TAG_MONSTER, so workers never trigger
 battles. A 5s sweep calls `EnsureHat()` — `KitchenHatService` pools 7 hat entities


### PR DESCRIPTION
Closes #375.

## Problem

- The kitchen was auto-staffed with exactly 3 monsters even during fully packed busy periods. Root cause: the solver filled desired staffing whole-demand-at-a-time in demand-list order, so farming (listed first) absorbed every spare monster before the kitchen's desired pass ran — its `3 + backlog/3` scaling math was correct but unreachable.
- Sticky kitchen workers could never be demoted, so there was no scale-down path at all.
- Farm monsters wandered doing nothing: the `careLoad/12` baseline staffed farmers who had no tasks to claim.

## What changed

**Per-job backpressure** (`BackpressureTracker`, one per demand evaluator): raw pressure is sampled every 5 scaled seconds; scale-up is instant off the raw signal, scale-down decays through an EMA with half-worker release hysteresis and drains at most **one worker per 60 scaled seconds** — the issue's "slow drain, not sudden".

**Solver fairness + drain** (`JobAssignmentSolver`):
- Desired slots now fill **round-robin** across demands (one worker per demand per cycle), so list order is a tiebreak, not a monopoly — the kitchen actually reaches its scaled desired count.
- New **sticky trim pass**: a sticky job holding more workers than it wants releases its lowest-proficiency worker, at most one per solve, before the fill passes — so the freed monster is reassigned to farming (or home) in the same solve.
- Swap pass relaxed to fire when the other job strictly gains and the sticky job doesn't lose (total proficiency strictly increases, so it still can't oscillate).

**Honest farming demand**: desired = `max(outstanding-task burst, drain-limited grant, caretaker min)`; the idle-farmer baseline is deleted. One caretaker stays while crops/plans exist.

**Kitchen demand**: extras = `max(live backlog blocks, granted)`, **+1 worker when any patron has waited an in-game hour** (wait time proves the pipeline is behind even when counts look modest). Cadence: reassess every 15 scaled seconds (was 60), sampling every 5.

**Demand-weighted role split** (`FillRoleMix`): posts 0–2 stay Cook/Server/Runner; posts 3+ go to the role with the highest pressure per assigned worker (D'Hondt greedy) — stalled fetches + dirty plates → runners, unclaimed board tickets → cooks, plated dishes + patrons waiting to order → servers. Recomputed at most once per 45s dwell (role changes are expensive walk-home/respawn trips). Zero pressure = exact legacy cycle.

**New signals**: `KitchenTicket.CreatedTime`, per-state ticket counts, fetch/bus queue depths, `TavernPatronComponent.StateElapsedSeconds`, `MercenaryManager.CountPatronsWaitingToOrder()` / `MaxPatronWaitSeconds()`.

No save-format change: all new state is transient and rebuilds within seconds after load. No RNG involved.

## Tests

1863 passed / 0 failed (baseline maintained). New coverage: `BackpressureTrackerTests` (attack/decay/drain/rebound), solver round-robin fairness + stepwise trim, evaluator scale-up/hold/drain math, weighted role-mix splits and caps, and an end-to-end test proving a 9-ticket rush staffs the kitchen to 6 while farming keeps its caretaker, then drains back to 3 one worker at a time.

Docs updated: `AutoJobAssignmentSystem.md`, `TavernDiningSystem.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)