### PR TITLE
Add manual job change and crystal tab improvements (#379)

### DIFF
--- a/PitHero.Tests/CrystalFeeCalculatorTests.cs
+++ b/PitHero.Tests/CrystalFeeCalculatorTests.cs
@@ -1,0 +1,79 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Services;
+using RolePlayingFramework.Heroes;
+using RolePlayingFramework.Jobs;
+using RolePlayingFramework.Jobs.Primary;
+using RolePlayingFramework.Stats;
+
+namespace PitHero.Tests
+{
+    /// <summary>Fee math for crystal creation and forging (issue #379).</summary>
+    [TestClass]
+    public class CrystalFeeCalculatorTests
+    {
+        private static HeroCrystal CreateCrystal(IJob job, int level)
+        {
+            var baseStats = new StatBlock(strength: 5, agility: 3, vitality: 5, magic: 1);
+            return new HeroCrystal("Test Crystal", job, level, baseStats);
+        }
+
+        [TestMethod]
+        public void CreationFee_Is100Gold()
+        {
+            Assert.AreEqual(100, GameConfig.CrystalCreationFee);
+        }
+
+        [TestMethod]
+        public void ForgeFee_IsHalfCombinedBuyBackPrice_LevelOnePair()
+        {
+            var a = CreateCrystal(new Knight(), 1);
+            var b = CreateCrystal(new Mage(), 1);
+
+            var expected = HeroCrystal.Combine("Combo Crystal", a, b).CalculateBuyBackPrice() / 2;
+            Assert.AreEqual(expected, CrystalFeeCalculator.GetForgeFee(a, b));
+            Assert.IsTrue(expected > 0, "Forge fee for a valid pair must be positive");
+        }
+
+        [TestMethod]
+        public void ForgeFee_IsHalfCombinedBuyBackPrice_MasteredWithSkills()
+        {
+            var knight = new Knight();
+            var mage = new Mage();
+            var a = CreateCrystal(knight, 10);
+            var b = CreateCrystal(mage, 20);
+            for (int i = 0; i < knight.Skills.Count; i++)
+                a.AddLearnedSkill(knight.Skills[i].Id);
+            for (int i = 0; i < mage.Skills.Count; i++)
+                b.AddLearnedSkill(mage.Skills[i].Id);
+            b.LearnSynergySkill("synergy.test_skill");
+
+            var expected = HeroCrystal.Combine("Combo Crystal", a, b).CalculateBuyBackPrice() / 2;
+            Assert.AreEqual(expected, CrystalFeeCalculator.GetForgeFee(a, b));
+        }
+
+        [TestMethod]
+        public void ForgeFee_DoesNotMutateSourceCrystals()
+        {
+            var a = CreateCrystal(new Knight(), 5);
+            var b = CreateCrystal(new Mage(), 7);
+            int priceABefore = a.CalculateBuyBackPrice();
+            int priceBBefore = b.CalculateBuyBackPrice();
+
+            CrystalFeeCalculator.GetForgeFee(a, b);
+
+            Assert.AreEqual(priceABefore, a.CalculateBuyBackPrice());
+            Assert.AreEqual(priceBBefore, b.CalculateBuyBackPrice());
+            Assert.AreEqual(5, a.Level);
+            Assert.AreEqual(7, b.Level);
+        }
+
+        [TestMethod]
+        public void ForgeFee_NullSource_ReturnsZero()
+        {
+            var a = CreateCrystal(new Knight(), 1);
+            Assert.AreEqual(0, CrystalFeeCalculator.GetForgeFee(a, null));
+            Assert.AreEqual(0, CrystalFeeCalculator.GetForgeFee(null, a));
+            Assert.AreEqual(0, CrystalFeeCalculator.GetForgeFee(null, null));
+        }
+    }
+}

--- a/PitHero.Tests/CrystalFeeCalculatorTests.cs
+++ b/PitHero.Tests/CrystalFeeCalculatorTests.cs
@@ -24,18 +24,18 @@ namespace PitHero.Tests
         }
 
         [TestMethod]
-        public void ForgeFee_IsHalfCombinedBuyBackPrice_LevelOnePair()
+        public void ForgeFee_IsDoubleCombinedBuyBackPrice_LevelOnePair()
         {
             var a = CreateCrystal(new Knight(), 1);
             var b = CreateCrystal(new Mage(), 1);
 
-            var expected = HeroCrystal.Combine("Combo Crystal", a, b).CalculateBuyBackPrice() / 2;
+            var expected = HeroCrystal.Combine("Combo Crystal", a, b).CalculateBuyBackPrice() * 2;
             Assert.AreEqual(expected, CrystalFeeCalculator.GetForgeFee(a, b));
             Assert.IsTrue(expected > 0, "Forge fee for a valid pair must be positive");
         }
 
         [TestMethod]
-        public void ForgeFee_IsHalfCombinedBuyBackPrice_MasteredWithSkills()
+        public void ForgeFee_IsDoubleCombinedBuyBackPrice_MasteredWithSkills()
         {
             var knight = new Knight();
             var mage = new Mage();
@@ -47,8 +47,30 @@ namespace PitHero.Tests
                 b.AddLearnedSkill(mage.Skills[i].Id);
             b.LearnSynergySkill("synergy.test_skill");
 
-            var expected = HeroCrystal.Combine("Combo Crystal", a, b).CalculateBuyBackPrice() / 2;
+            var expected = HeroCrystal.Combine("Combo Crystal", a, b).CalculateBuyBackPrice() * 2;
             Assert.AreEqual(expected, CrystalFeeCalculator.GetForgeFee(a, b));
+        }
+
+        [TestMethod]
+        public void ForgeFee_MasteredLevelOnePair_CostsMoreThanShopPrice()
+        {
+            // Regression for the 100G Legend forge: a level-1 many-skill combo hit the
+            // buy-back premium cap and the old half-price fee undercut the shop. Forging
+            // must always cost double what the shop would charge for the same crystal.
+            var knight = new Knight();
+            var mage = new Mage();
+            var a = CreateCrystal(knight, 1);
+            var b = CreateCrystal(mage, 1);
+            for (int i = 0; i < knight.Skills.Count; i++)
+                a.AddLearnedSkill(knight.Skills[i].Id);
+            for (int i = 0; i < mage.Skills.Count; i++)
+                b.AddLearnedSkill(mage.Skills[i].Id);
+
+            int shopPrice = HeroCrystal.Combine("Combo Crystal", a, b).CalculateBuyBackPrice();
+            int fee = CrystalFeeCalculator.GetForgeFee(a, b);
+
+            Assert.AreEqual(shopPrice * 2, fee);
+            Assert.IsTrue(fee > shopPrice, "Forging must never be cheaper than buying from the shop");
         }
 
         [TestMethod]

--- a/PitHero.Tests/CrystalFeeCalculatorTests.cs
+++ b/PitHero.Tests/CrystalFeeCalculatorTests.cs
@@ -24,18 +24,18 @@ namespace PitHero.Tests
         }
 
         [TestMethod]
-        public void ForgeFee_IsDoubleCombinedBuyBackPrice_LevelOnePair()
+        public void ForgeFee_IsDoubleUncappedBuyBackPrice_LevelOnePair()
         {
             var a = CreateCrystal(new Knight(), 1);
             var b = CreateCrystal(new Mage(), 1);
 
-            var expected = HeroCrystal.Combine("Combo Crystal", a, b).CalculateBuyBackPrice() * 2;
+            var expected = HeroCrystal.Combine("Combo Crystal", a, b).CalculateBuyBackPrice(capPremium: false) * 2;
             Assert.AreEqual(expected, CrystalFeeCalculator.GetForgeFee(a, b));
             Assert.IsTrue(expected > 0, "Forge fee for a valid pair must be positive");
         }
 
         [TestMethod]
-        public void ForgeFee_IsDoubleCombinedBuyBackPrice_MasteredWithSkills()
+        public void ForgeFee_IsDoubleUncappedBuyBackPrice_MasteredWithSkills()
         {
             var knight = new Knight();
             var mage = new Mage();
@@ -47,16 +47,16 @@ namespace PitHero.Tests
                 b.AddLearnedSkill(mage.Skills[i].Id);
             b.LearnSynergySkill("synergy.test_skill");
 
-            var expected = HeroCrystal.Combine("Combo Crystal", a, b).CalculateBuyBackPrice() * 2;
+            var expected = HeroCrystal.Combine("Combo Crystal", a, b).CalculateBuyBackPrice(capPremium: false) * 2;
             Assert.AreEqual(expected, CrystalFeeCalculator.GetForgeFee(a, b));
         }
 
         [TestMethod]
-        public void ForgeFee_MasteredLevelOnePair_CostsMoreThanShopPrice()
+        public void ForgeFee_SkillPremiumIsUncapped_ScalesBeyondShopCap()
         {
-            // Regression for the 100G Legend forge: a level-1 many-skill combo hit the
-            // buy-back premium cap and the old half-price fee undercut the shop. Forging
-            // must always cost double what the shop would charge for the same crystal.
+            // Regression for the 100G Legend forge: at level 1 the shop's premium cap makes a
+            // mastered 12+-skill combo price identical to a barely-skilled one. The forge fee
+            // must ignore the cap so skill count always raises the price.
             var knight = new Knight();
             var mage = new Mage();
             var a = CreateCrystal(knight, 1);
@@ -66,11 +66,19 @@ namespace PitHero.Tests
             for (int i = 0; i < mage.Skills.Count; i++)
                 b.AddLearnedSkill(mage.Skills[i].Id);
 
-            int shopPrice = HeroCrystal.Combine("Combo Crystal", a, b).CalculateBuyBackPrice();
+            int cappedShopPrice = HeroCrystal.Combine("Combo Crystal", a, b).CalculateBuyBackPrice();
             int fee = CrystalFeeCalculator.GetForgeFee(a, b);
 
-            Assert.AreEqual(shopPrice * 2, fee);
-            Assert.IsTrue(fee > shopPrice, "Forging must never be cheaper than buying from the shop");
+            Assert.IsTrue(fee > cappedShopPrice * 2,
+                "A fully mastered level-1 combo must forge for more than double the capped shop price");
+
+            // And more skills must always mean a higher fee than fewer skills at the same level
+            var c = CreateCrystal(new Knight(), 1);
+            var d = CreateCrystal(new Mage(), 1);
+            c.AddLearnedSkill(knight.Skills[0].Id);
+
+            Assert.IsTrue(fee > CrystalFeeCalculator.GetForgeFee(c, d),
+                "Skill count must raise the forge fee at any crystal level");
         }
 
         [TestMethod]

--- a/PitHero.Tests/JobChangeGoapPlanTests.cs
+++ b/PitHero.Tests/JobChangeGoapPlanTests.cs
@@ -1,0 +1,78 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nez.AI.GOAP;
+using PitHero.AI;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Planner-level tests for the manual job change chain (issue #379): with NeedsCrystal set
+    /// while inside the pit, the hero plans jump-out → walk-to-statue; outside, the walk alone.
+    /// </summary>
+    [TestClass]
+    public class JobChangeGoapPlanTests
+    {
+        private static ActionPlanner CreatePlanner()
+        {
+            var planner = new ActionPlanner();
+            planner.AddAction(new JumpOutOfPitForJobChangeAction());
+            planner.AddAction(new WalkToStatueForCrystalAction());
+            return planner;
+        }
+
+        private static WorldState CreateState(ActionPlanner planner, bool insidePit)
+        {
+            var state = WorldState.Create(planner);
+            state.Set(GoapConstants.HeroInitialized, true);
+            state.Set(GoapConstants.InsidePit, insidePit);
+            state.Set(GoapConstants.OutsidePit, !insidePit);
+            state.Set(GoapConstants.NeedsCrystal, true);
+            return state;
+        }
+
+        private static WorldState CreateGoal(ActionPlanner planner)
+        {
+            var goal = WorldState.Create(planner);
+            goal.Set(GoapConstants.HasArrivedAtStatueForCrystal, true);
+            return goal;
+        }
+
+        [TestMethod]
+        public void NeedsCrystalInsidePit_PlansJumpOutThenWalkToStatue()
+        {
+            var planner = CreatePlanner();
+            var plan = planner.Plan(CreateState(planner, insidePit: true), CreateGoal(planner));
+
+            Assert.IsNotNull(plan, "Hero inside the pit should chain a jump-out before the statue walk");
+            Assert.AreEqual(2, plan.Count);
+            Assert.AreEqual(GoapConstants.JumpOutOfPitForJobChangeAction, plan.Pop().Name);
+            Assert.AreEqual(GoapConstants.WalkToStatueForCrystalAction, plan.Pop().Name);
+        }
+
+        [TestMethod]
+        public void NeedsCrystalOutsidePit_PlansWalkToStatueOnly()
+        {
+            var planner = CreatePlanner();
+            var plan = planner.Plan(CreateState(planner, insidePit: false), CreateGoal(planner));
+
+            Assert.IsNotNull(plan, "Hero outside the pit should walk straight to the statue");
+            Assert.AreEqual(1, plan.Count);
+            Assert.AreEqual(GoapConstants.WalkToStatueForCrystalAction, plan.Pop().Name);
+        }
+
+        [TestMethod]
+        public void NoNeedsCrystal_NoStatuePlan()
+        {
+            var planner = CreatePlanner();
+            var state = WorldState.Create(planner);
+            state.Set(GoapConstants.HeroInitialized, true);
+            state.Set(GoapConstants.InsidePit, true);
+            state.Set(GoapConstants.OutsidePit, false);
+            state.Set(GoapConstants.NeedsCrystal, false);
+
+            var plan = planner.Plan(state, CreateGoal(planner));
+
+            Assert.IsTrue(plan == null || plan.Count == 0,
+                "Without NeedsCrystal neither the jump nor the walk should be plannable");
+        }
+    }
+}

--- a/PitHero.Tests/JobChangeGoapPlanTests.cs
+++ b/PitHero.Tests/JobChangeGoapPlanTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Nez.AI.GOAP;
 using PitHero.AI;
