### PR TITLE
Shuffle-bag dialogue selection plus innkeeper and Second Chance merchant lines

### DIFF
--- a/PitHero.Tests/SpeechBubbleShuffleBagTests.cs
+++ b/PitHero.Tests/SpeechBubbleShuffleBagTests.cs
@@ -1,0 +1,177 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero;
+using System.Collections.Generic;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Tests for the shuffle-bag dialogue selection core (issue #385):
+    /// SpeechBubbleDialogue.SelectKey draws from a shared per-event bag with
+    /// bounded draw-and-skip over gate-ineligible options.
+    /// </summary>
+    [TestClass]
+    public class SpeechBubbleShuffleBagTests
+    {
+        private static SpeechBubbleDialogue.OptionBag MakeBag(params SpeechBubbleDialogue.Option[] options)
+        {
+            return new SpeechBubbleDialogue.OptionBag(options);
+        }
+
+        [TestMethod]
+        public void SelectKey_UngatedOptions_EachKeyOncePerCycle()
+        {
+            var bag = MakeBag(
+                new SpeechBubbleDialogue.Option("A"),
+                new SpeechBubbleDialogue.Option("B"),
+                new SpeechBubbleDialogue.Option("C"));
+            var rng = new System.Random(42);
+
+            for (int cycle = 0; cycle < 10; cycle++)
+            {
+                var seen = new HashSet<string>();
+                for (int i = 0; i < 3; i++)
+                {
+                    var key = SpeechBubbleDialogue.SelectKey(bag, hasMerc: false, tipPaid: null, rng);
+                    Assert.IsNotNull(key, "Ungated table must always yield a key");
+                    Assert.IsTrue(seen.Add(key), $"Key '{key}' repeated within cycle {cycle}");
+                }
+                Assert.AreEqual(3, seen.Count);
+            }
+        }
+
+        [TestMethod]
+        public void SelectKey_UngatedOptions_FairOverManyDraws()
+        {
+            var bag = MakeBag(
+                new SpeechBubbleDialogue.Option("A"),
+                new SpeechBubbleDialogue.Option("B"),
+                new SpeechBubbleDialogue.Option("C"));
+            var rng = new System.Random(7);
+
+            var counts = new Dictionary<string, int> { { "A", 0 }, { "B", 0 }, { "C", 0 } };
+            for (int i = 0; i < 30; i++)
+                counts[SpeechBubbleDialogue.SelectKey(bag, false, null, rng)]++;
+
+            Assert.AreEqual(10, counts["A"]);
+            Assert.AreEqual(10, counts["B"]);
+            Assert.AreEqual(10, counts["C"]);
+        }
+
+        [TestMethod]
+        public void SelectKey_SilentVariant_OncePerCycle()
+        {
+            var bag = MakeBag(
+                new SpeechBubbleDialogue.Option("A"),
+                new SpeechBubbleDialogue.Option("B"),
+                new SpeechBubbleDialogue.Option(null));
+            var rng = new System.Random(123);
+
+            for (int cycle = 0; cycle < 10; cycle++)
+            {
+                int silent = 0;
+                for (int i = 0; i < 3; i++)
+                {
+                    if (SpeechBubbleDialogue.SelectKey(bag, false, null, rng) == null)
+                        silent++;
+                }
+                Assert.AreEqual(1, silent, $"Silent variant should appear exactly once per cycle (cycle {cycle})");
+            }
+        }
+
+        [TestMethod]
+        public void SelectKey_MercGateOff_GatedKeyNeverReturned()
+        {
+            var bag = MakeBag(
+                new SpeechBubbleDialogue.Option("A"),
+                new SpeechBubbleDialogue.Option("MercOnly", SpeechBubbleDialogue.Gate.Merc),
+                new SpeechBubbleDialogue.Option("B"));
+            var rng = new System.Random(99);
+
+            var seen = new HashSet<string>();
+            for (int i = 0; i < 50; i++)
+            {
+                var key = SpeechBubbleDialogue.SelectKey(bag, hasMerc: false, tipPaid: null, rng);
+                Assert.AreNotEqual("MercOnly", key);
+                Assert.IsNotNull(key, "Ungated keys remain eligible");
+                seen.Add(key);
+            }
+            Assert.IsTrue(seen.Contains("A") && seen.Contains("B"));
+        }
+
+        [TestMethod]
+        public void SelectKey_MercGateOn_GatedKeyAppears()
+        {
+            var bag = MakeBag(
+                new SpeechBubbleDialogue.Option("A"),
+                new SpeechBubbleDialogue.Option("MercOnly", SpeechBubbleDialogue.Gate.Merc),
+                new SpeechBubbleDialogue.Option("B"));
+            var rng = new System.Random(5);
+
+            int mercCount = 0;
+            for (int i = 0; i < 30; i++)
+            {
+                if (SpeechBubbleDialogue.SelectKey(bag, hasMerc: true, tipPaid: null, rng) == "MercOnly")
+                    mercCount++;
+            }
+            Assert.AreEqual(10, mercCount, "With all options eligible, cycles are exact: 10 of 30 draws");
+        }
+
+        [TestMethod]
+        public void SelectKey_TipGates_FilterByTipPaid()
+        {
+            var bag = MakeBag(
+                new SpeechBubbleDialogue.Option("Always"),
+                new SpeechBubbleDialogue.Option("TipOnly", SpeechBubbleDialogue.Gate.Tip),
+                new SpeechBubbleDialogue.Option("NoTipOnly", SpeechBubbleDialogue.Gate.NoTip));
+            var rng = new System.Random(11);
+
+            for (int i = 0; i < 30; i++)
+            {
+                Assert.AreNotEqual("NoTipOnly", SpeechBubbleDialogue.SelectKey(bag, false, tipPaid: true, rng));
+                Assert.AreNotEqual("TipOnly", SpeechBubbleDialogue.SelectKey(bag, false, tipPaid: false, rng));
+                Assert.AreEqual("Always", SpeechBubbleDialogue.SelectKey(bag, false, tipPaid: null, rng));
+            }
+        }
+
+        [TestMethod]
+        public void SelectKey_NothingEligible_ReturnsNullWithoutDrawing()
+        {
+            var bag = MakeBag(
+                new SpeechBubbleDialogue.Option("MercOnly", SpeechBubbleDialogue.Gate.Merc),
+                new SpeechBubbleDialogue.Option("TipOnly", SpeechBubbleDialogue.Gate.Tip));
+            var rng = new System.Random(1);
+
+            int remainingBefore = bag.Bag.Remaining;
+            var key = SpeechBubbleDialogue.SelectKey(bag, hasMerc: false, tipPaid: null, rng);
+
+            Assert.IsNull(key);
+            Assert.AreEqual(remainingBefore, bag.Bag.Remaining, "Bag must not advance when nothing is eligible");
+        }
+
+        [TestMethod]
+        public void SelectKey_SameSeed_SameSequence()
+        {
+            var bag1 = MakeBag(
+                new SpeechBubbleDialogue.Option("A"),
+                new SpeechBubbleDialogue.Option("B"),
+                new SpeechBubbleDialogue.Option("C"),
+                new SpeechBubbleDialogue.Option("D"));
+            var bag2 = MakeBag(
+                new SpeechBubbleDialogue.Option("A"),
+                new SpeechBubbleDialogue.Option("B"),
+                new SpeechBubbleDialogue.Option("C"),
+                new SpeechBubbleDialogue.Option("D"));
+
+            var rng1 = new System.Random(2026);
+            var rng2 = new System.Random(2026);
+
+            for (int i = 0; i < 40; i++)
+            {
+                Assert.AreEqual(
+                    SpeechBubbleDialogue.SelectKey(bag1, false, null, rng1),
+                    SpeechBubbleDialogue.SelectKey(bag2, false, null, rng2),
+                    $"Sequences diverged at draw {i}");
+            }
+        }
+    }
+}

