### PR TITLE
Fixed-height variable-width resolution + hero AI stability fixes

### DIFF
--- a/PitHero.Tests/AttackMonsterActionTests.cs
+++ b/PitHero.Tests/AttackMonsterActionTests.cs
@@ -43,6 +43,34 @@ namespace PitHero.Tests
             Assert.AreEqual(3, action.Cost, "Action should have correct cost");
         }
 
+        /// <summary>An in-flight battle must block plan interrupts (stop, job change, replenish):
+        /// the battle coroutine is uncancellable, and a mid-battle replan flips the hero's
+        /// PitIntent and sends mercenaries out of the pit while the fight continues.</summary>
+        [TestMethod]
+        [TestCategory("GOAP")]
+        public void AttackMonsterAction_ShouldNotOverride_TrueWhileBattleCoroutineRuns()
+        {
+            var action = new AttackMonsterAction();
+
+            Assert.IsFalse(action.ShouldNotOverride(), "No battle in flight: action should be interruptible");
+
+            var field = typeof(AttackMonsterAction).GetField("_battleCoroutine",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            Assert.IsNotNull(field, "AttackMonsterAction should track its battle coroutine in _battleCoroutine");
+            field.SetValue(action, new StubCoroutine());
+
+            Assert.IsTrue(action.ShouldNotOverride(), "Battle coroutine in flight: action must not be overridden");
+
+            field.SetValue(action, null);
+            Assert.IsFalse(action.ShouldNotOverride(), "Battle finished: action should be interruptible again");
+        }
+
+        private sealed class StubCoroutine : Nez.ICoroutine
+        {
+            public void Stop() { }
+            public Nez.ICoroutine SetUseUnscaledDeltaTime(bool useUnscaledDeltaTime) => this;
+        }
+
         // ── BattleEngine.SelectPrimaryTarget helper tests (Fix 3) ─────────────────────
 
         [TestMethod]

--- a/PitHero/AI/AttackMonsterAction.cs
+++ b/PitHero/AI/AttackMonsterAction.cs
@@ -31,6 +31,16 @@ namespace PitHero.AI
             SetPostcondition(GoapConstants.BossDefeated, true);
         }
 