+using PitHero.ECS.Components;
 
 namespace PitHero.Tests
 {
@@ -57,6 +58,29 @@ namespace PitHero.Tests
             Assert.IsNotNull(plan, "Hero outside the pit should walk straight to the statue");
             Assert.AreEqual(1, plan.Count);
             Assert.AreEqual(GoapConstants.WalkToStatueForCrystalAction, plan.Pop().Name);
+        }
+
+        [TestMethod]
+        public void GoalPriority_NeedsCrystal_OutranksStoppedAdventure()
+        {
+            // A job change requested while the party is stopped (or while the dining service
+            // auto-stops for a meal trip) must send the hero to the statue, not the tavern
+            // table. StoppedAdventure survives and takes over after the ceremony.
+            var planner = new ActionPlanner();
+            var hero = new HeroComponent
+            {
+                NeedsCrystal = true,
+                StoppedAdventure = true
+            };
+
+            var goal = WorldState.Create(planner);
+            hero.SetGoalState(ref goal);
+
+            var expected = WorldState.Create(planner);
+            expected.Set(GoapConstants.HasArrivedAtStatueForCrystal, true);
+
+            Assert.IsTrue(goal.Equals(expected),
+                "With both NeedsCrystal and StoppedAdventure set, the goal must be the statue, not the tavern seat");
         }
 
         [TestMethod]

--- a/PitHero.Tests/ManualJobChangeTests.cs
+++ b/PitHero.Tests/ManualJobChangeTests.cs
@@ -1,0 +1,157 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Services;
+using RolePlayingFramework.Equipment;
+using RolePlayingFramework.Heroes;
+using RolePlayingFramework.Inventory;
+using RolePlayingFramework.Jobs;
+using RolePlayingFramework.Jobs.Primary;
+using RolePlayingFramework.Stats;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Manual job change plumbing (issue #379): the outgoing crystal returns to the crystal
+    /// inventory (Second Chance vault only as full-inventory fallback) and equipment carries
+    /// over to the new hero, falling back bag → vault for items the new job can't equip.
+    /// </summary>
+    [TestClass]
+    public class ManualJobChangeTests
+    {
+        private static readonly StatBlock BaseStats = new StatBlock(5, 5, 5, 5);
+
+        private static HeroCrystal CreateCrystal(IJob job, int level = 1)
+            => new HeroCrystal("Test Crystal", job, level, BaseStats);
+
+        private static Gear CreateGear(string name, ItemKind kind, JobType allowedJobs)
+            => new Gear(name, kind, ItemRarity.Normal, "desc", 10, new StatBlock(0, 0, 0, 0), allowedJobs: allowedJobs);
+
+        // ── Crystal routing ──────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void ReturnCrystal_LandsInCrystalInventory()
+        {
+            var service = new CrystalCollectionService();
+            var vault = new SecondChanceMerchantVault();
+            var crystal = CreateCrystal(new Knight());
+
+            bool inInventory = HeroJobChangeHelper.ReturnCrystalToInventory(crystal, service, vault);
+
+            Assert.IsTrue(inInventory);
+            Assert.AreEqual(1, service.InventoryCount);
+            Assert.AreEqual(0, vault.CrystalCount);
+        }
+
+        [TestMethod]
+        public void ReturnCrystal_FullInventory_FallsBackToVault()
+        {
+            var service = new CrystalCollectionService();
+            var vault = new SecondChanceMerchantVault();
+            for (int i = 0; i < service.InventoryCapacity; i++)
+                Assert.IsTrue(service.TryAddToInventory(CreateCrystal(new Knight())));
+
+            var crystal = CreateCrystal(new Mage());
+            bool inInventory = HeroJobChangeHelper.ReturnCrystalToInventory(crystal, service, vault);
+
+            Assert.IsFalse(inInventory);
+            Assert.AreEqual(service.InventoryCapacity, service.InventoryCount);
+            Assert.AreEqual(1, vault.CrystalCount);
+            Assert.AreSame(crystal, vault.LostCrystals[0]);
+        }
+
+        [TestMethod]
+        public void ReturnCrystal_NullCrystal_NoOp()
+        {
+            var service = new CrystalCollectionService();
+            var vault = new SecondChanceMerchantVault();
+
+            Assert.IsFalse(HeroJobChangeHelper.ReturnCrystalToInventory(null, service, vault));
+            Assert.AreEqual(0, service.InventoryCount);
+            Assert.AreEqual(0, vault.CrystalCount);
+        }
+
+        // ── Equipment transfer ───────────────────────────────────────────────────
+
+        [TestMethod]
+        public void TransferEquipment_EquippableGear_KeepsSlots()
+        {
+            var oldHero = new Hero("Old", new Knight(), 10, BaseStats);
+            var newHero = new Hero("New", new Mage(), 1, BaseStats);
+            var sword = CreateGear("Sword", ItemKind.WeaponSword, JobType.All);
+            var armor = CreateGear("Mail", ItemKind.ArmorMail, JobType.All);
+            var ring = CreateGear("Ring", ItemKind.Accessory, JobType.All);
+            Assert.IsTrue(oldHero.SetEquipmentSlot(EquipmentSlot.WeaponShield1, sword));
+            Assert.IsTrue(oldHero.SetEquipmentSlot(EquipmentSlot.Armor, armor));
+            Assert.IsTrue(oldHero.SetEquipmentSlot(EquipmentSlot.Accessory1, ring));
+
+            var bag = new ItemBag("Inventory", 10);
+            HeroJobChangeHelper.TransferEquipment(oldHero, newHero, bag, null);
+
+            Assert.AreSame(sword, newHero.WeaponShield1);
+            Assert.AreSame(armor, newHero.Armor);
+            Assert.AreSame(ring, newHero.Accessory1);
+        }
+
+        [TestMethod]
+        public void TransferEquipment_JobRestrictedGear_GoesToBag()
+        {
+            var oldHero = new Hero("Old", new Knight(), 10, BaseStats);
+            var newHero = new Hero("New", new Mage(), 1, BaseStats);
+            var knightSword = CreateGear("Knight Sword", ItemKind.WeaponSword, JobType.Knight);
+            Assert.IsTrue(oldHero.SetEquipmentSlot(EquipmentSlot.WeaponShield1, knightSword));
+
+            var bag = new ItemBag("Inventory", 10);
+            HeroJobChangeHelper.TransferEquipment(oldHero, newHero, bag, null);
+
+            Assert.IsNull(newHero.WeaponShield1);
+            bool inBag = false;
+            for (int i = 0; i < bag.Items.Count; i++)
+                if (ReferenceEquals(bag.Items[i], knightSword)) { inBag = true; break; }
+            Assert.IsTrue(inBag, "Unequippable item should land in the bag");
+        }
+
+        [TestMethod]
+        public void TransferEquipment_BagFull_GoesToVault()
+        {
+            var oldHero = new Hero("Old", new Knight(), 10, BaseStats);
+            var newHero = new Hero("New", new Mage(), 1, BaseStats);
+            var knightSword = CreateGear("Knight Sword", ItemKind.WeaponSword, JobType.Knight);
+            Assert.IsTrue(oldHero.SetEquipmentSlot(EquipmentSlot.WeaponShield1, knightSword));
+
+            var bag = new ItemBag("Inventory", 1);
+            Assert.IsTrue(bag.TryAdd(CreateGear("Filler", ItemKind.Accessory, JobType.All)));
+            var vault = new SecondChanceMerchantVault();
+
+            HeroJobChangeHelper.TransferEquipment(oldHero, newHero, bag, vault);
+
+            Assert.IsNull(newHero.WeaponShield1);
+            Assert.AreEqual(1, vault.StackCount);
+        }
+
+        [TestMethod]
+        public void TransferEquipment_EmptySlots_NoOp()
+        {
+            var oldHero = new Hero("Old", new Knight(), 10, BaseStats);
+            var newHero = new Hero("New", new Mage(), 1, BaseStats);
+            var bag = new ItemBag("Inventory", 10);
+            var vault = new SecondChanceMerchantVault();
+
+            HeroJobChangeHelper.TransferEquipment(oldHero, newHero, bag, vault);
+
+            Assert.IsNull(newHero.WeaponShield1);
+            Assert.IsNull(newHero.Armor);
+            Assert.IsNull(newHero.Hat);
+            Assert.IsNull(newHero.WeaponShield2);
+            Assert.IsNull(newHero.Accessory1);
+            Assert.IsNull(newHero.Accessory2);
+            Assert.AreEqual(0, vault.StackCount);
+        }
+
+        [TestMethod]
+        public void TransferEquipment_NullHeroes_NoThrow()
+        {
+            var hero = new Hero("Solo", new Knight(), 1, BaseStats);
+            HeroJobChangeHelper.TransferEquipment(null, hero, null, null);
+            HeroJobChangeHelper.TransferEquipment(hero, null, null, null);
+        }
+    }
+}

--- a/PitHero.Tests/MoveToPitActionTests.cs
+++ b/PitHero.Tests/MoveToPitActionTests.cs
@@ -41,10 +41,10 @@ namespace PitHero.Tests
             var constantsType = typeof(GoapConstants);
             var fields = constantsType.GetFields().Where(f => f.FieldType == typeof(string) && f.IsLiteral);
             
-            // Should have exactly 43 GOAP constants:
+            // Should have exactly 44 GOAP constants:
             // 16 hero states + 5 mercenary states + 2 crystal states + 1 time-of-day state + 2 stop-adventuring states
-            // + 10 hero actions + 4 mercenary actions + 1 crystal action + 2 stop-adventuring actions
-            Assert.AreEqual(43, fields.Count(), "Should have exactly 43 GOAP constants (16 hero states + 5 mercenary states + 2 crystal states + 1 time-of-day state + 2 stop-adventuring states + 10 hero actions + 4 mercenary actions + 1 crystal action + 2 stop-adventuring actions)");
+            // + 10 hero actions + 4 mercenary actions + 1 crystal action + 2 stop-adventuring actions + 1 job-change action
+            Assert.AreEqual(44, fields.Count(), "Should have exactly 44 GOAP constants (16 hero states + 5 mercenary states + 2 crystal states + 1 time-of-day state + 2 stop-adventuring states + 10 hero actions + 4 mercenary actions + 1 crystal action + 2 stop-adventuring actions + 1 job-change action)");
         }
 
         [TestMethod]

--- a/PitHero.Tests/SkillShortcutBarTests.cs
+++ b/PitHero.Tests/SkillShortcutBarTests.cs
@@ -106,6 +106,34 @@ namespace PitHero.Tests
         }
         
         [TestMethod]
+        public void ShortcutBar_ClearHeroSkillShortcuts_RemovesOnlyHeroSkills()
+        {
+            // Job change (death or manual): hero skill shortcuts must be dropped because the
+            // new job may not know them; mercenary skills and item shortcuts must survive.
+            var bar = new ShortcutBar();
+            var heroSkill = new KnightSkills.SpinSlashSkill();
+            var mercSkill = new KnightSkills.SpinSlashSkill();
+            var merc = new RolePlayingFramework.Mercenaries.Mercenary(
+                "Fynn Swift", new RolePlayingFramework.Jobs.Primary.Knight(), 5,
+                new RolePlayingFramework.Stats.StatBlock(10, 10, 10, 5));
+            var itemSlot = new InventorySlot(new InventorySlotData(0, 0, InventorySlotType.Inventory));
+
+            bar.SetShortcutSkill(0, heroSkill);
+            bar.SetShortcutSkill(1, mercSkill, merc);
+            bar.SetShortcutReference(2, itemSlot);
+
+            bar.ClearHeroSkillShortcuts();
+
+            Assert.AreEqual(ShortcutSlotType.Empty, bar.GetShortcutSlotData(0).SlotType,
+                "Hero-owned skill shortcut must be cleared on job change");
+            Assert.AreEqual(ShortcutSlotType.Skill, bar.GetShortcutSlotData(1).SlotType,
+                "Mercenary-owned skill shortcut must survive a hero job change");
+            Assert.AreEqual(merc, bar.GetShortcutSlotData(1).OwnerMercenary);
+            Assert.AreEqual(ShortcutSlotType.Item, bar.GetShortcutSlotData(2).SlotType,
+                "Item shortcut must survive a hero job change");
+        }
+
+        [TestMethod]
         public void ShortcutBar_ConnectToDragManager_IsIdempotent()
         {
             // ReconnectUIToHero (crystal ceremony after hero death) calls ConnectToDragManager a

--- a/PitHero.Tests/UI/StopAdventuringUIPromotionTests.cs
+++ b/PitHero.Tests/UI/StopAdventuringUIPromotionTests.cs
@@ -72,20 +72,21 @@ namespace PitHero.Tests.UI
         }
 
         [TestMethod]
-        public void StopAdventuringUI_PrivateMethod_ApplyPromotionVisibility_Exists()
+        public void StopAdventuringUI_PrivateMethod_ApplyEffectiveVisibility_Exists()
         {
+            // Visibility must be applied via a single combiner over all hide states (promotion,
+            // sleep) — per-state SetVisible calls stomped each other when one state cleared
+            // while the other was still active (Play button overlapping Fast Forward).
             var method = typeof(StopAdventuringUI).GetMethod(
-                "ApplyPromotionVisibility",
+                "ApplyEffectiveVisibility",
                 BindingFlags.NonPublic | BindingFlags.Instance);
 
             Assert.IsNotNull(method,
-                "ApplyPromotionVisibility method must exist");
+                "ApplyEffectiveVisibility method must exist");
 
             var parameters = method!.GetParameters();
-            Assert.AreEqual(1, parameters.Length,
-                "ApplyPromotionVisibility should accept exactly one parameter");
-            Assert.AreEqual(typeof(bool), parameters[0].ParameterType,
-                "ApplyPromotionVisibility parameter should be bool");
+            Assert.AreEqual(0, parameters.Length,
+                "ApplyEffectiveVisibility takes no parameters — it derives visibility from all hide-state fields");
         }
 
         [TestMethod]

--- a/PitHero/AI/GoapConstants.cs
+++ b/PitHero/AI/GoapConstants.cs
@@ -61,6 +61,7 @@
 
         // Stop adventuring actions
         public const string JumpOutOfPitForStopAction = "JumpOutOfPitForStopAction";
+        public const string JumpOutOfPitForJobChangeAction = "JumpOutOfPitForJobChangeAction";
         public const string WalkToTavernForStopAction = "WalkToTavernForStopAction";
     }
 }

--- a/PitHero/AI/HeroStateMachine.cs
+++ b/PitHero/AI/HeroStateMachine.cs
@@ -31,6 +31,7 @@ namespace PitHero.AI
         private JumpOutOfPitForStopAction _jumpOutOfPitForStopAction;
         private WalkToTavernForStopAction _walkToTavernForStopAction;
         private bool _lastStoppedAdventure;
+        private bool _lastNeedsCrystal;
         private bool _innRestEmitted;
         private bool _pitBubbleEmitted;
         private bool _pitExitBubbleEmitted;
