### PR TITLE
Better randomness with Marble Bag algorithm (#382)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,7 @@ Design docs under `PitHero/docs/` (kept as standalone references — don't dupli
 - `PitHero/docs/AutoJobAssignmentSystem.md` — Automated monster job assignment: demand evaluators, pure solver, day/night shifts, reassess cadence, and the step-by-step recipe for adding a new job (e.g. fishing)
 - `PitHero/docs/AutomationSystem.md` — The Settings → Automation tab as a whole: which service owns each toggle, ticked vs call-driven automations, the shared Gold Buffer, append-only save sections, the two-phase load sync, the grayed-control recipe, and how to add a new Automation option
 - `PitHero/docs/SpeechBubbleSystem.md` — Speech-bubble dialogue: SpeechBubbleComponent + SpeechBubbleDialogue option/gate tables, Dialogue.txt localization rules, full event catalog, the System.Random-not-Nez.Random rule, and the recipe for adding a new dialogue event or speaker
+- `PitHero/docs/ShuffleBagSystem.md` — Shuffle-bag ("marble bag") controlled randomness: ShuffleBag<T>/NextFromRoll, the two-floats-per-ally-attack battle RNG contract, CritBagSet persistence, LootBagSet compositions + LiveBags null fallback, boss epic chest rules, tavern dish bag, and the recipe for adding a new bag-driven drop
 
 **Per-feature docs:**
 - `features/`

--- a/PitHero.Tests/ShuffleBagLootTests.cs
+++ b/PitHero.Tests/ShuffleBagLootTests.cs
@@ -1,0 +1,267 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Xna.Framework;
+using PitHero;
+using PitHero.Dining;
+using PitHero.Farming;
+using PitHero.Services;
+using PitHero.VirtualGame;
+using RolePlayingFramework.Enemies;
+using RolePlayingFramework.Equipment;
+using RolePlayingFramework.Heroes;
+using RolePlayingFramework.Inventory;
+using RolePlayingFramework.Jobs.Primary;
+using RolePlayingFramework.Mercenaries;
+using RolePlayingFramework.Stats;
+using System.Collections.Generic;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Issue #382: shuffle-bag loot conformance. Each bag must reproduce its configured
+    /// rate EXACTLY over one full cycle (that is the whole point of the marble bag),
+    /// the epic pool must cycle all four PitLord items before any repeat, the Molten
+    /// Titan kill must drop an epic chest at the boss tile, and tavern patrons must
+    /// order dishes at inverse-price bag weights.
+    /// </summary>
+    [TestClass]
+    [DoNotParallelize] // draws consume the shared Nez.Random stream in some paths
+    public class ShuffleBagLootTests
+    {
+        // ── LootBagSet rate conformance ──────────────────────────────────────────
+
+        private static int[] DrawRarityCycle(LootBagSet bags, int pitLevel, System.Random rng, int draws)
+        {
+            var counts = new int[4]; // index = treasure level 1..3
+            for (int i = 0; i < draws; i++)
+                counts[bags.DrawCaveTreasureLevel(pitLevel, (float)rng.NextDouble())]++;
+            return counts;
+        }
+
+        [TestMethod]
+        public void CaveRarity_NonBoss16To25_ExactCompositionPer20()
+        {
+            var bags = new LootBagSet();
+            var counts = DrawRarityCycle(bags, 18, new System.Random(7), 20);
+            Assert.AreEqual(2, counts[3], "16-25 non-boss band: exactly 2 rare per 20");
+            Assert.AreEqual(7, counts[2], "16-25 non-boss band: exactly 7 uncommon per 20");
+            Assert.AreEqual(11, counts[1], "16-25 non-boss band: exactly 11 normal per 20");
+        }
+
+        [TestMethod]
+        public void CaveRarity_BossFloor25_ExactCompositionPer20()
+        {
+            var bags = new LootBagSet();
+            var counts = DrawRarityCycle(bags, 25, new System.Random(11), 20);
+            Assert.AreEqual(4, counts[3], "boss 20/25 band: exactly 4 rare per 20");
+            Assert.AreEqual(10, counts[2], "boss 20/25 band: exactly 10 uncommon per 20");
+            Assert.AreEqual(6, counts[1], "boss 20/25 band: exactly 6 normal per 20");
+        }
+
+        [TestMethod]
+        public void CaveRarity_Levels1To10_AlwaysNormal()
+        {
+            var bags = new LootBagSet();
+            var rng = new System.Random(3);
+            for (int i = 0; i < 30; i++)
+                Assert.AreEqual(1, bags.DrawCaveTreasureLevel(1 + i % 10, (float)rng.NextDouble()));
+        }
+
+        [TestMethod]
+        public void SeedGate_ExactlyOnePerTen()
+        {
+            var bags = new LootBagSet();
+            var rng = new System.Random(21);
+            for (int cycle = 0; cycle < 3; cycle++)
+            {
+                int seeds = 0;
+                for (int i = 0; i < 10; i++)
+                    if (bags.DrawSeedGate((float)rng.NextDouble())) seeds++;
+                Assert.AreEqual(1, seeds, $"cycle {cycle}: exactly 1 seed chest per 10 eligible rolls");
+            }
+        }
+
+        [TestMethod]
+        public void SeedType_AllCropsCycleBeforeRepeat()
+        {
+            var bags = new LootBagSet();
+            var rng = new System.Random(5);
+            var seen = new HashSet<CropType>();
+            for (int i = 0; i < CropTypeInfo.Count; i++)
+                Assert.IsTrue(seen.Add(bags.DrawSeedType((float)rng.NextDouble())),
+                    "every crop type must appear exactly once per rotation");
+        }
+
+        [TestMethod]
+        public void ConsumableGate_ExactlyThreePerFive()
+        {
+            var bags = new LootBagSet();
+            var rng = new System.Random(13);
+            for (int cycle = 0; cycle < 4; cycle++)
+            {
+                int consumables = 0;
+                for (int i = 0; i < 5; i++)
+                    if (bags.DrawConsumableGate((float)rng.NextDouble())) consumables++;
+                Assert.AreEqual(3, consumables, $"cycle {cycle}: exactly 3 consumables per 5 L1 chests");
+            }
+        }
+
+        [TestMethod]
+        public void PotionType_StrictRotationOfThree()
+        {
+            var bags = new LootBagSet();
+            var rng = new System.Random(17);
+            var seen = new HashSet<int>();
+            for (int i = 0; i < 3; i++)
+                Assert.IsTrue(seen.Add(bags.DrawPotionType((float)rng.NextDouble())),
+                    "HP/MP/Mix must each appear once per rotation");
+        }
+
+        [TestMethod]
+        public void AccessoryShare_ExactlyOnePerTen_PerRarityPool()
+        {
+            var bags = new LootBagSet();
+            var rng = new System.Random(29);
+            for (int level = 1; level <= 3; level++)
+            {
+                int accessories = 0;
+                for (int i = 0; i < 10; i++)
+                    if (bags.DrawAccessoryShare(level, (float)rng.NextDouble())) accessories++;
+                Assert.AreEqual(1, accessories, $"treasure level {level}: exactly 1 accessory per 10 equipment rolls");
+            }
+        }
+
+        [TestMethod]
+        public void EpicItems_AllFourPitLordPiecesBeforeAnyRepeat()
+        {
+            var bags = new LootBagSet();
+            var rng = new System.Random(31);
+            for (int cycle = 0; cycle < 2; cycle++)
+            {
+                var names = new HashSet<string>();
+                for (int i = 0; i < 4; i++)
+                {
+                    var item = bags.DrawEpicItem((float)rng.NextDouble());
+                    Assert.IsInstanceOfType(item, typeof(Gear));
+                    Assert.AreEqual(ItemRarity.Epic, ((Gear)item).Rarity);
+                    Assert.IsTrue(names.Add(item.Name), $"cycle {cycle}: {item.Name} repeated before the epic pool was exhausted");
+                }
+            }
+        }
+
+        [TestMethod]
+        public void LootShuffleService_DrawEpicItem_CyclesAllFour()
+        {
+            var service = new LootShuffleService();
+            var names = new HashSet<string>();
+            for (int i = 0; i < 4; i++)
+                Assert.IsTrue(names.Add(service.DrawEpicItem().Name), "service epic draw repeated early");
+        }
+
+        // ── Boss epic chest (virtual parity) ─────────────────────────────────────
+
+        [TestMethod]
+        public void MoltenTitanKill_SpawnsEpicChestAtBossTile()
+        {
+            var world = new VirtualWorldState();
+            world.RegeneratePit(25);
+
+            var hero = new Hero("EpicTester", new Knight(), 60, new StatBlock(60, 40, 60, 20));
+            var bag = new ItemBag();
+            var partyView = new VirtualBattlePartyView(hero, bag);
+            var runner = new VirtualBattleRunner(world, partyView);
+            runner.SetHeroAlly(hero);
+            runner.SetMercenaries(new List<Mercenary>(0));
+            runner.LootBags = new LootBagSet();
+
+            var heroPos = new Point(world.PitBounds.X + 2, world.PitBounds.Y + 2);
+            world.MoveHeroTo(heroPos);
+            var bossTile = new Point(heroPos.X + 1, heroPos.Y);
+            var boss = EnemyFactory.Create(EnemyId.MoltenTitan, level: 22);
+            world.AddMonster(bossTile, boss);
+
+            var metrics = runner.RunAdjacentBattle();
+
+            Assert.IsNotNull(metrics, "battle should have run");
+            Assert.IsFalse(world.HasLivingBoss(), "a level-60 Knight must defeat the Molten Titan");
+            Assert.IsTrue(world.TryGetTreasureAt(bossTile, out var item),
+                "an epic chest must spawn at the boss tile after a Molten Titan kill");
+            Assert.IsInstanceOfType(item, typeof(Gear));
+            Assert.AreEqual(ItemRarity.Epic, ((Gear)item).Rarity, "the boss chest must contain an Epic item");
+        }
+
+        [TestMethod]
+        public void NonMainBossKill_SpawnsNoChest()
+        {
+            var world = new VirtualWorldState();
+            world.RegeneratePit(5);
+
+            var hero = new Hero("BossTester", new Knight(), 40, new StatBlock(50, 30, 50, 10));
+            var partyView = new VirtualBattlePartyView(hero, new ItemBag());
+            var runner = new VirtualBattleRunner(world, partyView);
+            runner.SetHeroAlly(hero);
+            runner.SetMercenaries(new List<Mercenary>(0));
+            runner.LootBags = new LootBagSet();
+
+            var heroPos = new Point(world.PitBounds.X + 2, world.PitBounds.Y + 2);
+            world.MoveHeroTo(heroPos);
+            var bossTile = new Point(heroPos.X + 1, heroPos.Y);
+            world.AddMonster(bossTile, EnemyFactory.Create(EnemyId.StoneGuardian, level: 8));
+
+            runner.RunAdjacentBattle();
+
+            Assert.IsFalse(world.HasLivingBoss(), "StoneGuardian should be defeated");
+            Assert.IsFalse(world.TryGetTreasureAt(bossTile, out _),
+                "only the biome main boss (Molten Titan) drops an epic chest");
+        }
+
+        // ── Tavern dish bag ──────────────────────────────────────────────────────
+
+        private static int ExpectedMarbles(DishType dish, int maxPrice)
+            => System.Math.Max(1, (int)System.Math.Round((float)maxPrice / DishConfig.GetPrice(dish)));
+
+        [TestMethod]
+        public void PickPatronDish_FullMenu_MatchesInversePriceComposition()
+        {
+            var coordinator = new KitchenTaskCoordinator(null, new BuildingService(), 240, 12);
+
+            var allDishes = new List<DishType>(DishTypeInfo.Count);
+            for (int d = 0; d < DishTypeInfo.Count; d++)
+                allDishes.Add((DishType)d);
+
+            int maxPrice = 0;
+            for (int d = 0; d < DishTypeInfo.Count; d++)
+                maxPrice = System.Math.Max(maxPrice, DishConfig.GetPrice((DishType)d));
+
+            int totalMarbles = 0;
+            for (int d = 0; d < DishTypeInfo.Count; d++)
+                totalMarbles += ExpectedMarbles((DishType)d, maxPrice);
+
+            // One full bag cycle with everything orderable: draw counts must equal the
+            // inverse-price marble composition exactly.
+            var counts = new Dictionary<DishType, int>();
+            for (int i = 0; i < totalMarbles; i++)
+            {
+                var dish = coordinator.PickPatronDish(allDishes);
+                counts.TryGetValue(dish, out int c);
+                counts[dish] = c + 1;
+            }
+
+            for (int d = 0; d < DishTypeInfo.Count; d++)
+            {
+                var dish = (DishType)d;
+                counts.TryGetValue(dish, out int actual);
+                Assert.AreEqual(ExpectedMarbles(dish, maxPrice), actual,
+                    $"{dish} ({DishConfig.GetPrice(dish)}g) draw count must match its inverse-price marble count");
+            }
+        }
+
+        [TestMethod]
+        public void PickPatronDish_SingleOrderableDish_AlwaysReturnsIt()
+        {
+            var coordinator = new KitchenTaskCoordinator(null, new BuildingService(), 240, 12);
+            var onlyDish = new List<DishType> { DishType.RoastedOnionSkewers };
+            for (int i = 0; i < 5; i++)
+                Assert.AreEqual(DishType.RoastedOnionSkewers, coordinator.PickPatronDish(onlyDish));
+        }
+    }
+}