--- a/PitHero/AI/HeroStateMachine.cs
+++ b/PitHero/AI/HeroStateMachine.cs
@@ -487,6 +487,7 @@ namespace PitHero.AI
 
                 // Check for adjacent monsters after reaching a new tile
                 var currentTile = tileMover.GetCurrentTileCoordinates();
+                CheckInnFarewell(currentTile);
                 bool wasAdjacent = _hero.AdjacentToMonster;
                 _hero.AdjacentToMonster = _hero.CheckAdjacentToMonster();
 
@@ -1097,6 +1098,30 @@ namespace PitHero.AI
         private void EmitPitAdventureBubble()
         {
             SpeechBubbleDialogue.SayPitAdventure(Entity);
+        }
+
+        /// <summary>
+        /// One-shot innkeeper farewell when the hero crosses the inn-farewell tile on a
+        /// pit-bound trip that originated at the inn (issue #385). The first post-inn trip
+        /// that is NOT a pit trip (e.g. the auto-dine tavern detour) disarms the latch, so
+        /// a later pit trip from the tavern that also passes the tile stays silent.
+        /// </summary>
+        private void CheckInnFarewell(Point currentTile)
+        {
+            if (!_hero.JustLeftInn)
+                return;
+
+            if (_hero.PitIntent != HeroPitIntent.EnteringPit)
+            {
+                _hero.JustLeftInn = false; // trip no longer originates from the inn
+                return;
+            }
+
+            if (currentTile.X == GameConfig.InnFarewellTileX && currentTile.Y == GameConfig.InnFarewellTileY)
+            {
+                _hero.JustLeftInn = false;
+                SpeechBubbleDialogue.SayInnkeeperFarewell(Entity.Scene?.FindEntity("innkeeper"));
+            }
         }
 
         #endregion

--- a/PitHero/AI/SleepInBedAction.cs
+++ b/PitHero/AI/SleepInBedAction.cs
@@ -329,6 +329,7 @@ namespace PitHero.AI
                     gameState.Funds -= innCost;
                     _hasPaidInnkeeper = true;
                     soundEffectManager.PlaySoundAt(SoundEffectType.PayGold, heroEntity.Transform.Position);
+                    SpeechBubbleDialogue.SayInnkeeperGoodRest(Game1.Scene?.FindEntity("innkeeper"));
                     Debug.Log($"[SleepInBedAction] Paid {innCost} gold to innkeeper. Remaining funds: {gameState.Funds}");
 
                     Services.Analytics.AnalyticsService.LogInnSleep(innCost, gameState.Funds);
@@ -745,6 +746,7 @@ namespace PitHero.AI
             _sleepCoroutine = null;
             _isSleeping = false;
             hero.IsSleeping = false;
+            hero.JustLeftInn = true; // arms the innkeeper farewell at the inn-farewell tile (issue #385)
 
             // Morning breakfast trip (issue #319): if "Eat at tavern" is enabled and any party
             // member can actually order, enter Stop mode and head to the tavern

--- a/PitHero/Content/Localization/en-us/Dialogue.txt
+++ b/PitHero/Content/Localization/en-us/Dialogue.txt
@@ -51,3 +51,10 @@ WorkerGoodWork,That was some good work
 WorkerDoMyBest,I'll do my best!
 WorkerGoingToWork,Going to work!
 WorkerHappyToHelp,Happy to help!
+InnkeeperGoodRest,Have a good rest
+InnkeeperFarewellGoodLuck,Good luck!
+InnkeeperFarewellPleasantAdventures,Pleasant adventures!
+InnkeeperFarewellComeBackSoon,Come back soon!
+SecondChanceInterestedWares,Interested in my wares?
+SecondChanceBuyBackSomething,Perhaps you want to buy back something?
+SecondChanceMissSomething,Miss something you once had?

--- a/PitHero/DialogueTextKey.cs
+++ b/PitHero/DialogueTextKey.cs
@@ -69,5 +69,16 @@ namespace PitHero
         public const string WorkerDoMyBest                = "WorkerDoMyBest";
         public const string WorkerGoingToWork             = "WorkerGoingToWork";
         public const string WorkerHappyToHelp             = "WorkerHappyToHelp";
+
+        // Issue #385 — innkeeper
+        public const string InnkeeperGoodRest             = "InnkeeperGoodRest";
+        public const string InnkeeperFarewellGoodLuck     = "InnkeeperFarewellGoodLuck";
+        public const string InnkeeperFarewellPleasantAdventures = "InnkeeperFarewellPleasantAdventures";
+        public const string InnkeeperFarewellComeBackSoon = "InnkeeperFarewellComeBackSoon";
+
+        // Issue #385 — Second Chance merchant
+        public const string SecondChanceInterestedWares   = "SecondChanceInterestedWares";
+        public const string SecondChanceBuyBackSomething  = "SecondChanceBuyBackSomething";
+        public const string SecondChanceMissSomething     = "SecondChanceMissSomething";
     }
 }

--- a/PitHero/ECS/Components/HeroComponent.cs
+++ b/PitHero/ECS/Components/HeroComponent.cs
@@ -48,6 +48,13 @@ namespace PitHero.ECS.Components
         public HeroPitIntent PitIntent { get; set; }
 
         /// <summary>
+        /// True from inn-sleep completion until the first post-inn trip resolves. Drives the
+        /// innkeeper farewell bubble at the inn-farewell tile crossing (issue #385).
+        /// Transient — not saved; a load mid-walk simply skips one farewell.
+        /// </summary>
+        public bool JustLeftInn { get; set; }
+
+        /// <summary>
         /// InsidePit adjusted by plan intent — the pit state the hero is heading toward.
         /// Mercenaries key their own jump-in/jump-out goals off this so all party members
         /// move to the pit edge concurrently instead of waiting for the hero to land.

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -1819,6 +1819,8 @@ namespace PitHero.ECS.Scenes
                 headAnimator, eyesAnimator, hairAnimator, hand1Animator));
             innkeeperMultiAnimator.SetRenderLayer(GameConfig.RenderLayerActors);
 
+            innkeeperEntity.AddComponent(new SpeechBubbleComponent());
+
             Debug.Log($"[MainGameScene] Innkeeper spawned at tile ({tileX}, {tileY}) facing left");
         }
 

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -109,6 +109,8 @@ namespace PitHero
         public const int InnMercBed2TileY = 7;
         public const int InnExitTileX = 71; // Hero walks here after waking, between payment tile and bed
         public const int InnExitTileY = 3;