@@ -107,6 +108,9 @@ namespace PitHero.AI
 
             var walkToStatueForCrystal = new WalkToStatueForCrystalAction();
             _planner.AddAction(walkToStatueForCrystal);
+
+            var jumpOutOfPitForJobChange = new JumpOutOfPitForJobChangeAction();
+            _planner.AddAction(jumpOutOfPitForJobChange);
 
             // Add stop adventuring actions - store references for cost updates
             _jumpOutOfPitForStopAction = new JumpOutOfPitForStopAction();
@@ -395,6 +399,19 @@ namespace PitHero.AI
                 return;
             }
 
+            // Check if a manual job change flipped NeedsCrystal mid-plan
+            if (HasNeedsCrystalChanged())
+            {
+                UpdateStopAdventuringActionCosts();
+                Debug.Log("[HeroStateMachine] NeedsCrystal changed during GoTo - cancelling current plan and replanning");
+                _actionPlan = null;
+                _currentAction = null;
+                _currentPath = null;
+                _pathIndex = 0;
+                CurrentState = ActorState.Idle;
+                return;
+            }
+
             // Check if Replenish was pressed — interrupt current plan so healing starts immediately
             if (_hero.ReplenishPending)
             {
@@ -564,6 +581,17 @@ namespace PitHero.AI
             {
                 UpdateStopAdventuringActionCosts();
                 Debug.Log("[HeroStateMachine] StoppedAdventure changed during PerformAction - cancelling current plan and replanning");
+                _actionPlan.Clear();
+                _currentAction = null;
+                CurrentState = ActorState.Idle;
+                return;
+            }
+
+            // Check if a manual job change flipped NeedsCrystal mid-action (deferred while airborne)
+            if (HasNeedsCrystalChanged() && _currentAction != null && !_currentAction.ShouldNotOverride())
+            {
+                UpdateStopAdventuringActionCosts();
+                Debug.Log("[HeroStateMachine] NeedsCrystal changed during PerformAction - cancelling current plan and replanning");
                 _actionPlan.Clear();
                 _currentAction = null;
                 CurrentState = ActorState.Idle;
@@ -955,7 +983,8 @@ namespace PitHero.AI
             {
                 if (actions[i] is JumpIntoPitAction)
                     return HeroPitIntent.EnteringPit;
-                if (actions[i] is JumpOutOfPitForInnAction || actions[i] is JumpOutOfPitForStopAction)
+                if (actions[i] is JumpOutOfPitForInnAction || actions[i] is JumpOutOfPitForStopAction
+                    || actions[i] is JumpOutOfPitForJobChangeAction)
                     return HeroPitIntent.ExitingPit;
             }
             return HeroPitIntent.None;
@@ -1539,6 +1568,26 @@ namespace PitHero.AI
         }
 
         /// <summary>
+        /// Check if NeedsCrystal flipped since the last cost sync. Normally the flag is only set
+        /// at hero creation (respawn), but a manual job change sets it mid-life and the current
+        /// plan must be cancelled so the hero heads for the statue.
+        /// </summary>
+        private bool HasNeedsCrystalChanged()
+        {
+            if (_hero == null)
+                return false;
+
+            bool hasChanged = _hero.NeedsCrystal != _lastNeedsCrystal;
+
+            if (hasChanged)
+            {
+                Debug.Log($"[HeroStateMachine] NeedsCrystal changed from {_lastNeedsCrystal} to {_hero.NeedsCrystal} - triggering replan");
+            }
+
+            return hasChanged;
+        }
+
+        /// <summary>
         /// Update stop adventuring action costs based on current StoppedAdventure state.
         /// When StoppedAdventure is true, set costs very low (1) so planner picks them.
         /// When false, set costs very high (99) so planner ignores them.
@@ -1557,6 +1606,8 @@ namespace PitHero.AI
                 _walkToTavernForStopAction.Cost = cost;
 
             _lastStoppedAdventure = stopped;
+            // Piggyback on the same sync sites so the NeedsCrystal tracker stays current
+            _lastNeedsCrystal = _hero.NeedsCrystal;
         }
 
         #endregion

--- a/PitHero/AI/JumpOutOfPitForJobChangeAction.cs
+++ b/PitHero/AI/JumpOutOfPitForJobChangeAction.cs
@@ -1,0 +1,222 @@
+using Microsoft.Xna.Framework;
+using Nez;
+using PitHero.ECS.Components;
+using PitHero.Services;
+using PitHero.Util;
+using PitHero.Util.SoundEffectTypes;
+using System.Collections;
+
+namespace PitHero.AI
+{
+    /// <summary>
+    /// Action that causes the hero to jump out of the pit when a manual job change was requested
+    /// while inside the pit. Jump mechanics are identical to JumpOutOfPitForStopAction; the
+    /// NeedsCrystal precondition lets the planner chain this into WalkToStatueForCrystalAction.
+    /// </summary>
+    public class JumpOutOfPitForJobChangeAction : HeroActionBase
+    {
+        private bool _isJumping = false;
+        private bool _jumpFinished = false;
+        private Point _plannedTargetTile;
+
+        public JumpOutOfPitForJobChangeAction() : base(GoapConstants.JumpOutOfPitForJobChangeAction, 1)
+        {
+            SetPrecondition(GoapConstants.InsidePit, true);
+            SetPrecondition(GoapConstants.NeedsCrystal, true);
+
+            SetPostcondition(GoapConstants.OutsidePit, true);
+        }
+
+        /// <summary>A jump is a short atomic animation — never interrupt it mid-air (the movement
+        /// coroutine cannot be cancelled and would fight any replanned movement). Only applies
+        /// while airborne; a jump that has not started yet remains interruptible.</summary>
+        public override bool ShouldNotOverride()
+        {
+            return _isJumping;
+        }
+
+        /// <summary>
+        /// Execute action - jump hero out of the pit
+        /// </summary>
+        public override bool Execute(HeroComponent hero)
+        {
+            // If already jumping, check if movement is complete
+            if (_isJumping)
+            {
+                if (!_jumpFinished)
+                {
+                    return false;
+                }
+
+                // Verify we actually reached the intended tile before completing
+                var tileMover = hero.Entity.GetComponent<TileByTileMover>();
+                var currentTile = tileMover?.GetCurrentTileCoordinates()
+                    ?? new Point((int)(hero.Entity.Transform.Position.X / GameConfig.TileSize),
+                               (int)(hero.Entity.Transform.Position.Y / GameConfig.TileSize));
+
+                if (currentTile.X != _plannedTargetTile.X || currentTile.Y != _plannedTargetTile.Y)
+                {
+                    // Stale state from a jump that was interrupted mid-air (the coroutine finished
+                    // but the hero has since been moved elsewhere). Waiting cannot resolve this —
+                    // reset so the next Execute starts a fresh jump from the actual position.
+                    Debug.Warn($"[JumpOutOfPitForJobChange] Jump finished flag set but hero at {currentTile.X},{currentTile.Y} not at planned target {_plannedTargetTile.X},{_plannedTargetTile.Y}. Restarting jump from current tile.");
+                    _isJumping = false;
+                    _jumpFinished = false;
+                    return false;
+                }
+
+                // Movement complete, finalize the jump
+                _isJumping = false;
+                _jumpFinished = false;
+
+                // Ensure triggers update so pit exit is registered
+                tileMover?.UpdateTriggersAfterTeleport();
+
+                Debug.Log("[JumpOutOfPitForJobChange] Jump out completed successfully");
+                return true;
+            }
+
+            // Start the jump out
+            var targetTile = CalculateJumpOutTargetTile(hero);
+            if (!targetTile.HasValue)
+            {
+                Debug.Warn("[JumpOutOfPitForJobChange] Cannot calculate jump out target tile");
+                return true;
+            }
+
+            _plannedTargetTile = targetTile.Value;
+
+            // Update InsidePit flag BEFORE starting movement
+            hero.InsidePit = false;
+
+            // Start the coroutine-based movement
+            StartJumpOutMovement(hero, _plannedTargetTile);
+            _isJumping = true;
+            _jumpFinished = false;
+
+            Debug.Log($"[JumpOutOfPitForJobChange] Started jump out to tile {_plannedTargetTile.X},{_plannedTargetTile.Y}, set InsidePit=false");
+            return false;
+        }
+
+        /// <summary>
+        /// Calculate the target tile for jumping out (2 tiles to the right from current position)
+        /// </summary>
+        private Point? CalculateJumpOutTargetTile(HeroComponent hero)
+        {
+            var currentTile = hero.Entity.GetComponent<TileByTileMover>()?.GetCurrentTileCoordinates()
+                ?? new Point((int)(hero.Entity.Transform.Position.X / GameConfig.TileSize),
+                           (int)(hero.Entity.Transform.Position.Y / GameConfig.TileSize));
+
+            var targetTile = new Point(currentTile.X + 2, currentTile.Y);
+
+            Debug.Log($"[JumpOutOfPitForJobChange] Calculated jump out target from {currentTile.X},{currentTile.Y} to {targetTile.X},{targetTile.Y}");
+            return targetTile;
+        }
+
+        /// <summary>
+        /// Start coroutine-based movement to target tile
+        /// </summary>
+        private void StartJumpOutMovement(HeroComponent hero, Point targetTile)
+        {
+            var entity = hero.Entity;
+
+            // Snap to grid BEFORE calculating target position
+            var tileMover = entity.GetComponent<TileByTileMover>();
+            if (tileMover != null)
+            {
+                tileMover.SnapToTileGrid();
+            }
+
+            var targetPosition = TileToWorldPosition(targetTile);
+
+            // Play jump sound effect
+            SoundEffectManager soundEffectManager = Core.GetGlobalManager<SoundEffectManager>();
+            soundEffectManager.PlaySoundAt(SoundEffectType.Jump, entity.Transform.Position);
+
+            // Start the movement coroutine
+            Core.StartCoroutine(JumpOutMovementCoroutine(entity, targetPosition, GameConfig.HeroJumpSpeed));
+        }
+
+        /// <summary>
+        /// Coroutine that smoothly moves the entity to target position over time
+        /// </summary>
+        private IEnumerator JumpOutMovementCoroutine(Entity entity, Vector2 targetPosition, float tilesPerSecond)
+        {
+            var startPosition = entity.Transform.Position;
+            var distance = Vector2.Distance(startPosition, targetPosition);
+            var duration = distance / (tilesPerSecond * GameConfig.TileSize);
+
+            // Start jump animation
+            var jumpDirection = GetJumpDirection(startPosition, targetPosition);
+            var jumpAnimComponent = entity.GetComponent<HeroJumpComponent>();
+            if (jumpAnimComponent != null)
+            {
+                jumpAnimComponent.StartJump(jumpDirection, duration);
+            }
+
+            var elapsed = 0f;
+
+            while (elapsed < duration)
+            {
+                elapsed += Time.DeltaTime;
+                var progress = elapsed / duration;
+
+                entity.Transform.Position = Vector2.Lerp(startPosition, targetPosition, progress);
+
+                yield return null;
+            }
+
+            // Ensure we end exactly at target
+            entity.Transform.Position = targetPosition;
+
+            // End jump animation
+            if (jumpAnimComponent != null)
+            {
+                jumpAnimComponent.EndJump();
+            }
+
+            // Snap to tile grid for precision
+            var tileMover = entity.GetComponent<TileByTileMover>();
+            if (tileMover != null)
+            {
+                tileMover.SnapToTileGrid();
+                tileMover.UpdateTriggersAfterTeleport();
+            }
+
+            // Clear fog of war around the landing position
+            var hero = entity.GetComponent<HeroComponent>();
+            var tiledMapService = Core.Services.GetService<TiledMapService>();
+            bool fogCleared = tiledMapService?.ClearFogOfWarAroundTile(
+                (int)(targetPosition.X / GameConfig.TileSize),
+                (int)(targetPosition.Y / GameConfig.TileSize), hero
+            ) ?? false;
+
+            if (fogCleared)
+            {
+                var heroComponent = entity.GetComponent<HeroComponent>();
+                heroComponent?.TriggerFogCooldown();
+            }
+
+            _jumpFinished = true;
+
+            Debug.Log($"[JumpOutOfPitForJobChange] Jump out movement completed at {entity.Transform.Position.X},{entity.Transform.Position.Y}");
+        }
+
+        /// <summary>
+        /// Determine jump direction based on start and target positions
+        /// </summary>
+        private Direction GetJumpDirection(Vector2 startPosition, Vector2 targetPosition)
+        {
+            var delta = targetPosition - startPosition;
+
+            if (System.Math.Abs(delta.X) > System.Math.Abs(delta.Y))
+            {
+                return delta.X > 0 ? Direction.Right : Direction.Left;
+            }
+            else
+            {
+                return delta.Y > 0 ? Direction.Down : Direction.Up;
+            }
+        }
+    }
+}

--- a/PitHero/AI/WalkToStatueForCrystalAction.cs
+++ b/PitHero/AI/WalkToStatueForCrystalAction.cs
@@ -21,6 +21,9 @@ namespace PitHero.AI
         {
             SetPrecondition(GoapConstants.HeroInitialized, true);
             SetPrecondition(GoapConstants.NeedsCrystal, true);
+            // Respawned heroes always spawn outside; requiring it lets the planner chain a
+            // jump-out first when a manual job change is requested inside the pit
+            SetPrecondition(GoapConstants.OutsidePit, true);
             SetPostcondition(GoapConstants.HasArrivedAtStatueForCrystal, true);
         }
 
@@ -60,11 +63,15 @@ namespace PitHero.AI
 
             Debug.Log($"[WalkToStatueForCrystalAction] Hero walking to statue at ({StatueTileX},{StatueTileY}) to receive crystal");
 
-            SpeechBubbleDialogue.SayRespawn(hero.Entity);
+            // Respawn chatter belongs to the death path only; a manual job change is not a respawn
+            if (!hero.PendingManualJobChange)
+            {
+                SpeechBubbleDialogue.SayRespawn(hero.Entity);
 
-            if (hero.LinkedHero != null)
-                Core.Services.GetService<GameEventService>()?.EmitLocalized(UITextKey.ConsoleHeroRespawn,
-                    (hero.LinkedHero.Name, GameConfig.ConsoleColorHeroName));
+                if (hero.LinkedHero != null)
+                    Core.Services.GetService<GameEventService>()?.EmitLocalized(UITextKey.ConsoleHeroRespawn,
+                        (hero.LinkedHero.Name, GameConfig.ConsoleColorHeroName));
+            }
 
             var currentPos = hero.Entity.Transform.Position;
             var currentTile = new Point(

--- a/PitHero/AI/WalkToStatueForCrystalAction.cs
+++ b/PitHero/AI/WalkToStatueForCrystalAction.cs
@@ -39,14 +39,22 @@ namespace PitHero.AI
             if (hero.HasArrivedAtStatueForCrystal)
                 return true;
 
-            // Start walking coroutine if not already started
-            if (_walkCoroutine == null)
+            // Start walking coroutine if not already started. The NeedsCrystal guard stops a
+            // spurious restart on the frame after the walk aborts a manual job change (the
+            // state machine replans off that flag flip one tick later).
+            if (_walkCoroutine == null && hero.NeedsCrystal)
             {
                 _walkCoroutine = Core.StartCoroutine(WalkToStatue(hero));
             }
 
             return hero.HasArrivedAtStatueForCrystal;
         }