--- a/PitHero.Tests/ShuffleBagTests.cs
+++ b/PitHero.Tests/ShuffleBagTests.cs
@@ -1,0 +1,117 @@
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RolePlayingFramework.Utils;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// ShuffleBag invariants: every cycle draws the exact added composition (no repeats
+    /// beyond the marble counts), the bag refills after exhaustion, and NextFromRoll is
+    /// fully deterministic for a given roll sequence (it consumes no RNG itself).
+    /// </summary>
+    [TestClass]
+    public class ShuffleBagTests
+    {
+        private static Dictionary<string, int> DrawFullCycle(ShuffleBag<string> bag, System.Random rng)
+        {
+            var counts = new Dictionary<string, int>();
+            int cycle = bag.Count;
+            for (int i = 0; i < cycle; i++)
+            {
+                var item = bag.Next(rng);
+                counts.TryGetValue(item, out int c);
+                counts[item] = c + 1;
+            }
+            return counts;
+        }
+
+        [TestMethod]
+        public void FullCycle_DrawsExactComposition()
+        {
+            var bag = new ShuffleBag<string>(20);
+            bag.Add("crit", 1);
+            bag.Add("miss", 19);
+
+            var rng = new System.Random(1234);
+            for (int cycle = 0; cycle < 5; cycle++)
+            {
+                var counts = DrawFullCycle(bag, rng);
+                Assert.AreEqual(1, counts["crit"], $"cycle {cycle}: expected exactly 1 crit per 20 draws");
+                Assert.AreEqual(19, counts["miss"], $"cycle {cycle}: expected exactly 19 misses per 20 draws");
+            }
+        }
+
+        [TestMethod]
+        public void Refill_HappensAutomaticallyAfterExhaustion()
+        {
+            var bag = new ShuffleBag<int>(3);
+            bag.Add(7, 3);
+            Assert.AreEqual(3, bag.Remaining);
+
+            var rng = new System.Random(5);
+            for (int i = 0; i < 3; i++) bag.Next(rng);
+            Assert.AreEqual(0, bag.Remaining);
+
+            // Next draw refills transparently
+            Assert.AreEqual(7, bag.Next(rng));
+            Assert.AreEqual(2, bag.Remaining);
+        }
+
+        [TestMethod]
+        public void NextFromRoll_IsDeterministicForFixedRolls()
+        {
+            var bagA = new ShuffleBag<int>(4);
+            var bagB = new ShuffleBag<int>(4);
+            for (int i = 0; i < 4; i++) { bagA.Add(i); bagB.Add(i); }
+
+            float[] rolls = { 0.1f, 0.9f, 0.5f, 0.0f, 0.7f, 0.3f, 0.99f, 0.2f };
+            for (int i = 0; i < rolls.Length; i++)
+                Assert.AreEqual(bagA.NextFromRoll(rolls[i]), bagB.NextFromRoll(rolls[i]), $"draw {i} diverged");
+        }
+
+        [TestMethod]
+        public void NextFromRoll_BoundaryRolls_StayInRange()
+        {
+            var bag = new ShuffleBag<int>(2);
+            bag.Add(1, 1);
+            bag.Add(2, 1);
+
+            // 0f always picks the first undrawn slot; ~1f clamps to the cursor
+            var lo = bag.NextFromRoll(0f);
+            var hi = bag.NextFromRoll(0.9999f);
+            Assert.AreNotEqual(lo, hi, "two-marble bag must yield both marbles in one cycle");
+        }
+
+        [TestMethod]
+        public void SingleItemBag_AlwaysReturnsThatItem()
+        {
+            var bag = new ShuffleBag<string>(1);
+            bag.Add("only");
+            for (int i = 0; i < 5; i++)
+                Assert.AreEqual("only", bag.NextFromRoll(0.42f));
+        }
+
+        [TestMethod]
+        public void AddMidCycle_ResetsCycle()
+        {
+            var bag = new ShuffleBag<int>(4);
+            bag.Add(1, 2);
+            bag.NextFromRoll(0.5f);
+            Assert.AreEqual(1, bag.Remaining);
+
+            bag.Add(2, 2);
+            Assert.AreEqual(4, bag.Count);
+            Assert.AreEqual(4, bag.Remaining, "Add must restart the cycle with a full bag");
+        }
+
+        [TestMethod]
+        public void Clear_EmptiesBag()
+        {
+            var bag = new ShuffleBag<int>(2);
+            bag.Add(1, 2);
+            bag.Clear();
+            Assert.AreEqual(0, bag.Count);
+            Assert.AreEqual(0, bag.Remaining);
+        }
+    }
+}

--- a/PitHero.Tests/StubSkillTests.cs
+++ b/PitHero.Tests/StubSkillTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RolePlayingFramework.Balance;
 using RolePlayingFramework.Combat;
 using RolePlayingFramework.Enemies;
 using RolePlayingFramework.Heroes;
@@ -13,8 +14,8 @@ namespace PitHero.Tests
     /// <summary>
     /// End-to-end tests for the Phase 4 stub-skill mechanics:
     /// Eagle Eye (sight bonus), Shadowstep (evasion), Vanish (Untargetable buff),
-    /// Sneak Attack (first-strike AGI conditioning), and Quickdraw
-    /// (BattleReactionHelper.RollFirstAttackCrit boundaries).
+    /// Sneak Attack (first-strike AGI conditioning), and the crit shuffle bags
+    /// (BattleReactionHelper.RollCrit boundaries, issue #382).
     /// </summary>
     [TestClass]
     public class StubSkillTests
@@ -329,73 +330,111 @@ namespace PitHero.Tests
                 $"Out-of-battle (null context): SneakAttack should deal base(10) + AGI/2({expectedAgi / 2}) = {expected}");
         }
 
-        // ── Quickdraw — RollFirstAttackCrit boundaries ──────────────────────────────
+        // ── Crit bags (#382) — RollCrit boundaries ──────────────────────────────────
 
         [TestMethod]
         [TestCategory("StubSkills")]
-        public void Quickdraw_RollFirstAttackCrit_FirstActionAndRollBelowChance_ReturnsCrit()
+        public void RollCrit_FirstActionQuickdraw_LowQuickdrawRoll_Crits()
         {
             var caster = MakeHero();
             caster.FirstAttackCritChance = 0.5f;
 
-            bool result = BattleReactionHelper.RollFirstAttackCrit(caster, isFirstAction: true, roll: 0.3f);
+            // baseRoll 0.9 lands in the fresh base bag's non-crit region (1 crit marble at
+            // index 0 of 20); qdRoll 0.3 lands in the quickdraw bag's crit half (10 of 20).
+            bool result = BattleReactionHelper.RollCrit(caster, isFirstAction: true,
+                baseRoll: 0.9f, quickdrawRoll: 0.3f);
 
-            Assert.IsTrue(result,
-                "First action + roll (0.3) < chance (0.5) should return true (crit)");
+            Assert.IsTrue(result, "First action with Quickdraw and a crit-region quickdraw roll should crit");
         }
 
         [TestMethod]
         [TestCategory("StubSkills")]
-        public void Quickdraw_RollFirstAttackCrit_NotFirstAction_NeverCrits()
+        public void RollCrit_NotFirstAction_QuickdrawIgnored()
         {
             var caster = MakeHero();
             caster.FirstAttackCritChance = 0.5f;
 
-            // Even with roll = 0 (guaranteed win) and high crit chance, non-first action never crits
-            bool result = BattleReactionHelper.RollFirstAttackCrit(caster, isFirstAction: false, roll: 0.0f);
+            // qdRoll 0 would be a guaranteed quickdraw crit, but non-first actions never use it;
+            // baseRoll 0.9 misses the single base crit marble.
+            bool result = BattleReactionHelper.RollCrit(caster, isFirstAction: false,
+                baseRoll: 0.9f, quickdrawRoll: 0.0f);
 
-            Assert.IsFalse(result,
-                "Non-first action should never trigger a crit regardless of roll or chance");
+            Assert.IsFalse(result, "Non-first action must ignore the quickdraw bag entirely");
         }
 
         [TestMethod]
         [TestCategory("StubSkills")]
-        public void Quickdraw_RollFirstAttackCrit_RollAtChance_NoCrit()
+        public void RollCrit_NoQuickdraw_BaseBagStillCrits()
         {
             var caster = MakeHero();
-            caster.FirstAttackCritChance = 0.5f;
-
-            bool result = BattleReactionHelper.RollFirstAttackCrit(caster, isFirstAction: true, roll: 0.5f);
-
-            Assert.IsFalse(result,
-                "Roll equal to chance (not strictly less-than) should not crit");
-        }
-
-        [TestMethod]
-        [TestCategory("StubSkills")]
-        public void Quickdraw_RollFirstAttackCrit_RollAboveChance_NoCrit()
-        {
-            var caster = MakeHero();
-            caster.FirstAttackCritChance = 0.5f;
-
-            bool result = BattleReactionHelper.RollFirstAttackCrit(caster, isFirstAction: true, roll: 0.8f);
-
-            Assert.IsFalse(result,
-                "Roll (0.8) above chance (0.5) should not crit");
-        }
-
-        [TestMethod]
-        [TestCategory("StubSkills")]
-        public void Quickdraw_RollFirstAttackCrit_ZeroCritChance_NeverCrits()
-        {
-            var caster = MakeHero();
-            // Default FirstAttackCritChance = 0 (no Quickdraw passive)
             Assert.AreEqual(0f, caster.FirstAttackCritChance);
 
-            bool result = BattleReactionHelper.RollFirstAttackCrit(caster, isFirstAction: true, roll: 0.0f);
+            // The new general crit: baseRoll 0 hits the fresh base bag's single crit marble.
+            bool result = BattleReactionHelper.RollCrit(caster, isFirstAction: true,
+                baseRoll: 0.0f, quickdrawRoll: 0.9f);
 
-            Assert.IsFalse(result,
-                "Zero FirstAttackCritChance should never produce a crit even with roll = 0");
+            Assert.IsTrue(result, "Base crit bag applies to every combatant, Quickdraw or not");
+        }
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void RollCrit_BaseBag_ExactlyOneCritPerCycle()
+        {
+            var caster = MakeHero();
+            var rng = new System.Random(99);
+
+            for (int cycle = 0; cycle < 3; cycle++)
+            {
+                int crits = 0;
+                for (int i = 0; i < BalanceConfig.CritBagSize; i++)
+                {
+                    if (BattleReactionHelper.RollCrit(caster, isFirstAction: false,
+                            baseRoll: (float)rng.NextDouble(), quickdrawRoll: 0f))
+                        crits++;
+                }
+                Assert.AreEqual(1, crits,
+                    $"cycle {cycle}: base bag must yield exactly 1 crit per {BalanceConfig.CritBagSize} attacks");
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void RollCrit_BagState_SurvivesClearBattleState()
+        {
+            var caster = MakeHero();
+
+            // Consume the base bag's single crit marble (roll 0 on a fresh bag).
+            Assert.IsTrue(BattleReactionHelper.RollCrit(caster, false, 0.0f, 0f));
+
+            // ClearBattleState runs at battle start AND end — pity progress must survive.
+            caster.ClearBattleState();
+
+            // Remaining 19 draws of the cycle must all be non-crit regardless of roll.
+            for (int i = 0; i < BalanceConfig.CritBagSize - 1; i++)
+                Assert.IsFalse(BattleReactionHelper.RollCrit(caster, false, 0.0f, 0f),
+                    $"draw {i}: crit marble already spent this cycle; bag must persist across battles");
+        }
+
+        [TestMethod]
+        [TestCategory("StubSkills")]
+        public void RollCrit_QuickdrawBag_RebuildsWhenChanceChanges()
+        {
+            var caster = MakeHero();
+            caster.FirstAttackCritChance = 1.0f;
+
+            // 100% quickdraw bag: every marble crits.
+            Assert.IsTrue(BattleReactionHelper.RollCrit(caster, true, 0.9f, 0.9f));
+
+            // Simulate CombatantPassiveApplier.ResetAndApply landing on a different chance:
+            // the quickdraw bag must rebuild for the new composition (0 => untouched/no crit).
+            caster.FirstAttackCritChance = 0f;
+            Assert.IsFalse(BattleReactionHelper.RollCrit(caster, true, 0.9f, 0.0f),
+                "With no quickdraw chance the quickdraw bag must not fire");
+
+            caster.FirstAttackCritChance = 0.5f;
+            // Rebuilt 10/20 bag: roll 0.0 lands on a crit marble.
+            Assert.IsTrue(BattleReactionHelper.RollCrit(caster, true, 0.9f, 0.0f),
+                "Quickdraw bag must rebuild at the newly observed chance");
         }
 
         [TestMethod]

--- a/PitHero/AI/LiveBattleAdapter.cs
+++ b/PitHero/AI/LiveBattleAdapter.cs
@@ -698,6 +698,12 @@ namespace PitHero.AI
                     }
                 }
                 Debug.Log($"[LiveBattleAdapter] Boss {enemy.Name} defeated - BossDefeated=true");
+
+                // Biome main boss drops an epic chest at its tile (#382). This runs mid-battle
+                // inside the engine coroutine, so it must consume ZERO Nez.Random — the epic
+                // draw uses LootShuffleService's private System.Random.
+                if (enemy.EnemyId == RolePlayingFramework.Enemies.EnemyId.MoltenTitan)
+                    SpawnBossEpicChest(enemy);
             }
 
             // Console event for monster death (after recruit, matching original line order)