+        public const int InnFarewellTileX = 63; // Innkeeper waves goodbye when the hero crosses (63,6) heading to the pit
+        public const int InnFarewellTileY = 6;
         // Render-only Y offset applied to a sleeping actor's composite sprite so they nestle
         // into the bed instead of standing on top of it
         public const float SleepInBedSpriteOffsetY = 8f;
@@ -475,6 +477,11 @@ namespace PitHero
         // Sprite is 256x256; Y=50 places it within the 360px stage height (50 to 306)
         public const float SecondChanceMerchantSpriteX = 935f;
         public const float SecondChanceMerchantSpriteY = 50f;
+
+        // Merchant greeting bubble tail-tip anchor, relative to the sprite's top-left (issue #385).
+        // X centers on the 256px art; Y sits at the top of the merchant's head within the frame.
+        public const float SecondChanceMerchantBubbleAnchorX = 128f;
+        public const float SecondChanceMerchantBubbleAnchorY = 40f;
 
         // Inventory interaction
         /// <summary>Minimum pixel movement to initiate a drag operation.</summary>

--- a/PitHero/SpeechBubbleDialogue.cs
+++ b/PitHero/SpeechBubbleDialogue.cs
@@ -2,6 +2,7 @@ using Nez;
 using PitHero.Dining;
 using PitHero.ECS.Components;
 using PitHero.Services;
+using RolePlayingFramework.Utils;
 
 namespace PitHero
 {
@@ -17,12 +18,14 @@ namespace PitHero
         // as a seeded determinism contract (see PitHero/Combat/BattleEngine.cs:64-68;
         // the virtual sim seeds it at VirtualGameSimulation.cs:75). Any Nez.Random call
         // mid-battle would break BattleEngineTests and virtual/live run parity.
+        // The number of _rng draws per bubble event is variable (bounded draw-and-skip),
+        // which is fine — _rng is private to dialogue and not contract-bound.
         private static readonly System.Random _rng = new System.Random();
 
         // ── Gate ─────────────────────────────────────────────────────────────────
 
         /// <summary>Eligibility gate that may restrict an option to a specific context.</summary>
-        private enum Gate
+        public enum Gate
         {
             /// <summary>Always eligible.</summary>
             None,
@@ -34,13 +37,13 @@ namespace PitHero
             NoTip,
         }
 
-        // ── Option set type ──────────────────────────────────────────────────────
+        // ── Option set types ─────────────────────────────────────────────────────
 
         /// <summary>
         /// One variant inside a multi-choice bubble event.
         /// A null <see cref="Key"/> represents the "show nothing" silent variant.
         /// </summary>
-        private readonly struct Option
+        public readonly struct Option
         {
             /// <summary>Dialogue key, or null for the silent variant.</summary>
             public readonly string Key;
@@ -55,70 +58,96 @@ namespace PitHero
             }
         }
 
+        /// <summary>
+        /// An option table paired with its shared shuffle bag of option indices (issue #385).
+        /// Tables are static, so each bag is a single pool shared by every speaker of the
+        /// event — two cooks draw from the same bag and cannot repeat a line within a cycle.
+        /// </summary>
+        public sealed class OptionBag
+        {
+            public readonly Option[] Options;
+            public readonly ShuffleBag<int> Bag;
+
+            /// <summary>Precomputed so hasMerc stays a lazy one-shot resolve per call.</summary>
+            public readonly bool HasMercGate;
+
+            public OptionBag(Option[] options)
+            {
+                Options = options;
+                Bag = new ShuffleBag<int>(options.Length);
+                for (int i = 0; i < options.Length; i++)
+                {
+                    Bag.Add(i);
+                    if (options[i].Gate == Gate.Merc)
+                        HasMercGate = true;
+                }
+            }
+        }
+
         // ── Option tables ────────────────────────────────────────────────────────
 
         // SayBreakfast — three variants, no gate
-        private static readonly Option[] BreakfastOptions =
+        private static readonly OptionBag BreakfastOptions = new OptionBag(new Option[]
         {
             new Option(DialogueTextKey.HeroBreakfast),
             new Option(DialogueTextKey.HeroBreakfastJustWokeUp),
             new Option(DialogueTextKey.HeroBreakfastWhatsFor),
-        };
+        });
 
         // SayPitAdventure — five variants, no gate
-        private static readonly Option[] PitAdventureOptions =
+        private static readonly OptionBag PitAdventureOptions = new OptionBag(new Option[]
         {
             new Option(DialogueTextKey.HeroPitAdventure),
             new Option(DialogueTextKey.HeroPitAdventureLetsGo),
             new Option(DialogueTextKey.HeroPitAdventureGoodRun),
             new Option(DialogueTextKey.HeroPitAdventureLoot),
             new Option(DialogueTextKey.HeroPitAdventureExcited),
-        };
+        });
 
         // Event 2 — Pit entry: three non-silent + merc-gated + silent
-        private static readonly Option[] PitEntryOptions =
+        private static readonly OptionBag PitEntryOptions = new OptionBag(new Option[]
         {
             new Option(DialogueTextKey.HeroPitEntryGreatRun),
             new Option(DialogueTextKey.HeroPitEntryWeGotThis, Gate.Merc),
             new Option(DialogueTextKey.HeroPitEntryWhatsAtEnd),
             new Option(null), // silent variant
-        };
+        });
 
         // Event 4 — Pit rest: three variants, no gate
-        private static readonly Option[] PitRestOptions =
+        private static readonly OptionBag PitRestOptions = new OptionBag(new Option[]
         {
             new Option(DialogueTextKey.HeroRestSleepOff),
             new Option(DialogueTextKey.HeroRestHealAtInn),
             new Option(DialogueTextKey.HeroRestWouldBeGood),
-        };
+        });
 
         // Event 6 — Boss defeated: merc-gated + always + silent
-        private static readonly Option[] BossDefeatedOptions =
+        private static readonly OptionBag BossDefeatedOptions = new OptionBag(new Option[]
         {
             new Option(DialogueTextKey.HeroBossTeamwork, Gate.Merc),
             new Option(DialogueTextKey.HeroBossWorthyFoe),
             new Option(null), // silent variant
-        };
+        });
 
         // Respawn — five variants, no gate
-        private static readonly Option[] RespawnOptions =
+        private static readonly OptionBag RespawnOptions = new OptionBag(new Option[]
         {
             new Option(DialogueTextKey.HeroRespawnToughBattle),
             new Option(DialogueTextKey.HeroRespawnNextRunBetter),
             new Option(DialogueTextKey.HeroRespawnStronger),
             new Option(DialogueTextKey.HeroRespawnOuch),
             new Option(DialogueTextKey.HeroRespawnNotAsPlanned),
-        };
+        });
 
         // Patron order — two variants with {0} dish name
-        private static readonly Option[] PatronOrderOptions =
+        private static readonly OptionBag PatronOrderOptions = new OptionBag(new Option[]
         {
             new Option(DialogueTextKey.PatronOrderIllHave),
             new Option(DialogueTextKey.PatronOrderOnePlease),
-        };
+        });
 
         // Patron paid — non-tip + tip-gated + no-tip-gated + silent