+
+        /// <summary>Give up on pathing after this long. Death path falls back to a ceremony in
+        /// place (worse than misplaced lightning is a softlocked crystal-less hero); the manual
+        /// path aborts the job change instead — the hero keeps its job and the player can retry.</summary>
+        private const float MaxPathRetrySeconds = 60f;
+        private const float PathRetryDelay = 0.5f;
 
         private IEnumerator WalkToStatue(HeroComponent hero)
         {
@@ -58,6 +66,7 @@ namespace PitHero.AI
             {
                 Debug.Warn("[WalkToStatueForCrystalAction] Missing required components on hero entity");
                 hero.HasArrivedAtStatueForCrystal = true;
+                _walkCoroutine = null;
                 yield break;
             }
 
@@ -73,64 +82,117 @@ namespace PitHero.AI
                         (hero.LinkedHero.Name, GameConfig.ConsoleColorHeroName));
             }
 
-            var currentPos = hero.Entity.Transform.Position;
-            var currentTile = new Point(
-                (int)(currentPos.X / GameConfig.TileSize),
-                (int)(currentPos.Y / GameConfig.TileSize)
-            );
-
             var statueTile = new Point(StatueTileX, StatueTileY);
+            float retryElapsed = 0f;
+            bool arrived = false;
 
-            var path = pathfinding.CalculatePath(currentTile, statueTile);
-
-            if (path == null || path.Count == 0)
+            // Self-healing walk: repath on any blocked step instead of silently skipping the
+            // rest of the path. A single failed StartMoving (a mercenary in the corridor, tavern
+            // furniture, a stale tile after seating) previously no-opped every remaining step
+            // and then faked arrival — putting the ceremony wherever the hero stood.
+            while (!arrived && retryElapsed < MaxPathRetrySeconds)
             {
-                Debug.Warn("[WalkToStatueForCrystalAction] Could not find path to hero statue — marking arrived anyway");
-                hero.HasArrivedAtStatueForCrystal = true;
-                yield break;
-            }
+                if (hero.Entity == null || hero.Entity.IsDestroyed)
+                {
+                    _walkCoroutine = null;
+                    yield break;
+                }
 
-            Debug.Log($"[WalkToStatueForCrystalAction] Found path with {path.Count} steps to statue");
+                // Let any in-flight tile move finish, then path from a clean grid position
+                while (tileMover.IsMoving)
+                    yield return null;
+                tileMover.SnapToTileGrid();
 
-            for (int i = 0; i < path.Count; i++)
-            {
-                var targetTile = path[i];
-                var currentTilePos = new Point(
+                var currentTile = new Point(
                     (int)(hero.Entity.Transform.Position.X / GameConfig.TileSize),
                     (int)(hero.Entity.Transform.Position.Y / GameConfig.TileSize)
                 );
 
-                var dx = targetTile.X - currentTilePos.X;
-                var dy = targetTile.Y - currentTilePos.Y;
-
-                Direction? direction = null;
-                if (dx > 0) direction = Direction.Right;
-                else if (dx < 0) direction = Direction.Left;
-                else if (dy > 0) direction = Direction.Down;
-                else if (dy < 0) direction = Direction.Up;
-
-                if (direction.HasValue)
+                if (currentTile.X == statueTile.X && currentTile.Y == statueTile.Y)
                 {
-                    tileMover.StartMoving(direction.Value);
-
-                    while (tileMover.IsMoving)
-                    {
-                        yield return null;
-                    }
+                    arrived = true;
+                    break;
                 }
 
-                yield return Coroutine.WaitForSeconds(0.05f);
+                var path = pathfinding.CalculatePath(currentTile, statueTile);
+                if (path == null || path.Count == 0)
+                {
+                    Debug.Warn($"[WalkToStatueForCrystalAction] No path from ({currentTile.X},{currentTile.Y}) to statue — retrying in {PathRetryDelay}s");
+                    yield return Coroutine.WaitForSeconds(PathRetryDelay);
+                    retryElapsed += PathRetryDelay;
+                    continue;
+                }
+
+                bool blocked = false;
+                for (int i = 0; i < path.Count; i++)
+                {
+                    var targetTile = path[i];
+                    var currentTilePos = new Point(
+                        (int)(hero.Entity.Transform.Position.X / GameConfig.TileSize),
+                        (int)(hero.Entity.Transform.Position.Y / GameConfig.TileSize)
+                    );
+
+                    var dx = targetTile.X - currentTilePos.X;
+                    var dy = targetTile.Y - currentTilePos.Y;
+
+                    Direction? direction = null;
+                    if (dx > 0) direction = Direction.Right;
+                    else if (dx < 0) direction = Direction.Left;
+                    else if (dy > 0) direction = Direction.Down;
+                    else if (dy < 0) direction = Direction.Up;
+
+                    if (direction.HasValue)
+                    {
+                        if (!tileMover.StartMoving(direction.Value))
+                        {
+                            blocked = true;
+                            break;
+                        }
+
+                        while (tileMover.IsMoving)
+                        {
+                            yield return null;
+                        }
+                    }
+
+                    yield return Coroutine.WaitForSeconds(0.05f);
+                }
+
+                if (blocked)
+                {
+                    Debug.Log("[WalkToStatueForCrystalAction] Step blocked — waiting and repathing to statue");
+                    yield return Coroutine.WaitForSeconds(PathRetryDelay);
+                    retryElapsed += PathRetryDelay;
+                }
+                // Loop re-checks actual arrival at the top; a fully walked path falls through
+                // to the position check instead of assuming success.
             }
 
-            // Face up toward the statue
-            if (facingComponent != null)
+            if (arrived)
             {
-                facingComponent.SetFacing(Direction.Up);
+                // Face up toward the statue
+                if (facingComponent != null)
+                {
+                    facingComponent.SetFacing(Direction.Up);
+                }
+
+                Debug.Log("[WalkToStatueForCrystalAction] Hero arrived at statue — awaiting crystal promotion ceremony");
+                hero.HasArrivedAtStatueForCrystal = true;
+            }
+            else if (hero.PendingManualJobChange)
+            {
+                // Never run a manual ceremony away from the statue — abort the request instead
+                Debug.Warn("[WalkToStatueForCrystalAction] Could not reach statue — aborting manual job change, hero keeps current job");
+                hero.PendingManualJobChange = false;
+                hero.NeedsCrystal = false;
+            }
+            else
+            {
+                // Death path: a crystal-less hero must not softlock; ceremony in place as last resort
+                Debug.Warn("[WalkToStatueForCrystalAction] Could not reach statue — marking arrived anyway to avoid softlock");
+                hero.HasArrivedAtStatueForCrystal = true;
             }
 
-            Debug.Log("[WalkToStatueForCrystalAction] Hero arrived at statue — awaiting crystal promotion ceremony");
-
-            hero.HasArrivedAtStatueForCrystal = true;
             _walkCoroutine = null;
         }
     }

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -248,6 +248,13 @@ CrystalInventoryEmpty,No crystals in collection
 DialogConfirmForge,Confirm Forge
 ConfirmForgeMessage,Combine these 2 crystals into a Combo Crystal?
 CrystalInventoryFull,Crystal inventory is full
+CrystalCreationFeeLabel,Fee: {0} Gold
+CrystalForgeFeeLabel,Fee: {0} Gold
+DialogChangeJobTitle,Change Job
+DialogChangeJobPrompt,Change Job to next Crystal? Resets Hero and Pit level to 1.
+DialogNoCrystalQueued,No crystal lined up. Please set a crystal
+ButtonChangeJob,Change Job
+ButtonChangeJobTooltip,Infuse the next queued crystal at the Hero Statue
 ButtonDismiss,Dismiss
 ButtonDiscard,Sell
 DialogConfirmDismissMercenary,Dismiss Mercenary

--- a/PitHero/ECS/Components/HeroComponent.cs
+++ b/PitHero/ECS/Components/HeroComponent.cs
@@ -311,8 +311,9 @@ namespace PitHero.ECS.Components
         /// True while a player-requested job change is in flight (set together with NeedsCrystal).
         /// Distinguishes the manual flow from the death-respawn flow in the crystal ceremony.
         /// Lives on the component so a mid-flow death self-heals: the entity is destroyed, the flag
-        /// dies with it, and the normal death ceremony takes over. Never persisted — saving is
-        /// disabled for the entire window this can be true.
+        /// dies with it, and the normal death ceremony takes over. Never persisted — the hero keeps
+        /// its job and crystal until the ceremony grants, so a save/load mid-flow just forgets the
+        /// request and the player can re-issue it.
         /// </summary>
         public bool PendingManualJobChange { get; set; }
 

--- a/PitHero/ECS/Components/HeroComponent.cs
+++ b/PitHero/ECS/Components/HeroComponent.cs
@@ -971,7 +971,18 @@ namespace PitHero.ECS.Components
         /// </summary>
         public override void SetGoalState(ref WorldState goalState)
         {
-            // HIGHEST PRIORITY: Player stopped adventuring — go to tavern and stay there.
+            // HIGHEST PRIORITY: Hero needs a crystal — walk to statue for promotion ceremony.
+            // Outranks StoppedAdventure so a manual job change requested while the party is
+            // stopped (or while the dining service auto-stops for a meal trip) goes to the
+            // statue first; StoppedAdventure survives the ceremony, so the hero returns to
+            // the tavern table afterwards on its own.
+            if (NeedsCrystal)
+            {
+                goalState.Set(GoapConstants.HasArrivedAtStatueForCrystal, true);
+                return;
+            }
+
+            // Player stopped adventuring — go to tavern and stay there.
             // When SeatedInTavern is already true the goal is already satisfied, so the
             // planner returns no actions and the hero stays idle until Continue is pressed.
             // Night sleep still preempts the seat: at 10 PM the party leaves the table,
@@ -987,13 +998,6 @@ namespace PitHero.ECS.Components
                 }
 
                 goalState.Set(GoapConstants.SeatedInTavern, true);
-                return;
-            }
-
-            // HIGHEST PRIORITY: Hero needs a crystal — walk to statue for promotion ceremony
-            if (NeedsCrystal)
-            {
-                goalState.Set(GoapConstants.HasArrivedAtStatueForCrystal, true);
                 return;
             }
 

--- a/PitHero/ECS/Components/HeroComponent.cs
+++ b/PitHero/ECS/Components/HeroComponent.cs
@@ -308,6 +308,15 @@ namespace PitHero.ECS.Components
         public bool NeedsCrystal { get; set; }
 
         /// <summary>
+        /// True while a player-requested job change is in flight (set together with NeedsCrystal).
+        /// Distinguishes the manual flow from the death-respawn flow in the crystal ceremony.
+        /// Lives on the component so a mid-flow death self-heals: the entity is destroyed, the flag
+        /// dies with it, and the normal death ceremony takes over. Never persisted — saving is
+        /// disabled for the entire window this can be true.
+        /// </summary>
+        public bool PendingManualJobChange { get; set; }
+
+        /// <summary>
         /// True when the hero has arrived at the statue tile (112,6) to receive a crystal promotion ceremony
         /// </summary>
         public bool HasArrivedAtStatueForCrystal { get; set; }

--- a/PitHero/ECS/Components/SpeechBubbleComponent.cs
+++ b/PitHero/ECS/Components/SpeechBubbleComponent.cs
@@ -233,25 +233,37 @@ namespace PitHero.ECS.Components
             float delay = 1f / GameConfig.SpeechBubbleCharsPerSecond;
             int length  = _wrappedText?.Length ?? 0;
 
-            for (int i = 0; i < length; i++)
+            // Accumulate scaled delta time and reveal as many characters as it covers each
+            // frame. Per-character WaitForSeconds quantized to whole frames (remainder
+            // discarded), which capped the reveal near one char per frame and made fast
+            // forward barely speed the text up.
+            float accumulated = 0f;
+            int revealed = 0;
+            while (revealed < length)
             {
                 while (_pauseService?.IsPaused == true)
-                    yield return 1;
+                    yield return null;
 
-                yield return Coroutine.WaitForSeconds(delay);
-                _visibleText.Append(_wrappedText[i]);
+                yield return null;
+                accumulated += Time.DeltaTime;
+
+                while (accumulated >= delay && revealed < length)
+                {
+                    accumulated -= delay;
+                    _visibleText.Append(_wrappedText[revealed]);
+                    revealed++;
+                }
             }
 
-            // Linger after full text is revealed; check pause in small slices
-            float lingered  = 0f;
-            const float slice = 0.1f;
+            // Linger after full text is revealed; scaled so fast forward shortens it too
+            float lingered = 0f;
             while (lingered < GameConfig.SpeechBubbleLingerSeconds)
             {
                 while (_pauseService?.IsPaused == true)
-                    yield return 1;
+                    yield return null;
 
-                yield return Coroutine.WaitForSeconds(slice);
-                lingered += slice;
+                yield return null;
+                lingered += Time.DeltaTime;
             }
 
             _active = false;

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -1636,6 +1636,15 @@ namespace PitHero.ECS.Scenes
         }
 
         /// <summary>
+        /// Starts the wait-for-mercenaries-then-reset-pit coroutine. Called by the crystal
+        /// ceremony when a manual job change completes (the death path starts it from RespawnHero).
+        /// </summary>
+        public void StartPitResetForNewCycle()
+        {
+            Core.StartCoroutine(WaitForAllMercenariesToExitPitThenReset());
+        }
+
+        /// <summary>
         /// Resets the pit level back to 1, shrinking its width and regenerating level-1 content.
         /// </summary>
         private void ResetPitToLevelOne()
@@ -2682,6 +2691,10 @@ namespace PitHero.ECS.Scenes
             // Handle placed-building hover outline and click-to-open context menu
             HandleBuildingHover();
             HandleBuildingClicks();