+        /// <summary>The battle coroutine is fire-and-forget and cannot be cancelled — a mid-battle
+        /// replan (stop, manual job change, replenish, heal-priority change) would abandon this
+        /// action while the engine keeps running and flip the hero's PitIntent, sending the
+        /// mercenaries out of the pit mid-fight. Defer all interrupts until the battle resolves;
+        /// they fire on the next tick after completion.</summary>
+        public override bool ShouldNotOverride()
+        {
+            return _battleCoroutine != null;
+        }
+
         public override bool Execute(HeroComponent hero)
         {
             if (_battleCoroutine != null)

--- a/PitHero/AI/HeroStateMachine.cs
+++ b/PitHero/AI/HeroStateMachine.cs
@@ -691,6 +691,7 @@ namespace PitHero.AI
                     return null;
 
                 case GoapConstants.JumpOutOfPitForStopAction:
+                case GoapConstants.JumpOutOfPitForJobChangeAction:
                     _targetLocationType = LocationType.PitInsideEdge;
                     return CalculatePitInsideEdgeLocation();
 

--- a/PitHero/AI/HeroStateMachine.cs
+++ b/PitHero/AI/HeroStateMachine.cs
@@ -59,6 +59,11 @@ namespace PitHero.AI
         // Stuck detection: time spent in GoTo state without making path progress
         private float _goToStuckTimer;
 
+        // Re-entrancy depth for Idle_Enter. CurrentState assignments invoke the new state's
+        // Enter method synchronously, so a persistent plan/path failure would otherwise
+        // recurse Idle_Enter -> GoTo_Enter -> Idle_Enter forever and overflow the stack.
+        private int _idleEnterDepth;
+
         // Battle state tracking
         public static bool IsBattleInProgress { get; set; } = false;
 
@@ -193,6 +198,30 @@ namespace PitHero.AI
         #region State Methods
 
         void Idle_Enter()
+        {
+            // If a plan started from Idle_Enter is still on the stack, this entry came from a
+            // synchronous failure transition (e.g. GoTo_Enter found no path and set Idle).
+            // Planning again here would produce the same plan, fail the same way, and recurse
+            // until the stack overflows. Bail out and let Idle_Tick retry on its 1s throttle,
+            // which also gives world-state (pit triggers etc.) a chance to self-heal.
+            if (_idleEnterDepth > 0)
+            {
+                _actionPlan = null;
+                return;
+            }
+
+            _idleEnterDepth++;
+            try
+            {
+                IdleEnterPlan();
+            }
+            finally
+            {
+                _idleEnterDepth--;
+            }
+        }
+
+        private void IdleEnterPlan()
         {
             // Clear any pending replenish flag since we are about to re-plan
             _hero.ReplenishPending = false;

--- a/PitHero/ECS/Components/CameraControllerComponent.cs
+++ b/PitHero/ECS/Components/CameraControllerComponent.cs
@@ -19,6 +19,8 @@ namespace PitHero.ECS.Components
         private float _currentMaximumZoom = GameConfig.CameraMaximumZoom;
         private const float PixelPerfectZoomStep = 0.125f; // 1/8 increments keeps scaling clean (32 * 0.125 = 4)
 
+        private Point _lastRenderTargetSize; // re-clamps the camera when the render target is resized
+
         private bool _isFollowingHero = true; // camera auto-follows hero by default
         private float _manualControlTimer = 0f; // tracks time since last manual control input
         private float _keyboardPanHeldTime = 0f; // continuous seconds arrow/WASD pan keys have been held
@@ -48,22 +50,33 @@ namespace PitHero.ECS.Components
         public override void OnAddedToEntity()
         {
             _camera = Entity.GetComponent<Camera>() ?? Entity.Scene.Camera;
+            InitializeTileMapBounds();
             if (_camera != null)
             {
                 _camera.SetMinimumZoom(_currentMinimumZoom);
                 _camera.SetMaximumZoom(_currentMaximumZoom);
                 _camera.RawZoom = GameConfig.CameraDefaultZoom;
-                _defaultCameraPosition = new Vector2(GameConfig.VirtualWidth / 2f, GameConfig.VirtualHeight / 2f);
+                _defaultCameraPosition = ConstrainCameraPosition(new Vector2(
+                    _tileMapBounds.X + _tileMapBounds.Width / 2f, GameConfig.VirtualHeight / 2f));
                 _camera.Position = _defaultCameraPosition;
                 QuantizeCameraPosition();
             }
-            InitializeTileMapBounds();
         }
 
         public void Update()
         {
             if (_camera == null)
                 return;
+
+            // Nothing re-clamps after a graphics reset (window shrink/restore, dock, monitor swap),
+            // and Camera.OnSceneRenderTargetSizeChanged can leave the camera out of bounds.
+            var renderTargetSize = GetSceneRenderTargetSize();
+            if (renderTargetSize != _lastRenderTargetSize)
+            {
+                _lastRenderTargetSize = renderTargetSize;
+                _camera.Position = ConstrainCameraPosition(_camera.Position);
+                QuantizeCameraPosition();
+            }
 
             // Only the manual (menu) pause freezes the camera; the farm-mode pause keeps camera
             // controls live so the player can right-mouse pan while planning crops.
@@ -525,10 +538,25 @@ namespace PitHero.ECS.Components
             }
         }
 
+        /// <summary>
+        /// Size of the scene render target in world pixels — the true visible area at 1x zoom.
+        /// Falls back to the design consts if the render target does not exist yet.
+        /// </summary>
+        private Point GetSceneRenderTargetSize()
+        {
+            var scene = Entity?.Scene;
+            if (scene?.SceneRenderTarget != null)
+                return scene.SceneRenderTargetSize;
+            return new Point(GameConfig.VirtualWidth, GameConfig.VirtualHeight);
+        }
+
         private Vector2 ConstrainCameraPosition(Vector2 desiredPosition)
         {
-            var viewportWidth = GameConfig.VirtualWidth / _camera.RawZoom;
-            var viewportHeight = GameConfig.VirtualHeight / _camera.RawZoom;
+            // Under FixedHeight the render target width varies with the window aspect, so the
+            // visible viewport must come from the actual render target, not the design consts.
+            var renderTargetSize = GetSceneRenderTargetSize();
+            var viewportWidth = renderTargetSize.X / _camera.RawZoom;
+            var viewportHeight = renderTargetSize.Y / _camera.RawZoom;
 
             var minX = _tileMapBounds.X + viewportWidth / 2f;
             var maxX = _tileMapBounds.Right - viewportWidth / 2f;

--- a/PitHero/ECS/Scenes/HeroCreationScene.cs
+++ b/PitHero/ECS/Scenes/HeroCreationScene.cs
@@ -23,7 +23,7 @@ namespace PitHero.ECS.Scenes
         {
             base.Initialize();
 
-            SetDesignResolution(GameConfig.VirtualWidth, GameConfig.VirtualHeight, SceneResolutionPolicy.BestFit);
+            SetDesignResolution(GameConfig.VirtualWidth, GameConfig.VirtualHeight, SceneResolutionPolicy.FixedHeight);
             ClearColor = Color.CornflowerBlue;
         }
 
@@ -44,19 +44,21 @@ namespace PitHero.ECS.Scenes
             // Create UI entity with UICanvas
             var uiEntity = CreateEntity("hero-creation-ui");
             var uiCanvas = uiEntity.AddComponent(new UICanvas());
-            uiCanvas.IsFullScreen = true;
+            // Stage in render-target space (like MainGameScene) so layout and mouse input stay
+            // consistent under the FixedHeight policy on any aspect ratio
+            uiCanvas.IsFullScreen = false;
             uiCanvas.RenderLayer = 999;
 
             // Compute preview entity position to appear above the direction buttons in the Appearance window
-            // Window layout: totalWidth = 560 + 10 + 350 = 920, startX = (1920 - 920) / 2 = 500
+            // Window layout: totalWidth = 560 + 10 + 350 = 920, centered on the stage width
             // Controls table is ~290px wide; preview centered above the direction arrows to its right
             const float windowWidth = 560f;
             const float jobInfoWidth = 350f;
             const float gap = 10f;
             float totalWidth = windowWidth + gap + jobInfoWidth;
-            float startX = (GameConfig.VirtualWidth - totalWidth) / 2f;
+            float startX = (uiCanvas.Stage.GetWidth() - totalWidth) / 2f;
             float previewX = startX + windowWidth - 128f;
-            float previewY = GameConfig.VirtualHeight * 0.48f;
+            float previewY = uiCanvas.Stage.GetHeight() * 0.48f;
 
             var previewEntity = CreateEntity("hero-preview");
             previewEntity.SetPosition(previewX, previewY);

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -30,6 +30,9 @@ namespace PitHero.ECS.Scenes
         private CameraControllerComponent _cameraController;
         private TmxMap _tmxMap; // Store reference to the map
         private Entity _pauseOverlayEntity; // Pause overlay entity
+        private PrototypeSpriteRenderer _pauseOverlayRenderer; // resized when the stage size changes
+        private float _lastStageWidth;  // stage-size-change detection for right/center-anchored HUD
+        private float _lastStageHeight;
         private Label _pitLevelLabel; // UI label showing pit level
         private Label _fundsLabel; // UI label showing total funds
         private Label _clockLabel; // UI label showing in-game time
@@ -130,7 +133,9 @@ namespace PitHero.ECS.Scenes
                 SaveLoadService.PendingLoadData != null ? "load" : "new_game",
                 Core.Services.GetService<GameStateService>()?.Funds ?? 0);
 
-            SetDesignResolution(GameConfig.VirtualWidth, GameConfig.VirtualHeight, SceneResolutionPolicy.BestFit);
+            // FixedHeight locks the vertical resolution at VirtualHeight and expands the render
+            // target width to match the window aspect, so ultrawide monitors see more world.
+            SetDesignResolution(GameConfig.VirtualWidth, GameConfig.VirtualHeight, SceneResolutionPolicy.FixedHeight);
             ClearColor = Color.Transparent;
 
             var cameraEntity = CreateEntity("camera-controller");
@@ -1822,13 +1827,16 @@ namespace PitHero.ECS.Scenes
             _pauseOverlayEntity = CreateEntity("pause-overlay");
             _pauseOverlayEntity.SetPosition(0, 0); // Top-left corner
 
-            // Size to backbuffer for ScreenSpaceRenderer and set origin to top-left
+            // Size to the render target (stage space) with margin; resized on stage-size change.
+            // Under FixedHeight the render target can be wider than the backbuffer, so Screen.* is
+            // not a safe stand-in for stage dimensions.
             var pauseOverlay = _pauseOverlayEntity.AddComponent(
-                new PrototypeSpriteRenderer(Screen.Width * 2, Screen.Height * 2)
+                new PrototypeSpriteRenderer(SceneRenderTargetSize.X * 2, SceneRenderTargetSize.Y * 2)
             );
             pauseOverlay.SetOrigin(Vector2.Zero); // or pauseOverlay.SetOriginNormalized(Vector2.Zero);
             pauseOverlay.SetColor(new Color(0, 0, 0, 100));
             pauseOverlay.SetRenderLayer(GameConfig.TransparentPauseOverlay);
+            _pauseOverlayRenderer = pauseOverlay;
             _pauseOverlayEntity.SetEnabled(false); // Initially hidden
 
             var uiEntity = CreateEntity("ui-overlay");
@@ -2054,7 +2062,7 @@ namespace PitHero.ECS.Scenes
             string text = timeService.FormatTime();
             _clockLabel.SetText(text);
             float labelWidth = _hudFontNormal.MeasureString(text).X;
-            _clockLabel.SetPosition(GameConfig.VirtualWidth - labelWidth - ClockLabelRightPadding, ClockLabelBaseY);
+            _clockLabel.SetPosition(_uiStage.GetWidth() - labelWidth - ClockLabelRightPadding, ClockLabelBaseY);
         }
 
         private void UpdateTillingLabel()