-        private static readonly Option[] PatronPaidOptions =
+        private static readonly OptionBag PatronPaidOptions = new OptionBag(new Option[]
         {
             new Option(DialogueTextKey.PatronPaidDelicious),
             new Option(DialogueTextKey.PatronPaidPrettyGood),
@@ -126,62 +155,78 @@ namespace PitHero
             new Option(DialogueTextKey.PatronPaidTellFriends),
             new Option(DialogueTextKey.PatronPaidHadBetter, Gate.NoTip),
             new Option(null), // silent
-        };
+        });
 
         // Server farewell — three variants + silent
-        private static readonly Option[] ServerFarewellOptions =
+        private static readonly OptionBag ServerFarewellOptions = new OptionBag(new Option[]
         {
             new Option(DialogueTextKey.ServerFarewellComeBack),
             new Option(DialogueTextKey.ServerFarewellComeAgain),
             new Option(DialogueTextKey.ServerFarewellGladToHaveYou),
             new Option(null), // silent
-        };
+        });
 
         // Cook places dish — four variants with {0} dish name
-        private static readonly Option[] CookServedOptions =
+        private static readonly OptionBag CookServedOptions = new OptionBag(new Option[]
         {
             new Option(DialogueTextKey.CookOrderUp),
             new Option(DialogueTextKey.CookHandsPlease),
             new Option(DialogueTextKey.CookNeedHands),
             new Option(DialogueTextKey.CookDishReady),
-        };
+        });
 
         // Runner fetch — four variants + silent
-        private static readonly Option[] RunnerFetchOptions =
+        private static readonly OptionBag RunnerFetchOptions = new OptionBag(new Option[]
         {
             new Option(DialogueTextKey.RunnerBusy),
             new Option(DialogueTextKey.RunnerOffIGo),
             new Option(DialogueTextKey.RunnerQuick),
             new Option(DialogueTextKey.RunnerGoGetIt),
             new Option(null), // silent
-        };
+        });
 
         // Farmer reaches storage — three variants + silent
-        private static readonly Option[] FarmerStoreOptions =
+        private static readonly OptionBag FarmerStoreOptions = new OptionBag(new Option[]
         {
             new Option(DialogueTextKey.FarmerStorePuttingAway),
             new Option(DialogueTextKey.FarmerStoreAnotherHarvest),
             new Option(DialogueTextKey.FarmerStoreInYouGo),
             new Option(null), // silent
-        };
+        });
 
         // Worker shift end — three variants + silent
-        private static readonly Option[] WorkerShiftEndOptions =
+        private static readonly OptionBag WorkerShiftEndOptions = new OptionBag(new Option[]
         {
             new Option(DialogueTextKey.WorkerShiftDone),
             new Option(DialogueTextKey.WorkerTimeForRest),
             new Option(DialogueTextKey.WorkerGoodWork),
             new Option(null), // silent
-        };
+        });
 
         // Worker shift start — three variants + silent
-        private static readonly Option[] WorkerShiftStartOptions =
+        private static readonly OptionBag WorkerShiftStartOptions = new OptionBag(new Option[]
         {
             new Option(DialogueTextKey.WorkerDoMyBest),
             new Option(DialogueTextKey.WorkerGoingToWork),
             new Option(DialogueTextKey.WorkerHappyToHelp),
             new Option(null), // silent
-        };
+        });
+
+        // Innkeeper farewell — three variants, no silent (issue #385)
+        private static readonly OptionBag InnkeeperFarewellOptions = new OptionBag(new Option[]
+        {
+            new Option(DialogueTextKey.InnkeeperFarewellGoodLuck),
+            new Option(DialogueTextKey.InnkeeperFarewellPleasantAdventures),
+            new Option(DialogueTextKey.InnkeeperFarewellComeBackSoon),
+        });
+
+        // Second Chance merchant greeting — three variants, no silent (issue #385)
+        private static readonly OptionBag SecondChanceGreetingOptions = new OptionBag(new Option[]
+        {
+            new Option(DialogueTextKey.SecondChanceInterestedWares),
+            new Option(DialogueTextKey.SecondChanceBuyBackSomething),
+            new Option(DialogueTextKey.SecondChanceMissSomething),
+        });
 
         // ── Public API ───────────────────────────────────────────────────────────
 
@@ -326,7 +371,93 @@ namespace PitHero
             SayFromOptions(entity, WorkerShiftStartOptions);
         }
 
+        /// <summary>Shows the "Have a good rest" bubble on the innkeeper after the party pays.</summary>
+        public static void SayInnkeeperGoodRest(Entity innkeeper)
+        {
+            SaySingle(innkeeper, DialogueTextKey.InnkeeperGoodRest);
+        }
+
+        /// <summary>
+        /// Shows a randomly-picked innkeeper farewell bubble when the hero crosses the
+        /// inn-farewell tile on a pit-bound trip that originated at the inn.
+        /// </summary>
+        public static void SayInnkeeperFarewell(Entity innkeeper)
+        {
+            SayFromOptions(innkeeper, InnkeeperFarewellOptions);
+        }
+
+        /// <summary>
+        /// Returns the localized Second Chance merchant greeting for the shop UI bubble,
+        /// drawn from the shared greeting bag. Returns null when unavailable (headless).
+        /// The merchant is a UI sprite, not an entity, so the caller displays the text itself.
+        /// </summary>
+        public static string GetSecondChanceGreeting()
+        {
+            if (Core.Instance == null)
+                return null;
+            var textService = Core.Services?.GetService<TextService>();
+            if (textService == null)
+                return null;
+            string key = SelectKey(SecondChanceGreetingOptions, hasMerc: false, tipPaid: null, _rng);
+            if (key == null)
+                return null;
+            return textService.DisplayText(TextType.Dialogue, key);
+        }
+
+        // ── Selection core ───────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Pure selection core: draws option indices from the set's shared shuffle bag,
+        /// skipping gate-ineligible marbles (bounded draw-and-skip, precedent
+        /// KitchenTaskCoordinator.PickPatronDish). Ineligible marbles are consumed and
+        /// return next cycle — statistically harmless. Returns the chosen key, or null
+        /// for the silent variant / no eligible option. When nothing is eligible the bag
+        /// is left untouched. AOT-safe: no LINQ; no per-call heap allocation.
+        /// </summary>
+        public static string SelectKey(OptionBag set, bool hasMerc, bool? tipPaid, System.Random rng)
+        {
+            if (set == null || set.Options.Length == 0)
+                return null;
+
+            // Count eligible options first — never draw when nothing can match
+            int eligibleCount = 0;
+            for (int i = 0; i < set.Options.Length; i++)
+            {
+                if (IsEligible(set.Options[i].Gate, hasMerc, tipPaid))
+                    eligibleCount++;
+            }
+
+            if (eligibleCount == 0)
+                return null;
+
+            // Bounded draw-and-skip: at most Remaining draws finish the current cycle,
+            // then one full refilled cycle sees every marble, and eligibleCount > 0
+            // guarantees a hit within Count * 2 draws.
+            int limit = set.Bag.Count * 2;
+            for (int n = 0; n < limit; n++)
+            {
+                int idx = set.Bag.Next(rng);
+                var opt = set.Options[idx];
+                if (IsEligible(opt.Gate, hasMerc, tipPaid))
+                    return opt.Key; // null Key = silent variant (a real, consumed outcome)
+            }
+
+            return null; // unreachable when eligibleCount > 0; defensive
+        }
+
         // ── Private helpers ──────────────────────────────────────────────────────