+
+            // Handle hero-statue hover outline and click-to-open job change dialog
+            HandleStatueHover();
+            HandleStatueClicks();
         }
 
         /// <summary>
@@ -2944,6 +2957,98 @@ namespace PitHero.ECS.Scenes
             _buildingHoverOutlineEntity.GetComponent<BuildingOutlineRenderComponent>()?.SetSize(w, h);
             _buildingHoverOutlineEntity.SetPosition(left, top);
             _buildingHoverOutlineEntity.SetEnabled(true);
+        }
+
+        private bool _statueHovered;
+        private Entity _statueHoverOutlineEntity;
+
+        /// <summary>
+        /// True when hero-statue hover/click interactions should be suppressed — while the cursor
+        /// is outside the game window, while a confirmation is open, when the pointer is over UI,
+        /// or when no job change can currently be requested (no hero, or ceremony already pending).
+        /// </summary>
+        private bool StatueInteractionsBlocked()
+        {
+            if (!Util.MouseUtils.IsMouseInsideWindow())
+                return true;
+            if (UI.ConfirmationDialog.AnyVisible)
+                return true;
+            if (_uiStage != null && _uiStage.Hit(_uiStage.GetMousePosition()) != null)
+                return true;
+            if (!UI.JobChangeFlow.CanRequestJobChange())
+                return true;
+            return false;
+        }
+
+        /// <summary>Returns the hero statue's renderable bounds if the cursor is over it, else null.</summary>
+        private Entity GetStatueUnderCursor()
+        {
+            var statues = FindEntitiesWithTag(GameConfig.TAG_HERO_STATUE);
+            if (statues.Count == 0)
+                return null;
+
+            var statue = statues[0];
+            var mousePos = Camera.MouseToWorldPoint();
+            var renderer = statue.GetComponent<YSortSpriteRenderer>();
+            if (renderer != null)
+                return renderer.Bounds.Contains(mousePos) ? statue : null;
+
+            return Vector2.Distance(mousePos, statue.Transform.Position) < GameConfig.TileSize ? statue : null;
+        }
+
+        /// <summary>Draws a white outline around the hero statue under the cursor to signal it is clickable.</summary>
+        private void HandleStatueHover()
+        {
+            var hovered = StatueInteractionsBlocked() ? null : GetStatueUnderCursor();
+            bool isHovered = hovered != null;
+
+            // Statue never moves, so only state changes need work
+            if (isHovered == _statueHovered)
+                return;
+
+            _statueHovered = isHovered;
+
+            if (!isHovered)
+            {
+                _statueHoverOutlineEntity?.SetEnabled(false);
+                return;
+            }
+
+            if (_statueHoverOutlineEntity == null)
+            {
+                _statueHoverOutlineEntity = CreateEntity("statue-hover-outline");
+                var outline = _statueHoverOutlineEntity.AddComponent(new BuildingOutlineRenderComponent());
+                outline.SetRenderLayer(GameConfig.RenderLayerTop);
+                outline.SetColor(Color.White);
+            }
+
+            var renderer = hovered.GetComponent<YSortSpriteRenderer>();
+            if (renderer != null)
+            {
+                var bounds = renderer.Bounds;
+                _statueHoverOutlineEntity.GetComponent<BuildingOutlineRenderComponent>()?.SetSize(bounds.Width, bounds.Height);
+                _statueHoverOutlineEntity.SetPosition(bounds.X, bounds.Y);
+            }
+            _statueHoverOutlineEntity.SetEnabled(true);
+        }
+
+        /// <summary>Opens the job change dialog when the hero statue is clicked.</summary>
+        private void HandleStatueClicks()
+        {
+            if (!Input.LeftMouseButtonPressed)
+                return;
+            if (StatueInteractionsBlocked())
+                return;
+
+            var statue = GetStatueUnderCursor();
+            if (statue == null)
+                return;
+
+            // Clear the hover outline before the dialog opens.
+            _statueHovered = false;
+            _statueHoverOutlineEntity?.SetEnabled(false);
+
+            UI.JobChangeFlow.ShowChangeJobDialog(_uiStage, UI.PitHeroSkin.CreateSkin());
         }
 
         /// <summary>Opens the building context menu when a placed building is clicked.</summary>

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -122,6 +122,9 @@ namespace PitHero
         public const int CrystalCreationFee = 100;      // Gold cost to create a brand-new crystal
         public const int CrystalForgeFeeDivisor = 2;    // Forge fee = combined crystal buy-back price / divisor
 
+        // Minimum height for dialog buttons (Yes/No/OK) so they present a comfortable click target
+        public const float DialogButtonMinHeight = 16f;
+
         // Tavern seat configuration (for Stop Adventuring)
         public const int TavernHeroSeatTileX = 93;
         public const int TavernHeroSeatTileY = 6;

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -119,6 +119,8 @@ namespace PitHero
         public const int CrystalBuyBackBasePrice = 100; // Base gold cost per crystal level for Second Chance Shop
         public const float CrystalJPToGoldRate = 0.5f;  // Gold per JP invested in learned job skills (buy-back premium)
         public const int CrystalSynergySkillFee = 150;  // Flat gold per learned synergy skill (buy-back premium)
+        public const int CrystalCreationFee = 100;      // Gold cost to create a brand-new crystal
+        public const int CrystalForgeFeeDivisor = 2;    // Forge fee = combined crystal buy-back price / divisor
 
         // Tavern seat configuration (for Stop Adventuring)
         public const int TavernHeroSeatTileX = 93;

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -120,7 +120,7 @@ namespace PitHero
         public const float CrystalJPToGoldRate = 0.5f;  // Gold per JP invested in learned job skills (buy-back premium)
         public const int CrystalSynergySkillFee = 150;  // Flat gold per learned synergy skill (buy-back premium)
         public const int CrystalCreationFee = 100;      // Gold cost to create a brand-new crystal
-        public const int CrystalForgeFeeDivisor = 2;    // Forge fee = combined crystal buy-back price / divisor
+        public const int CrystalForgeFeeMultiplier = 2; // Forge fee = combined crystal buy-back price x multiplier
 
         // Minimum height for dialog buttons (Yes/No/OK) so they present a comfortable click target
         public const float DialogButtonMinHeight = 16f;

--- a/PitHero/RolePlayingFramework/Heroes/HeroCrystal.cs
+++ b/PitHero/RolePlayingFramework/Heroes/HeroCrystal.cs
@@ -217,10 +217,12 @@ namespace RolePlayingFramework.Heroes
 
         /// <summary>
         /// Calculates the Second Chance buy-back price: base gold per level plus a premium for
-        /// learned skills, anchored to the JP invested in them. The premium is capped at the base
-        /// price so recovering a mastered crystal never costs more than double the flat price.
+        /// learned skills, anchored to the JP invested in them. By default the premium is capped
+        /// at the base price so recovering a mastered crystal never costs more than double the
+        /// flat price; pass capPremium: false for prices that must fully reflect skill count
+        /// (e.g. the forge fee, where a many-skill Legend combo should cost accordingly).
         /// </summary>
-        public int CalculateBuyBackPrice()
+        public int CalculateBuyBackPrice(bool capPremium = true)
         {
             int basePrice = Level * PitHero.GameConfig.CrystalBuyBackBasePrice;
 
@@ -234,7 +236,7 @@ namespace RolePlayingFramework.Heroes
 
             int premium = (int)(jpInvested * PitHero.GameConfig.CrystalJPToGoldRate)
                 + _learnedSynergySkillIds.Count * PitHero.GameConfig.CrystalSynergySkillFee;
-            if (premium > basePrice) premium = basePrice;
+            if (capPremium && premium > basePrice) premium = basePrice;
 
             return basePrice + premium;
         }

--- a/PitHero/Services/CrystalFeeCalculator.cs
+++ b/PitHero/Services/CrystalFeeCalculator.cs
@@ -6,14 +6,16 @@ namespace PitHero.Services
     public static class CrystalFeeCalculator
     {
         /// <summary>Forge fee is the Second Chance Shop's purchase-price algorithm for the
-        /// combined crystal, doubled — forging a many-skill crystal must cost more than
-        /// buying one back. Combine is a pure factory, so previewing is side-effect free.</summary>
+        /// combined crystal, doubled, with the skill premium UNCAPPED — a 16-skill Legend
+        /// combo must cost more to forge than a 6-skill one at any crystal level (the shop's
+        /// cap exists only to keep recovering a lost crystal affordable). Combine is a pure
+        /// factory, so previewing is side-effect free.</summary>
         public static int GetForgeFee(HeroCrystal a, HeroCrystal b)
         {
             if (a == null || b == null)
                 return 0;
             var preview = HeroCrystal.Combine("Combo Crystal", a, b);
-            return preview.CalculateBuyBackPrice() * GameConfig.CrystalForgeFeeMultiplier;
+            return preview.CalculateBuyBackPrice(capPremium: false) * GameConfig.CrystalForgeFeeMultiplier;
         }
     }
 }

--- a/PitHero/Services/CrystalFeeCalculator.cs
+++ b/PitHero/Services/CrystalFeeCalculator.cs
@@ -1,0 +1,18 @@
+using RolePlayingFramework.Heroes;
+
+namespace PitHero.Services
+{
+    /// <summary>Pure fee math for crystal creation and forging (no Core dependencies).</summary>
+    public static class CrystalFeeCalculator
+    {
+        /// <summary>Forge fee is half of what the combined crystal would cost to buy back
+        /// in the Second Chance Shop. Combine is a pure factory, so previewing is side-effect free.</summary>
+        public static int GetForgeFee(HeroCrystal a, HeroCrystal b)
+        {
+            if (a == null || b == null)
+                return 0;
+            var preview = HeroCrystal.Combine("Combo Crystal", a, b);
+            return preview.CalculateBuyBackPrice() / GameConfig.CrystalForgeFeeDivisor;
+        }
+    }
+}

--- a/PitHero/Services/CrystalFeeCalculator.cs
+++ b/PitHero/Services/CrystalFeeCalculator.cs
@@ -5,14 +5,15 @@ namespace PitHero.Services
     /// <summary>Pure fee math for crystal creation and forging (no Core dependencies).</summary>
     public static class CrystalFeeCalculator
     {
-        /// <summary>Forge fee is half of what the combined crystal would cost to buy back
-        /// in the Second Chance Shop. Combine is a pure factory, so previewing is side-effect free.</summary>
+        /// <summary>Forge fee is the Second Chance Shop's purchase-price algorithm for the
+        /// combined crystal, doubled — forging a many-skill crystal must cost more than
+        /// buying one back. Combine is a pure factory, so previewing is side-effect free.</summary>
         public static int GetForgeFee(HeroCrystal a, HeroCrystal b)
         {
             if (a == null || b == null)
                 return 0;
             var preview = HeroCrystal.Combine("Combo Crystal", a, b);
-            return preview.CalculateBuyBackPrice() / GameConfig.CrystalForgeFeeDivisor;
+            return preview.CalculateBuyBackPrice() * GameConfig.CrystalForgeFeeMultiplier;
         }
     }
 }

--- a/PitHero/Services/HeroJobChangeHelper.cs
+++ b/PitHero/Services/HeroJobChangeHelper.cs
@@ -1,0 +1,78 @@
+using RolePlayingFramework.Equipment;
+using RolePlayingFramework.Heroes;
+using RolePlayingFramework.Inventory;
+
+namespace PitHero.Services
+{
+    /// <summary>Pure helpers for the manual job change flow (no Core dependencies).</summary>
+    public static class HeroJobChangeHelper
+    {
+        private static readonly EquipmentSlot[] AllSlots =
+        {
+            EquipmentSlot.WeaponShield1,
+            EquipmentSlot.Armor,
+            EquipmentSlot.Hat,
+            EquipmentSlot.WeaponShield2,
+            EquipmentSlot.Accessory1,
+            EquipmentSlot.Accessory2
+        };
+
+        /// <summary>
+        /// Returns the outgoing crystal to the hero's crystal inventory. Crystals only go to the
+        /// Second Chance Shop on death — the vault is just the never-lose-it fallback when the
+        /// inventory is full. Returns true when the crystal landed in the inventory.
+        /// </summary>
+        public static bool ReturnCrystalToInventory(HeroCrystal crystal, CrystalCollectionService crystalService, SecondChanceMerchantVault vault)
+        {
+            if (crystal == null)
+                return false;
+
+            if (crystalService != null && crystalService.TryAddToInventory(crystal))
+                return true;
+
+            vault?.AddCrystal(crystal);
+            return false;
+        }
+
+        /// <summary>
+        /// Copies the old hero's six equipment slots onto the new hero. Items the new job cannot
+        /// equip go to the bag; if the bag is full they go to the Second Chance vault so nothing
+        /// is ever lost.
+        /// </summary>
+        public static void TransferEquipment(Hero oldHero, Hero newHero, ItemBag bag, SecondChanceMerchantVault vault)
+        {
+            if (oldHero == null || newHero == null)
+                return;
+
+            for (int i = 0; i < AllSlots.Length; i++)
+            {
+                var slot = AllSlots[i];
+                var item = GetSlotItem(oldHero, slot);
+                if (item == null)
+                    continue;
+
+                if (newHero.SetEquipmentSlot(slot, item))
+                    continue;
+
+                if (bag != null && bag.TryAdd(item))
+                    continue;
+
+                vault?.AddItems(new[] { item });
+            }
+        }
+
+        private static IItem GetSlotItem(Hero hero, EquipmentSlot slot)
+        {
+            switch (slot)
+            {
+                case EquipmentSlot.WeaponShield1: return hero.WeaponShield1;
+                case EquipmentSlot.Armor: return hero.Armor;
+                case EquipmentSlot.Hat: return hero.Hat;
+                case EquipmentSlot.WeaponShield2: return hero.WeaponShield2;
+                case EquipmentSlot.Accessory1: return hero.Accessory1;
+                case EquipmentSlot.Accessory2: return hero.Accessory2;
+                default: return null;
+            }
+        }
+    }
+}

--- a/PitHero/Services/HeroPromotionService.cs
+++ b/PitHero/Services/HeroPromotionService.cs
@@ -152,6 +152,10 @@ namespace PitHero.Services
             if (isManualJobChange)
                 FinishManualJobChange(heroComponent, oldHero);
 