@@ -707,6 +713,49 @@ namespace PitHero.AI
                     enemy.IsBoss ? EventPriority.High : EventPriority.Normal,
                     UITextKey.ConsoleMonsterDied,
                     (evtSvc.MonsterName(enemy.Name), GameConfig.ConsoleColorEnemyName));
+        }
+
+        /// <summary>
+        /// Spawns the epic treasure chest for a biome main-boss kill (#382). The boss entity
+        /// is still alive here (fade/destroy happens later in ShowMonsterDeath), so its tile
+        /// anchors the chest. GOAP flags are reset so the post-battle replan targets the new
+        /// chest. Must consume zero Nez.Random — this runs mid-battle (RNG contract).
+        /// </summary>
+        private void SpawnBossEpicChest(IEnemy enemy)
+        {
+            var scene = Core.Scene;
+            if (scene == null)
+                return;
+
+            var lootService = Core.Services.GetService<PitHero.Services.LootShuffleService>();
+            if (lootService == null)
+                return;
+
+            var bossEntity = GetEntityForEnemy(enemy);
+            var anchor = bossEntity != null
+                ? bossEntity.Transform.Position
+                : _heroComponent.Entity.Transform.Position;
+            var tile = new Point((int)(anchor.X / GameConfig.TileSize), (int)(anchor.Y / GameConfig.TileSize));
+
+            var item = lootService.DrawEpicItem();
+
+            // Tier-2+ runs upgrade the epic drop exactly like chest gear (TreasureComponent parity).
+            var pitWidthManager = Core.Services.GetService<PitWidthManager>();
+            int pitTier = pitWidthManager?.CurrentPitTier ?? 1;
+            if (pitTier >= 2 && item is RolePlayingFramework.Equipment.Gear gear)
+            {
+                int depthDelta = (pitTier - 1) * Config.BiomeProgressionConfig.MaxBiomeLevel;
+                item = RolePlayingFramework.Equipment.Gear.CreateTierScaledCopy(gear, pitTier, depthDelta);
+            }
+
+            TreasureSpawner.SpawnTreasureChestAtTile(scene, tile, item);
+
+            // Un-latch ExploredPit and refresh chest adjacency so the post-battle replan
+            // (Idle_Enter/Idle_Tick) sees the new CLOSED chest and goes to open it.
+            _heroComponent.ExploredPit = false;
+            _heroComponent.AdjacentToChest = _heroComponent.CheckAdjacentToChest();
+
+            Debug.Log($"[LiveBattleAdapter] Boss epic chest spawned at ({tile.X},{tile.Y}) containing {item.Name}");
         }
 
         /// <inheritdoc/>

--- a/PitHero/Combat/BattleEngine.cs
+++ b/PitHero/Combat/BattleEngine.cs
@@ -571,10 +571,12 @@ namespace PitHero.Combat
             Debug.Log($"[BattleEngine] Hero attacking {targetEnemy.Name}");
             var heroAttackResult = attackResolver.Resolve(heroBattleStats, targetBattleStats, DamageKind.Physical);
 
-            // Phase 4: Quickdraw — crit roll BEFORE dealing damage
-            bool isCrit = BattleReactionHelper.RollFirstAttackCrit(hero,
+            // Crit bags (#382): two floats always consumed per ally attack (RNG contract)
+            float heroCritRoll = Random.NextFloat();
+            float heroQdRoll = Random.NextFloat();
+            bool isCrit = BattleReactionHelper.RollCrit(hero,
                 battleContext.IsFirstOffensiveAction(hero),
-                Random.NextFloat());
+                heroCritRoll, heroQdRoll);
             battleContext.MarkActed(hero);
 
             if (queuedAction.WeaponItem == null)
@@ -783,10 +785,12 @@ namespace PitHero.Combat
             var attackResolver = new EnhancedAttackResolver();
             var mercAttackResult = attackResolver.Resolve(mercBattleStats, targetBattleStats, DamageKind.Physical);
 
-            // Phase 4: Quickdraw — crit roll BEFORE dealing damage
-            bool isCrit = BattleReactionHelper.RollFirstAttackCrit(mercenary,
+            // Crit bags (#382): two floats always consumed per ally attack (RNG contract)
+            float mercCritRoll = Random.NextFloat();
+            float mercQdRoll = Random.NextFloat();
+            bool isCrit = BattleReactionHelper.RollCrit(mercenary,
                 battleContext.IsFirstOffensiveAction(mercenary),
-                Random.NextFloat());
+                mercCritRoll, mercQdRoll);
             battleContext.MarkActed(mercenary);
 
             _sink.PlaySound(BattleSound.Punch, mercenary);
@@ -839,7 +843,7 @@ namespace PitHero.Combat
         /// <summary>
         /// Shared coroutine for both hero and mercenary attack skills.
         /// Snapshots HP before Execute, diffs damage, handles crits, deaths, rewards.
-        /// Preserves the exact Nez.Random call sequence (crit roll BEFORE Execute,
+        /// Preserves the exact Nez.Random call sequence (two crit-bag rolls BEFORE Execute,
         /// MarkActed AFTER, second crit pass on crit exactly as original).
         /// </summary>
         private IEnumerator ExecuteCombatantAttackSkill(ISkill skill, ICombatant caster,
@@ -865,10 +869,12 @@ namespace PitHero.Combat
             for (int i = 1; i < _tempLivingEnemies.Count; i++)
                 _surroundingTargets.Add(_tempLivingEnemies[i]);
 
-            // Phase 4: Quickdraw crit roll BEFORE Execute
-            bool isCrit = BattleReactionHelper.RollFirstAttackCrit(caster,
+            // Crit bags (#382): two floats always consumed per ally attack, BEFORE Execute (RNG contract)
+            float skillCritRoll = Random.NextFloat();
+            float skillQdRoll = Random.NextFloat();
+            bool isCrit = BattleReactionHelper.RollCrit(caster,
                 battleContext.IsFirstOffensiveAction(caster),
-                Random.NextFloat());
+                skillCritRoll, skillQdRoll);
 
             var attackResolver = new EnhancedAttackResolver();
             skill.Execute(caster, primaryTarget, _surroundingTargets, attackResolver, battleContext);

--- a/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
+++ b/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
@@ -390,7 +390,9 @@ namespace PitHero.ECS.Components
             _coordinator.GetOrderableDishes(orderable);
             if (orderable.Count == 0)
                 return;
-            var dish = orderable[Nez.Random.Range(0, orderable.Count)];
+            // Inverse-price shuffle bag (#382): cheap dishes more often, pricey ones on a
+            // predictable cadence instead of pure uniform random.
+            var dish = _coordinator.PickPatronDish(orderable);
             var t = _coordinator.CreateTicket(dish, false, -1, patron, comp.SeatTile);
             if (t != null)
             {

--- a/PitHero/ECS/Components/TreasureComponent.cs
+++ b/PitHero/ECS/Components/TreasureComponent.cs
@@ -211,27 +211,35 @@ namespace PitHero.ECS.Components
         /// </summary>
         public static IItem GenerateCaveItemForTreasureLevel(int treasureLevel, LootJobContext ctx = default)
         {
+            // Session shuffle bags (#382); null falls back to the legacy pure-random path.
+            var bags = LootShuffleService.LiveBags;
+
             if (treasureLevel == 1)
             {
-                bool isConsumable = Nez.Random.NextFloat() < BalanceConfig.CaveConsumableDropRate;
-                return isConsumable ? GenerateNormalPotion() : GenerateCaveCommonEquipment(ctx);
+                float gateRoll = Nez.Random.NextFloat();
+                bool isConsumable = bags != null
+                    ? bags.DrawConsumableGate(gateRoll)
+                    : gateRoll < BalanceConfig.CaveConsumableDropRate;
+                return isConsumable ? GenerateNormalPotion(bags) : GenerateCaveCommonEquipment(ctx, bags);
             }
 
             return treasureLevel switch
             {
-                2 => GenerateCaveUncommonEquipment(ctx),
-                3 => GenerateCaveRareEquipment(ctx),
+                2 => GenerateCaveUncommonEquipment(ctx, bags),
+                3 => GenerateCaveRareEquipment(ctx, bags),
                 4 => GenerateCaveEpicEquipment(ctx),
                 _ => GenerateCaveEpicEquipment(ctx),
             };
         }
 
         /// <summary>
-        /// Generate a random Normal (Common) potion
+        /// Generate a random Normal (Common) potion. With bags, HP/MP/Mix rotate strictly.
         /// </summary>
-        private static IItem GenerateNormalPotion()
+        private static IItem GenerateNormalPotion(LootBagSet bags = null)
         {
-            var random = Nez.Random.NextInt(3);
+            var random = bags != null
+                ? bags.DrawPotionType(Nez.Random.NextFloat())
+                : Nez.Random.NextInt(3);
             return random switch
             {
                 0 => PotionItems.HPPotion(),
@@ -416,7 +424,7 @@ namespace PitHero.ECS.Components
             ItemKind.Accessory,      // 38: RingOfPower
         };
 
-        /// <summary>Generate cave rare equipment from all Rare-rarity cave gear items (12 items).</summary>
+        /// <summary>Generate cave rare equipment from all Rare-rarity cave gear items (13 items).</summary>
         private static readonly ItemKind[] _rarePoolKinds = new ItemKind[]
         {
             ItemKind.WeaponSword,    // 0:  AbyssFang
@@ -431,6 +439,7 @@ namespace PitHero.ECS.Components
             ItemKind.HatHelm,        // 9:  AbyssHelm
             ItemKind.HatHeadband,    // 10: DiamondCirclet
             ItemKind.HatHelm,        // 11: MagmaHelm
+            ItemKind.Accessory,      // 12: NecklaceOfHealth (#382 — was registered but in no pool)
         };
 
         /// <summary>Generate cave epic equipment from all Epic-rarity cave gear items (4 items).</summary>
@@ -446,13 +455,13 @@ namespace PitHero.ECS.Components
         /// Selects a weighted pool index biased toward gear usable by the active party.
         /// Falls back to flat random when no party context is available.
         /// </summary>
-        private static int SelectWeightedPoolIndex(ItemKind[] poolKinds, LootJobContext ctx)
+        private static int SelectWeightedPoolIndex(ItemKind[] poolKinds, LootJobContext ctx, bool excludeAccessories = false)
         {
-            if (ctx.IsEmpty)
+            if (ctx.IsEmpty && !excludeAccessories)
                 return Nez.Random.NextInt(poolKinds.Length);
 
             var weights = new int[poolKinds.Length];
-            int totalWeight = ComputePoolWeights(poolKinds, in ctx, weights);
+            int totalWeight = ComputePoolWeights(poolKinds, in ctx, weights, excludeAccessories);
             return WalkWeightedIndex(weights, Nez.Random.NextInt(totalWeight));
         }
 
@@ -461,33 +470,52 @@ namespace PitHero.ECS.Components
         /// layer: identical job-bias weights, but the roll comes from a caller-supplied
         /// <see cref="System.Random"/> instead of the global <c>Nez.Random</c>.
         /// </summary>
-        internal static int SelectWeightedPoolIndexDeterministic(ItemKind[] poolKinds, in LootJobContext ctx, System.Random rng)
+        internal static int SelectWeightedPoolIndexDeterministic(ItemKind[] poolKinds, in LootJobContext ctx, System.Random rng, bool excludeAccessories = false)
         {
-            if (ctx.IsEmpty)
+            if (ctx.IsEmpty && !excludeAccessories)
                 return rng.Next(poolKinds.Length);
 
             var weights = new int[poolKinds.Length];
-            int totalWeight = ComputePoolWeights(poolKinds, in ctx, weights);
+            int totalWeight = ComputePoolWeights(poolKinds, in ctx, weights, excludeAccessories);
             return WalkWeightedIndex(weights, rng.Next(totalWeight));
         }
 
-        /// <summary>Fills <paramref name="weights"/> with the party-job bias per pool entry; returns the total.</summary>
-        private static int ComputePoolWeights(ItemKind[] poolKinds, in LootJobContext ctx, int[] weights)
+        /// <summary>
+        /// Fills <paramref name="weights"/> with the party-job bias per pool entry; returns the total.
+        /// With <paramref name="excludeAccessories"/> (bag-driven path, #382) accessory entries get
+        /// weight 0 — the accessory-share shuffle bag decides accessories separately, so they must
+        /// not also compete in the weighted walk. With an empty job context each remaining entry
+        /// weighs 1 (flat pick minus accessories).
+        /// </summary>
+        private static int ComputePoolWeights(ItemKind[] poolKinds, in LootJobContext ctx, int[] weights, bool excludeAccessories = false)
         {
             int totalWeight = 0;
             for (int i = 0; i < poolKinds.Length; i++)
             {
-                JobType allowed = Gear.GetDefaultAllowedJobs(poolKinds[i]);
-                int weight;
+                if (excludeAccessories && poolKinds[i] == ItemKind.Accessory)
+                {
+                    weights[i] = 0;
+                    continue;
+                }
 
-                if (allowed == JobType.All)
-                    weight = BalanceConfig.LootWeightAllJobs;
-                else if ((allowed & ctx.HeroJob) != 0)
-                    weight = BalanceConfig.LootWeightHeroJob;
-                else if ((allowed & ctx.MercJobs) != 0)
-                    weight = BalanceConfig.LootWeightMercJob;
+                int weight;
+                if (ctx.IsEmpty)
+                {
+                    weight = 1;
+                }
                 else
-                    weight = BalanceConfig.LootWeightNoPartyJob;
+                {
+                    JobType allowed = Gear.GetDefaultAllowedJobs(poolKinds[i]);
+
+                    if (allowed == JobType.All)
+                        weight = BalanceConfig.LootWeightAllJobs;
+                    else if ((allowed & ctx.HeroJob) != 0)
+                        weight = BalanceConfig.LootWeightHeroJob;
+                    else if ((allowed & ctx.MercJobs) != 0)
+                        weight = BalanceConfig.LootWeightMercJob;
+                    else
+                        weight = BalanceConfig.LootWeightNoPartyJob;
+                }
 
                 weights[i] = weight;
                 totalWeight += weight;
@@ -511,8 +539,16 @@ namespace PitHero.ECS.Components
         /// <summary>
         /// Generate cave common equipment from all Normal-rarity cave gear items (78 items).
         /// </summary>
-        private static IItem GenerateCaveCommonEquipment(LootJobContext ctx = default)
+        private static IItem GenerateCaveCommonEquipment(LootJobContext ctx = default, LootBagSet bags = null)
         {
+            if (bags != null)
+            {
+                // Accessory share (#382): the bag guarantees 1 accessory per 10 equipment rolls
+                // instead of ProtectRing being 1 of 78 weighted entries.
+                if (bags.DrawAccessoryShare(1, Nez.Random.NextFloat()))
+                    return GetCaveCommonItemAtIndex(55); // ProtectRing — the pool's only accessory
+                return GetCaveCommonItemAtIndex(SelectWeightedPoolIndex(_commonPoolKinds, ctx, excludeAccessories: true));
+            }
             int index = SelectWeightedPoolIndex(_commonPoolKinds, ctx);
             return GetCaveCommonItemAtIndex(index);
         }
@@ -620,8 +656,17 @@ namespace PitHero.ECS.Components
         /// <summary>
         /// Generate cave uncommon equipment from all Uncommon-rarity cave gear items (39 items).
         /// </summary>
-        private static IItem GenerateCaveUncommonEquipment(LootJobContext ctx = default)
+        private static IItem GenerateCaveUncommonEquipment(LootJobContext ctx = default, LootBagSet bags = null)
         {
+            if (bags != null)
+            {
+                if (bags.DrawAccessoryShare(2, Nez.Random.NextFloat()))
+                {
+                    // MagicChain (37) / RingOfPower (38) rotate via their own 2-marble bag.
+                    return GetCaveUncommonItemAtIndex(37 + bags.DrawUncommonAccessoryIndex(Nez.Random.NextFloat()));
+                }
+                return GetCaveUncommonItemAtIndex(SelectWeightedPoolIndex(_uncommonPoolKinds, ctx, excludeAccessories: true));
+            }
             int index = SelectWeightedPoolIndex(_uncommonPoolKinds, ctx);
             return GetCaveUncommonItemAtIndex(index);
         }
@@ -683,14 +728,20 @@ namespace PitHero.ECS.Components
             }
         }
 
-        /// <summary>Generate cave rare equipment from all Rare-rarity cave gear items (12 items).</summary>
-        private static IItem GenerateCaveRareEquipment(LootJobContext ctx = default)
+        /// <summary>Generate cave rare equipment from all Rare-rarity cave gear items (13 items).</summary>
+        private static IItem GenerateCaveRareEquipment(LootJobContext ctx = default, LootBagSet bags = null)
         {
+            if (bags != null)
+            {
+                if (bags.DrawAccessoryShare(3, Nez.Random.NextFloat()))
+                    return GetCaveRareItemAtIndex(12); // NecklaceOfHealth — the pool's only accessory
+                return GetCaveRareItemAtIndex(SelectWeightedPoolIndex(_rarePoolKinds, ctx, excludeAccessories: true));
+            }
             int index = SelectWeightedPoolIndex(_rarePoolKinds, ctx);
             return GetCaveRareItemAtIndex(index);
         }
 
-        /// <summary>Returns the cave rare (Rare-rarity) item at the given pool index (0–11).</summary>
+        /// <summary>Returns the cave rare (Rare-rarity) item at the given pool index (0–12).</summary>
         private static IItem GetCaveRareItemAtIndex(int index)
         {
             switch (index)
@@ -706,7 +757,8 @@ namespace PitHero.ECS.Components
                 case 8:  return GearItems.MagmaWall();
                 case 9:  return GearItems.AbyssHelm();
                 case 10: return GearItems.DiamondCirclet();
-                default: return GearItems.MagmaHelm();
+                case 11: return GearItems.MagmaHelm();
+                default: return GearItems.NecklaceOfHealth();
             }
         }
 
@@ -741,20 +793,31 @@ namespace PitHero.ECS.Components
         /// Mirrors <see cref="GenerateCaveItemForTreasureLevel"/> but without a job context
         /// (virtual layer uses flat pool selection).
         /// </summary>
-        internal static IItem GenerateCaveItemForTreasureLevelDeterministic(int treasureLevel, in LootJobContext ctx, System.Random rng)
+        internal static IItem GenerateCaveItemForTreasureLevelDeterministic(int treasureLevel, in LootJobContext ctx, System.Random rng, LootBagSet bags = null)
         {
             if (treasureLevel == 1)
             {
-                bool isConsumable = rng.NextDouble() < BalanceConfig.CaveConsumableDropRate;
+                bool isConsumable = bags != null
+                    ? bags.DrawConsumableGate((float)rng.NextDouble())
+                    : rng.NextDouble() < BalanceConfig.CaveConsumableDropRate;
                 if (isConsumable)
-                    return GenerateNormalPotionDeterministic(rng);
-                return GetCaveCommonItemAtIndex(SelectWeightedPoolIndexDeterministic(_commonPoolKinds, in ctx, rng));
+                    return GenerateNormalPotionDeterministic(rng, bags);
+                if (bags != null && bags.DrawAccessoryShare(1, (float)rng.NextDouble()))
+                    return GetCaveCommonItemAtIndex(55); // ProtectRing
+                return GetCaveCommonItemAtIndex(SelectWeightedPoolIndexDeterministic(_commonPoolKinds, in ctx, rng, excludeAccessories: bags != null));
             }
             switch (treasureLevel)
             {
-                case 2:  return GetCaveUncommonItemAtIndex(SelectWeightedPoolIndexDeterministic(_uncommonPoolKinds, in ctx, rng));
-                case 3:  return GetCaveRareItemAtIndex(SelectWeightedPoolIndexDeterministic(_rarePoolKinds, in ctx, rng));
-                default: return GetCaveEpicItemAtIndex(SelectWeightedPoolIndexDeterministic(_epicPoolKinds, in ctx, rng));
+                case 2:
+                    if (bags != null && bags.DrawAccessoryShare(2, (float)rng.NextDouble()))
+                        return GetCaveUncommonItemAtIndex(37 + bags.DrawUncommonAccessoryIndex((float)rng.NextDouble()));
+                    return GetCaveUncommonItemAtIndex(SelectWeightedPoolIndexDeterministic(_uncommonPoolKinds, in ctx, rng, excludeAccessories: bags != null));
+                case 3:
+                    if (bags != null && bags.DrawAccessoryShare(3, (float)rng.NextDouble()))
+                        return GetCaveRareItemAtIndex(12); // NecklaceOfHealth
+                    return GetCaveRareItemAtIndex(SelectWeightedPoolIndexDeterministic(_rarePoolKinds, in ctx, rng, excludeAccessories: bags != null));
+                default:
+                    return GetCaveEpicItemAtIndex(SelectWeightedPoolIndexDeterministic(_epicPoolKinds, in ctx, rng));
             }
         }
 
@@ -778,10 +841,11 @@ namespace PitHero.ECS.Components
             }
         }
 