+
+        /// <summary>Evaluates a gate against the current context.</summary>
+        private static bool IsEligible(Gate gate, bool hasMerc, bool? tipPaid)
+        {
+            switch (gate)
+            {
+                case Gate.Merc:  return hasMerc;
+                case Gate.Tip:   return tipPaid == true;
+                case Gate.NoTip: return tipPaid == false;
+                default:         return true;
+            }
+        }
 
         /// <summary>
         /// Emits a single fixed dialogue key on <paramref name="entity"/>'s bubble.
@@ -346,75 +477,25 @@ namespace PitHero
         }
 
         /// <summary>
-        /// Picks a uniformly-random eligible option from <paramref name="options"/> and displays it.
+        /// Draws an eligible option from the set's shared shuffle bag and displays it.
         /// Gate.Merc options are excluded when no mercenaries are hired; hasMerc is resolved at most
-        /// once per call (one-shot-call property preserved). Gate.Tip/NoTip filter by
-        /// <paramref name="tipPaid"/>. A null key is the silent variant — shows nothing.
-        /// If <paramref name="formatArg"/> is non-null the localized text is formatted with it.
-        /// AOT-safe: no LINQ; no per-call heap allocation.
+        /// once per call and only when the table has a merc gate (one-shot-call property preserved).
+        /// Gate.Tip/NoTip filter by <paramref name="tipPaid"/>. A null key is the silent
+        /// variant — shows nothing. If <paramref name="formatArg"/> is non-null the localized
+        /// text is formatted with it. Headless calls bail before any draw so bags never
+        /// advance in tests.
         /// </summary>