+            // The new job may not know the old job's skills — drop the hero's skill shortcuts
+            // (mercenary skills and item shortcuts stay). Applies to both death and manual paths.
+            Core.Services.GetService<ShortcutBarService>()?.ShortcutBar?.ClearHeroSkillShortcuts();
+
             Debug.Log($"[HeroPromotionService] Hero granted crystal: {nextCrystal.Job.Name} Level {spawnLevel} (crystal={nextCrystal.Level}, tierBase={tierBaseLevel})");
 
             Core.Services.GetService<GameEventService>()?.EmitLocalized(UITextKey.ConsoleCrystalPromotion,

--- a/PitHero/Services/HeroPromotionService.cs
+++ b/PitHero/Services/HeroPromotionService.cs
@@ -58,7 +58,6 @@ namespace PitHero.Services
                 heroComponent.PendingManualJobChange = false;
                 heroComponent.NeedsCrystal = false;
                 heroComponent.HasArrivedAtStatueForCrystal = false;
-                Core.Services.GetService<SettingsUI>()?.SetSaveEnabled(true);
                 return;
             }
 
@@ -121,7 +120,6 @@ namespace PitHero.Services
                     tileMover.SetEnabled(true);
                 if (stateMachine != null)
                     stateMachine.SetEnabled(true);
-                Core.Services.GetService<SettingsUI>()?.SetSaveEnabled(true);
                 _isGrantingCrystal = false;
                 yield break;
             }

--- a/PitHero/Services/HeroPromotionService.cs
+++ b/PitHero/Services/HeroPromotionService.cs
@@ -49,6 +49,19 @@ namespace PitHero.Services
             if (!heroComponent.NeedsCrystal || !heroComponent.HasArrivedAtStatueForCrystal)
                 return;
 
+            // A manual job change must never fall back to a random crystal: if the queue was
+            // emptied during the walk to the statue, abort cleanly and keep the current job.
+            if (heroComponent.PendingManualJobChange
+                && Core.Services.GetService<CrystalCollectionService>()?.PeekQueue() == null)
+            {
+                Debug.Log("[HeroPromotionService] Crystal queue emptied before manual job change ceremony — aborting, hero keeps current job");
+                heroComponent.PendingManualJobChange = false;
+                heroComponent.NeedsCrystal = false;
+                heroComponent.HasArrivedAtStatueForCrystal = false;
+                Core.Services.GetService<SettingsUI>()?.SetSaveEnabled(true);
+                return;
+            }
+
             Debug.Log("[HeroPromotionService] Hero has arrived at statue and needs a crystal — starting crystal ceremony");
             _isGrantingCrystal = true;
             Core.StartCoroutine(ExecuteHeroCrystalCeremony(heroEntity));
@@ -95,14 +108,39 @@ namespace PitHero.Services
 
             Debug.Log("[HeroPromotionService] Crystal ceremony lightning complete — granting crystal to hero");
 
+            // A manual job change must never fall back to a random crystal — the queue may have
+            // been emptied during the ceremony dwell. Abort cleanly; the hero keeps its job.
+            if (heroComponent.PendingManualJobChange
+                && Core.Services.GetService<CrystalCollectionService>()?.PeekQueue() == null)
+            {
+                Debug.Log("[HeroPromotionService] Crystal queue emptied during manual job change ceremony — aborting, hero keeps current job");
+                heroComponent.PendingManualJobChange = false;
+                heroComponent.NeedsCrystal = false;
+                heroComponent.HasArrivedAtStatueForCrystal = false;
+                if (tileMover != null)
+                    tileMover.SetEnabled(true);
+                if (stateMachine != null)
+                    stateMachine.SetEnabled(true);
+                Core.Services.GetService<SettingsUI>()?.SetSaveEnabled(true);
+                _isGrantingCrystal = false;
+                yield break;
+            }
+
             // Get next crystal for hero (from pending, queue, or random)
             var nextCrystal = GetNextCrystalForHero();
-            // LinkedHero is null when hero respawned without a crystal (needsCrystal path)
-            var heroName = heroComponent.LinkedHero?.Name
+            // LinkedHero is null when hero respawned without a crystal (needsCrystal path);
+            // it is non-null when the player requested a manual job change on a living hero.
+            var oldHero = heroComponent.LinkedHero;
+            bool isManualJobChange = heroComponent.PendingManualJobChange && oldHero != null;
+            var heroName = oldHero?.Name
                 ?? Core.Services.GetService<HeroDesignService>()?.GetDesign().Name
                 ?? "Hero";
             // When tier ≥ 2 the hero starts at least at the recorded tier base level.
             var pitWidthManagerForSpawn = Core.Services.GetService<PitWidthManager>();
+            // A manual job change starts a fresh cycle: reset the tier BEFORE computing the spawn
+            // level so the new hero's floor is 1, mirroring RespawnHero's ordering on the death path.
+            if (isManualJobChange)
+                pitWidthManagerForSpawn?.ResetTierForNewCycle();
             int tierBaseLevel = pitWidthManagerForSpawn?.TierBaseLevel ?? 1;
             int spawnLevel = nextCrystal.Level > tierBaseLevel ? nextCrystal.Level : tierBaseLevel;
             heroComponent.LinkedHero = new RolePlayingFramework.Heroes.Hero(
@@ -112,6 +150,9 @@ namespace PitHero.Services
                 nextCrystal.BaseStats,
                 nextCrystal
             );
+
+            if (isManualJobChange)
+                FinishManualJobChange(heroComponent, oldHero);
 
             Debug.Log($"[HeroPromotionService] Hero granted crystal: {nextCrystal.Job.Name} Level {spawnLevel} (crystal={nextCrystal.Level}, tierBase={tierBaseLevel})");
 
@@ -137,6 +178,38 @@ namespace PitHero.Services
 
             _isGrantingCrystal = false;
             Debug.Log("[HeroPromotionService] *** HERO CRYSTAL CEREMONY COMPLETE ***");
+        }
+
+        /// <summary>
+        /// Manual-job-change extras run right after the new Hero is constructed: the outgoing
+        /// crystal returns to the crystal inventory (crystals only go to the Second Chance Shop
+        /// on death — the vault is just the never-lose-it fallback for a full inventory), the
+        /// hero keeps their equipment, and the pit resets for the new cycle.
+        /// </summary>
+        private void FinishManualJobChange(HeroComponent heroComponent, RolePlayingFramework.Heroes.Hero oldHero)
+        {
+            var secondChanceVault = Core.Services.GetService<SecondChanceMerchantVault>();
+
+            var oldCrystal = oldHero.BoundCrystal;
+            if (oldCrystal != null)
+            {
+                var crystalService = Core.Services.GetService<CrystalCollectionService>();
+                bool inInventory = HeroJobChangeHelper.ReturnCrystalToInventory(oldCrystal, crystalService, secondChanceVault);
+                Debug.Log(inInventory
+                    ? $"[HeroPromotionService] Returned {oldCrystal.Name} to crystal inventory after manual job change"
+                    : $"[HeroPromotionService] Crystal inventory full — {oldCrystal.Name} sent to Second Chance vault instead");
+            }
+
+            // The hero didn't die: carry the six equipment slots onto the new job's hero
+            // (unequippable items fall back to bag, then vault). The bag itself lives on the
+            // component and survives untouched.
+            HeroJobChangeHelper.TransferEquipment(oldHero, heroComponent.LinkedHero, heroComponent.Bag, secondChanceVault);
+
+            heroComponent.PendingManualJobChange = false;
+
+            // New job, new cycle: shrink the pit back to level 1 (waits for any mercenaries
+            // still inside; the party followed the hero out, so this is normally immediate)
+            (_scene as MainGameScene)?.StartPitResetForNewCycle();
         }
 
         /// <summary>

--- a/PitHero/UI/ConfirmationDialog.cs
+++ b/PitHero/UI/ConfirmationDialog.cs
@@ -78,7 +78,7 @@ namespace PitHero.UI
                 onYes?.Invoke();
                 Remove();
             };
-            buttonTable.Add(yesButton).Width(80).SetPadRight(10);
+            buttonTable.Add(yesButton).Width(80).SetMinHeight(GameConfig.DialogButtonMinHeight).SetPadRight(10);
 
             var noButton = new TextButton(textService.DisplayText(TextType.UI, UITextKey.ButtonNo), skin, "ph-default");
             noButton.ClickSoundCategory = ButtonClickCategory.Cancel;
@@ -87,7 +87,7 @@ namespace PitHero.UI
                 onNo?.Invoke();
                 Remove();
             };
-            buttonTable.Add(noButton).Width(80);
+            buttonTable.Add(noButton).Width(80).SetMinHeight(GameConfig.DialogButtonMinHeight);
 
             YesButton = yesButton;
             NoButton = noButton;

--- a/PitHero/UI/CrystalCreationDialog.cs
+++ b/PitHero/UI/CrystalCreationDialog.cs
@@ -35,9 +35,58 @@ namespace PitHero.UI
         private TextService _textService;
         private Skin _skin;
         private Stage _stage;
+        private TextButton _createBtn;
+        private int _lastFundsSeen = -1;
 
         public event Action<HeroCrystal> OnCrystalCreated;
         public event Action OnClosed;
+
+        // Shown dialogs, tracked so HeroUI's polled outside-click dismissal and Escape handling can
+        // defer to an open creation dialog (same pattern as ConfirmationDialog). Self-pruning.
+        private static readonly List<CrystalCreationDialog> _shown = new List<CrystalCreationDialog>();
+
+        /// <summary>True while any creation dialog is on a stage and visible.</summary>
+        public static bool AnyVisible
+        {
+            get
+            {
+                Prune();
+                return _shown.Count > 0;
+            }
+        }
+
+        /// <summary>Frame on which a creation dialog last closed. Lets same-frame outside-click
+        /// polling ignore the click that dismissed the dialog.</summary>
+        public static uint LastCloseFrame { get; private set; }
+
+        /// <summary>Closes the most recently shown visible dialog. Returns true if one was closed
+        /// (used by Escape handling to peel the dialog before the hero window).</summary>
+        public static bool TryCloseTopMost()
+        {
+            Prune();
+            if (_shown.Count == 0) return false;
+            _shown[_shown.Count - 1].Close();
+            return true;
+        }
+
+        private static void Prune()
+        {
+            for (int i = _shown.Count - 1; i >= 0; i--)
+            {
+                var d = _shown[i];
+                if (d.GetParent() == null || !d.IsVisible())
+                    _shown.RemoveAt(i);
+            }
+        }
+
+        /// <summary>Single close path: stamps LastCloseFrame, fires OnClosed and removes the dialog.</summary>
+        public void Close()
+        {
+            LastCloseFrame = Time.FrameCount;
+            _shown.Remove(this);
+            OnClosed?.Invoke();
+            Remove();
+        }
 
         public CrystalCreationDialog(Skin skin, Stage stage, CrystalCollectionService crystalService) : base("", skin)
         {
@@ -59,6 +108,17 @@ namespace PitHero.UI
 
             var titleText = GetText(UITextKey.CrystalCreationTitle);
             leftTable.Add(new Label(titleText, skin, "ph-default")).Left().Pad(4);
+            leftTable.Row();
+
+            // Fee line, gold-colored like MercenaryHireDialog's cost label
+            var defaultLabelStyle = skin.Get<LabelStyle>("ph-default");
+            var feeLabelStyle = new LabelStyle
+            {
+                Font = defaultLabelStyle.Font,
+                FontColor = new Color(184, 138, 13)
+            };
+            var feeLabel = new Label(string.Format(GetText(UITextKey.CrystalCreationFeeLabel), GameConfig.CrystalCreationFee), feeLabelStyle);
+            leftTable.Add(feeLabel).Left().Pad(0, 4, 4, 4);
             leftTable.Row();
 
             // < JobName > row
@@ -86,16 +146,31 @@ namespace PitHero.UI
             leftTable.Add(selectorRow).Left().Pad(6);
             leftTable.Row();
 
-            // Create / Cancel buttons
-            var createBtn = new TextButton(GetText(UITextKey.CrystalCreationCreateButton), skin, "ph-default");
-            createBtn.OnClicked += OnCreateClicked;
+            // Create / Cancel buttons. Create gets a cloned style so it has a disabled
+            // visual when the player can't afford the fee (shared styles must never be mutated).
+            var baseButtonStyle = skin.Get<TextButtonStyle>("ph-default");
+            var createButtonStyle = new TextButtonStyle
+            {
+                Up = baseButtonStyle.Up,
+                Down = baseButtonStyle.Down,
+                Over = baseButtonStyle.Over,
+                FontColor = baseButtonStyle.FontColor,
+                DownFontColor = baseButtonStyle.DownFontColor,
+                OverFontColor = baseButtonStyle.OverFontColor,
+                DisabledFontColor = Color.Gray,
+                PressedOffsetX = baseButtonStyle.PressedOffsetX,
+                PressedOffsetY = baseButtonStyle.PressedOffsetY
+            };
+            _createBtn = new TextButton(GetText(UITextKey.CrystalCreationCreateButton), createButtonStyle);
+            _createBtn.OnClicked += OnCreateClicked;
             var cancelBtn = new TextButton(GetText(UITextKey.ButtonCancel), skin, "ph-default");
-            cancelBtn.OnClicked += _ => { OnClosed?.Invoke(); Remove(); };
+            cancelBtn.OnClicked += _ => Close();
 
             var btnRow = new Table();
-            btnRow.Add(createBtn).Height(24).Pad(4);
+            btnRow.Add(_createBtn).Height(24).Pad(4);
             btnRow.Add(cancelBtn).Height(24).Pad(4);
             leftTable.Add(btnRow).Left();
+            UpdateCreateAffordability();
 
             // ── Right panel: job info ──────────────────────────────────────────
             _jobInfoTable = new Table();
@@ -117,11 +192,32 @@ namespace PitHero.UI
 
             _skillTooltip = new SkillTooltip(this, skin);
             RefreshJobInfo();
+
+            // Track for HeroUI's outside-click/Escape deferral. The dialog is added to the stage
+            // synchronously right after construction, so pruning never sees a pre-stage gap.
+            _shown.Add(this);
         }
 
         // ── Helpers ───────────────────────────────────────────────────────────────
 
         private string GetText(string key) => _textService?.DisplayText(TextType.UI, key) ?? key;
