### PR TITLE
Unify save format to a single version 29

### DIFF
--- a/PitHero.Tests/SaveLoadTests.cs
+++ b/PitHero.Tests/SaveLoadTests.cs
@@ -790,12 +790,19 @@ namespace PitHero.Tests
         }
 
         /// <summary>
-        /// Verifies that a save stream with an older version header is rejected with
-        /// InvalidDataException. Simulated by writing a current-version binary and patching the
-        /// version bytes down by one.
+        /// The save format is a single version: any header other than CurrentVersion is rejected
+        /// with InvalidDataException, whether it is older or newer. Simulated by writing a
+        /// current-version binary and patching the version bytes.
         /// </summary>
         [TestMethod]
-        public void SaveData_OlderVersionHeader_ThrowsInvalidData()
+        public void SaveData_ForeignVersionHeader_ThrowsInvalidData()
+        {
+            AssertHeaderRejected(SaveData.CurrentVersion - 1, "An older save version must be rejected");
+            AssertHeaderRejected(SaveData.CurrentVersion + 1, "A newer save version must be rejected");
+        }
+
+        /// <summary>Writes a current-version save, patches its version header, and asserts the load throws.</summary>
+        private static void AssertHeaderRejected(int patchedVersion, string message)
         {
             var ms = new MemoryStream();
             using (var writer = new BinaryPersistableWriter(ms))
@@ -807,8 +814,8 @@ namespace PitHero.Tests
 
             byte[] bytes = ms.ToArray();
 
-            // Patch bytes [0-3] to one version below the supported floor (little-endian int)
-            bytes[0] = (byte)(SaveData.MinSupportedVersion - 1);
+            // Patch bytes [0-3] to the target version (little-endian int)
+            bytes[0] = (byte)patchedVersion;
             bytes[1] = 0;
             bytes[2] = 0;
             bytes[3] = 0;
@@ -816,65 +823,8 @@ namespace PitHero.Tests
             var loaded = new SaveData();
             using (var rdr = new BinaryPersistableReader(new MemoryStream(bytes)))
             {
-                Assert.ThrowsException<InvalidDataException>(() => rdr.ReadPersistableInto(loaded),
-                    "Loading a save older than MinSupportedVersion should throw InvalidDataException");
+                Assert.ThrowsException<InvalidDataException>(() => rdr.ReadPersistableInto(loaded), message);
             }
-        }
-
-        /// <summary>
-        /// Verifies that a v17 save (a byte-exact prefix of the current format — no dining
-        /// section 33, automation section 34, or auto-dine section 35) still loads, with
-        /// defaults for all three.
-        /// </summary>
-        [TestMethod]
-        public void SaveData_V17File_LoadsWithDefaultDining()
-        {
-            var ms = new MemoryStream();
-            using (var writer = new BinaryPersistableWriter(ms))
-            {
-                var original = new SaveData();
-                original.HeroName = "LegacyHero";
-                original.FavoriteDishId = 7;
-                original.EatAtTavern = true;
-                writer.Write(original);
-            }
-            byte[] currentBytes = ms.ToArray();
-
-            // Measure the writer's int/bool encodings so the sections-33/34 tail length is exact
-            var probe = new MemoryStream();
-            int intSize, boolSize;
-            using (var probeWriter = new BinaryPersistableWriter(probe))
-            {
-                probeWriter.Write(0);
-                intSize = (int)probe.Length;
-                probeWriter.Write(false);
-                boolSize = (int)probe.Length - intSize;
-            }
-
-            // Section 33 = FavoriteDishId + EatAtTavern + count + 3 records of (2 ints + 3 bools);
-            // section 34 = AutomateMonsterJobs (1 bool); section 35 = PartyAutoDineResume (1 bool)
-            int tailLength = 2 * intSize + boolSize + 3 * (2 * intSize + 3 * boolSize) + 2 * boolSize;
-            byte[] v17Bytes = new byte[currentBytes.Length - tailLength];
-            System.Array.Copy(currentBytes, v17Bytes, v17Bytes.Length);
-
-            // Patch the header to version 17 (little-endian int)
-            v17Bytes[0] = 17;
-            v17Bytes[1] = 0;
-            v17Bytes[2] = 0;
-            v17Bytes[3] = 0;
-
-            var loaded = new SaveData();
-            using (var rdr = new BinaryPersistableReader(new MemoryStream(v17Bytes)))
-            {
-                rdr.ReadPersistableInto(loaded);
-            }
-
-            Assert.AreEqual("LegacyHero", loaded.HeroName, "v17 body should round-trip");
-            Assert.AreEqual(0, loaded.FavoriteDishId, "v17 load should default FavoriteDishId");
-            Assert.IsFalse(loaded.EatAtTavern, "v17 load should default EatAtTavern");
-            Assert.IsNotNull(loaded.PartyDining, "v17 load should get default dining records");
-            Assert.AreEqual(-1, loaded.PartyDining[0].OrderedDishId, "default dining record expected");
-            Assert.IsFalse(loaded.AutomateMonsterJobs, "v17 load should default AutomateMonsterJobs");
         }
 
         /// <summary>