-        /// <summary>Deterministic normal potion selection using caller-supplied RNG.</summary>
-        private static IItem GenerateNormalPotionDeterministic(System.Random rng)
+        /// <summary>Deterministic normal potion selection using caller-supplied RNG (bag rotation when bags exist).</summary>
+        private static IItem GenerateNormalPotionDeterministic(System.Random rng, LootBagSet bags = null)
         {
-            switch (rng.Next(3))
+            int potionPick = bags != null ? bags.DrawPotionType((float)rng.NextDouble()) : rng.Next(3);
+            switch (potionPick)
             {
                 case 0:  return PotionItems.HPPotion();
                 case 1:  return PotionItems.MPPotion();
@@ -820,6 +884,11 @@ namespace PitHero.ECS.Components
 
             if (CaveBiomeConfig.IsCaveLevel(pitLevel))
             {
+                // Shuffle-bag rarity (#382): same band rates, enforced exactly per bag cycle.
+                // Falls back to the pure-random table when no session bags exist (headless tests).
+                var bags = LootShuffleService.LiveBags;
+                if (bags != null)
+                    return bags.DrawCaveTreasureLevel(pitLevel, random);
                 return CaveBiomeConfig.DetermineCaveTreasureLevel(pitLevel, random);
             }
 
@@ -872,13 +941,25 @@ namespace PitHero.ECS.Components
 
             // Seed drop: any uncommon (level-2) roll has a chance to yield seeds instead of normal loot.
             // Seeds are not tier-scaled (they are consumables, not gear).
-            if (Level == 2 && Nez.Random.NextFloat() < BalanceConfig.SeedChestDropRate)
+            // With session bags (#382) the gate fires exactly 1-in-10 eligible rolls and the
+            // seed type rotates through every crop before repeating. RNG call count unchanged.
+            if (Level == 2)
             {
-                ContainedSeedType  = (CropType)Nez.Random.NextInt(CropTypeInfo.Count);
-                ContainedSeedCount = Nez.Random.NextInt(3) + 1; // 1..3
-                ContainedItem = null;
-                Level = 1; // seeds are consumables — always a brown chest (#337)
-                return;
+                var seedBags = LootShuffleService.LiveBags;
+                float seedGateRoll = Nez.Random.NextFloat();
+                bool isSeedChest = seedBags != null
+                    ? seedBags.DrawSeedGate(seedGateRoll)
+                    : seedGateRoll < BalanceConfig.SeedChestDropRate;
+                if (isSeedChest)
+                {
+                    ContainedSeedType = seedBags != null
+                        ? seedBags.DrawSeedType(Nez.Random.NextFloat())
+                        : (CropType)Nez.Random.NextInt(CropTypeInfo.Count);
+                    ContainedSeedCount = Nez.Random.NextInt(3) + 1; // 1..3
+                    ContainedItem = null;
+                    Level = 1; // seeds are consumables — always a brown chest (#337)
+                    return;
+                }
             }
 
             // Stencil drop: chests of level 2+ have an 8% chance to yield an undiscovered stencil.

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -166,6 +166,10 @@ namespace PitHero.ECS.Scenes
             // resolve it via Core.Services.GetService<CrystalCollectionService>() during Initialize.
             Core.Services.AddService(new Services.CrystalCollectionService());
 
+            // Register the loot shuffle bags (#382) before any pit generation so chest rolls
+            // route through session-persistent bags. Transient by design — never saved.
+            Core.Services.AddService(new Services.LootShuffleService());
+
             // Register building service so farm building placement and counts are queryable.
             Core.Services.AddService(new Services.BuildingService());
 

--- a/PitHero/RolePlayingFramework/Balance/BalanceConfig.cs
+++ b/PitHero/RolePlayingFramework/Balance/BalanceConfig.cs
@@ -170,6 +170,28 @@ namespace RolePlayingFramework.Balance
         /// </summary>
         public const int LootWeightAllJobs = 2;
 
+        /// <summary>
+        /// Share of cave equipment drops reserved for accessories, enforced by a shuffle bag
+        /// (1 accessory marble per 10) so accessories reliably appear instead of starving in
+        /// the large weighted pools (issue #382).
+        /// </summary>
+        public const float AccessoryLootShare = 0.10f;
+
+        #endregion
+
+        #region Crit Constants
+
+        /// <summary>
+        /// Base critical-hit chance for every hero and mercenary attack (physical or attack
+        /// skill). Enforced by a per-combatant shuffle bag: exactly
+        /// BaseCritChance × CritBagSize crits per CritBagSize attacks (issue #382).
+        /// Monsters never crit.
+        /// </summary>
+        public const float BaseCritChance = 0.05f;
+
+        /// <summary>Marble count of each crit shuffle bag (the pity cycle length).</summary>
+        public const int CritBagSize = 20;
+
         #endregion
 
         #region Rarity Multipliers

--- a/PitHero/RolePlayingFramework/Combat/BattleReactionHelper.cs
+++ b/PitHero/RolePlayingFramework/Combat/BattleReactionHelper.cs
@@ -28,19 +28,26 @@ namespace RolePlayingFramework.Combat
         }
 
         /// <summary>
-        /// Returns true when the caster's first-attack crit chance applies and the roll wins.
-        /// This is the testable seam for Quickdraw: production code passes <c>Nez.Random.NextFloat()</c>;
-        /// tests supply a deterministic value.
+        /// Rolls the caster's critical hit for one attack action via the per-combatant crit
+        /// shuffle bags (issue #382): the base bag advances on every attack; the quickdraw bag
+        /// only applies on the caster's first offensive action when Quickdraw is learned.
+        /// This is the testable seam: production code passes two <c>Nez.Random.NextFloat()</c>
+        /// values (always both consumed, keeping the battle RNG stream a fixed two floats per
+        /// ally attack); tests supply deterministic values.
         /// </summary>
         /// <param name="caster">The attacking combatant.</param>
         /// <param name="isFirstAction">
         /// Whether this is the caster's first offensive action this battle
         /// (from <c>IBattleContext.IsFirstOffensiveAction</c>).
         /// </param>
-        /// <param name="roll">A value in [0, 1) supplied by the caller.</param>
-        public static bool RollFirstAttackCrit(ICombatant caster, bool isFirstAction, float roll)
+        /// <param name="baseRoll">A value in [0, 1) for the base-crit bag draw.</param>
+        /// <param name="quickdrawRoll">A value in [0, 1) for the quickdraw bag draw.</param>
+        public static bool RollCrit(ICombatant caster, bool isFirstAction, float baseRoll, float quickdrawRoll)
         {
-            return isFirstAction && caster.FirstAttackCritChance > 0f && roll < caster.FirstAttackCritChance;
+            var crit = caster.CritBags.RollBase(baseRoll);
+            if (isFirstAction && caster.FirstAttackCritChance > 0f)
+                crit |= caster.CritBags.RollQuickdraw(quickdrawRoll, caster.FirstAttackCritChance);
+            return crit;
         }
     }
 }