+
+        /// <summary>Disables the Create button while the player can't cover the creation fee.
+        /// Re-evaluated from Draw whenever funds change (the game keeps running behind the dialog).</summary>
+        private void UpdateCreateAffordability()
+        {
+            var funds = Core.Services?.GetService<GameStateService>()?.Funds ?? 0;
+            _lastFundsSeen = funds;
+            _createBtn.SetDisabled(funds < GameConfig.CrystalCreationFee);
+        }
+
+        public override void Draw(Batcher batcher, float parentAlpha)
+        {
+            var funds = Core.Services?.GetService<GameStateService>()?.Funds ?? 0;
+            if (funds != _lastFundsSeen)
+                UpdateCreateAffordability();
+            base.Draw(batcher, parentAlpha);
+        }
 
         /// <summary>Repopulates the job info panel with the currently selected job's data.</summary>
         private void RefreshJobInfo()
@@ -214,9 +310,16 @@ namespace PitHero.UI
 
         private void OnCreateClicked(Button btn)
         {
+            if (_createBtn.GetDisabled())
+                return;
+
             // Lazy-fetch service in case it wasn't available at construction time.
             if (_crystalService == null)
                 _crystalService = Core.Services?.GetService<CrystalCollectionService>();
+
+            var gameState = Core.Services?.GetService<GameStateService>();
+            if (gameState == null || gameState.Funds < GameConfig.CrystalCreationFee)
+                return;
 
             var job  = Jobs[_currentJobIndex];
             var stats = new StatBlock(
@@ -228,9 +331,10 @@ namespace PitHero.UI
             var crystal = new HeroCrystal(JobNames[_currentJobIndex], job, 1, stats);
             if (_crystalService != null && _crystalService.TryAddToInventory(crystal))
             {
+                // Deduct only after the crystal actually landed in the inventory
+                gameState.Funds -= GameConfig.CrystalCreationFee;
                 OnCrystalCreated?.Invoke(crystal);
-                OnClosed?.Invoke();
-                Remove();
+                Close();
             }
         }
 

--- a/PitHero/UI/CrystalsTab.cs
+++ b/PitHero/UI/CrystalsTab.cs
@@ -24,6 +24,9 @@ namespace PitHero.UI
         private CrystalSlotElement _forgeInputB;
         private CrystalSlotElement _forgeOutput;
         private TextButton _forgeButton;
+        private Label _forgeFeeLabel;
+        private int _currentForgeFee;
+        private int _lastFundsSeen = -1;
         private CrystalSlotElement[] _inventorySlots;
         private CrystalSlotElement[] _queueSlots;
         private HoverableTextButton _createButton;
@@ -109,10 +112,36 @@ namespace PitHero.UI
             forgeRow.Add(new Label("=", skin, "ph-default")).Pad(2);
             forgeRow.Add(_forgeOutput).Size(SLOT_SIZE).Pad(2);
 
-            _forgeButton = new TextButton(GetText(UITextKey.CrystalForgeButton), skin, "ph-default");
+            // Forge button uses a cloned style so it has a disabled visual (shared styles must
+            // never be mutated; plain ph-default renders identically when disabled).
+            var baseButtonStyle = skin.Get<TextButtonStyle>("ph-default");
+            var forgeButtonStyle = new TextButtonStyle
+            {
+                Up = baseButtonStyle.Up,
+                Down = baseButtonStyle.Down,
+                Over = baseButtonStyle.Over,
+                FontColor = baseButtonStyle.FontColor,
+                DownFontColor = baseButtonStyle.DownFontColor,
+                OverFontColor = baseButtonStyle.OverFontColor,
+                DisabledFontColor = Color.Gray,
+                PressedOffsetX = baseButtonStyle.PressedOffsetX,
+                PressedOffsetY = baseButtonStyle.PressedOffsetY
+            };
+            _forgeButton = new TextButton(GetText(UITextKey.CrystalForgeButton), forgeButtonStyle);
             _forgeButton.OnClicked += OnForgeClicked;
             _forgeButton.SetDisabled(true);
             forgeRow.Add(_forgeButton).Height(24).Pad(4);
+
+            // Fee label appears only while both forge slots are filled
+            var defaultLabelStyle = skin.Get<LabelStyle>("ph-default");
+            var feeLabelStyle = new LabelStyle
+            {
+                Font = defaultLabelStyle.Font,
+                FontColor = new Color(184, 138, 13)
+            };
+            _forgeFeeLabel = new Label("", feeLabelStyle);
+            _forgeFeeLabel.SetVisible(false);
+            forgeRow.Add(_forgeFeeLabel).Pad(4);
 
             forgeSection.Add(forgeRow).Left().Pad(2);
 
@@ -207,9 +236,21 @@ namespace PitHero.UI
             _forgeInputA.SetCrystal(svc.ForgeSlotA);
             _forgeInputB.SetCrystal(svc.ForgeSlotB);
 
-            // Update forge button enabled state
-            bool canForge = svc.ForgeSlotA != null && svc.ForgeSlotB != null;
-            _forgeButton.SetDisabled(!canForge);
+            // Update forge fee + button enabled state (fee recomputed only here, not per frame)
+            bool bothFilled = svc.ForgeSlotA != null && svc.ForgeSlotB != null;
+            _currentForgeFee = bothFilled ? CrystalFeeCalculator.GetForgeFee(svc.ForgeSlotA, svc.ForgeSlotB) : 0;
+            if (bothFilled)
+                _forgeFeeLabel.SetText(string.Format(GetText(UITextKey.CrystalForgeFeeLabel), _currentForgeFee));
+            _forgeFeeLabel.SetVisible(bothFilled);
+            UpdateForgeAffordability(bothFilled);
+        }
+
+        /// <summary>Applies the forge button disabled state from slot fill + current funds.</summary>
+        private void UpdateForgeAffordability(bool bothFilled)
+        {
+            var funds = Core.Services?.GetService<GameStateService>()?.Funds ?? 0;
+            _lastFundsSeen = funds;
+            _forgeButton.SetDisabled(!bothFilled || funds < _currentForgeFee);
         }
 
         // ── Hover tooltip ────────────────────────────────────────────────────────
@@ -386,6 +427,14 @@ namespace PitHero.UI
 
             DismissCrystalCardOnOutsideClick();
 
+            // Keep the forge button's affordability honest while gold changes behind the UI
+            var currentFunds = Core.Services?.GetService<GameStateService>()?.Funds ?? 0;
+            if (currentFunds != _lastFundsSeen)
+            {
+                var svc = GetCrystalService();
+                UpdateForgeAffordability(svc?.ForgeSlotA != null && svc?.ForgeSlotB != null);
+            }
+
             _hoverCheckFrame++;
             if (_hoverCheckFrame % 5 != 0) return;
 
@@ -459,16 +508,28 @@ namespace PitHero.UI
 
         private void OnForgeClicked(Button b)
         {
+            if (_forgeButton.GetDisabled())
+                return;
+
             var svc = GetCrystalService();
-            if (svc != null)
+            if (svc == null)
+                return;
+
+            // Re-check funds and a free inventory slot before forging so neither the fee nor
+            // the forged crystal can be lost to a race (gold spent elsewhere, inventory filled).
+            var gameState = Core.Services?.GetService<GameStateService>();
+            if (gameState == null || gameState.Funds < _currentForgeFee)
+                return;
+            if (svc.InventoryCount >= svc.InventoryCapacity)
+                return;
+
+            var result = svc.TryForge("Combo Crystal");
+            if (result != null)
             {
-                var result = svc.TryForge("Combo Crystal");
-                if (result != null)
-                {
-                    svc.TryAddToInventory(result);
-                    RefreshAll();
-                    HideCrystalCard();
-                }
+                svc.TryAddToInventory(result);
+                gameState.Funds -= _currentForgeFee;
+                RefreshAll();
+                HideCrystalCard();
             }
         }
 
@@ -479,13 +540,15 @@ namespace PitHero.UI
             dialog.OnCrystalCreated += c => RefreshAll();
 
             // Add a full-screen dismiss layer behind the dialog so clicking outside closes it.
+            // Close via dialog.Close() so LastCloseFrame is stamped and HeroUI's outside-click
+            // poll ignores this same click.
             Element dismissLayer = null;
             dismissLayer = new DismissLayer(() =>
             {
                 dismissLayer?.SetVisible(false);
                 dismissLayer?.Remove();
                 dismissLayer = null;
-                dialog.Remove();
+                dialog.Close();
             });
             dismissLayer.SetSize(_stage.GetWidth(), _stage.GetHeight());
 

--- a/PitHero/UI/HeroCrystalTab.cs
+++ b/PitHero/UI/HeroCrystalTab.cs
@@ -47,6 +47,8 @@ namespace PitHero.UI
         private SkillTooltip _skillTooltip;
         private Stage _stage;
         private TextService _textService;
+        private Skin _skin;
+        private HoverableTextButton _changeJobButton;
 
         public HeroCrystalTab()
         {
@@ -58,6 +60,7 @@ namespace PitHero.UI
         public Table CreateContent(Skin skin, Stage stage)
         {
             _stage = stage;
+            _skin = skin;
             _mainContainer = new Table();
             _mainContainer.SetFillParent(false);
 
@@ -121,6 +124,16 @@ namespace PitHero.UI
 
             _jobLevelLabel = new Label(GetText(TextType.UI, UITextKey.HeroJobLevelLabel), skin, "ph-default");
             leftCol.Add(_jobLevelLabel).Left();
+            leftCol.Row();
+
+            _changeJobButton = new HoverableTextButton(GetText(TextType.UI, UITextKey.ButtonChangeJob), skin, "ph-default",
+                GetText(TextType.UI, UITextKey.ButtonChangeJobTooltip), _stage);
+            _changeJobButton.OnClicked += _ =>
+            {
+                _changeJobButton.HideTooltip();
+                JobChangeFlow.ShowChangeJobDialog(_stage, _skin);
+            };
+            leftCol.Add(_changeJobButton).Height(24).Left().SetPadTop(6f);
 
             // Middle column: Hero sprite preview
             _heroPreviewContainer = new Table();
@@ -209,6 +222,9 @@ namespace PitHero.UI
 
             var stats = hero.GetTotalStats();
             _statsLabel.SetText(string.Format(GetText(TextType.UI, UITextKey.HeroStatsLabel), stats.Strength, stats.Agility, stats.Vitality, stats.Magic));
+
+            // Hidden while a job change/respawn ceremony is already in flight
+            _changeJobButton?.SetVisible(!_heroComponent.NeedsCrystal);
 
             // Rebuild skill grid
             RebuildSkillGrid(hero);
@@ -608,6 +624,7 @@ namespace PitHero.UI
 
         private void ClearDisplay()
         {
+            _changeJobButton?.SetVisible(false);
             _jobNameLabel?.SetText("Job: Unknown");
             _levelLabel?.SetText("Level: 1");
             _jobLevelLabel?.SetText("Job Level: 1");

--- a/PitHero/UI/HeroUI.cs
+++ b/PitHero/UI/HeroUI.cs
@@ -1162,6 +1162,7 @@ namespace PitHero.UI
             if (escPressed)
             {
                 if (ConfirmationDialog.TryCancelTopMost()) return;
+                if (CrystalCreationDialog.TryCloseTopMost()) return;
                 if (_stencilLibraryPanel != null && _stencilLibraryPanel.IsVisible()) { _stencilLibraryPanel.SetVisible(false); return; }
                 var crystalCard = _crystalsTabComponent?.CrystalCardElement;
                 if (crystalCard != null && crystalCard.IsVisible()) { _crystalsTabComponent.Cleanup(); return; }
@@ -1171,6 +1172,9 @@ namespace PitHero.UI
             }
 
             if (ConfirmationDialog.AnyVisible) return;
+            // A stage-centered creation dialog sits outside the window envelope; defer while it's
+            // open and skip the click that closed it (its dismiss layer consumed that click).
+            if (CrystalCreationDialog.AnyVisible || CrystalCreationDialog.LastCloseFrame == Time.FrameCount) return;
             // Clicks on the window's own top-bar button are the toggle handler's job, not ours
             if (OutsideClickDismissal.IsMouseInside(_heroButton, _stage)) return;
             if (OutsideClickDismissal.ShouldDismiss(GetWindowBoundsElements(), _stage, _windowShownFrame))

--- a/PitHero/UI/JobChangeFlow.cs
+++ b/PitHero/UI/JobChangeFlow.cs
@@ -52,9 +52,11 @@ namespace PitHero.UI
         }
 
         /// <summary>
-        /// Kicks off the manual job change: clears Stop mode so the statue goal isn't shadowed,
-        /// sets the ceremony flags (the state machine replans off the NeedsCrystal flip), and
-        /// disables saving for the duration of the transition, mirroring the respawn path.
+        /// Kicks off the manual job change: clears Stop mode so the statue goal isn't shadowed
+        /// and sets the ceremony flags (the state machine replans off the NeedsCrystal flip).
+        /// Saving stays enabled — unlike the respawn path the hero keeps its job and crystal
+        /// until the ceremony grants, and neither flag is persisted, so a save/load during the
+        /// walk simply forgets the request.
         /// </summary>
         public static void BeginManualJobChange()
         {
@@ -70,19 +72,14 @@ namespace PitHero.UI
             }
 
             var heroComponent = Core.Scene.FindEntity("hero").GetComponent<HeroComponent>();
-            var settingsUI = Core.Services.GetService<SettingsUI>();
 
             // StoppedAdventure is a higher-priority goal than NeedsCrystal; resume adventuring
             // first so the planner actually targets the statue
             if (heroComponent.StoppedAdventure)
-                settingsUI?.StopAdventuringUI?.SetStopped(false);
+                Core.Services.GetService<SettingsUI>()?.StopAdventuringUI?.SetStopped(false);
 
             heroComponent.PendingManualJobChange = true;
             heroComponent.NeedsCrystal = true;
-
-            // Same transitional-state protection as RespawnHero; re-enabled when the ceremony
-            // completes (or aborts because the queue emptied during the walk)
-            settingsUI?.SetSaveEnabled(false);
 
             Debug.Log("[JobChangeFlow] Manual job change requested - hero heading to statue");
         }

--- a/PitHero/UI/JobChangeFlow.cs
+++ b/PitHero/UI/JobChangeFlow.cs
@@ -1,0 +1,90 @@
+using Nez;
+using Nez.UI;
+using PitHero.ECS.Components;
+using PitHero.Services;
+
+namespace PitHero.UI
+{
+    /// <summary>
+    /// Shared entry point for the manual job change flow (issue #379). Used by both the Hero
+    /// Statue world click and the Hero Info tab's Change Job button: confirms with the player,
+    /// then flags the hero so GOAP routes it to the statue for the crystal ceremony.
+    /// </summary>
+    public static class JobChangeFlow
+    {
+        /// <summary>True while a job change may be requested: a living hero with a crystal and
+        /// no ceremony already in flight (covers both respawn and a pending manual change).</summary>
+        public static bool CanRequestJobChange()
+        {
+            var heroComponent = Core.Scene?.FindEntity("hero")?.GetComponent<HeroComponent>();
+            return heroComponent != null
+                && heroComponent.LinkedHero != null
+                && !heroComponent.NeedsCrystal;
+        }
+
+        /// <summary>
+        /// Shows the job change confirmation, or the "no crystal lined up" notice when the queue
+        /// is empty. Safe to call from any click handler.
+        /// </summary>
+        public static void ShowChangeJobDialog(Stage stage, Skin skin)
+        {
+            if (stage == null || !CanRequestJobChange())
+                return;
+
+            var textService = Core.Services.GetService<TextService>();
+            string GetText(string key) => textService?.DisplayText(TextType.UI, key) ?? key;
+
+            var crystalService = Core.Services.GetService<CrystalCollectionService>();
+            if (crystalService?.PeekQueue() == null)
+            {
+                var notice = new MessageDialog(GetText(UITextKey.DialogChangeJobTitle),
+                    GetText(UITextKey.DialogNoCrystalQueued), skin);
+                notice.OkButton.SuppressGlobalClick = true;
+                notice.Show(stage);
+                return;
+            }
+
+            var dialog = new ConfirmationDialog(GetText(UITextKey.DialogChangeJobTitle),
+                GetText(UITextKey.DialogChangeJobPrompt), skin,
+                onYes: BeginManualJobChange);
+            dialog.YesButton.SuppressGlobalClick = true;
+            dialog.Show(stage);
+        }
+
+        /// <summary>
+        /// Kicks off the manual job change: clears Stop mode so the statue goal isn't shadowed,
+        /// sets the ceremony flags (the state machine replans off the NeedsCrystal flip), and
+        /// disables saving for the duration of the transition, mirroring the respawn path.
+        /// </summary>
+        public static void BeginManualJobChange()
+        {
+            if (!CanRequestJobChange())
+                return;
+
+            // Queue may have been emptied while the confirmation sat open
+            var crystalService = Core.Services.GetService<CrystalCollectionService>();
+            if (crystalService?.PeekQueue() == null)
+            {
+                Debug.Log("[JobChangeFlow] Crystal queue emptied before confirmation - job change not started");
+                return;
+            }
+
+            var heroComponent = Core.Scene.FindEntity("hero").GetComponent<HeroComponent>();
+            var settingsUI = Core.Services.GetService<SettingsUI>();
+
+            // StoppedAdventure is a higher-priority goal than NeedsCrystal; resume adventuring
+            // first so the planner actually targets the statue
+            if (heroComponent.StoppedAdventure)
+                settingsUI?.StopAdventuringUI?.SetStopped(false);
+
+            heroComponent.PendingManualJobChange = true;
+            heroComponent.NeedsCrystal = true;
+
+            // Same transitional-state protection as RespawnHero; re-enabled when the ceremony
+            // completes (or aborts because the queue emptied during the walk)
+            settingsUI?.SetSaveEnabled(false);
+
+            Debug.Log("[JobChangeFlow] Manual job change requested - hero heading to statue");
+        }
+    }
+}

--- a/PitHero/UI/JobChangeFlow.cs
+++ b/PitHero/UI/JobChangeFlow.cs
@@ -52,8 +52,10 @@ namespace PitHero.UI
         }
 
         /// <summary>