@@ -905,60 +855,6 @@ namespace PitHero.Tests
             {
                 try { Directory.Delete(tempDir, recursive: true); } catch { }
             }
-        }
-
-        /// <summary>
-        /// Verifies the legacy inference for pre-v20 saves: a reloaded member with a meal still
-        /// in progress means the party auto-resumes when done; with no open orders it does not.
-        /// </summary>
-        [TestMethod]
-        public void SaveData_PreV20File_InfersAutoDineResumeFromOpenOrders()
-        {
-            Assert.IsTrue(LoadAsV19(openOrder: true).PartyAutoDineResume,
-                "Pre-v20 file with an open order should infer PartyAutoDineResume = true");
-            Assert.IsFalse(LoadAsV19(openOrder: false).PartyAutoDineResume,
-                "Pre-v20 file with no open orders should leave PartyAutoDineResume = false");
-        }
-
-        /// <summary>Writes a current save, truncates section 35, and patches the header to v19.</summary>
-        private static SaveData LoadAsV19(bool openOrder)
-        {
-            var ms = new MemoryStream();
-            using (var writer = new BinaryPersistableWriter(ms))
-            {
-                var original = new SaveData();
-                if (openOrder)
-                {
-                    original.PartyDining = SaveData.CreateDefaultDiningRecords();
-                    original.PartyDining[1].OrderedDishId = 3;
-                    original.PartyDining[1].HasEatenToday = false;
-                }
-                writer.Write(original);
-            }
-            byte[] v20Bytes = ms.ToArray();
-
-            // Measure the writer's bool encoding so the section-35 tail length is exact
-            var probe = new MemoryStream();
-            int boolSize;
-            using (var probeWriter = new BinaryPersistableWriter(probe))
-            {
-                probeWriter.Write(false);
-                boolSize = (int)probe.Length;
-            }
-
-            byte[] v19Bytes = new byte[v20Bytes.Length - boolSize];
-            System.Array.Copy(v20Bytes, v19Bytes, v19Bytes.Length);
-
-            // Patch the header to version 19 (little-endian int)
-            v19Bytes[0] = 19;
-            v19Bytes[1] = 0;
-            v19Bytes[2] = 0;
-            v19Bytes[3] = 0;
-
-            var loaded = new SaveData();
-            using (var rdr = new BinaryPersistableReader(new MemoryStream(v19Bytes)))
-                rdr.ReadPersistableInto(loaded);
-            return loaded;
         }
 
         /// <summary>
@@ -1012,7 +908,7 @@ namespace PitHero.Tests
                 }
 
                 byte[] bytes = ms.ToArray();
-                bytes[0] = (byte)(SaveData.MinSupportedVersion - 1);
+                bytes[0] = (byte)(SaveData.CurrentVersion - 1);
                 bytes[1] = 0;
                 bytes[2] = 0;
                 bytes[3] = 0;
@@ -1371,28 +1267,6 @@ namespace PitHero.Tests
         }
 
         /// <summary>
-        /// v23–v25 gated consumable auto-purchasing behind a master flag v26 removed. Loading an old
-        /// file with the flag off must clear the selections so behavior is preserved; v26+ files and
-        /// flag-on files must keep them.
-        /// </summary>
-        [TestMethod]
-        public void SaveData_LegacyPurchaseConsumablesMigration()
-        {
-            var selected = new bool[] { true, false, true };
-
-            SaveData.ApplyLegacyPurchaseConsumablesMigration(25, purchaseConsumables: false, selected);
-            CollectionAssert.AreEqual(new bool[3], selected, "Pre-v26 with the flag off clears every selection");
-
-            selected = new bool[] { true, false, true };
-            SaveData.ApplyLegacyPurchaseConsumablesMigration(25, purchaseConsumables: true, selected);
-            CollectionAssert.AreEqual(new[] { true, false, true }, selected, "Pre-v26 with the flag on keeps selections");
-
-            selected = new bool[] { true, false, true };
-            SaveData.ApplyLegacyPurchaseConsumablesMigration(26, purchaseConsumables: false, selected);
-            CollectionAssert.AreEqual(new[] { true, false, true }, selected, "v26+ files never migrate — the flag is a dead slot");
-        }
-
-        /// <summary>
         /// v27 round-trip: SaveData.PlacedStencils (2 records) persists and recovers correctly
         /// through the binary serializer (section 44).
         /// </summary>
@@ -1434,53 +1308,6 @@ namespace PitHero.Tests
             {
                 try { Directory.Delete(tempDir, recursive: true); } catch { }
             }