@@ -2074,7 +2082,7 @@ namespace PitHero.ECS.Scenes
             // Clock left edge
             string timeText = Core.Services.GetService<InGameTimeService>()?.FormatTime() ?? "6:00 AM";
             float clockWidth = _hudFontNormal.MeasureString(timeText).X;
-            float clockX = GameConfig.VirtualWidth - clockWidth - ClockLabelRightPadding;
+            float clockX = _uiStage.GetWidth() - clockWidth - ClockLabelRightPadding;
 
             // Button bar right edge (exposed by SettingsUI; falls back to 0 before first PositionUI)
             float barRight = _settingsUI?.UIBarRight ?? 0f;
@@ -2099,7 +2107,7 @@ namespace PitHero.ECS.Scenes
             float labelWidth = _hudFontNormal.MeasureString(labelText).X;
             string timeText = Core.Services.GetService<InGameTimeService>()?.FormatTime() ?? "6:00 AM";
             float clockWidth = _hudFontNormal.MeasureString(timeText).X;
-            float clockX = GameConfig.VirtualWidth - clockWidth - ClockLabelRightPadding;
+            float clockX = _uiStage.GetWidth() - clockWidth - ClockLabelRightPadding;
             float barRight = _settingsUI?.UIBarRight ?? 0f;
             float midX = (barRight + clockX) / 2f;
             _plantingCropsLabel.SetPosition(midX - labelWidth / 2f, ClockLabelBaseY);