--- a/PitHero/RolePlayingFramework/Combat/CritBagSet.cs
+++ b/PitHero/RolePlayingFramework/Combat/CritBagSet.cs
@@ -1,0 +1,65 @@
+using RolePlayingFramework.Balance;
+using RolePlayingFramework.Utils;
+
+namespace RolePlayingFramework.Combat
+{
+    /// <summary>
+    /// Per-combatant critical-hit shuffle bags (issue #382). Lives on Hero/Mercenary so
+    /// pity progress persists across battles: it must survive ClearBattleState (which
+    /// only clears buffs) and CombatantPassiveApplier.ResetAndApply (which only zeroes
+    /// scalar passive fields).
+    /// Two bags: the base bag advances on every attack (exactly one crit per
+    /// <see cref="BalanceConfig.CritBagSize"/> attacks at 5%); the quickdraw bag covers
+    /// the Quickdraw first-attack bonus and rebuilds lazily whenever the observed
+    /// FirstAttackCritChance differs from the chance it was built for (the passive
+    /// applier resets and re-adds that field on every equip/level/skill change).
+    /// Draws consume no RNG — callers feed in already-consumed Nez.Random floats so the
+    /// battle RNG call sequence stays a fixed two floats per ally attack.
+    /// </summary>
+    public sealed class CritBagSet
+    {
+        private ShuffleBag<bool> _baseBag;
+        private ShuffleBag<bool> _quickdrawBag;
+        private float _builtQuickdrawChance;
+
+        /// <summary>Draws the base-crit bag using a caller-supplied [0,1) roll.</summary>
+        public bool RollBase(float roll01)
+        {
+            if (_baseBag == null)
+                _baseBag = BuildBag(BalanceConfig.BaseCritChance);
+            return _baseBag.NextFromRoll(roll01);
+        }
+
+        /// <summary>
+        /// Draws the quickdraw bag using a caller-supplied [0,1) roll. Returns false without
+        /// touching the bag when the combatant has no first-attack crit chance (the caller's
+        /// RNG consumption, not bag advancement, is what the battle RNG contract fixes).
+        /// </summary>
+        public bool RollQuickdraw(float roll01, float currentChance)
+        {
+            if (currentChance <= 0f)
+                return false;
+
+            if (_quickdrawBag == null || currentChance != _builtQuickdrawChance)
+            {
+                _quickdrawBag = BuildBag(currentChance);
+                _builtQuickdrawChance = currentChance;
+            }
+            return _quickdrawBag.NextFromRoll(roll01);
+        }
+
+        private static ShuffleBag<bool> BuildBag(float chance)
+        {
+            var size = BalanceConfig.CritBagSize;
+            var crits = (int)System.Math.Round(chance * size);
+            if (crits < 1) crits = 1;
+            else if (crits > size) crits = size;
+
+            var bag = new ShuffleBag<bool>(size);
+            bag.Add(true, crits);
+            if (size - crits > 0)
+                bag.Add(false, size - crits);
+            return bag;
+        }
+    }
+}

--- a/PitHero/RolePlayingFramework/Combat/ICombatant.cs
+++ b/PitHero/RolePlayingFramework/Combat/ICombatant.cs
@@ -99,6 +99,12 @@ namespace RolePlayingFramework.Combat
         /// <summary>First-attack critical-hit chance bonus from Quickdraw (Phase 4 plumbing).</summary>
         float FirstAttackCritChance { get; set; }
 
+        /// <summary>
+        /// Per-combatant crit shuffle bags (issue #382). Persist across battles — never
+        /// reset by ClearBattleState or passive re-application.
+        /// </summary>
+        CritBagSet CritBags { get; }
+
         /// <summary>Defense bonus applied only when wearing heavy mail armor (Phase 5 plumbing).</summary>
         int HeavyArmorDefenseBonus { get; set; }
 

--- a/PitHero/RolePlayingFramework/Heroes/Hero.cs
+++ b/PitHero/RolePlayingFramework/Heroes/Hero.cs
@@ -39,6 +39,9 @@ namespace RolePlayingFramework.Heroes
         public int HeavyArmorDefenseBonus { get; set; }
         public bool TrapSense { get; set; }
 
+        // Crit shuffle bags — persist across battles; never reset (issue #382)
+        public CritBagSet CritBags { get; } = new CritBagSet();
+
         // Synergy-based stat modifiers (internal for synergy effect access)
         internal StatBlock _synergyStatBonus = new StatBlock(0, 0, 0, 0);
         internal int _synergyHPBonus = 0;

--- a/PitHero/RolePlayingFramework/Mercenaries/Mercenary.cs
+++ b/PitHero/RolePlayingFramework/Mercenaries/Mercenary.cs
@@ -36,6 +36,9 @@ namespace RolePlayingFramework.Mercenaries
         public int HeavyArmorDefenseBonus { get; set; }
         public bool TrapSense { get; set; }
 
+        // Crit shuffle bags — persist across battles; never reset (issue #382)
+        public CritBagSet CritBags { get; } = new CritBagSet();
+
         // Extra equip permissions granted by learned passives (e.g. knight.light_armor allows robes)
         private readonly HashSet<ItemKind> _extraEquipPermissions = new HashSet<ItemKind>();
 

--- a/PitHero/RolePlayingFramework/Utils/ShuffleBag.cs
+++ b/PitHero/RolePlayingFramework/Utils/ShuffleBag.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+
+namespace RolePlayingFramework.Utils
+{
+    /// <summary>
+    /// Classic shuffle bag ("marble bag"): a weighted finite pool drawn without
+    /// replacement, refilled automatically when exhausted. Over any full cycle the
+    /// draw counts exactly match the added composition, so streaks and droughts are
+    /// bounded while individual draws still feel random.
+    /// The core primitive <see cref="NextFromRoll"/> consumes no RNG itself — the
+    /// caller supplies a [0,1) roll — so bags can sit behind existing RNG call
+    /// sites without changing the number or order of global RNG calls (the battle
+    /// Nez.Random stream is a determinism contract).
+    /// </summary>
+    public sealed class ShuffleBag<T>
+    {
+        private readonly List<T> _items;
+
+        /// <summary>Index of the last undrawn slot; bag is exhausted when below 0.</summary>
+        private int _cursor;
+
+        public ShuffleBag(int capacity)
+        {
+            _items = new List<T>(capacity);
+            _cursor = -1;
+        }
+
+        /// <summary>Total marbles in the bag (full-cycle size).</summary>
+        public int Count => _items.Count;
+
+        /// <summary>Marbles left before the bag refills.</summary>
+        public int Remaining => _cursor + 1;
+
+        /// <summary>
+        /// Adds <paramref name="count"/> copies of an item. Adding resets the cursor
+        /// to a full bag, restarting the current cycle.
+        /// </summary>
+        public void Add(T item, int count = 1)
+        {
+            for (var i = 0; i < count; i++)
+                _items.Add(item);
+            _cursor = _items.Count - 1;
+        }
+
+        /// <summary>Removes all marbles.</summary>
+        public void Clear()
+        {
+            _items.Clear();
+            _cursor = -1;
+        }
+
+        /// <summary>
+        /// Draws using a caller-supplied roll in [0, 1). Consumes no RNG. Swap-to-boundary:
+        /// the drawn marble trades places with the cursor slot and the cursor shrinks, so
+        /// every marble is seen exactly once per cycle.
+        /// </summary>
+        public T NextFromRoll(float roll01)
+        {
+            if (_cursor < 0)
+                _cursor = _items.Count - 1;
+
+            var index = (int)(roll01 * (_cursor + 1));
+            if (index < 0) index = 0;
+            else if (index > _cursor) index = _cursor;
+
+            var selected = _items[index];
+            _items[index] = _items[_cursor];
+            _items[_cursor] = selected;
+            _cursor--;
+            return selected;
+        }
+
+        /// <summary>Draws using the global Nez.Random stream.</summary>
+        public T Next()
+        {
+            return NextFromRoll(Nez.Random.NextFloat());
+        }
+
+        /// <summary>Draws using a caller-owned RNG (virtual layer / deterministic paths).</summary>
+        public T Next(System.Random rng)
+        {
+            return NextFromRoll((float)rng.NextDouble());
+        }
+    }
+}

--- a/PitHero/Services/KitchenTaskCoordinator.cs
+++ b/PitHero/Services/KitchenTaskCoordinator.cs
@@ -1118,6 +1118,55 @@ namespace PitHero.Services
             }
         }
 
+        // Patron dish shuffle bag (#382): every dish weighted inversely to its price, so
+        // cheap dishes are ordered more often but even the priciest cycles through
+        // predictably. Lazily built — prices are static per session (DishConfig cache).
+        private RolePlayingFramework.Utils.ShuffleBag<DishType> _dishBag;
+
+        /// <summary>
+        /// Picks the dish a walk-in patron orders from the currently orderable set.
+        /// Bounded draw-and-skip over the persistent full-menu bag: unorderable draws are
+        /// skipped (their marbles restore on the next bag cycle when stock returns), so
+        /// pricey-dish pity persists across stock fluctuations. Falls back to a uniform
+        /// pick if a full cycle yields nothing orderable.
+        /// </summary>
+        public DishType PickPatronDish(List<DishType> orderable)
+        {
+            if (_dishBag == null)
+                BuildDishBag();
+
+            int limit = _dishBag.Count;
+            for (int i = 0; i < limit; i++)
+            {
+                var dish = _dishBag.Next();
+                for (int j = 0; j < orderable.Count; j++)
+                {
+                    if (orderable[j] == dish)
+                        return dish;
+                }
+            }
+            return orderable[Nez.Random.Range(0, orderable.Count)];
+        }
+
+        /// <summary>Builds the inverse-price dish bag: marbles(d) = max(1, round(maxPrice / price(d))).</summary>
+        private void BuildDishBag()
+        {
+            int maxPrice = 0;
+            for (int d = 0; d < DishTypeInfo.Count; d++)
+            {
+                int price = DishConfig.GetPrice((DishType)d);
+                if (price > maxPrice) maxPrice = price;
+            }
+
+            _dishBag = new RolePlayingFramework.Utils.ShuffleBag<DishType>(DishTypeInfo.Count * 4);
+            for (int d = 0; d < DishTypeInfo.Count; d++)
+            {
+                var dish = (DishType)d;
+                int marbles = Math.Max(1, (int)Math.Round((float)maxPrice / DishConfig.GetPrice(dish)));
+                _dishBag.Add(dish, marbles);
+            }
+        }
+
         /// <summary>Registers the party order source.</summary>
         public void SetPartyOrderSource(IPartyOrderSource source) => _partyOrderSource = source;
 