-        }
-
-        /// <summary>
-        /// Backward-compatibility: a v26 binary (no section 44) loads with an empty PlacedStencils
-        /// list. This mirrors the v17-file pattern in SaveData_V17File_LoadsWithDefaultDining.
-        /// </summary>
-        [TestMethod]
-        public void SaveData_V26File_LoadsWithEmptyPlacedStencils()
-        {
-            // Write a v27 (current-version) binary.
-            var ms = new MemoryStream();
-            using (var writer = new BinaryPersistableWriter(ms))
-            {
-                var original = new SaveData();
-                original.HeroName = "PreStencilHero";
-                writer.Write(original);
-            }
-            byte[] currentBytes = ms.ToArray();
-
-            // Measure the encoded size of one int (the stencil count for an empty list = writer.Write(0)).
-            var probe = new MemoryStream();
-            int intSize;
-            using (var probeWriter = new BinaryPersistableWriter(probe))
-            {
-                probeWriter.Write(0);
-                intSize = (int)probe.Length;
-            }
-
-            // Truncate the last intSize bytes (section 44: count=0 is the only byte written for an empty list).
-            byte[] v26Bytes = new byte[currentBytes.Length - intSize];
-            System.Array.Copy(currentBytes, v26Bytes, v26Bytes.Length);
-
-            // Patch the version header to 26 (little-endian int at bytes 0-3).
-            v26Bytes[0] = 26;
-            v26Bytes[1] = 0;
-            v26Bytes[2] = 0;
-            v26Bytes[3] = 0;
-
-            var loaded = new SaveData();
-            using (var rdr = new BinaryPersistableReader(new MemoryStream(v26Bytes)))
-            {
-                rdr.ReadPersistableInto(loaded);
-            }
-
-            Assert.AreEqual("PreStencilHero", loaded.HeroName, "v26 body must still load correctly");
-            Assert.IsNotNull(loaded.PlacedStencils, "v26 load must initialize PlacedStencils to an empty list");
-            Assert.AreEqual(0, loaded.PlacedStencils.Count, "v26 load must yield zero placed stencils");
         }
 
         /// <summary>