@@ -2365,12 +2373,13 @@ namespace PitHero.ECS.Scenes
                 float barWidth = 8 * (32f + 1f) * scale;
                 float barHeight = 32f * scale;
 
+                // Stage space, not Screen.* — under FixedHeight the stage width varies per monitor
                 float halfShift = WindowManager.IsHalfHeightMode() ? -64f : 0f;
-                float centerX = Screen.Width / 2f - barWidth / 2f + halfShift;
+                float centerX = _uiStage.GetWidth() / 2f - barWidth / 2f + halfShift;
                 // Add extra padding for shortcut number text below slots (14px for text + 2px offset = 16px total)
                 // Shift up by 16 pixels when in Half mode
                 float yOffset = WindowManager.IsHalfHeightMode() ? -16f : 0f;
-                float bottomY = Screen.Height - barHeight - 16f + yOffset;
+                float bottomY = _uiStage.GetHeight() - barHeight - 16f + yOffset;
 
                 _shortcutBar.SetBasePosition(centerX, bottomY);
 
@@ -2394,16 +2403,17 @@ namespace PitHero.ECS.Scenes
             float scale = halfMode ? 2f : 1f;
             float displayScale = halfMode ? 2f : 1f;
 
+            float stageW = _uiStage.GetWidth();
             float slotSize = 32f;
             float barWidth = 8 * (slotSize + 1f) * scale;