-        private static void SayFromOptions(Entity entity, Option[] options,
+        private static void SayFromOptions(Entity entity, OptionBag set,
             bool? tipPaid = null, string formatArg = null)
         {
-            if (Core.Instance == null || entity == null || options == null || options.Length == 0)
+            if (Core.Instance == null || entity == null || set == null || set.Options.Length == 0)
                 return;
 
-            // Lazily resolve hasMerc — only when at least one option has Gate.Merc
-            bool hasMercKnown = false;
-            bool hasMerc      = false;
+            bool hasMerc = set.HasMercGate && HasHiredMercenary();
 
-            // Count eligible options (no LINQ)
-            int eligibleCount = 0;
-            for (int i = 0; i < options.Length; i++)
-            {
-                switch (options[i].Gate)
-                {
-                    case Gate.None:
-                        eligibleCount++;
-                        break;
-                    case Gate.Merc:
-                        if (!hasMercKnown) { hasMerc = HasHiredMercenary(); hasMercKnown = true; }
-                        if (hasMerc) eligibleCount++;
-                        break;
-                    case Gate.Tip:
-                        if (tipPaid == true) eligibleCount++;
-                        break;
-                    case Gate.NoTip:
-                        if (tipPaid == false) eligibleCount++;
-                        break;
-                }
-            }
+            string key = SelectKey(set, hasMerc, tipPaid, _rng);
 
-            if (eligibleCount == 0)
-                return;
-
-            // Pick uniformly at random among eligible options
-            int pick   = _rng.Next(eligibleCount);
-            int walked = 0;
-            string key = null;
-            for (int i = 0; i < options.Length; i++)
-            {
-                bool eligible = false;
-                switch (options[i].Gate)
-                {
-                    case Gate.None:  eligible = true;             break;
-                    case Gate.Merc:  eligible = hasMerc;          break;
-                    case Gate.Tip:   eligible = tipPaid == true;  break;
-                    case Gate.NoTip: eligible = tipPaid == false; break;
-                }
-
-                if (eligible)
-                {
-                    if (walked == pick)
-                    {
-                        key = options[i].Key;
-                        break;
-                    }
-                    walked++;
-                }
-            }
-
-            // Null key = silent variant — show nothing
+            // Null key = silent variant (or nothing eligible) — show nothing
             if (key == null)
                 return;
 

--- a/PitHero/UI/MerchantSpeechBubble.cs
+++ b/PitHero/UI/MerchantSpeechBubble.cs
@@ -1,0 +1,174 @@
+using Microsoft.Xna.Framework;
+using Nez;
+using Nez.BitmapFonts;
+using Nez.Textures;
+using Nez.UI;
+using System.Text;
+
+namespace PitHero.UI
+{
+    /// <summary>
+    /// Stage-space speech bubble for the Second Chance merchant (issue #385). Mirrors the look
+    /// of <see cref="ECS.Components.SpeechBubbleComponent"/> (nine-patch bubble + tail +
+    /// typewriter reveal) but lives on the UI stage, anchored above the merchant sprite, and is
+    /// sized to the full wrapped text (no scroll-and-drop). Unlike world bubbles it never
+    /// auto-hides: once the reveal completes the full text persists until <see cref="Hide"/>
+    /// (shop close). The caller ticks it with unscaled time because the shop pauses gameplay
+    /// while open and fast-forward scales <see cref="Time.DeltaTime"/>.
+    /// </summary>
+    public class MerchantSpeechBubble : Element
+    {
+        private const string AtlasPath = "Content/Atlases/UI.atlas";
+        private const string BubbleSpriteName = "NinePatchSpeechBubble";
+        private const string TailSpriteName = "SpeechBubbleTail";
+
+        private const int TailSpriteW = 9;
+        private const int TailSpriteH = 8;
+
+        private const float TextWrapWidth = GameConfig.SpeechBubbleWidth - GameConfig.SpeechBubblePadding * 2;
+
+        private static readonly Color BubbleColor = Color.White;
+        private static readonly Color TextColor = new Color(50, 30, 20);
+
+        // Null when asset loading failed — the bubble then stays inert
+        private NinePatchDrawable _bubbleDrawable;
+        private Sprite _tailSprite;
+        private BitmapFont _font;
+
+        // Tail-tip anchor in stage coordinates; bubble body is drawn centered above it
+        private float _anchorX;
+        private float _anchorY;
+
+        // Reveal state
+        private bool _active;
+        private string _wrappedText;
+        private readonly StringBuilder _visibleText = new StringBuilder(128);
+        private int _revealed;
+        private float _accumulated;
+        private float _bubbleHeight;
+
+        public MerchantSpeechBubble()
+        {
+            try
+            {
+                var uiAtlas = Core.Content.LoadSpriteAtlas(AtlasPath);
+                var bubbleSprite = uiAtlas?.GetSprite(BubbleSpriteName);
+                _tailSprite = uiAtlas?.GetSprite(TailSpriteName);
+                _font = Core.Content.LoadBitmapFont(GameConfig.FontPathSpeechBubble);
+
+                if (bubbleSprite == null || _tailSprite == null || _font == null)
+                {
+                    Debug.Warn("[MerchantSpeechBubble] Missing bubble sprites or font — bubble disabled");
+                    return;
+                }
+
+                _bubbleDrawable = new NinePatchDrawable(
+                    new NinePatchSprite(bubbleSprite.Texture2D, bubbleSprite.SourceRect, 4, 4, 4, 4));
+            }
+            catch (System.Exception ex)
+            {
+                Debug.Warn($"[MerchantSpeechBubble] Initialisation failed: {ex.Message}");
+            }
+
+            SetTouchable(Touchable.Disabled);
+            SetVisible(false);
+        }
+
+        /// <summary>
+        /// Sets the tail-tip position in stage coordinates. Call before <see cref="Show"/>.
+        /// </summary>
+        public void SetTailAnchor(float x, float y)
+        {
+            _anchorX = x;
+            _anchorY = y;
+        }
+
+        /// <summary>
+        /// Starts the typewriter reveal of <paramref name="localizedText"/>. The bubble is sized
+        /// to the full wrapped text so every line stays visible once revealed.
+        /// </summary>
+        public void Show(string localizedText)
+        {
+            if (_bubbleDrawable == null || string.IsNullOrEmpty(localizedText))
+                return;
+
+            _wrappedText = _font.WrapText(localizedText, TextWrapWidth);
+
+            int lineCount = 1;
+            for (int i = 0; i < _wrappedText.Length; i++)
+            {
+                if (_wrappedText[i] == '\n')
+                    lineCount++;
+            }
+            _bubbleHeight = GameConfig.SpeechBubblePadding * 2 + lineCount * _font.LineHeight;
+
+            _visibleText.Clear();
+            _revealed = 0;
+            _accumulated = 0f;
+            _active = true;
+
+            // Real bounds so OutsideClickDismissal's envelope math sees the bubble
+            float totalHeight = _bubbleHeight + TailSpriteH - GameConfig.SpeechBubbleTailOverlap;
+            SetBounds(_anchorX - GameConfig.SpeechBubbleWidth / 2f, _anchorY - totalHeight,
+                GameConfig.SpeechBubbleWidth, totalHeight);
+            SetVisible(true);
+        }
+
+        /// <summary>
+        /// Advances the typewriter reveal. Once the full text is revealed this becomes a no-op —
+        /// the bubble persists until <see cref="Hide"/>.
+        /// </summary>
+        public void Tick(float deltaTime)
+        {
+            if (!_active || _wrappedText == null || _revealed >= _wrappedText.Length)
+                return;
+
+            float delay = 1f / GameConfig.SpeechBubbleCharsPerSecond;
+            _accumulated += deltaTime;
+            while (_accumulated >= delay && _revealed < _wrappedText.Length)
+            {
+                _accumulated -= delay;
+                _visibleText.Append(_wrappedText[_revealed]);
+                _revealed++;
+            }
+        }
+
+        /// <summary>Immediately hides the bubble and clears its text.</summary>
+        public void Hide()
+        {
+            _active = false;
+            _visibleText.Clear();
+            _wrappedText = null;
+            SetVisible(false);
+        }
+
+        public override void Draw(Batcher batcher, float parentAlpha)
+        {
+            if (!_active || _bubbleDrawable == null)
+                return;
+
+            // Same layout math as SpeechBubbleComponent.Render at scale 1, in stage coordinates:
+            //   tail bottom = anchor (tail tip), bubble bottom overlaps the tail top by 2 px
+            float tailTopY      = _anchorY - TailSpriteH;
+            float bubbleBottomY = tailTopY + GameConfig.SpeechBubbleTailOverlap;
+            float bubbleTopY    = bubbleBottomY - _bubbleHeight;
+            float bubbleX       = _anchorX - GameConfig.SpeechBubbleWidth / 2f;
+            float tailX         = _anchorX - TailSpriteW / 2f;
+
+            _bubbleDrawable.Draw(batcher, bubbleX, bubbleTopY,
+                GameConfig.SpeechBubbleWidth, _bubbleHeight, BubbleColor);
+
+            batcher.Draw(_tailSprite.Texture2D, new Vector2(tailX, tailTopY),
+                _tailSprite.SourceRect, BubbleColor);
+
+            if (_visibleText.Length > 0)
+            {
+                var textOrigin = new Vector2(
+                    bubbleX + GameConfig.SpeechBubblePadding,
+                    bubbleTopY + GameConfig.SpeechBubblePadding);
+                _font.DrawInto(batcher, _visibleText, textOrigin, TextColor,
+                    0f, Vector2.Zero, Vector2.One, Microsoft.Xna.Framework.Graphics.SpriteEffects.None, 0f);
+            }
+        }
+    }
+}

--- a/PitHero/UI/SecondChanceShopUI.cs
+++ b/PitHero/UI/SecondChanceShopUI.cs
@@ -35,6 +35,9 @@ namespace PitHero.UI
         // Merchant sprite shown between the two panels
         private Image _merchantSprite;
 
+        // Greeting bubble above the merchant's head; persists until the shop closes (issue #385)
+        private MerchantSpeechBubble _merchantBubble;
+
         private bool _windowVisible = false;
         private ImageButtonStyle _shopNormalStyle;
         private ImageButtonStyle _shopHalfStyle;
@@ -112,6 +115,8 @@ namespace PitHero.UI
             _merchantSprite = new Image(new SpriteDrawable(merchantSprite));
             // Display at natural sprite dimensions so the full character is visible
             _merchantSprite.SetSize(merchantSprite.SourceRect.Width, merchantSprite.SourceRect.Height);
+
+            _merchantBubble = new MerchantSpeechBubble();
 
             CreateShopWindow(_skin);
             CreateHeroInventoryWindow(_skin);
@@ -468,6 +473,18 @@ namespace PitHero.UI
                 _merchantSprite.SetPosition(GameConfig.SecondChanceMerchantSpriteX + xOffset, GameConfig.SecondChanceMerchantSpriteY);
                 _merchantSprite.ToFront();
 
+                // Greeting bubble above the merchant's head; persists until the shop closes
+                var greeting = SpeechBubbleDialogue.GetSecondChanceGreeting();
+                if (greeting != null && _merchantBubble != null)
+                {
+                    _stage.AddElement(_merchantBubble);
+                    _merchantBubble.SetTailAnchor(
+                        GameConfig.SecondChanceMerchantSpriteX + xOffset + GameConfig.SecondChanceMerchantBubbleAnchorX,
+                        GameConfig.SecondChanceMerchantSpriteY + GameConfig.SecondChanceMerchantBubbleAnchorY);
+                    _merchantBubble.Show(greeting);
+                    _merchantBubble.ToFront();
+                }
+
                 // Hero panel (right) — show the one matching the active tab
                 _stage.AddElement(_heroInventoryWindow);
                 _stage.AddElement(_heroCrystalWindow);
@@ -507,6 +524,7 @@ namespace PitHero.UI
                 _shopWindow.SetVisible(false);
                 _shopWindow.Remove();
                 _merchantSprite.Remove();
+                RemoveMerchantBubble();
                 _heroInventoryWindow.SetVisible(false);
                 _heroInventoryWindow.Remove();
                 _heroCrystalWindow.SetVisible(false);
@@ -521,6 +539,13 @@ namespace PitHero.UI
             }
         }
 