--- a/PitHero/Services/SaveData.cs
+++ b/PitHero/Services/SaveData.cs
@@ -262,19 +262,13 @@ namespace PitHero.Services
     /// <summary>Central save data container implementing IPersistable for binary persistence.</summary>
     public class SaveData : IPersistable
     {
-        /// <summary>Current save file version.</summary>
-        public const int CurrentVersion = 29;
-
         /// <summary>
-        /// Oldest save file version this build can still load. v17–v26 files are byte-exact
-        /// prefixes of v27 (sections 33 dining, 34 automation, 35 auto-dine resume,
-        /// 36 auto-sell excess items, 37 auto-sell priority, 38 gear sell types,
-        /// 39 auto-purchase items, 40 auto-equip, 41 auto-hire mercenaries,
-        /// 42 auto-learn hero skills, 43 consumable sell options,
-        /// 44 placed stencils, 45 refrigerator, and 46 runner carry level were appended
-        /// at the end), so they load with default state for the missing sections.
+        /// The one and only save file version this build reads or writes. There is no migration
+        /// path and no reader for any other layout: a file whose header is not exactly this value
+        /// is rejected with InvalidDataException, and SaveLoadService treats that slot as empty.
+        /// Bump it whenever the byte layout changes.
         /// </summary>
-        public const int MinSupportedVersion = 17;
+        public const int CurrentVersion = 29;
 
         // Total Time
         /// <summary>Total time played in seconds.</summary>
@@ -546,10 +540,9 @@ namespace PitHero.Services
         public bool AutoPurchaseMercenaryGear = false;
 
         /// <summary>
-        /// Legacy (v23–v25): whether the selected consumables were auto-purchased. The master flag
-        /// was removed in v26 — selection alone decides — but the slot stays in section 39 to keep
-        /// old files byte-exact prefixes; v26+ always writes true. On pre-v26 loads a false value
-        /// clears AutoPurchaseConsumableSelected so old behavior is preserved.
+        /// Dead slot. A v23-era master flag gating consumable auto-purchase; v26 removed it —
+        /// selection alone decides. The bool stays in section 39 so the layout is not reshaped
+        /// (Persist always writes true), and nothing reads this field outside serialization.
         /// </summary>
         public bool AutoPurchaseConsumables = true;
 
@@ -1039,7 +1032,7 @@ namespace PitHero.Services
             writer.Write(AutoPurchaseItems);
             writer.Write(AutoPurchaseConsumablesFirst);
             writer.Write(AutoPurchaseMercenaryGear);
-            writer.Write(true); // legacy AutoPurchaseConsumables slot — master flag removed in v26
+            writer.Write(true); // dead AutoPurchaseConsumables slot — kept so the layout stays unreshaped
 
             int buyRarityCount = AutoPurchaseRarityAllowed != null ? AutoPurchaseRarityAllowed.Length : 0;
             writer.Write(buyRarityCount);
@@ -1115,8 +1108,8 @@ namespace PitHero.Services
         {
             // 1. File Version
             int fileVersion = reader.ReadInt();
-            if (fileVersion < MinSupportedVersion || fileVersion > CurrentVersion)
-                throw new System.IO.InvalidDataException($"Unsupported save file version {fileVersion} (expected {MinSupportedVersion}-{CurrentVersion})");
+            if (fileVersion != CurrentVersion)
+                throw new System.IO.InvalidDataException($"Unsupported save file version {fileVersion} (expected {CurrentVersion})");
 
             // 2. Total Time Played
             TotalTimePlayed = reader.ReadFloat();
@@ -1476,95 +1469,64 @@ namespace PitHero.Services
             // 32. Auto-sell keep stacks
             AutoSellKeepStacks = reader.ReadInt();
 
-            // 33. Party dining (issue #319, v18+). v17 files end at section 32 — defaults apply.
+            // 33. Party dining (issue #319, section added in v18). The array is pre-built because a
+            // saved party smaller than the current one leaves the trailing slots at their defaults.
             PartyDining = CreateDefaultDiningRecords();
-            if (fileVersion >= 18)
+            FavoriteDishId = reader.ReadInt();
+            EatAtTavern = reader.ReadBool();
+            int diningCount = reader.ReadInt();
+            for (int i = 0; i < diningCount; i++)
             {
-                FavoriteDishId = reader.ReadInt();
-                EatAtTavern = reader.ReadBool();
-                int diningCount = reader.ReadInt();
-                for (int i = 0; i < diningCount; i++)
+                var record = new SavedDiningRecord
                 {
-                    var record = new SavedDiningRecord
-                    {
-                        OrderedDishId = reader.ReadInt(),
-                        HasPaid = reader.ReadBool(),
-                        HasEatenToday = reader.ReadBool(),
-                        MealDishId = reader.ReadInt(),
-                        MealDeluxe = reader.ReadBool(),
-                    };
-                    if (i < PartyDining.Length)
-                        PartyDining[i] = record;
-                }
+                    OrderedDishId = reader.ReadInt(),
+                    HasPaid = reader.ReadBool(),
+                    HasEatenToday = reader.ReadBool(),
+                    MealDishId = reader.ReadInt(),
+                    MealDeluxe = reader.ReadBool(),
+                };
+                if (i < PartyDining.Length)
+                    PartyDining[i] = record;
             }
 
-            // 34. Automation (issue #321, v19+). Older files end at section 33 — default false.
-            if (fileVersion >= 19)
-                AutomateMonsterJobs = reader.ReadBool();
+            // 34. Automation (issue #321, section added in v19).
+            AutomateMonsterJobs = reader.ReadBool();
 
-            // 35. Auto-dine resume (v20+). Legacy files can't distinguish a manual Stop from a
-            // breakfast trip, so infer: a reloaded member with a meal still in progress means
-            // the party should stand up when everyone finishes — otherwise they'd sit at the
-            // tavern forever waiting for a Play press.
-            if (fileVersion >= 20)
-            {
-                PartyAutoDineResume = reader.ReadBool();
-            }
-            else if (PartyDining != null)
-            {
-                for (int i = 0; i < PartyDining.Length; i++)
-                {
-                    if (PartyDining[i].OrderedDishId >= 0 && !PartyDining[i].HasEatenToday)
-                    {
-                        PartyAutoDineResume = true;
-                        break;
-                    }
-                }
-            }
+            // 35. Auto-dine resume (section added in v20).
+            PartyAutoDineResume = reader.ReadBool();
 
-            // 36. Auto-sell excess items (v21+). Older files end at section 35 — defaults apply
-            // (enabled, all rarities allowed). Rarities default to all-true so rarities added
-            // after the save was written behave like a fresh enable.
+            // 36. Auto-sell excess items (section added in v21). Rarities are pre-filled all-true so
+            // a rarity added after the file was written behaves like a fresh enable.
             AutoSellRarityAllowed = new bool[5];
             for (int i = 0; i < AutoSellRarityAllowed.Length; i++)
                 AutoSellRarityAllowed[i] = true;
-            if (fileVersion >= 21)
+            AutoSellExcessItems = reader.ReadBool();
+            int rarityCount = reader.ReadInt();
+            for (int i = 0; i < rarityCount; i++)
             {
-                AutoSellExcessItems = reader.ReadBool();
-                int rarityCount = reader.ReadInt();
-                for (int i = 0; i < rarityCount; i++)
-                {
-                    bool allowed = reader.ReadBool();
-                    if (i < AutoSellRarityAllowed.Length)
-                        AutoSellRarityAllowed[i] = allowed;
-                }
+                bool allowed = reader.ReadBool();
+                if (i < AutoSellRarityAllowed.Length)
+                    AutoSellRarityAllowed[i] = allowed;
             }
 
-            // 37. Auto-sell priority (v22+). Older files default to consumables-first.
-            AutoSellConsumablesFirst = true;
-            if (fileVersion >= 22)
-                AutoSellConsumablesFirst = reader.ReadBool();
+            // 37. Auto-sell priority (section added in v22).
+            AutoSellConsumablesFirst = reader.ReadBool();
 
-            // 38. Gear sell types (v23+). Older files end at section 37 — all categories sellable.
+            // 38. Gear sell types (section added in v23). Pre-filled all-true so categories added
+            // after the file was written stay sellable.
             AutoSellGearTypeAllowed = new bool[RolePlayingFramework.Equipment.GearCategoryUtils.Count];
             for (int i = 0; i < AutoSellGearTypeAllowed.Length; i++)
                 AutoSellGearTypeAllowed[i] = true;
-            if (fileVersion >= 23)
+            int sellTypeCount = reader.ReadInt();
+            for (int i = 0; i < sellTypeCount; i++)
             {
-                int sellTypeCount = reader.ReadInt();
-                for (int i = 0; i < sellTypeCount; i++)
-                {
-                    bool allowed = reader.ReadBool();
-                    if (i < AutoSellGearTypeAllowed.Length)
-                        AutoSellGearTypeAllowed[i] = allowed;
-                }
+                bool allowed = reader.ReadBool();
+                if (i < AutoSellGearTypeAllowed.Length)
+                    AutoSellGearTypeAllowed[i] = allowed;
             }
 
-            // 39. Auto-purchase items (v23+). Older files default to disabled with all filters open.
-            AutoPurchaseItems = false;
-            AutoPurchaseConsumablesFirst = false;
-            AutoPurchaseMercenaryGear = false;
-            AutoPurchaseConsumables = true;
+            // 39. Auto-purchase items (section added in v23). Filter arrays are pre-filled permissive
+            // and stacks default to 1 so entries beyond the saved count keep fresh-game behavior.
             AutoPurchaseRarityAllowed = new bool[5];
             for (int i = 0; i < AutoPurchaseRarityAllowed.Length; i++)
                 AutoPurchaseRarityAllowed[i] = true;
@@ -1575,74 +1537,55 @@ namespace PitHero.Services
             AutoPurchaseConsumableStacks = new int[RolePlayingFramework.Equipment.ConsumableCatalog.Count];
             for (int i = 0; i < AutoPurchaseConsumableStacks.Length; i++)
                 AutoPurchaseConsumableStacks[i] = 1;
-            if (fileVersion >= 23)
-            {
-                AutoPurchaseItems = reader.ReadBool();
-                AutoPurchaseConsumablesFirst = reader.ReadBool();
-                AutoPurchaseMercenaryGear = reader.ReadBool();
-                AutoPurchaseConsumables = reader.ReadBool();
 
-                int buyRarityCount = reader.ReadInt();
-                for (int i = 0; i < buyRarityCount; i++)
+            AutoPurchaseItems = reader.ReadBool();
+            AutoPurchaseConsumablesFirst = reader.ReadBool();
+            AutoPurchaseMercenaryGear = reader.ReadBool();
+            AutoPurchaseConsumables = reader.ReadBool(); // dead slot, always written true
+
+            int buyRarityCount = reader.ReadInt();
+            for (int i = 0; i < buyRarityCount; i++)
+            {
+                bool allowed = reader.ReadBool();
+                if (i < AutoPurchaseRarityAllowed.Length)
+                    AutoPurchaseRarityAllowed[i] = allowed;
+            }
+
+            int buyTypeCount = reader.ReadInt();
+            for (int i = 0; i < buyTypeCount; i++)
+            {
+                bool allowed = reader.ReadBool();
+                if (i < AutoPurchaseGearTypeAllowed.Length)
+                    AutoPurchaseGearTypeAllowed[i] = allowed;
+            }
+
+            int consumableCount = reader.ReadInt();
+            for (int i = 0; i < consumableCount; i++)
+            {
+                bool selected = reader.ReadBool();
+                int stacks = reader.ReadInt();
+                if (i < AutoPurchaseConsumableSelected.Length)
                 {
-                    bool allowed = reader.ReadBool();
-                    if (i < AutoPurchaseRarityAllowed.Length)
-                        AutoPurchaseRarityAllowed[i] = allowed;
+                    AutoPurchaseConsumableSelected[i] = selected;
+                    AutoPurchaseConsumableStacks[i] = stacks;
                 }
-
-                int buyTypeCount = reader.ReadInt();
-                for (int i = 0; i < buyTypeCount; i++)
-                {
-                    bool allowed = reader.ReadBool();
-                    if (i < AutoPurchaseGearTypeAllowed.Length)
-                        AutoPurchaseGearTypeAllowed[i] = allowed;
-                }
-
-                int consumableCount = reader.ReadInt();
-                for (int i = 0; i < consumableCount; i++)
-                {
-                    bool selected = reader.ReadBool();
-                    int stacks = reader.ReadInt();
-                    if (i < AutoPurchaseConsumableSelected.Length)
-                    {
-                        AutoPurchaseConsumableSelected[i] = selected;
-                        AutoPurchaseConsumableStacks[i] = stacks;
-                    }
-                }
-
-                ApplyLegacyPurchaseConsumablesMigration(fileVersion, AutoPurchaseConsumables, AutoPurchaseConsumableSelected);
             }
 
-            // 40. Auto-equip (v23+). Older files default to both on, matching the runtime defaults.
-            AutoEquipHero = true;
-            AutoEquipMercenaries = true;
-            if (fileVersion >= 23)
-            {
-                AutoEquipHero = reader.ReadBool();
-                AutoEquipMercenaries = reader.ReadBool();
-            }
+            // 40. Auto-equip (section added in v23).
+            AutoEquipHero = reader.ReadBool();
+            AutoEquipMercenaries = reader.ReadBool();
 
-            // 41. Auto-hire mercenaries (v24+). Older files default to disabled, both slots None.
-            AutoHireMercenariesEnabled = false;
-            AutoHireMerc1Job = 0;
-            AutoHireMerc2Job = 0;
-            if (fileVersion >= 24)
-            {
-                AutoHireMercenariesEnabled = reader.ReadBool();
-                AutoHireMerc1Job = reader.ReadInt();
-                AutoHireMerc2Job = reader.ReadInt();
-            }
+            // 41. Auto-hire mercenaries (section added in v24).
+            AutoHireMercenariesEnabled = reader.ReadBool();
+            AutoHireMerc1Job = reader.ReadInt();
+            AutoHireMerc2Job = reader.ReadInt();
 
-            // 42. Auto-learn hero skills (v25+). Older files default to disabled, Smart mode.
-            AutoLearnSkillsEnabled = false;
-            AutoLearnMode = 0;
-            if (fileVersion >= 25)
-            {
-                AutoLearnSkillsEnabled = reader.ReadBool();
-                AutoLearnMode = reader.ReadInt();
-            }
+            // 42. Auto-learn hero skills (section added in v25).
+            AutoLearnSkillsEnabled = reader.ReadBool();
+            AutoLearnMode = reader.ReadInt();
 
-            // 43. Consumable sell options (v26+). Older files default to everything sellable, keep 1 stack.
+            // 43. Consumable sell options (section added in v26). Pre-filled sellable/keep-1 so
+            // consumables added after the file was written stay sellable.
             AutoSellConsumableSelected = new bool[RolePlayingFramework.Equipment.ConsumableCatalog.Count];
             AutoSellConsumableMinStacks = new int[RolePlayingFramework.Equipment.ConsumableCatalog.Count];
             for (int i = 0; i < AutoSellConsumableSelected.Length; i++)
@@ -1650,78 +1593,51 @@ namespace PitHero.Services
                 AutoSellConsumableSelected[i] = true;
                 AutoSellConsumableMinStacks[i] = 1;
             }
-            if (fileVersion >= 26)
+            int sellConsumableCount = reader.ReadInt();
+            for (int i = 0; i < sellConsumableCount; i++)
             {
-                int sellConsumableCount = reader.ReadInt();
-                for (int i = 0; i < sellConsumableCount; i++)
+                bool selected = reader.ReadBool();
+                int minStacks = reader.ReadInt();
+                if (i < AutoSellConsumableSelected.Length)
                 {
-                    bool selected = reader.ReadBool();
-                    int minStacks = reader.ReadInt();
-                    if (i < AutoSellConsumableSelected.Length)
-                    {
-                        AutoSellConsumableSelected[i] = selected;
-                        AutoSellConsumableMinStacks[i] = minStacks;
-                    }
+                    AutoSellConsumableSelected[i] = selected;
+                    AutoSellConsumableMinStacks[i] = minStacks;
                 }
             }
 
-            // 44. Placed stencils (v27+). Older files default to no placed stencils.
+            // 44. Placed stencils (section added in v27).
             PlacedStencils = new List<SavedPlacedStencil>();
-            if (fileVersion >= 27)
+            int placedCount = reader.ReadInt();
+            for (int i = 0; i < placedCount; i++)
             {
-                int placedCount = reader.ReadInt();
-                for (int i = 0; i < placedCount; i++)
-                {
-                    SavedPlacedStencil s;
-                    s.PatternId = reader.ReadString();
-                    s.AnchorX = reader.ReadInt();
-                    s.AnchorY = reader.ReadInt();
-                    PlacedStencils.Add(s);
-                }
+                SavedPlacedStencil s;
+                s.PatternId = reader.ReadString();
+                s.AnchorX = reader.ReadInt();
+                s.AnchorY = reader.ReadInt();
+                PlacedStencils.Add(s);
             }
 
-            // 45. Refrigerator (v28+). Older files default to an empty fridge, slider at 1.
+            // 45. Refrigerator (section added in v28).
             FridgeSlots = new List<SavedHarvestSlot>();
-            FridgePreStockStackSize = 1;
-            if (fileVersion >= 28)
+            int fridgeSlotCount = reader.ReadInt();
+            for (int i = 0; i < fridgeSlotCount; i++)
             {
-                int fridgeSlotCount = reader.ReadInt();
-                for (int i = 0; i < fridgeSlotCount; i++)
-                {
-                    SavedHarvestSlot s;
-                    s.SlotIndex = reader.ReadInt();
-                    s.CropTypeId = reader.ReadInt();
-                    s.Count = reader.ReadInt();
-                    FridgeSlots.Add(s);
-                }
-                int preStock = reader.ReadInt();
-                if (preStock < GameConfig.KitchenPreStockStackSizeMin) preStock = GameConfig.KitchenPreStockStackSizeMin;
-                if (preStock > GameConfig.KitchenPreStockStackSizeMax) preStock = GameConfig.KitchenPreStockStackSizeMax;
-                FridgePreStockStackSize = preStock;
+                SavedHarvestSlot s;
+                s.SlotIndex = reader.ReadInt();
+                s.CropTypeId = reader.ReadInt();
+                s.Count = reader.ReadInt();
+                FridgeSlots.Add(s);
             }
+            int preStock = reader.ReadInt();
+            if (preStock < GameConfig.KitchenPreStockStackSizeMin) preStock = GameConfig.KitchenPreStockStackSizeMin;
+            if (preStock > GameConfig.KitchenPreStockStackSizeMax) preStock = GameConfig.KitchenPreStockStackSizeMax;
+            FridgePreStockStackSize = preStock;
 
-            // 46. Runner carry level (v29+). Older files default to level 1 (1 unit per crop).
-            RunnerCarryLevel = 1;
-            if (fileVersion >= 29)
-            {
-                int carry = reader.ReadInt();
-                if (carry < GameConfig.KitchenRunnerCarryLevelMin) carry = GameConfig.KitchenRunnerCarryLevelMin;
-                if (carry > GameConfig.KitchenRunnerCarryLevelMax) carry = GameConfig.KitchenRunnerCarryLevelMax;
-                RunnerCarryLevel = carry;
-            }
-        }
-
-        /// <summary>
-        /// v23–v25 gated consumable auto-purchasing behind a master flag that v26 removed. A pre-v26
-        /// file with the flag off must come back with no consumables selected, otherwise selections
-        /// the player made while the flag was off would silently start purchasing.
-        /// </summary>
-        public static void ApplyLegacyPurchaseConsumablesMigration(int fileVersion, bool purchaseConsumables, bool[] consumableSelected)
-        {
-            if (fileVersion >= 26 || purchaseConsumables || consumableSelected == null)
-                return;
-            for (int i = 0; i < consumableSelected.Length; i++)
-                consumableSelected[i] = false;
+            // 46. Runner carry level (section added in v29).
+            int carry = reader.ReadInt();
+            if (carry < GameConfig.KitchenRunnerCarryLevelMin) carry = GameConfig.KitchenRunnerCarryLevelMin;
+            if (carry > GameConfig.KitchenRunnerCarryLevelMax) carry = GameConfig.KitchenRunnerCarryLevelMax;
+            RunnerCarryLevel = carry;
         }
 
         /// <summary>Writes a Color as four individual int components (R, G, B, A).</summary>