-            float barRightEdge = Screen.Width / 2f + barWidth / 2f;
+            float barRightEdge = stageW / 2f + barWidth / 2f;
             float oneSlotPadding = slotSize * scale;
 
             const float panelH = 120f;
             float visualH = panelH * displayScale;
 
             // Anchor the visual bottom edge 16px above the screen bottom.
-            float panelY = GameConfig.VirtualHeight - 16f - visualH;
+            float panelY = _uiStage.GetHeight() - 16f - visualH;
 
             // Lower bound for panelX so the console never overlaps the shortcut bar.
             float halfShift = halfMode ? -96f : 0f;
@@ -2417,12 +2427,12 @@ namespace PitHero.ECS.Scenes
             if (halfMode)
             {
                 panelX = minPanelX;
-                layoutW = (GameConfig.VirtualWidth - panelX) / displayScale;
+                layoutW = (stageW - panelX) / displayScale;
             }
             else
             {
                 layoutW = 480f;
-                panelX = System.Math.Max(minPanelX, GameConfig.VirtualWidth - layoutW * displayScale);
+                panelX = System.Math.Max(minPanelX, stageW - layoutW * displayScale);
             }
 
             _eventConsolePanel.SetDisplayScale(displayScale);
@@ -2504,6 +2514,27 @@ namespace PitHero.ECS.Scenes
         public override void Update()
         {
             base.Update();
+
+            // Re-anchor stage-space HUD when the render target size changes (window shrink/restore,
+            // dock, monitor swap). Clock/tilling/planting labels already reposition every frame.
+            if (_uiStage != null)
+            {
+                float stageW = _uiStage.GetWidth();
+                float stageH = _uiStage.GetHeight();
+                if (stageW != _lastStageWidth || stageH != _lastStageHeight)
+                {
+                    _lastStageWidth = stageW;
+                    _lastStageHeight = stageH;
+                    PositionShortcutBar();
+                    PositionEventConsolePanel();
+                    if (_pauseOverlayRenderer != null)
+                    {
+                        _pauseOverlayRenderer.SetWidth(stageW * 2f);
+                        _pauseOverlayRenderer.SetHeight(stageH * 2f);
+                    }
+                }
+            }
+
             _settingsUI?.Update();
             // Remove duplicate HeroUI update since SettingsUI handles it
 

--- a/PitHero/ECS/Scenes/TitleScreenScene.cs
+++ b/PitHero/ECS/Scenes/TitleScreenScene.cs
@@ -15,7 +15,7 @@ namespace PitHero.ECS.Scenes
         {
             base.Initialize();
 
-            SetDesignResolution(GameConfig.VirtualWidth, GameConfig.VirtualHeight, SceneResolutionPolicy.BestFit);
+            SetDesignResolution(GameConfig.VirtualWidth, GameConfig.VirtualHeight, SceneResolutionPolicy.FixedHeight);
             ClearColor = Color.CornflowerBlue;
 
             // Set up UI overlay using ScreenSpaceRenderer
@@ -31,7 +31,9 @@ namespace PitHero.ECS.Scenes
             // Create UI entity with UICanvas component for screen-space UI
             var uiEntity = CreateEntity("title-ui");
             var uiCanvas = uiEntity.AddComponent(new UICanvas());
-            uiCanvas.IsFullScreen = true;
+            // Stage in render-target space (like MainGameScene) so layout and mouse input stay
+            // consistent under the FixedHeight policy on any aspect ratio
+            uiCanvas.IsFullScreen = false;
             uiCanvas.RenderLayer = 999; // Render on screen space layer
 
             // Initialize title menu UI

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -9,6 +9,10 @@ namespace PitHero
     public static class GameConfig
     {
         // Screen and Resolution
+        // Scenes use SceneResolutionPolicy.FixedHeight: VirtualHeight is the fixed design height,
+        // while the render-target width grows with the window aspect (ultrawide sees more world).
+        // VirtualWidth is only a reference width (initial backbuffer, minimum-layout reference) —
+        // runtime layout/camera code must use Stage.GetWidth()/Scene.SceneRenderTargetSize instead.
         public const int VirtualWidth = 1920;
         public const int VirtualHeight = 360;
         public const int InternalWorldWidth = 1920;
@@ -444,6 +448,8 @@ namespace PitHero
         public const float UIBarProximityY = 48f;     // Mouse Y <= this (stage coords) triggers proximity-unhide
 
         // Second Chance Shop layout positions
+        // Composed for a 1920-wide stage; SecondChanceShopUI centers the whole composition on
+        // wider stages by shifting all X positions right by (stageWidth - VirtualWidth) / 2.
         // Shop window (vault grid + tabs) positioned near left-center
         public const float SecondChanceShopWindowX = 573f;
         public const float SecondChanceShopWindowY = 12f;

--- a/PitHero/UI/HeroCreationUI.cs
+++ b/PitHero/UI/HeroCreationUI.cs
@@ -24,6 +24,18 @@ namespace PitHero.UI
         private string _mapPath;
         private Skin _skin;
 
+        // Fixed-position windows re-centered when the stage size changes (FixedHeight policy)
+        private Window _controlsWindow;
+        private Window _jobInfoWindow;
+        private float _lastStageWidth;
+        private float _lastStageHeight;
+
+        // Shared layout constants for the Appearance + Job Info window pair
+        private const float AppearanceWindowWidth = 560f;
+        private const float CreationWindowHeight = 340f;
+        private const float CreationWindowGap = 10f;
+        private const float JobInfoWindowWidth = 350f;
+
         // Current selections
         private string _currentName;
         private int _currentJobIndex;
@@ -101,11 +113,12 @@ namespace PitHero.UI
         {
             var windowStyle = skin.Get<WindowStyle>();
             var window = new Window(_textService.DisplayText(TextType.UI, UITextKey.WindowAppearance), windowStyle);
+            _controlsWindow = window;
 
-            const float windowWidth = 560f;
-            const float windowHeight = 340f;
-            const float gap = 10f;
-            const float jobInfoWidth = 350f;
+            const float windowWidth = AppearanceWindowWidth;
+            const float windowHeight = CreationWindowHeight;
+            const float gap = CreationWindowGap;
+            const float jobInfoWidth = JobInfoWindowWidth;
             float totalWidth = windowWidth + gap + jobInfoWidth;
             float startX = (_stage.GetWidth() - totalWidth) / 2f;
 
@@ -414,11 +427,12 @@ namespace PitHero.UI
         {
             var windowStyle = skin.Get<WindowStyle>();
             var jobInfoWindow = new Window("Job Info", windowStyle);
+            _jobInfoWindow = jobInfoWindow;
 
-            const float windowWidth = 560f;
-            const float jobInfoWidth = 350f;
-            const float windowHeight = 340f;
-            const float gap = 10f;
+            const float windowWidth = AppearanceWindowWidth;
+            const float jobInfoWidth = JobInfoWindowWidth;
+            const float windowHeight = CreationWindowHeight;
+            const float gap = CreationWindowGap;
             float totalWidth = windowWidth + gap + jobInfoWidth;
             float startX = (_stage.GetWidth() - totalWidth) / 2f;
 
@@ -573,7 +587,25 @@ namespace PitHero.UI
         /// <summary>Per-frame update for the hero creation UI</summary>
         public void Update()
         {
-            // Handle any per-frame updates if needed
+            // Re-center the window pair and preview when the stage size changes. The stage reports
+            // the backbuffer size until the UICanvas is registered, and under the FixedHeight policy
+            // the render-target width varies per monitor, so init-time layout is not enough.
+            float stageW = _stage.GetWidth();
+            float stageH = _stage.GetHeight();
+            if (stageW != _lastStageWidth || stageH != _lastStageHeight)
+            {
+                _lastStageWidth = stageW;
+                _lastStageHeight = stageH;
+
+                float totalWidth = AppearanceWindowWidth + CreationWindowGap + JobInfoWindowWidth;
+                float startX = (stageW - totalWidth) / 2f;
+                float windowY = (stageH - CreationWindowHeight) / 2f;
+
+                _controlsWindow?.SetPosition(startX, windowY);
+                _jobInfoWindow?.SetPosition(startX + AppearanceWindowWidth + CreationWindowGap, windowY);
+                // Preview sits above the direction buttons on the right side of the Appearance window
+                _previewEntity?.SetPosition(startX + AppearanceWindowWidth - 128f, stageH * 0.48f);
+            }
         }
 
         /// <summary>Skill button for job info display with hover tooltip support</summary>

--- a/PitHero/UI/SecondChanceShopUI.cs
+++ b/PitHero/UI/SecondChanceShopUI.cs
@@ -453,22 +453,26 @@ namespace PitHero.UI
             {
                 UIWindowManager.OnUIWindowOpening();
 
+                // The layout constants compose a full-strip arrangement designed for a 1920-wide
+                // stage; center the intact composition on wider stages (FixedHeight policy).
+                float xOffset = System.Math.Max(0f, (_stage.GetWidth() - GameConfig.VirtualWidth) / 2f);
+
                 // Shop (left panel)
                 _stage.AddElement(_shopWindow);
                 _shopWindow.SetVisible(true);
-                _shopWindow.SetPosition(GameConfig.SecondChanceShopWindowX, GameConfig.SecondChanceShopWindowY);
+                _shopWindow.SetPosition(GameConfig.SecondChanceShopWindowX + xOffset, GameConfig.SecondChanceShopWindowY);
                 _shopWindow.ToFront();
 
                 // Merchant sprite (between panels)
                 _stage.AddElement(_merchantSprite);
-                _merchantSprite.SetPosition(GameConfig.SecondChanceMerchantSpriteX, GameConfig.SecondChanceMerchantSpriteY);
+                _merchantSprite.SetPosition(GameConfig.SecondChanceMerchantSpriteX + xOffset, GameConfig.SecondChanceMerchantSpriteY);
                 _merchantSprite.ToFront();
 
                 // Hero panel (right) — show the one matching the active tab
                 _stage.AddElement(_heroInventoryWindow);
                 _stage.AddElement(_heroCrystalWindow);
-                _heroInventoryWindow.SetPosition(GameConfig.SecondChanceHeroPanelX, GameConfig.SecondChanceHeroPanelY);
-                _heroCrystalWindow.SetPosition(GameConfig.SecondChanceHeroPanelX, GameConfig.SecondChanceHeroPanelY);
+                _heroInventoryWindow.SetPosition(GameConfig.SecondChanceHeroPanelX + xOffset, GameConfig.SecondChanceHeroPanelY);
+                _heroCrystalWindow.SetPosition(GameConfig.SecondChanceHeroPanelX + xOffset, GameConfig.SecondChanceHeroPanelY);
 
                 if (_activeTabIndex == 0)
                 {

--- a/PitHero/UI/TitleMenuUI.cs
+++ b/PitHero/UI/TitleMenuUI.cs
@@ -13,10 +13,13 @@ namespace PitHero.UI
     {
         private Stage _stage;
         private Image _titleLogo;
+        private float _titleSpriteWidth;
         private Table _mainMenuTable;
         private Window _quitConfirmationDialog;
         private SaveLoadUI _saveLoadUI;
         private TextService _textService;
+        private float _lastStageWidth;
+        private float _lastStageHeight;
 
         public void InitializeUI(Stage stage)
         {
@@ -54,10 +57,11 @@ namespace PitHero.UI
             var uiAtlas = Core.Content.LoadSpriteAtlas("Content/Atlases/UI.atlas");
             var titleSprite = uiAtlas.GetSprite("EverpitTitle");
             _titleLogo = new Image(titleSprite);
+            _titleSpriteWidth = titleSprite.SourceRect.Width;
 
             // Center the logo horizontally and position it higher to allow more space for buttons
-            float logoX = (_stage.GetWidth() - titleSprite.SourceRect.Width) / 2f;
-            float logoY = GameConfig.VirtualHeight * 0.30f; // 30% from top (moved higher)
+            float logoX = (_stage.GetWidth() - _titleSpriteWidth) / 2f;
+            float logoY = _stage.GetHeight() * 0.30f; // 30% from top (moved higher)
 
             _titleLogo.SetPosition(logoX, logoY);
             _stage.AddElement(_titleLogo);
@@ -168,7 +172,23 @@ namespace PitHero.UI
 
         public void Update()
         {
-            // Handle any per-frame updates if needed
+            // Re-center fixed-position elements when the stage size changes. The stage reports the
+            // backbuffer size until the UICanvas is registered, and under the FixedHeight policy the
+            // render-target width varies per monitor, so a single layout pass at init is not enough.
+            float stageW = _stage.GetWidth();
+            float stageH = _stage.GetHeight();
+            if (stageW != _lastStageWidth || stageH != _lastStageHeight)
+            {
+                _lastStageWidth = stageW;
+                _lastStageHeight = stageH;
+
+                _titleLogo?.SetPosition((stageW - _titleSpriteWidth) / 2f, stageH * 0.30f);
+                _mainMenuTable?.SetY(stageH * 0.25f);
+                _quitConfirmationDialog?.SetPosition(
+                    (stageW - _quitConfirmationDialog.GetWidth()) / 2,
+                    (stageH - _quitConfirmationDialog.GetHeight()) / 2
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
## Fixed-height variable-width resolution

Switches all scenes from BestFit (locked 1920x360 render target) to `SceneResolutionPolicy.FixedHeight`: vertical resolution stays 360 world pixels while the render target width grows with the window aspect, so ultrawide monitors see more of the map at the same pixel scale.

- **Camera**: clamp/default position derive from `SceneRenderTargetSize` instead of `GameConfig.VirtualWidth`, and re-clamp when the render target resizes (window shrink/restore, dock, monitor swap).
- **MainGameScene HUD**: clock/tilling/planting labels, shortcut bar, event console, and pause overlay anchor to stage size instead of design constants or `Screen.*`, with a stage-size-change re-layout hook.
- **Title / Hero Creation**: stages flipped to render-target space (`IsFullScreen=false`) with stage-size-change re-centering, fixing layout and mouse hit-testing on non-16:9 aspects.
- **Second Chance Shop**: 1920-wide composition centers on wider stages.
- `GameConfig.VirtualWidth` documented as reference width only — UI must anchor to `Stage.GetWidth()`.

## Hero AI stability fixes (playtest bugs)

- **Job-change jump bounced in place mid-pit** (`fe6a17c`): `JumpOutOfPitForJobChangeAction` had no `CalculateTargetLocation` case, so GoTo skipped straight to executing the jump wherever the hero stood. He landed still inside the pit, `InsidePit` re-tripped, and the replan loop bounced him forever while the mercs left. Now shares the `PitInsideEdge` walk-to-edge case with the Stop jump.
- **Stack overflow from stop/play spam** (`1240291`): `SimpleStateMachine` invokes state `_Enter` methods synchronously from the `CurrentState` setter, so a persistent path failure recursed `GoTo_Enter → Idle_Enter → GoTo_Enter → …` until the stack died. Added an `_idleEnterDepth` re-entrancy guard in `Idle_Enter`: a nested failure entry defers to `Idle_Tick`'s 1-second retry throttle, giving pit triggers time to self-heal stale `InsidePit` state.
- **Mercenaries abandoned the hero mid-battle on Stop** (`ca55b80`): `AttackMonsterAction` was interruptible while its uncancellable battle coroutine ran, so pressing Stop mid-fight re-planned the hero's exit, flipped `PitIntent = ExitingPit`, and sent the mercs out of the pit while the fight continued. The action now reports `ShouldNotOverride()` while the battle is in flight; stop/job-change/replenish interrupts defer until the battle resolves, then the whole party exits together.

## Tests

- New regression test pinning `AttackMonsterAction.ShouldNotOverride()` to the battle-coroutine lifetime.
- Full suite: **1897 passed, 0 failed, 6 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)