+        /// <summary>Hides the merchant greeting bubble and detaches it from the stage.</summary>
+        private void RemoveMerchantBubble()
+        {
+            _merchantBubble?.Hide();
+            _merchantBubble?.Remove();
+        }
+
         /// <summary>Force-closes the shop window. Used by single window policy.</summary>
         public void ForceCloseWindow()
         {
@@ -531,6 +556,7 @@ namespace PitHero.UI
                 _shopWindow?.SetVisible(false);
                 _shopWindow?.Remove();
                 _merchantSprite?.Remove();
+                RemoveMerchantBubble();
                 _heroInventoryWindow?.SetVisible(false);
                 _heroInventoryWindow?.Remove();
                 _heroCrystalWindow?.SetVisible(false);
@@ -612,6 +638,10 @@ namespace PitHero.UI
 
             if (_windowVisible && _stage != null)
             {
+                // Unscaled time: the shop pauses gameplay while open, and fast-forward
+                // scales Time.DeltaTime — the greeting reveal should do neither
+                _merchantBubble?.Tick(Time.UnscaledDeltaTime);
+
                 var mousePos = _stage.GetMousePosition();
                 if (_activeTabIndex == 0)
                 {
@@ -658,10 +688,11 @@ namespace PitHero.UI
         private List<Nez.UI.Element> GetWindowBoundsElements()
         {
             if (_windowBoundsElements == null)
-                _windowBoundsElements = new List<Nez.UI.Element>(5);
+                _windowBoundsElements = new List<Nez.UI.Element>(6);
             _windowBoundsElements.Clear();
             _windowBoundsElements.Add(_shopWindow);
             _windowBoundsElements.Add(_merchantSprite);
+            _windowBoundsElements.Add(_merchantBubble);
             _windowBoundsElements.Add(_heroInventoryWindow);
             _windowBoundsElements.Add(_heroCrystalWindow);
             _windowBoundsElements.Add(_vaultCrystalCard);

--- a/PitHero/docs/ShuffleBagSystem.md
+++ b/PitHero/docs/ShuffleBagSystem.md
@@ -6,8 +6,8 @@ cycle the draw counts exactly match the bag's composition, so streaks and drough
 bounded while individual draws still feel random. Average rates are unchanged from the
 pure-random constants the bags replaced — only the variance is tamed.
 
-Four systems are bag-driven: **battle crits**, **treasure-chest loot**, the **biome-boss epic
-chest**, and **tavern patron dish orders**.
+Five systems are bag-driven: **battle crits**, **treasure-chest loot**, the **biome-boss epic
+chest**, **tavern patron dish orders**, and **speech-bubble dialogue variants** (issue #385).
 
 ## The primitive: `ShuffleBag<T>`
 
@@ -160,6 +160,21 @@ still cycles through on a bounded cadence. Selection is **bounded draw-and-skip*
 first drawn dish present in the orderable list wins; skipped unorderable marbles restore next
 cycle so pricey-dish pity persists across stock fluctuations; a fully unorderable cycle falls
 back to a uniform pick.
+
+## Speech-bubble dialogue variants
+
+Files: `PitHero/SpeechBubbleDialogue.cs`; details in `SpeechBubbleSystem.md`.
+
+Every multi-variant dialogue event's `OptionBag` pairs its `Option[]` with a static
+`ShuffleBag<int>` of option indices — a single pool shared by all speakers of the event
+(the issue #385 requirement: two cooks can't repeat a line within a cycle). Draws use the
+class's **private `System.Random`** via `Next(rng)` — never `Nez.Random`, because
+`SayBossDefeated` fires mid-battle (rule 1 of the epic-chest section applies). Gates
+(merc/tip) use **bounded draw-and-skip** like the dish bag, capped at `Count * 2` draws
+with an eligibility pre-count that returns early without touching the bag. The headless
+guard (`Core.Instance == null`) sits before any draw, so bags never advance in unit tests.
+Selection core `SelectKey` is public and pure — tested in
+`PitHero.Tests/SpeechBubbleShuffleBagTests.cs`.
 
 ## Persistence: none, by design
 

--- a/PitHero/docs/SpeechBubbleSystem.md
+++ b/PitHero/docs/SpeechBubbleSystem.md
@@ -80,10 +80,18 @@ line lives in `WalkToStatueForCrystalAction`, not `RespawnHero()`).
 
 ## SpeechBubbleDialogue — option sets, gates, formatting
 
-Multi-variant events are `Option[]` tables picked **uniformly at random**:
+Multi-variant events are `OptionBag` tables — an `Option[]` plus a **shared
+`ShuffleBag<int>` of option indices** (issue #385). Selection (`SelectKey`, public and
+pure for tests) draws indices from the bag with **bounded draw-and-skip**: gate-ineligible
+marbles are consumed and skipped (they return next cycle), bounded at `Count * 2` draws;
+an eligibility pre-count returns early — without advancing the bag — when nothing can
+match. Because the tables are static, one bag per event is automatically the shared
+per-job pool: two cooks draw from the same `CookServedOptions` bag, so no line repeats
+within a cycle no matter which worker speaks.
 
-- `new Option(null)` is the **silent variant** — that roll shows no bubble at all.
-- `Option.Gate` restricts eligibility (ineligible options are excluded before the roll):
+- `new Option(null)` is the **silent variant** — drawing it shows no bubble; it's a real
+  marble, consumed like any other, so silence also cycles fairly.
+- `Option.Gate` restricts eligibility (ineligible draws are skipped):
   `Gate.Merc` = at least one hired mercenary; `Gate.Tip` / `Gate.NoTip` = filtered by the
   `tipPaid` argument (only `SayPatronPaid` supplies it). Design-notation mapping: `""` → silent,
   `[G]` → `Gate.Merc`, `[T]`/`[!T]` → `Gate.Tip`/`Gate.NoTip`.
@@ -92,7 +100,8 @@ Multi-variant events are `Option[]` tables picked **uniformly at random**:
   `formatArg` → `string.Format` at emit time. `TextService` itself has no placeholder support.
 - Every public `Say*` funnels through `SaySingle`, which guards `Core.Instance == null` and
   `entity == null` — this is what keeps triggers headless-safe (patron order/payment paths run
-  without `Core` in `KitchenServiceLoopTests`).
+  without `Core` in `KitchenServiceLoopTests`). `SayFromOptions` repeats the guard **before**
+  any bag draw, so headless calls never advance a bag (keeps those tests deterministic).
 
 ### ⚠ RNG rule (do not break)
 
@@ -134,6 +143,36 @@ virtual/live run parity. See the comment block at the top of `SpeechBubbleDialog
 a worker is unwanted — never emit from coordinator `Update()`. The FSM `_Enter` callbacks and
 one-shot tick transitions fire exactly once and are the correct hook points.
 
+### Innkeeper (issue #385)
+
+The innkeeper (entity name `"innkeeper"`, tile 69,3) gets its `SpeechBubbleComponent` in
+`MainGameScene.SpawnInnkeeper`.
+
+| Trigger | Emit site | Notes |
+|---|---|---|
+| Party pays for an inn nap | `SleepInBedAction.SleepCoroutine` paid branch | "Have a good rest" — **paid stays only**; the free night-sleep branch stays silent |
+| Hero crosses (63,6) heading to the pit after an inn stay | `HeroStateMachine.CheckInnFarewell` (GoTo move-complete edge) | 3-variant farewell bag. Armed by `HeroComponent.JustLeftInn` (set at sleep completion, transient/not saved); the first post-inn trip whose `PitIntent != EnteringPit` (e.g. the auto-dine tavern detour) disarms it, so tavern-origin pit trips that also pass (63,6) stay silent. Tile constant: `GameConfig.InnFarewellTileX/Y` |
+
+### Second Chance merchant (issue #385)
+
+The shop owner is a UI `Image`, not a world entity, so it uses its own view:
+`PitHero/UI/MerchantSpeechBubble.cs` — a stage-space `Nez.UI.Element` reusing the same
+`NinePatchSpeechBubble`/`SpeechBubbleTail` sprites and Express font. Differences from
+`SpeechBubbleComponent`:
+
+- **Persists after reveal**: no linger/auto-hide — the full text stays until the shop closes
+  (`RemoveMerchantBubble()` runs in both `ToggleShopWindow`'s close branch and
+  `ForceCloseWindow`).
+- **Sized to the full wrapped text** (no scroll-and-drop), so every line stays visible.
+- **Ticked with `Time.UnscaledDeltaTime`** from `SecondChanceShopUI.Update()` — the shop sets
+  `PauseService.IsPaused` while open (a pure flag; `Time.DeltaTime` still ticks) and
+  fast-forward scales `Time.TimeScale`; unscaled time keeps the reveal speed constant.
+- Greeting text comes from `SpeechBubbleDialogue.GetSecondChanceGreeting()` (3-variant bag,
+  re-drawn on every shop open; returns the localized string since there's no entity).
+- Tail anchor = merchant sprite position + `GameConfig.SecondChanceMerchantBubbleAnchorX/Y`
+  (plus the shop's stage-centering `xOffset`). The bubble is in `GetWindowBoundsElements()`
+  so clicking it doesn't dismiss the shop, and it's `Touchable.Disabled`.
+
 ## Localization
 
 Dialogue is its **own** table: `TextType.Dialogue`, `DialogueTextKey` consts,
@@ -146,9 +185,10 @@ injected via `formatArg`.
 ## Recipe: adding a new dialogue event
 
 1. Add key consts to `DialogueTextKey.cs` + lines to `Dialogue.txt` (use `{0}` if parameterized).
-2. In `SpeechBubbleDialogue`: add an `Option[]` table (include `new Option(null)` if a silent
-   roll is wanted, gates as needed) and a public `SayXxx(Entity, …)` that calls
-   `SayFromOptions` (or `SaySingle` for a fixed line).
+2. In `SpeechBubbleDialogue`: add an `OptionBag` table (`new OptionBag(new Option[] { … })`;
+   include `new Option(null)` if a silent draw is wanted, gates as needed) and a public
+   `SayXxx(Entity, …)` that calls `SayFromOptions` (or `SaySingle` for a fixed line). The bag
+   is static, so it's automatically the shared pool across all speakers of the event.
 3. Call `SpeechBubbleDialogue.SayXxx(entity)` from the trigger. Pick a spot that fires **once**
    per logical event (FSM `_Enter`, a latched plan-formation block, a state transition) — never
    a per-frame branch. Check whether the code path also runs headless (tests / virtual layer);


### PR DESCRIPTION
Closes #385

## What

**Shuffle-bag dialogue variety.** Every multi-option dialogue event in `SpeechBubbleDialogue` now draws from a `ShuffleBag<int>` of option indices instead of a uniform random pick, so no line repeats within a full cycle. The tables are static, which makes each bag automatically the **shared per-job+event pool** the issue asks for — two cooks (or servers, runners, farmers) draw from the same bag and can't say the same thing back-to-back.

- New `OptionBag` wrapper (`Option[]` + bag + precomputed merc-gate flag) and a pure, public `SelectKey(set, hasMerc, tipPaid, rng)` selection core.
- Gated options (Merc/Tip/NoTip) use **bounded draw-and-skip** (precedent: `PickPatronDish`), capped at `Count * 2` draws, with an eligibility pre-count that returns early **without advancing the bag**.
- Silent (`null`-key) variants are ordinary marbles — silence also cycles fairly.
- RNG rules preserved: draws use the class's private `System.Random` via `ShuffleBag.Next(rng)` — no `Nez.Random` anywhere in the diff (battle determinism contract), and the headless `Core.Instance` guard stays ahead of any draw so bags never advance in unit tests.

**Innkeeper dialogue (new).**
- `SpeechBubbleComponent` attached in `SpawnInnkeeper`.
- "Have a good rest" emitted from `SleepInBedAction`'s **paid** branch (free night sleep stays silent).
- 3-variant farewell ({Good luck! / Pleasant adventures! / Come back soon!}) when the hero crosses tile (63,6) heading to the pit **after an inn stay**: armed by a transient `HeroComponent.JustLeftInn` flag set at sleep completion, consumed at the crossing in `HeroStateMachine.GoTo_Tick`'s move-complete edge. The first post-inn trip that isn't pit-bound (e.g. the auto-dine tavern detour) disarms the latch, so tavern-origin pit trips that also pass (63,6) stay silent.

**Second Chance merchant greeting (new).** The shop owner is a UI sprite, not an entity, so this adds `MerchantSpeechBubble` — a stage-space `Nez.UI.Element` reusing the `NinePatchSpeechBubble`/`SpeechBubbleTail` sprites and Express font:
- 3-variant greeting drawn from its shuffle bag on every shop open.
- **Persists with full text after the typewriter reveal** until the UI is dismissed (no linger/auto-hide, sized to the full wrapped text with no scroll-and-drop) — torn down in both close paths (`ToggleShopWindow` close branch and `ForceCloseWindow`).
- Ticked with `Time.UnscaledDeltaTime` (the shop pauses gameplay while open; fast-forward scales `Time.TimeScale`).
- Included in `GetWindowBoundsElements()` so clicking it doesn't dismiss the shop; `Touchable.Disabled`.

## Testing

- `dotnet test`: **1927 passed, 0 failed** (baseline 0 maintained), including 8 new tests in `SpeechBubbleShuffleBagTests` covering full-cycle fairness, silent-variant cycling, merc/tip gate filtering, no-eligible early-out (bag untouched), and same-seed determinism.
- Verified no `Nez.Random` in the diff.

## Manual playtest checklist

- [x] Inn nap: innkeeper says "Have a good rest" at payment
- [x] Farewell fires once at (63,6) after an inn stay; silent on tavern-origin pit trips
- [x] Second Chance: bubble reveals, persists fully, disappears on every close path (Escape, outside click, top-bar button, single-window force-close)
- [x] Bubble anchor position over the merchant's head (`GameConfig.SecondChanceMerchantBubbleAnchorX/Y = 128/40` — tune if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)