-        /// Kicks off the manual job change: clears Stop mode so the statue goal isn't shadowed
-        /// and sets the ceremony flags (the state machine replans off the NeedsCrystal flip).
+        /// Kicks off the manual job change by setting the ceremony flags (the state machine
+        /// replans off the NeedsCrystal flip, and that goal outranks StoppedAdventure). Stop
+        /// mode is deliberately left intact: the ceremony preempts it, and afterwards the
+        /// still-stopped party returns to the tavern table on its own.
         /// Saving stays enabled — unlike the respawn path the hero keeps its job and crystal
         /// until the ceremony grants, and neither flag is persisted, so a save/load during the
         /// walk simply forgets the request.
@@ -73,10 +75,11 @@ namespace PitHero.UI
 
             var heroComponent = Core.Scene.FindEntity("hero").GetComponent<HeroComponent>();
 
-            // StoppedAdventure is a higher-priority goal than NeedsCrystal; resume adventuring
-            // first so the planner actually targets the statue
-            if (heroComponent.StoppedAdventure)
-                Core.Services.GetService<SettingsUI>()?.StopAdventuringUI?.SetStopped(false);
+            // Stand up if seated: with the flag left true the post-ceremony return-to-table
+            // goal would already read as satisfied (hero idles at the statue forever), and the
+            // kitchen would keep serving an absent hero. Mercenaries stay at their seats and
+            // are re-seated when the hero walks back after the ceremony.
+            heroComponent.SeatedInTavern = false;
 
             heroComponent.PendingManualJobChange = true;
             heroComponent.NeedsCrystal = true;

--- a/PitHero/UI/MessageDialog.cs
+++ b/PitHero/UI/MessageDialog.cs
@@ -7,6 +7,8 @@ namespace PitHero.UI
     /// <summary>Simple message dialog with a single OK button.</summary>
     public class MessageDialog : Window
     {
+        public TextButton OkButton { get; }
+
         public MessageDialog(string title, string message, Skin skin, System.Action onOk = null) : base(title, skin)
         {
             var textService = Core.Services.GetService<TextService>();
@@ -30,6 +32,7 @@ namespace PitHero.UI
                 Remove();
             };
             dialogTable.Add(okButton).Width(80);
+            OkButton = okButton;
 
             Add(dialogTable).Expand().Fill();
         }

--- a/PitHero/UI/MessageDialog.cs
+++ b/PitHero/UI/MessageDialog.cs
@@ -31,7 +31,7 @@ namespace PitHero.UI
                 onOk?.Invoke();
                 Remove();
             };
-            dialogTable.Add(okButton).Width(80);
+            dialogTable.Add(okButton).Width(80).SetMinHeight(GameConfig.DialogButtonMinHeight);
             OkButton = okButton;
 
             Add(dialogTable).Expand().Fill();

--- a/PitHero/UI/ShortcutBar.cs
+++ b/PitHero/UI/ShortcutBar.cs
@@ -234,6 +234,32 @@ namespace PitHero.UI
             return _shortcutSlots[shortcutIndex]?.ReferencedSlot;
         }
 
+        /// <summary>
+        /// Clears every hero-owned skill shortcut. Called when the hero changes jobs (death
+        /// respawn or manual change) — the new job may not know the old job's skills. Mercenary
+        /// skill shortcuts and item shortcuts are untouched.
+        /// </summary>
+        public void ClearHeroSkillShortcuts()
+        {
+            bool clearedAny = false;
+            for (int i = 0; i < SHORTCUT_COUNT; i++)
+            {
+                var slot = _shortcutSlots[i];
+                if (slot != null && slot.SlotType == ShortcutSlotType.Skill && slot.OwnerMercenary == null)
+                {
+                    slot.Clear();
+                    _referencedItems[i] = null;
+                    clearedAny = true;
+                }
+            }
+
+            if (clearedAny)
+            {
+                Debug.Log("[ShortcutBar] Cleared hero skill shortcuts after job change");
+                RefreshVisualSlots();
+            }
+        }
+
         /// <summary>Clears the reference at the specified shortcut index.</summary>
         public void ClearShortcutReference(int shortcutIndex)
         {

--- a/PitHero/UI/StopAdventuringUI.cs
+++ b/PitHero/UI/StopAdventuringUI.cs
@@ -299,21 +299,19 @@ namespace PitHero.UI
         }
 
         /// <summary>
-        /// Applies button visibility based on whether the hero promotion is in progress.
-        /// Also sets _styleChanged so SettingsUI triggers a layout reflow (GetWidth/GetHeight return 0 while hidden).
+        /// The button is visible only when no hide state (promotion, sleep) wants it hidden.
+        /// Hide states MUST combine here rather than call SetVisible directly — clearing one
+        /// state while the other is still active previously re-showed the button while
+        /// GetWidth() still reported 0, overlapping it with the Fast Forward button (issue #335
+        /// lesson, applied to visibility). Also sets _styleChanged so SettingsUI reflows.
         /// </summary>
-        private void ApplyPromotionVisibility(bool hidden)
+        private void ApplyEffectiveVisibility()
         {
-            _button.SetVisible(!hidden);
+            if (_button == null)
+                return;
+            _button.SetVisible(!_isHiddenForPromotion && !_isHiddenForSleep);
             ApplyEffectiveTouchable();
             _styleChanged = true; // Triggers SettingsUI layout reflow via ConsumeStyleChangedFlag
-        }
-
-        private void ApplySleepVisibility(bool hidden)
-        {
-            _button.SetVisible(!hidden);
-            ApplyEffectiveTouchable();
-            _styleChanged = true;
         }
 
         private void UpdateSleepVisibilityIfNeeded()
@@ -328,7 +326,7 @@ namespace PitHero.UI
                 return;
 
             _isHiddenForSleep = shouldHide;
-            ApplySleepVisibility(shouldHide);
+            ApplyEffectiveVisibility();
         }
 
         /// <summary>
@@ -349,7 +347,7 @@ namespace PitHero.UI
                 return;
 
             _isHiddenForPromotion = shouldHide;
-            ApplyPromotionVisibility(shouldHide);
+            ApplyEffectiveVisibility();
         }
 
         /// <summary>

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -266,6 +266,13 @@ namespace PitHero
         public const string DialogConfirmForge = "DialogConfirmForge";
         public const string ConfirmForgeMessage = "ConfirmForgeMessage";
         public const string CrystalInventoryFull = "CrystalInventoryFull";
+        public const string CrystalCreationFeeLabel = "CrystalCreationFeeLabel";
+        public const string CrystalForgeFeeLabel = "CrystalForgeFeeLabel";
+        public const string DialogChangeJobTitle = "DialogChangeJobTitle";
+        public const string DialogChangeJobPrompt = "DialogChangeJobPrompt";
+        public const string DialogNoCrystalQueued = "DialogNoCrystalQueued";
+        public const string ButtonChangeJob = "ButtonChangeJob";
+        public const string ButtonChangeJobTooltip = "ButtonChangeJobTooltip";
         public const string DialogConfirmDismissMercenary = "DialogConfirmDismissMercenary";
         public const string ConfirmDismissMercenaryMessage = "ConfirmDismissMercenaryMessage";
         public const string WindowSecondChanceShop = "WindowSecondChanceShop";


### PR DESCRIPTION
Closes #379

## Manual job change
- Clicking the Hero Statue (hover outline + distance click, mirroring the mercenary/building pattern) or the new **Change Job** button in the Hero Info tab opens "Change Job to next Crystal? Resets Hero and Pit level to 1." — or an OK-only "No crystal lined up. Please set a crystal" notice when the queue is empty.
- On Yes, the hero jumps out of the pit if inside (new `JumpOutOfPitForJobChangeAction` chains into `WalkToStatueForCrystalAction` via a new `OutsidePit` precondition), walks to the statue, and the existing crystal ceremony infuses the next queued crystal. Mercenaries follow out via the pit-intent system; the pit resets to level 1 after the ceremony.
- The outgoing crystal returns to the hero's **crystal inventory** (crystals only go to the Second Chance Shop on death); the vault is a never-lose-it fallback for a full inventory. Equipment carries onto the new hero — gear the new job can't equip falls back to bag, then vault. New hero level = max(crystal level, 1) after the tier reset, matching respawn semantics.
- `NeedsCrystal` is now the **top-priority GOAP goal**, above `StoppedAdventure`: a job change requested while the party is stopped (or while the dining service auto-stops for breakfast) goes to the statue first, and the surviving stop state sends the party to the table afterwards on its own.
- The statue walk is now **self-healing**: it repaths on any blocked step and only marks arrival on the actual statue tile. On persistent failure the manual path aborts (hero keeps its job) while the death path keeps its ceremony-in-place softlock guard. Queue-empty aborts exist at dialog-Yes, statue arrival, and mid-ceremony — the manual path never falls back to a random crystal.
- Saving stays enabled during the manual walk: the hero keeps its job/crystal/gear until the synchronous grant, and neither request flag is persisted, so a save/load mid-flow just forgets the request.
- Every job change (death or manual) clears **hero-owned skill shortcuts** (`ShortcutBar.ClearHeroSkillShortcuts`); mercenary skills and item shortcuts survive.

## Crystal fees
- Creating a crystal costs **100G** (`GameConfig.CrystalCreationFee`): "Fee: 100 Gold" under the Create Crystal title, Create button grayed/disabled when unaffordable, fee deducted only after the crystal lands in inventory.
- Forging costs **double the Second Chance Shop purchase price of the combined crystal, with the skill premium uncapped** (`CalculateBuyBackPrice(capPremium: false) × CrystalForgeFeeMultiplier`) — a 16-skill Legend combo always costs more than a lightly-skilled one at any level, and forging never undercuts the shop. "Fee: X Gold" appears next to the Forge button while both source slots are filled, updates on swaps, and disappears with fewer than 2 crystals; Forge is grayed/disabled when slots or gold are short. Shop prices themselves are unchanged (cap stays).
- Price ladder: forge > shop buy-back > sell.

## Bug fixes
- **Create Crystal dialog dismissal**: clicking "&lt;"/"&gt;" (or anywhere in the dialog) no longer closes the hero window — the dialog now tracks visibility like `ConfirmationDialog` and HeroUI's polled outside-click dismissal defers to it; Escape peels the dialog before the window.
- **Play/Fast-Forward overlap**: StopAdventuringUI's sleep-hide and promotion-hide each called `SetVisible` directly and stomped each other; visibility now goes through a single `ApplyEffectiveVisibility` combiner (issue #335 lesson applied to visibility).
- **Speech bubble fast-forward**: the typewriter reveal accumulated per-char `WaitForSeconds` quantized to whole frames; it now accumulates scaled `Time.DeltaTime` and emits multiple characters per frame, so 2.5× fast-forward scrolls 2.5× faster (linger scales too; pause behavior unchanged).

## UI polish
- Dialog Yes/No/OK buttons get a 16px minimum height via new `GameConfig.DialogButtonMinHeight`.

## Tests
17 new tests: fee math (uncapped scaling regression included), equipment transfer (slot → bag → vault), crystal routing (inventory + full-inventory vault fallback), GOAP plan chains (jump→walk, walk-only, goal priority), hero-only shortcut clearing. Full suite: **1896 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)