--- a/PitHero/docs/AutomationSystem.md
+++ b/PitHero/docs/AutomationSystem.md
@@ -91,30 +91,35 @@ Two distinct patterns — pick deliberately:
 
 ## Persistence
 
-Save version constants live in `PitHero/Services/SaveData.cs` (`CurrentVersion`,
-`MinSupportedVersion`). The format is **strictly append-only**: older files are byte-exact prefixes
-of newer ones, so a v17 file still loads into a v23 build with defaults for the missing tail.
+The save format is **a single version**. `SaveData.CurrentVersion` is the only header value the
+build reads or writes; `Recover` rejects anything else with `InvalidDataException` and
+`SaveLoadService` treats that slot as empty. There is no migration path, no `MinSupportedVersion`,
+and no version-gated branch anywhere in `Recover` — pre-launch, changing the layout means existing
+saves stop loading, which is the accepted cost.
 
-Removing a setting does **not** remove its bytes. The v26 removal of the "Auto-Purchase
-Consumables" master flag kept its bool slot in section 39 (always written `true` now) so older
-files stay byte-exact prefixes; `SaveData.ApplyLegacyPurchaseConsumablesMigration` translates a
-pre-v26 flag-off file into cleared selections on load. Follow that pattern — a dead slot plus a
-version-gated migration — rather than reshaping an existing section.
+Sections are still appended at the end and still numbered, because that keeps diffs and the
+Persist/Recover pairing readable — not because older files need to be prefixes of newer ones.
+
+Removing a setting does **not** remove its bytes; reshaping a section in the middle is what forces
+a version bump. The v26 removal of the "Auto-Purchase Consumables" master flag left its bool as a
+dead slot in section 39 (`Persist` always writes `true`, `Recover` reads and discards it). Follow
+that pattern when a setting goes away.
 
 Adding a persisted setting means, in order:
 