--- a/PitHero/Services/LootBagSet.cs
+++ b/PitHero/Services/LootBagSet.cs
@@ -1,0 +1,136 @@
+using PitHero.Config;
+using PitHero.Farming;
+using RolePlayingFramework.Utils;
+
+namespace PitHero.Services
+{
+    /// <summary>
+    /// Shuffle bags for treasure-chest loot (issue #382). Rates mirror the pure-random
+    /// constants they replace (CaveBiomeConfig rarity bands, BalanceConfig drop rates)
+    /// but are enforced exactly over each bag cycle, so rarity streaks and droughts are
+    /// bounded and accessories/seeds appear on a predictable cadence.
+    /// All draws go through ShuffleBag.NextFromRoll with a caller-supplied [0,1) roll,
+    /// so one instance serves both the live layer (Nez.Random rolls) and the virtual
+    /// layer (per-run System.Random rolls) without owning any RNG itself.
+    /// One instance should live per session (LootShuffleService) or per virtual sim run
+    /// (VirtualPitGenerator) so pity carries across pit floors.
+    /// </summary>
+    public sealed class LootBagSet
+    {
+        // Cave rarity bands, denominator 20 — compositions mirror CaveBiomeConfig.DetermineCaveTreasureLevel.
+        private readonly ShuffleBag<int> _cave11To14;     // 35% L2 / 65% L1
+        private readonly ShuffleBag<int> _caveBoss15;     // 60% L2 / 40% L1
+        private readonly ShuffleBag<int> _caveBoss20And25; // 20% L3 / 50% L2 / 30% L1
+        private readonly ShuffleBag<int> _cave16To25;     // 10% L3 / 35% L2 / 55% L1
+
+        // Chest content gates.
+        private readonly ShuffleBag<bool> _seedGate;        // SeedChestDropRate 10% => 1/10
+        private readonly ShuffleBag<int> _seedType;         // one marble per crop — full rotation
+        private readonly ShuffleBag<bool> _consumableGate;  // CaveConsumableDropRate 60% => 3/5
+        private readonly ShuffleBag<int> _potionType;       // HP/MP/Mix strict rotation
+
+        // Accessory share per cave equipment pool (AccessoryLootShare 10% => 1/10).
+        private readonly ShuffleBag<bool> _accessoryCommon;
+        private readonly ShuffleBag<bool> _accessoryUncommon;
+        private readonly ShuffleBag<bool> _accessoryRare;
+        private readonly ShuffleBag<int> _uncommonAccessoryPick; // MagicChain / RingOfPower rotation
+
+        // Epic pool rotation (PitLord set) — boss epic chest drops.
+        private readonly ShuffleBag<int> _epicIndex;
+
+        public LootBagSet()
+        {
+            _cave11To14 = BuildRarityBag(l3: 0, l2: 7);
+            _caveBoss15 = BuildRarityBag(l3: 0, l2: 12);
+            _caveBoss20And25 = BuildRarityBag(l3: 4, l2: 10);
+            _cave16To25 = BuildRarityBag(l3: 2, l2: 7);
+
+            _seedGate = BuildGateBag(trueMarbles: 1, totalMarbles: 10);
+            _consumableGate = BuildGateBag(trueMarbles: 3, totalMarbles: 5);
+
+            _seedType = new ShuffleBag<int>(CropTypeInfo.Count);
+            for (var i = 0; i < CropTypeInfo.Count; i++)
+                _seedType.Add(i);
+
+            _potionType = new ShuffleBag<int>(3);
+            for (var i = 0; i < 3; i++)
+                _potionType.Add(i);
+
+            _accessoryCommon = BuildGateBag(1, 10);
+            _accessoryUncommon = BuildGateBag(1, 10);
+            _accessoryRare = BuildGateBag(1, 10);
+
+            _uncommonAccessoryPick = new ShuffleBag<int>(2);
+            _uncommonAccessoryPick.Add(0);
+            _uncommonAccessoryPick.Add(1);
+
+            _epicIndex = new ShuffleBag<int>(4);
+            for (var i = 0; i < 4; i++)
+                _epicIndex.Add(i);
+        }
+
+        private static ShuffleBag<int> BuildRarityBag(int l3, int l2)
+        {
+            var bag = new ShuffleBag<int>(20);
+            if (l3 > 0) bag.Add(3, l3);
+            bag.Add(2, l2);
+            bag.Add(1, 20 - l3 - l2);
+            return bag;
+        }
+
+        private static ShuffleBag<bool> BuildGateBag(int trueMarbles, int totalMarbles)
+        {
+            var bag = new ShuffleBag<bool>(totalMarbles);
+            bag.Add(true, trueMarbles);
+            bag.Add(false, totalMarbles - trueMarbles);
+            return bag;
+        }
+
+        /// <summary>
+        /// Bag-driven counterpart of <see cref="CaveBiomeConfig.DetermineCaveTreasureLevel"/>:
+        /// same per-band rates, enforced exactly per 20 chests of that band.
+        /// </summary>
+        public int DrawCaveTreasureLevel(int pitLevel, float roll01)
+        {
+            if (pitLevel <= 10)
+                return 1;
+            if (pitLevel == 15)
+                return _caveBoss15.NextFromRoll(roll01);
+            if (pitLevel < 16)
+                return _cave11To14.NextFromRoll(roll01);
+            if (CaveBiomeConfig.IsBossFloor(pitLevel))
+                return _caveBoss20And25.NextFromRoll(roll01);
+            return _cave16To25.NextFromRoll(roll01);
+        }
+
+        /// <summary>Whether an eligible level-2 chest becomes a seed chest (exactly 1 per 10).</summary>
+        public bool DrawSeedGate(float roll01) => _seedGate.NextFromRoll(roll01);
+
+        /// <summary>Which crop's seeds drop — every crop appears once per rotation.</summary>
+        public CropType DrawSeedType(float roll01) => (CropType)_seedType.NextFromRoll(roll01);
+
+        /// <summary>Whether a level-1 cave chest holds a consumable (exactly 3 per 5).</summary>
+        public bool DrawConsumableGate(float roll01) => _consumableGate.NextFromRoll(roll01);
+
+        /// <summary>Potion selector: 0 = HP, 1 = MP, 2 = Mix — strict rotation.</summary>
+        public int DrawPotionType(float roll01) => _potionType.NextFromRoll(roll01);
+
+        /// <summary>Whether a cave equipment roll of the given treasure level yields an accessory (exactly 1 per 10).</summary>
+        public bool DrawAccessoryShare(int treasureLevel, float roll01)
+        {
+            switch (treasureLevel)
+            {
+                case 1: return _accessoryCommon.NextFromRoll(roll01);
+                case 2: return _accessoryUncommon.NextFromRoll(roll01);
+                case 3: return _accessoryRare.NextFromRoll(roll01);
+                default: return false; // epic pool has no accessories
+            }
+        }
+
+        /// <summary>Uncommon accessory selector: 0 = MagicChain, 1 = RingOfPower — strict rotation.</summary>
+        public int DrawUncommonAccessoryIndex(float roll01) => _uncommonAccessoryPick.NextFromRoll(roll01);
+
+        /// <summary>Epic pool selector (0–3, PitLord set) — all four cycle before any repeats.</summary>
+        public int DrawEpicIndex(float roll01) => _epicIndex.NextFromRoll(roll01);
+    }
+}

--- a/PitHero/Services/LootBagSet.cs
+++ b/PitHero/Services/LootBagSet.cs
@@ -132,5 +132,20 @@ namespace PitHero.Services
 
         /// <summary>Epic pool selector (0–3, PitLord set) — all four cycle before any repeats.</summary>
         public int DrawEpicIndex(float roll01) => _epicIndex.NextFromRoll(roll01);
+
+        /// <summary>
+        /// Draws the next epic item for a biome main-boss chest — all four PitLord items
+        /// cycle before any repeat.
+        /// </summary>
+        public RolePlayingFramework.Equipment.IItem DrawEpicItem(float roll01)
+        {
+            switch (DrawEpicIndex(roll01))
+            {
+                case 0: return RolePlayingFramework.Equipment.GearItems.PitLordsSword();
+                case 1: return RolePlayingFramework.Equipment.GearItems.PitLordsArmor();
+                case 2: return RolePlayingFramework.Equipment.GearItems.PitLordsAegis();
+                default: return RolePlayingFramework.Equipment.GearItems.PitLordsCrown();
+            }
+        }
     }
 }

--- a/PitHero/Services/LootShuffleService.cs
+++ b/PitHero/Services/LootShuffleService.cs
@@ -40,14 +40,7 @@ namespace PitHero.Services
         /// </summary>
         public IItem DrawEpicItem()
         {
-            var index = Bags.DrawEpicIndex((float)_epicRng.NextDouble());
-            switch (index)
-            {
-                case 0: return GearItems.PitLordsSword();
-                case 1: return GearItems.PitLordsArmor();
-                case 2: return GearItems.PitLordsAegis();
-                default: return GearItems.PitLordsCrown();
-            }
+            return Bags.DrawEpicItem((float)_epicRng.NextDouble());
         }
     }
 }

--- a/PitHero/Services/LootShuffleService.cs
+++ b/PitHero/Services/LootShuffleService.cs
@@ -1,0 +1,53 @@
+using Nez;
+using RolePlayingFramework.Equipment;
+
+namespace PitHero.Services
+{
+    /// <summary>
+    /// Session-scoped owner of the treasure loot shuffle bags (issue #382). Registered per
+    /// MainGameScene load; transient by design — bags refill fresh each session and are
+    /// never saved (chests themselves are not persisted; the pit regenerates on load).
+    /// Also owns the epic-chest draw for biome main-boss kills. That draw runs mid-battle
+    /// (inside the BattleEngine coroutine via LiveBattleAdapter.OnEnemyDefeated), so it
+    /// uses a private System.Random and must NEVER touch Nez.Random — the battle stream's
+    /// call sequence is a determinism contract.
+    /// </summary>
+    public sealed class LootShuffleService
+    {
+        private readonly System.Random _epicRng = new System.Random();
+
+        /// <summary>The session's loot bags, shared by every chest roll.</summary>
+        public LootBagSet Bags { get; } = new LootBagSet();
+
+        /// <summary>
+        /// The live layer's bags, or null when no scene/service exists (headless tests,
+        /// virtual layer). Callers fall back to the legacy pure-random path on null.
+        /// </summary>
+        public static LootBagSet LiveBags
+        {
+            get
+            {
+                if (Core.Instance == null)
+                    return null;
+                var service = Core.Services.GetService<LootShuffleService>();
+                return service?.Bags;
+            }
+        }
+
+        /// <summary>
+        /// Draws the next epic item for a biome main-boss chest. Cycles all four PitLord
+        /// items before any repeat. Consumes zero Nez.Random (safe mid-battle).
+        /// </summary>
+        public IItem DrawEpicItem()
+        {
+            var index = Bags.DrawEpicIndex((float)_epicRng.NextDouble());
+            switch (index)
+            {
+                case 0: return GearItems.PitLordsSword();
+                case 1: return GearItems.PitLordsArmor();
+                case 2: return GearItems.PitLordsAegis();
+                default: return GearItems.PitLordsCrown();
+            }
+        }
+    }
+}

--- a/PitHero/TreasureSpawner.cs
+++ b/PitHero/TreasureSpawner.cs
@@ -1,0 +1,51 @@
+using Microsoft.Xna.Framework;
+using Nez;
+using PitHero.ECS.Components;
+using RolePlayingFramework.Equipment;
+
+namespace PitHero
+{
+    /// <summary>
+    /// Runtime treasure-chest spawner (issue #382). PitGenerator creates chests only during
+    /// level generation; this mirrors its TAG_TREASURE branch for chests spawned mid-level
+    /// with explicit contents — currently the biome main-boss epic drop. Does NOT call
+    /// InitializeForPitLevel (contents are supplied, not rolled).
+    /// </summary>
+    public static class TreasureSpawner
+    {
+        /// <summary>
+        /// Spawns a closed treasure chest at the given tile containing exactly
+        /// <paramref name="item"/>. Chest color derives from the item's rarity (#337).
+        /// </summary>
+        public static Entity SpawnTreasureChestAtTile(Scene scene, Point tile, IItem item)
+        {
+            var worldPos = new Vector2(
+                tile.X * GameConfig.TileSize + GameConfig.TileSize / 2,
+                tile.Y * GameConfig.TileSize + GameConfig.TileSize / 2);
+
+            var entity = scene.CreateEntity("treasures");
+            entity.SetTag(GameConfig.TAG_TREASURE);
+            entity.SetPosition(worldPos);
+
+            // TreasureComponent self-installs renderers, compositor, and FogHideableComponent
+            // in OnAddedToEntity; the Level setter drives the wood color.
+            var treasureComponent = entity.AddComponent(new TreasureComponent());
+            treasureComponent.ContainedItem = item;
+            treasureComponent.Level = item is Gear gear
+                ? RarityUtils.GetTreasureLevelForRarity(gear.Rarity)
+                : 1;
+
+            var collider = entity.AddComponent(new BoxCollider(GameConfig.TileSize, GameConfig.TileSize));
+            collider.IsTrigger = true;
+            Flags.SetFlagExclusive(ref collider.PhysicsLayer, GameConfig.PhysicsHeroWorldLayer);
+
+            var pitWidthManager = Core.Services?.GetService<PitWidthManager>();
+            int currentPitLevel = pitWidthManager?.CurrentPitLevel ?? 1;
+            Services.Analytics.AnalyticsService.LogChestSpawned(currentPitLevel, tile.X, tile.Y,
+                treasureComponent.Level, treasureComponent.ContainedItem, null, 0, null);
+
+            Debug.Log($"[TreasureSpawner] Spawned level {treasureComponent.Level} chest at tile ({tile.X},{tile.Y}) containing {item?.Name}");
+            return entity;
+        }
+    }
+}

--- a/PitHero/VirtualGame/VirtualBattleRunner.cs
+++ b/PitHero/VirtualGame/VirtualBattleRunner.cs
@@ -1,3 +1,4 @@
+using Microsoft.Xna.Framework;
 using PitHero.AI;
 using PitHero.Combat;
 using RolePlayingFramework.Combat;
@@ -47,6 +48,22 @@ namespace PitHero.VirtualGame
 
         /// <summary>Read-only list of metrics from every battle run through this runner.</summary>
         public IReadOnlyList<VirtualBattleMetrics> AllBattleMetrics => _allBattleMetrics;
+
+        // ── Boss epic chest (#382) ────────────────────────────────────────────────
+
+        // Epic draw RNG — independent of the Nez.Random combat stream (mirrors the live
+        // LootShuffleService, whose mid-battle epic draw must not touch the global stream).
+        private readonly System.Random _epicRng = new System.Random(382);
+
+        /// <summary>
+        /// Loot bags used for the biome main-boss epic drop. Inject the simulation's shared
+        /// set so the PitLord items cycle without repeats across the whole run; when null,
+        /// boss kills spawn no epic chest (standalone engine tests keep legacy behavior).
+        /// </summary>
+        public Services.LootBagSet LootBags { get; set; }
+
+        /// <summary>Pit tier for epic-drop gear scaling (mirrors live chest tier scaling).</summary>
+        public int CurrentPitTier { get; set; } = 1;
 
         // ── Construction ──────────────────────────────────────────────────────────
 
@@ -159,11 +176,23 @@ namespace PitHero.VirtualGame
             _world.GetLivingMonstersAdjacentTo(_world.HeroPosition, _adjacentBuffer);
             if (_adjacentBuffer.Count == 0) return null;
 
-            // Determine if this battle contains a boss
+            // Determine if this battle contains a boss; capture the biome main boss and its
+            // tile BEFORE the battle — the sink removes dead monsters from the world state.
             bool isBoss = false;
+            IEnemy mainBoss = null;
+            Point mainBossTile = default;
             for (int i = 0; i < _adjacentBuffer.Count; i++)
             {
-                if (_adjacentBuffer[i].IsBoss) { isBoss = true; break; }
+                var candidate = _adjacentBuffer[i];
+                if (candidate.IsBoss)
+                {
+                    isBoss = true;
+                    if (candidate.EnemyId == EnemyId.MoltenTitan && _world.TryGetMonsterPosition(candidate, out var bossPos))
+                    {
+                        mainBoss = candidate;
+                        mainBossTile = bossPos;
+                    }
+                }
             }
 
             // Reset burst flags so each battle starts clean
@@ -181,6 +210,19 @@ namespace PitHero.VirtualGame
             var engine = new BattleEngine(_partyView, _sink);
             HeadlessCoroutineRunner.RunToCompletion(
                 engine.Run(_heroAlly, _mercAllyInterfaces, monsters, _heroActionQueue));
+
+            // Biome main-boss epic chest (#382) — mirrors LiveBattleAdapter.SpawnBossEpicChest.
+            // Draws with a runner-owned System.Random, never the Nez.Random combat stream.
+            if (mainBoss != null && mainBoss.CurrentHP <= 0 && LootBags != null)
+            {
+                var epicItem = LootBags.DrawEpicItem((float)_epicRng.NextDouble());
+                if (CurrentPitTier >= 2 && epicItem is Gear epicGear)
+                {
+                    int depthDelta = (CurrentPitTier - 1) * Config.BiomeProgressionConfig.MaxBiomeLevel;
+                    epicItem = Gear.CreateTierScaledCopy(epicGear, CurrentPitTier, depthDelta);
+                }
+                _world.AddTreasure(mainBossTile, epicItem);
+            }
 
             var metrics = _sink.CurrentMetrics;
             if (metrics != null) _allBattleMetrics.Add(metrics);