-1. Add the field to `SaveData` with a default and a `// Feature name (vNN)` comment.
+1. Add the field to `SaveData` with a default and a `// Feature name` comment.
 2. Append a **new numbered section at the very end** of `Persist`. Arrays are written as a count
    followed by the elements.
-3. Append the mirrored read at the very end of `Recover`: **initialize defaults first, then**
-   `if (fileVersion >= NN) { ... }`. Clamp array reads with `if (i < arr.Length)` so arrays that
-   grow later still load. Defaults for "allowed" filters are all-true, so categories added after a
-   save was written behave like a fresh enable.
-4. Bump `CurrentVersion` and extend the `MinSupportedVersion` doc comment's section list.
+3. Append the mirrored read at the very end of `Recover`, unconditionally. Clamp array reads with
+   `if (i < arr.Length)` and **pre-fill the array's defaults before reading** — a saved count
+   shorter than the current array leaves the tail at those defaults, which is how a rarity, gear
+   category, or consumable added later behaves like a fresh enable. Scalars need no pre-assignment;
+   the read always overwrites them.
+4. Bump `CurrentVersion`.
 5. Service → `SaveData` in `SaveLoadService` (the collect method); `SaveData` → service in
    `MainGameScene`'s load-apply path.
 6. Extend `SaveLoadTests` with a round-trip test *and* a defaults test (a null array persists a
-   zero count, which also exercises the "older file, section absent" path).
+   zero count, which exercises the pre-fill path).
 
 **Two indices are persisted identities and must stay append-only:**
 

--- a/PitHero/docs/SynergySystem.md
+++ b/PitHero/docs/SynergySystem.md
@@ -415,9 +415,9 @@ snapshot in `GameStateService.PlacedStencils` (`List<PlacedStencilRecord>`, each
 - `RemovePlacedStencil(patternId)` — no-op when absent.
 - `ClearPlacedStencils()` — removes all records.
 
-This list is persisted in **save v27, section 44** (appended after section 43, gated
-`fileVersion >= 27`). Older files (v17–v26) recover with an empty list; the grid re-mirrors
-placements on its next `ConnectToHero` call after loading.
+This list is persisted in **section 44** of the save file (appended after section 43). A save with
+no placed stencils recovers an empty list; the grid re-mirrors placements on its next
+`ConnectToHero` call after loading.
 
 `SaveLoadService` copies `GameStateService.PlacedStencils ↔ SaveData.PlacedStencils`
 (`List<SavedPlacedStencil>`) on save and load respectively.

--- a/PitHero/docs/TavernDiningSystem.md
+++ b/PitHero/docs/TavernDiningSystem.md
@@ -350,11 +350,11 @@ point)`, rounded to 5g, min 10g. A monotonicity pass then guarantees that among 
 dishes of the same buff type, more magnitude costs strictly more. Rebalancing crop sell prices
 reprices the whole menu automatically (`DishPricingTests` guards this).
 
-## Persistence (save v18, section 33)
+## Persistence (section 33)
 
 Persisted per party slot (`SavedDiningRecord`): `OrderedDishId`, `HasPaid`, `HasEatenToday`,
-`MealDishId`, `MealDeluxe`; plus `FavoriteDishId` and `EatAtTavern`. v17 saves load with
-defaults. On load, meal buffs are rebuilt via `MealBuffService.RestoreRecord` (no HP/MP
+`MealDishId`, `MealDeluxe`; plus `FavoriteDishId` and `EatAtTavern`. On load, meal buffs are
+rebuilt via `MealBuffService.RestoreRecord` (no HP/MP
 re-grant), and an open order forces Stop mode back on so the party returns to the table —
 crops were deducted pre-save and `HasPaid` prevents double payment
 (`CreateTicketPreReserved` recreates the ticket as `ReadyToCook` with full-recipe refund data).


### PR DESCRIPTION
Backwards compatibility has no value pre-launch, so the multi-version reader is gone:

- MinSupportedVersion deleted; CurrentVersion is the only version constant and Recover rejects any header != CurrentVersion
- All `if (fileVersion >= N)` guards removed from Recover sections 33-46
- Removed ApplyLegacyPurchaseConsumablesMigration and the pre-v20 auto-dine-resume inference branch
- Dropped scalar pre-assignments the unconditional reads overwrote; array pre-fills stay, since a saved count shorter than a grown catalog still needs the tail left at defaults

The byte layout is deliberately unchanged so existing v29 saves keep loading: the dead AutoPurchaseConsumables bool still occupies its slot in section 39. Verified by diffing the ordered reader.Read*/writer.Write sequences against the previous commit - 181 calls each, identical.

Tests: removed the four that only proved multi-version loading; the header test now rejects both CurrentVersion-1 and CurrentVersion+1. 1963 passed, 0 failed, 6 skipped.

Docs: AutomationSystem.md Persistence section rewritten for the single-version policy and the new append-a-section recipe; SynergySystem.md and TavernDiningSystem.md save notes de-versioned.