--- a/PitHero/VirtualGame/VirtualGameSimulation.cs
+++ b/PitHero/VirtualGame/VirtualGameSimulation.cs
@@ -20,6 +20,10 @@ namespace PitHero.VirtualGame
     public class VirtualGameSimulation
     {
         private readonly VirtualWorldState _world;
+
+        // Loot shuffle bags (#382) — one shared set per simulation run, injected into each
+        // per-level VirtualPitGenerator and VirtualBattleRunner so pity spans floors.
+        private readonly Services.LootBagSet _lootBags = new Services.LootBagSet();
         private readonly VirtualHero _hero;
         private readonly VirtualPitLevelQueue _pitQueue;
         private string _currentAction;
@@ -445,6 +449,9 @@ namespace PitHero.VirtualGame
             var pitWidthManager = new VirtualPitWidthManager(tiledMapService);
             var generator       = new VirtualPitGenerator(_world, tiledMapService, pitWidthManager);
             generator.LootContext = BuildLootJobContext();
+            // Share one loot bag set across every level of this run (#382) so rarity/
+            // accessory pity carries across floors like the live session bags.
+            generator.LootBags = _lootBags;
             generator.RegenerateForLevel(pitLevel);
 
             // Build the battle runner with the real hero + mercs.
@@ -454,6 +461,9 @@ namespace PitHero.VirtualGame
             _battleRunner  = new VirtualBattleRunner(_world, partyView);
             _battleRunner.SetHeroAlly(_hero.LinkedHero);
             _battleRunner.SetMercenaries(_mercenaries);
+            // Boss epic chest parity (#382): shared bags + current tier for gear scaling.
+            _battleRunner.LootBags = _lootBags;
+            _battleRunner.CurrentPitTier = _simPitWidthManager.CurrentPitTier;
 
             // Place hero at pit start and reset the per-level GOAP flags — without this,
             // a persistent multi-level run (RunLevelRange) would carry ActivatedWizardOrb

--- a/PitHero/VirtualGame/VirtualPitGenerator.cs
+++ b/PitHero/VirtualGame/VirtualPitGenerator.cs
@@ -19,6 +19,11 @@ namespace PitHero.VirtualGame
         private readonly VirtualTiledMapService _tiledMapService;
         private readonly VirtualPitWidthManager _pitWidthManager;
 
+        // Loot shuffle bags (#382): one set per generator instance (= per sim run), so
+        // rarity/accessory/seedless pity carries across floors like the live session bags.
+        // Draws are fed from the per-level Random(depth), keeping generation deterministic.
+        private readonly Services.LootBagSet _lootBags = new Services.LootBagSet();
+
         /// <summary>
         /// Party job context used to bias chest gear toward equipable kinds, mirroring
         /// the live PitGenerator.BuildLootJobContext weighting.  Leave default (empty)
@@ -139,9 +144,9 @@ namespace PitHero.VirtualGame
                     if (CaveBiomeConfig.IsCaveLevel(displayedLevel))
                     {
                         float roll = (float)random.NextDouble();
-                        int treasureLevel = CaveBiomeConfig.DetermineCaveTreasureLevel(displayedLevel, roll);
+                        int treasureLevel = _lootBags.DrawCaveTreasureLevel(displayedLevel, roll);
                         var lootCtx = LootContext;
-                        item = TreasureComponent.GenerateCaveItemForTreasureLevelDeterministic(treasureLevel, in lootCtx, random);
+                        item = TreasureComponent.GenerateCaveItemForTreasureLevelDeterministic(treasureLevel, in lootCtx, random, _lootBags);
                     }
                     else
                     {

--- a/PitHero/VirtualGame/VirtualPitGenerator.cs
+++ b/PitHero/VirtualGame/VirtualPitGenerator.cs
@@ -19,10 +19,18 @@ namespace PitHero.VirtualGame
         private readonly VirtualTiledMapService _tiledMapService;
         private readonly VirtualPitWidthManager _pitWidthManager;
 
-        // Loot shuffle bags (#382): one set per generator instance (= per sim run), so
-        // rarity/accessory/seedless pity carries across floors like the live session bags.
-        // Draws are fed from the per-level Random(depth), keeping generation deterministic.
-        private readonly Services.LootBagSet _lootBags = new Services.LootBagSet();
+        // Loot shuffle bags (#382). The generator is recreated per level by
+        // VirtualGameSimulation, so the sim injects one shared set per run — that carries
+        // rarity/accessory pity across floors like the live session bags. Draws are fed
+        // from the per-level Random(depth), keeping generation deterministic.
+        private Services.LootBagSet _lootBags = new Services.LootBagSet();
+
+        /// <summary>The loot shuffle bags used for chest rolls; inject to share across levels.</summary>
+        public Services.LootBagSet LootBags
+        {
+            get => _lootBags;
+            set => _lootBags = value ?? _lootBags;
+        }
 
         /// <summary>
         /// Party job context used to bias chest gear toward equipable kinds, mirroring

--- a/PitHero/VirtualGame/VirtualWorldState.cs
+++ b/PitHero/VirtualGame/VirtualWorldState.cs
@@ -366,6 +366,15 @@ namespace PitHero.VirtualGame
         }
 
         /// <summary>
+        /// Tries to get a living-or-dead monster's tile. Used to capture a boss's position
+        /// before the battle sink removes it on death (#382 epic chest anchor).
+        /// </summary>
+        public bool TryGetMonsterPosition(IEnemy enemy, out Point position)
+        {
+            return _monsterPositions.TryGetValue(enemy, out position);
+        }
+
+        /// <summary>
         /// Removes a defeated monster from both the instance dictionaries and the
         /// <c>_entities["Monsters"]</c> position list so the world state stays consistent.
         /// </summary>

--- a/PitHero/docs/ShuffleBagSystem.md
+++ b/PitHero/docs/ShuffleBagSystem.md
@@ -1,0 +1,203 @@
+# Shuffle Bag System
+
+Issue #382. Controlled randomness via the classic **shuffle bag** ("marble bag"): a weighted
+finite pool drawn without replacement, refilled automatically when exhausted. Over any full
+cycle the draw counts exactly match the bag's composition, so streaks and droughts are
+bounded while individual draws still feel random. Average rates are unchanged from the
+pure-random constants the bags replaced — only the variance is tamed.
+
+Four systems are bag-driven: **battle crits**, **treasure-chest loot**, the **biome-boss epic
+chest**, and **tavern patron dish orders**.
+
+## The primitive: `ShuffleBag<T>`
+
+`PitHero/RolePlayingFramework/Utils/ShuffleBag.cs` (namespace `RolePlayingFramework.Utils` —
+usable from both RPF and PitHero code; RPF must not reference `PitHero.*`).
+
+- `Add(T item, int count = 1)` — adds marbles. **Adding resets the cursor to a full bag**
+  (restarts the current cycle), so build compositions once, up front.
+- `T NextFromRoll(float roll01)` — **the core primitive. Consumes no RNG.** The caller
+  supplies a [0,1) roll; the bag maps it onto its remaining marbles (swap-to-boundary, cursor
+  decrements, auto-refill on exhaustion). This is what lets bags sit behind existing RNG call
+  sites without changing the *number or order* of global RNG calls.
+- `T Next()` — convenience, draws via `Nez.Random.NextFloat()`. Only for streams that are
+  NOT determinism-contract-bound (e.g. the tavern dish bag).
+- `T Next(System.Random rng)` — convenience for caller-owned RNGs (virtual layer).
+- `Count` / `Remaining` / `Clear()`.
+
+AOT-safe: no LINQ, no per-draw allocation.
+
+### The one rule that must never be broken
+
+**In any RNG-contract-bound path, bags consume caller-supplied rolls (`NextFromRoll`), never
+their own.** The battle `Nez.Random` call sequence is a compatibility contract (see
+`VirtualGameLogicLayer.md` § behavior-preservation contract). A bag that draws RNG itself, or
+a call site that draws RNG conditionally, silently changes every downstream battle outcome.
+The structural guard is `BattleEngineTests` (`MercQueue_EmptyOrNull_ProducesIdenticalBattle`,
+same-seed determinism) — if those fail after a bag change, the RNG call count drifted.
+
+## Battle crits — `CritBagSet`
+
+Files: `RolePlayingFramework/Combat/CritBagSet.cs`, `BattleReactionHelper.RollCrit`,
+`PitHero/Combat/BattleEngine.cs` (three ally-attack sites),
+`RolePlayingFramework/Balance/BalanceConfig.cs` (`BaseCritChance = 0.05f`, `CritBagSize = 20`).
+
+- Every hero/merc attack (physical or attack skill) has a 5% base crit chance, enforced as
+  **exactly 1 crit per 20 attacks** by a per-combatant base bag. Monsters never crit. Crit
+  damage stays ×2.
+- **RNG contract (since #382): every ally attack consumes exactly TWO `Nez.Random.NextFloat()`
+  calls** — a base-crit roll, then a quickdraw roll — *both always consumed*, even when the
+  attacker can't crit (precedent: `RollDodge` always rolls at 0 dodge). The floats feed
+  `BattleReactionHelper.RollCrit(caster, isFirstAction, baseRoll, quickdrawRoll)`, which
+  drives the bags via `NextFromRoll`.
+- **Quickdraw** (Archer first-attack +50% crit) is its own bag —
+  `round(FirstAttackCritChance × 20)` crit marbles of 20 — drawn only on the caster's first
+  offensive action of a battle, OR-ed with the base result. `RollQuickdraw` returns false
+  without advancing the bag when the chance is 0 (bag advancement is not contract-bound; the
+  caller's RNG consumption is).
+- **Persistence**: `CritBagSet` lives on the domain objects (`Hero`/`Mercenary`, via
+  `ICombatant.CritBags`), so pity carries across battles. It deliberately survives
+  `ClearBattleState` (clears only buffs) and `CombatantPassiveApplier.ResetAndApply` (zeroes
+  only scalar passive fields). The quickdraw bag rebuilds lazily whenever the observed
+  `FirstAttackCritChance` differs from the chance it was built for — that is how it tracks
+  equip/level/skill changes without any hook into the passive applier.
+- Virtual sim needs no special wiring: `VirtualGameSimulation` holds persistent
+  `Hero`/`Mercenary` objects and `BattleEngine` is shared verbatim.
+
+Tuning knob: `BalanceConfig.BaseCritChance` (single constant; bag size 20 means the useful
+granularity is multiples of 5%).
+
+## Treasure-chest loot — `LootBagSet` + `LootShuffleService`
+
+Files: `PitHero/Services/LootBagSet.cs`, `PitHero/Services/LootShuffleService.cs`,
+`PitHero/ECS/Components/TreasureComponent.cs`, `PitHero/VirtualGame/VirtualPitGenerator.cs`.
+
+`LootBagSet` owns the compositions and no RNG (all draws via `NextFromRoll`), so **one class
+serves both layers**: live feeds it `Nez.Random` rolls, virtual feeds it per-run
+`System.Random` rolls.
+
+| Bag | Composition | Replaces |
+|---|---|---|
+| Cave rarity 11–14 | 7×L2 + 13×L1 (of 20) | `CaveBiomeConfig.DetermineCaveTreasureLevel` 35/65 |
+| Cave rarity boss 15 | 12×L2 + 8×L1 | 60/40 |
+| Cave rarity boss 20/25 | 4×L3 + 10×L2 + 6×L1 | 20/50/30 |
+| Cave rarity 16–25 non-boss | 2×L3 + 7×L2 + 11×L1 | 10/35/55 |
+| Seed gate | 1×true + 9×false | `SeedChestDropRate` 10% |
+| Seed type | 1 marble per `CropType` | uniform pick (now full rotation) |
+| Consumable gate (L1 cave) | 3×true + 2×false | `CaveConsumableDropRate` 60% |
+| Potion type | HP/MP/Mix, 1 each | uniform pick (now strict rotation) |
+| Accessory share (per rarity pool) | 1×true + 9×false | **new** — `BalanceConfig.AccessoryLootShare` 10% |
+| Uncommon accessory pick | MagicChain/RingOfPower, 1 each | — |
+| Epic index | 0–3 (PitLord set), 1 each | — |
+
+Pit levels ≤ 10 are always L1 (no bag). `DrawCaveTreasureLevel` picks the band internally.
+
+**Session ownership + null fallback**: `LootShuffleService` is registered in
+`MainGameScene`'s service block. `LootShuffleService.LiveBags` is the access pattern
+everywhere in `TreasureComponent`:
+
+```csharp
+var bags = LootShuffleService.LiveBags; // null when Core.Instance == null or service absent
+```
+
+**Null means fall back to the legacy pure-random path** — headless unit tests that construct
+`TreasureComponent` without a scene rely on this. Never assume `LiveBags` is non-null, and
+never let the two paths consume different RNG call counts.
+
+**Accessory starvation fix**: cave equipment rolls consult the accessory-share bag first
+(one extra `NextFloat` per cave equipment roll — chest generation is NOT contract-bound). On
+true: common → ProtectRing, uncommon → MagicChain/RingOfPower rotation, rare →
+NecklaceOfHealth (added to `_rarePoolKinds` as index 12 by #382 — it was previously in no
+pool at all). On false: the existing job-weighted pool walk runs with accessory weights
+zeroed (`excludeAccessories: true`) so accessories don't double-dip.
+
+**Deterministic twins**: `GenerateCaveItemForTreasureLevelDeterministic` (and friends) take an
+optional `LootBagSet` parameter and roll via `(float)rng.NextDouble()` — this is the virtual
+path.
+
+## Biome-boss epic chest
+
+Files: `PitHero/AI/LiveBattleAdapter.cs` (`SpawnBossEpicChest`), `PitHero/TreasureSpawner.cs`,
+`PitHero/VirtualGame/VirtualBattleRunner.cs`.
+
+Every **Molten Titan** kill (the Cave biome main boss, all tier repeats) spawns a purple
+chest at the boss tile containing one Epic PitLord item; the epic bag guarantees all four
+pieces (Sword/Armor/Aegis/Crown) before any repeat. Tier ≥ 2 runs tier-scale the gear
+exactly like chest loot (`Gear.CreateTierScaledCopy`).
+
+Sharp edges, in order of sharpness:
+
+1. **`OnEnemyDefeated` runs mid-battle inside the engine coroutine, so the epic draw must
+   consume ZERO `Nez.Random`.** `LootShuffleService.DrawEpicItem()` uses a private
+   `System.Random` (same rule as `SpeechBubbleSystem.md`). Anything else added to this hook
+   must obey the same rule.
+2. The boss entity is still alive at this point (destroy happens later in
+   `ShowMonsterDeath`), so `GetEntityForEnemy(enemy)` anchors the chest tile; fallback is the
+   hero's tile.
+3. **GOAP retarget**: after spawning, `_heroComponent.ExploredPit = false` (it's a latch) and
+   `AdjacentToChest = CheckAdjacentToChest()` so the post-battle replan (Idle_Enter/Idle_Tick)
+   sees the new CLOSED chest and goes to open it.
+4. `TreasureSpawner.SpawnTreasureChestAtTile(scene, tile, item)` sets `ContainedItem` +
+   `Level` (from rarity — Epic ⇒ 4, purple) directly and does **not** call
+   `InitializeForPitLevel`; `TreasureComponent.OnAddedToEntity` self-installs renderers,
+   compositor, and `FogHideableComponent`.
+
+**Virtual parity**: `VirtualBattleRunner` captures the Molten Titan + tile before the run
+(the sink removes dead monsters — `VirtualWorldState.TryGetMonsterPosition`), then after
+`RunToCompletion` draws from the shared `LootBagSet` with a runner-owned seeded
+`System.Random` and calls `_world.AddTreasure(bossTile, item)`. `LootBags == null` ⇒ no epic
+drop (keeps legacy tests untouched). `CurrentPitTier` must be set by the caller for scaling.
+
+## Tavern patron dishes
+
+Files: `PitHero/Services/KitchenTaskCoordinator.cs` (`PickPatronDish`),
+`PitHero/ECS/Components/KitchenMonsterStateMachine.cs` (`TakeOrderAtTarget`).
+
+Walk-in patrons draw from a persistent full-menu bag weighted **inversely to price**:
+`marbles(d) = max(1, round(maxPrice / price(d)))`. Cheap dishes dominate; the priciest dish
+still cycles through on a bounded cadence. Selection is **bounded draw-and-skip**: up to
+`Count` draws of `_dishBag.Next()` (this stream is not contract-bound, so `Next()` is fine),
+first drawn dish present in the orderable list wins; skipped unorderable marbles restore next
+cycle so pricey-dish pity persists across stock fluctuations; a fully unorderable cycle falls
+back to a uniform pick.
+
+## Persistence: none, by design
+
+All bags are transient in-memory state — they refill fresh each session and are **never
+saved** (save format untouched by #382, stays v27). Crit pity resets on load; chest bags
+reset with the scene (chests themselves aren't persisted — the pit regenerates); the dish bag
+rebuilds lazily. Do not add bag state to the save format without revisiting this decision.
+
+## Recipe: adding a new bag-driven drop
+
+1. **Decide which RNG stream the call site lives on.**
+   - Battle path (`BattleEngine`, anything reachable from the engine coroutine): the call
+     count per action is a contract. Consume the same fixed number of `Nez.Random` floats on
+     every code path (even when the result is ignored) and feed them to `NextFromRoll`.
+     Update the contract paragraph in `VirtualGameLogicLayer.md`.
+   - Mid-battle side effects (`OnEnemyDefeated` etc.): zero `Nez.Random` — use a private
+     `System.Random`.
+   - Everything else (chest spawn, kitchen, cosmetics): free to add rolls; `Next()` is fine.
+2. **Pick the owner for the bag's lifetime** — pity scope is ownership scope: per-combatant
+   (`CritBagSet` on Hero/Merc), per-session (`LootShuffleService`), per-sim-run
+   (`VirtualGameSimulation`'s shared `LootBagSet`), per-coordinator (dish bag).
+3. **Mirror the legacy rate exactly** in the composition (denominator 20 or the rate's
+   natural denominator) and keep a pure-random fallback when the owner can be absent
+   (headless tests) — follow the `LiveBags` null-fallback pattern.
+4. **Wire the virtual layer** if the live path has a virtual counterpart: share ONE bag set
+   per sim run (generators/runners are recreated per level — inject, don't construct) and
+   feed it deterministic `System.Random` rolls.
+5. **Write a conformance test** asserting the exact per-cycle composition (see
+   `ShuffleBagLootTests` / `ShuffleBagTests`; mark `[DoNotParallelize]` if any path touches
+   the shared `Nez.Random` stream).
+
+## Tests
+
+- `PitHero.Tests/ShuffleBagTests.cs` — primitive: exact multiset per cycle, refill,
+  `NextFromRoll` determinism/boundaries, `Add` cursor reset.
+- `PitHero.Tests/StubSkillTests.cs` — `RollCrit`: quickdraw fold-in, exactly-1-per-20 base
+  cycle, bag survival across `ClearBattleState`, lazy quickdraw rebuild.
+- `PitHero.Tests/ShuffleBagLootTests.cs` — every `LootBagSet` rate, epic 4-before-repeat,
+  virtual Molten Titan chest spawn (+ negative test for non-main bosses), dish-bag
+  inverse-price conformance.
+- `BattleEngineTests` — the unweakened structural guards for the RNG contract.

--- a/PitHero/docs/VirtualGameLogicLayer.md
+++ b/PitHero/docs/VirtualGameLogicLayer.md
@@ -120,7 +120,12 @@ layers:
 **⚠ Behavior-preservation contract:** the engine is a verbatim retype of the original live
 loop. The **sequence of `Nez.Random` calls is a compatibility contract** — adding, removing,
 or reordering any RNG call (turn values, target picks, crit/deflect rolls, resolver
-evasion/variance) changes live gameplay outcomes. Preserved quirks that must not be
+evasion/variance) changes live gameplay outcomes. Since issue #382 every ally attack action
+(physical or attack skill) consumes exactly **two** `NextFloat` calls — a base-crit-bag roll
+followed by a quickdraw-bag roll — both always consumed even when the attacker cannot crit,
+mirroring how `RollDodge` always rolls at 0 dodge chance. The crit *decision* comes from
+per-combatant `CritBagSet` shuffle bags on `Hero`/`Mercenary` (persist across battles; fed by
+those two floats, never drawing RNG themselves). Preserved quirks that must not be
 "fixed" casually: a hero who dies mid-round still takes their queued turn that round
 (hero turn-skip is pit-presence only); mercenary heals use `UseMP` while the hero uses
 `SpendMP`; merc kills award rewards with `heroKill=false` (no `InnExhausted` reset);


### PR DESCRIPTION
Closes #382.

Introduces a generic `ShuffleBag<T>` (weighted pool, draw without replacement, auto-refill) and applies it to the four areas from the issue. All bags are transient (in-memory per session; save format stays v27).

## ShuffleBag utility
- `RolePlayingFramework/Utils/ShuffleBag.cs` — swap-to-boundary draw. The core primitive `NextFromRoll(float)` consumes **no RNG itself** (caller supplies the roll), so bags can sit behind existing RNG call sites without changing global call order.

## 1. General crit system (crit bags)
- New: **5% base crit for every hero/merc attack** (`BalanceConfig.BaseCritChance`), enforced by a 20-marble bag per combatant — exactly 1 crit per 20 attacks, no droughts, no streaks. Monsters still never crit; crit damage stays ×2.
- Quickdraw's +50% first-attack crit folds in via its own 10/20 bag, lazily rebuilt when `FirstAttackCritChance` changes (passive re-application safe).
- Bags live on `Hero`/`Mercenary` (`ICombatant.CritBags`) so pity **persists across battles**; they survive `ClearBattleState` and passive resets.
- **RNG contract updated**: exactly two `Nez.Random.NextFloat()` per ally attack (base roll + quickdraw roll), both always consumed on every path — `MercQueue_EmptyOrNull_ProducesIdenticalBattle` and the same-seed determinism tests pass unweakened. Documented in `VirtualGameLogicLayer.md`.

## 2. Chest loot bags
- `LootBagSet` + session `LootShuffleService` (registered per MainGameScene; legacy pure-random fallback when absent):
  - Cave rarity bands enforced exactly per 20 chests per band (same rates as before).
  - Seed chests: exactly 1 per 10 eligible uncommon rolls; seed type rotates through **every crop** before repeating.
  - L1 consumable gate: exactly 3 per 5; HP/MP/Mix potions strictly rotate.
  - **Accessory fix**: 10% accessory share per equipment roll via bag (was ~1/78 weighted); `NecklaceOfHealth` added to the Rare pool (it was registered but unreachable).
- Stencil branch (#362) and chest-color reconciliation (#337) untouched.
- Virtual layer shares one `LootBagSet` per sim run (injected into each per-level generator), fed by the deterministic `Random(depth)` stream.

## 3. Boss epic chest
- Every **Molten Titan** kill spawns a chest at the boss tile via new `TreasureSpawner`, containing an Epic item that cycles all four PitLord pieces before any repeat (tier-scaled on tier ≥ 2).
- The draw uses a private `System.Random` — **zero `Nez.Random` mid-battle** (RNG contract).
- GOAP retarget: `ExploredPit` un-latched + `AdjacentToChest` refreshed so the hero picks it up on the post-battle replan.
- Virtual parity in `VirtualBattleRunner` (`world.AddTreasure` at the boss tile).

## 4. Tavern patron orders
- Walk-in patrons draw from a persistent full-menu bag weighted **inversely to dish price** (`max(1, round(maxPrice/price))` marbles), bounded draw-and-skip over the currently orderable set with uniform fallback — cheap dishes dominate, pricey dishes appear on a predictable cadence.

## Tests
- 21 new tests (`ShuffleBagTests`, `ShuffleBagLootTests`) + rewritten crit seam tests in `StubSkillTests`.
- Full suite: **1919 passed, 0 failed** (6 pre-existing skips). No baselines needed weakening.

Balance note: the universal 5% crit is roughly a +5% ally DPS uplift; `BalanceConfig.BaseCritChance` is the single tuning knob if boss floors feel too easy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)