### PR TITLE
Party eats lunch and dinner too

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,11 @@ See `PitHero/docs/RenderingSystem.md` for the full reference.  Key rules:
 - Route Cave enemy scaling through `GetScaledEnemyLevelForPitLevel` and Cave treasure transitions through `DetermineCaveTreasureLevel`
 - If a `private` method needs to be called from another class, make it `public` — don't use reflection
 
+### Save Format (backwards compatibility is mandatory)
+- The save system lives in `Services/SaveData.cs` (`CurrentVersion` / `MinSupportedVersion`). When a feature changes the byte layout, bump `CurrentVersion` **and keep every version from `MinSupportedVersion` up loadable**: read new fields conditionally on the file's version (`fileVersion >= N ? reader.ReadX() : safeDefault`) and pick defaults that degrade gracefully (e.g. "no active buff", "feature off")
+- Never raise `MinSupportedVersion` or drop a reader path on your own. Periodic **save unifications** (collapsing old versions into one, e.g. issue #311 → v17, PR #391 → v29) happen **only when the owner explicitly asks for one** — a past unification is a one-time cleanup, not a standing policy of rejecting old saves
+- Every version bump gets a backwards-compatibility test proving the previous layout still reads (see `SaveData_V29DiningRecord_ReadsWithDefaultExpiry` in `SaveLoadTests.cs`); loads always rewrite at `CurrentVersion` on the next save
+
 ### Code Style
 - Every public method gets a `/// <summary>` doc comment (keep it concise)
 - One component class per file (structs are exempt)

--- a/PitHero.Tests/AutoJobAssignmentServiceTests.cs
+++ b/PitHero.Tests/AutoJobAssignmentServiceTests.cs
@@ -172,8 +172,10 @@ namespace PitHero.Tests
         [TestMethod]
         public void ReassessNow_StaffsDayAndNightShiftsIndependently()
         {
-            // Day monsters (Slime) and nocturnal monsters (Orc) never work at the same time, so
-            // each shift must field its own kitchen crew — even when the day shift has better cooks.
+            // Day monsters (Slime) and nocturnal monsters (Orc) never work at the same time.
+            // The day shift fields its own kitchen crew independently of the night roster.
+            // Since issue #392 the kitchen is closed overnight (10 PM–6 AM): the nocturnal
+            // shift receives zero kitchen demand from the evaluator.
             var roster = new AlliedMonsterManager();
             roster.AddAlliedMonster(Monster("DayA", 1, 9, 1));
             roster.AddAlliedMonster(Monster("DayB", 1, 8, 1));
@@ -191,17 +193,19 @@ namespace PitHero.Tests
             Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[1].Job);
             Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[2].Job);
             Assert.AreEqual(MonsterJob.None, roster.AlliedMonsters[3].Job, "Fourth day monster exceeds the base crew");
-            Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[4].Job,
-                "Night shift fields its own kitchen crew despite lower cooking skill than the day shift");
-            Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[5].Job);
-            Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[6].Job);
-            Assert.AreEqual(MonsterJob.None, roster.AlliedMonsters[7].Job, "Fourth night monster exceeds the base crew");
+            // Night shift: kitchen is closed overnight — evaluator returns zero demand.
+            Assert.AreEqual(MonsterJob.None, roster.AlliedMonsters[4].Job, "Night monsters are not assigned to the closed kitchen");
+            Assert.AreEqual(MonsterJob.None, roster.AlliedMonsters[5].Job);
+            Assert.AreEqual(MonsterJob.None, roster.AlliedMonsters[6].Job);
+            Assert.AreEqual(MonsterJob.None, roster.AlliedMonsters[7].Job);
         }
 
         [TestMethod]
         public void ReassessNow_DemandClampsApplyPerShift()
         {
-            // Kitchen base crew clamps to each shift's own size, not the whole roster's.
+            // Kitchen base crew clamps to the day shift's own size, not the whole roster's.
+            // Since issue #392 the kitchen is closed overnight: nocturnal monsters receive zero
+            // kitchen demand regardless of roster size.
             var roster = new AlliedMonsterManager();
             roster.AddAlliedMonster(Monster("DayA", 1, 5, 1));
             roster.AddAlliedMonster(Monster("DayB", 1, 5, 1));
@@ -211,16 +215,23 @@ namespace PitHero.Tests
 
             service.ReassessNow();
 
-            for (int i = 0; i < 4; i++)
-                Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[i].Job,
-                    $"Monster {i}: with 2 monsters per shift, the whole shift staffs the kitchen");
+            Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[0].Job,
+                "Day shift: with 2 day monsters, both fill the clamped kitchen crew");
+            Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[1].Job,
+                "Day shift: second day monster fills the clamped base crew");
+            Assert.AreEqual(MonsterJob.None, roster.AlliedMonsters[2].Job,
+                "Night shift: kitchen is closed overnight — nocturnal monster gets no kitchen assignment");
+            Assert.AreEqual(MonsterJob.None, roster.AlliedMonsters[3].Job,
+                "Night shift: second nocturnal monster also gets no kitchen assignment");
         }
 
         [TestMethod]
         public void ReassessNow_StickyKitchenProtectionIsPerShift()
         {
             // A nocturnal monster already on Cooking must not shield the day shift from staffing
-            // its own kitchen, and vice versa — stickiness applies within each shift group only.
+            // its own kitchen — stickiness applies within each shift group only.
+            // Since issue #392 the kitchen is closed overnight: the night monster's Cooking job
+            // is removed by the solver (zero nocturnal demand) and the day shift is unaffected.
             var roster = new AlliedMonsterManager();
             roster.AddAlliedMonster(Monster("Day", 1, 4, 1));
             roster.AddAlliedMonster(Monster("Night", 1, 4, 1, MonsterJob.Cooking, typeName: "Monster_Orc"));
@@ -229,9 +240,9 @@ namespace PitHero.Tests
             service.ReassessNow();
 
             Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[0].Job,
-                "Day shift staffs its kitchen even though a night monster already holds a kitchen job");
-            Assert.AreEqual(MonsterJob.Cooking, roster.AlliedMonsters[1].Job,
-                "Sticky night kitchen worker keeps the job");
+                "Day shift staffs its kitchen regardless of what the night monster holds");
+            Assert.AreEqual(MonsterJob.None, roster.AlliedMonsters[1].Job,
+                "Night monster's Cooking job is removed — kitchen is closed overnight");
         }
 
         // ── Farming priority over kitchen (issue: dead-end kitchen with unworked farm) ──
@@ -364,7 +375,7 @@ namespace PitHero.Tests
             public FixedDemandEvaluator(MonsterJob job, int min, int desired)
                 => _entry = new JobDemandEntry { Job = job, MinWorkers = min, DesiredWorkers = desired, Sticky = false };
             public MonsterJob Job => _entry.Job;
-            public JobDemandEntry EvaluateDemand(int rosterSize, int availableWorkers) => _entry;
+            public JobDemandEntry EvaluateDemand(int rosterSize, int availableWorkers, bool nocturnal) => _entry;
             public void SamplePressure(float nowSeconds) { }
             public void ResetPressure(float nowSeconds) { }
         }
@@ -428,7 +439,7 @@ namespace PitHero.Tests
                 planting.AddPlan(new PlacedCropPlan { Type = CropType.Wheat, TileX = i, TileY = 0 });
             var evaluator = new FarmingJobDemandEvaluator(null, growth, planting);
 
-            var d = evaluator.EvaluateDemand(rosterSize: 10, availableWorkers: 10);
+            var d = evaluator.EvaluateDemand(rosterSize: 10, availableWorkers: 10, nocturnal: false);
 
             Assert.AreEqual(1, d.DesiredWorkers,
                 "Placed plans with no outstanding tasks staff exactly the caretaker");
@@ -540,7 +551,7 @@ namespace PitHero.Tests
             var coordinator = CreateHeadlessKitchen(out _, out _);
             var evaluator = new KitchenJobDemandEvaluator(coordinator, null, null);
 
-            var d = evaluator.EvaluateDemand(rosterSize: 3, availableWorkers: 3);
+            var d = evaluator.EvaluateDemand(rosterSize: 3, availableWorkers: 3, nocturnal: false);
 
             Assert.AreEqual(0, d.DesiredWorkers, "Empty fridge + storage: no dish is coverable");
             Assert.AreEqual(0, d.MinWorkers);
@@ -555,10 +566,31 @@ namespace PitHero.Tests
                 Assert.IsTrue(storage.TryDeposit(1, def.Recipe[i].Crop, def.Recipe[i].Qty));
             var evaluator = new KitchenJobDemandEvaluator(coordinator, null, null);
 
-            var d = evaluator.EvaluateDemand(rosterSize: 3, availableWorkers: 3);
+            var d = evaluator.EvaluateDemand(rosterSize: 3, availableWorkers: 3, nocturnal: false);
 
             Assert.AreEqual(GameConfig.AutoJobKitchenBaseStaff, d.DesiredWorkers,
                 "One coverable dish is enough to staff the kitchen");
+        }
+
+        // ── Kitchen night-shift zero demand (issue #392) ────────────────────
+
+        [TestMethod]
+        public void KitchenEvaluator_Nocturnal_ReportsZeroDemandRegardlessOfLarder()
+        {
+            // Even with a stocked larder and a live backlog, the kitchen evaluator must
+            // return Min=0/Desired=0/Sticky=true when nocturnal=true — kitchen only
+            // operates during the day shift (6 AM–10 PM).
+            var coordinator = CreateHeadlessKitchen(out _, out var storage);
+            var def = DishConfig.GetDefinition((DishType)0);
+            for (int i = 0; i < def.Recipe.Length; i++)
+                Assert.IsTrue(storage.TryDeposit(1, def.Recipe[i].Crop, def.Recipe[i].Qty));
+            var evaluator = new KitchenJobDemandEvaluator(coordinator, null, null);
+
+            var d = evaluator.EvaluateDemand(rosterSize: 10, availableWorkers: 10, nocturnal: true);
+
+            Assert.AreEqual(0, d.MinWorkers,    "Nocturnal kitchen must not hold any minimum workers");
+            Assert.AreEqual(0, d.DesiredWorkers, "Nocturnal kitchen must not want any workers");
+            Assert.IsTrue(d.Sticky,              "Nocturnal kitchen entry must be sticky to prevent reshuffling");
         }
 
         // ── End-to-end backpressure scaling (issue #375) ─────────────────────

--- a/PitHero.Tests/HeroDishFallbackTests.cs
+++ b/PitHero.Tests/HeroDishFallbackTests.cs
@@ -1,0 +1,115 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Dining;
+using PitHero.Services;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Tests for the hero's dish fallback ladder (issue #392 follow-up): favorite → job
+    /// fallback 0 → job fallback 1, each gated on ingredients AND price. Previously the hero
+    /// ordered only his favorite, so one missing crop skipped the whole party's meal.
+    /// </summary>
+    [TestClass]
+    public class HeroDishFallbackTests
+    {
+        private const int PlentyOfGold = 100000;
+
+        [TestMethod]
+        [TestCategory("PartyDining")]
+        public void FavoriteCoverableAndAffordable_PicksFavorite()
+        {
+            bool ok = PartyDiningService.TryPickHeroDishCore(
+                DishType.CheesyMashedPotatoes, "Knight", PlentyOfGold,
+                _ => true, out var dish, out var anyCoverable);
+
+            Assert.IsTrue(ok);
+            Assert.AreEqual(DishType.CheesyMashedPotatoes, dish);
+            Assert.IsTrue(anyCoverable);
+        }
+
+        [TestMethod]
+        [TestCategory("PartyDining")]
+        public void FavoriteNotCoverable_FallsBackToJobFallback()
+        {
+            // Thief fallbacks: TomatoCheeseBisque, RoastedOnionSkewers
+            bool ok = PartyDiningService.TryPickHeroDishCore(
+                DishType.GardenSalad, "Thief", PlentyOfGold,
+                d => d != DishType.GardenSalad, out var dish, out var anyCoverable);
+
+            Assert.IsTrue(ok);
+            Assert.AreEqual(DishType.TomatoCheeseBisque, dish);
+            Assert.IsTrue(anyCoverable);
+        }
+
+        [TestMethod]
+        [TestCategory("PartyDining")]
+        public void FavoriteEqualsJobFallback_SkipsDuplicateAndTriesNext()
+        {
+            // The production bug scenario: a Knight favoring Cheesy Mashed Potatoes (which is
+            // also the Knight's fallback 0) with no potatoes in stock must land on fallback 1
+            // (Buttered Bread) instead of re-checking the favorite and skipping the meal.
+            bool ok = PartyDiningService.TryPickHeroDishCore(
+                DishType.CheesyMashedPotatoes, "Knight", PlentyOfGold,
+                d => d != DishType.CheesyMashedPotatoes, out var dish, out var anyCoverable);
+
+            Assert.IsTrue(ok);
+            Assert.AreEqual(DishType.ButteredBread, dish);
+            Assert.IsTrue(anyCoverable);
+        }
+
+        [TestMethod]
+        [TestCategory("PartyDining")]
+        public void NothingCoverable_FailsWithAnyCoverableFalse()
+        {
+            bool ok = PartyDiningService.TryPickHeroDishCore(
+                DishType.CheesyMashedPotatoes, "Knight", PlentyOfGold,
+                _ => false, out _, out var anyCoverable);
+
+            Assert.IsFalse(ok);
+            Assert.IsFalse(anyCoverable, "No candidate had ingredients — skip must read as no_ingredients");
+        }
+
+        [TestMethod]
+        [TestCategory("PartyDining")]
+        public void CoverableButUnaffordable_FailsWithAnyCoverableTrue()
+        {
+            bool ok = PartyDiningService.TryPickHeroDishCore(
+                DishType.CheesyMashedPotatoes, "Knight", 0,
+                _ => true, out _, out var anyCoverable);
+
+            Assert.IsFalse(ok);
+            Assert.IsTrue(anyCoverable, "Candidates had ingredients — skip must read as no_gold");
+        }
+
+        [TestMethod]
+        [TestCategory("PartyDining")]
+        public void FavoriteUnaffordable_FallsBackToCheaperDish()
+        {
+            // Gold covers the cheap fallback but not the favorite: the hero still eats.
+            int fallbackPrice = DishConfig.GetPrice(DishConfig.GetFallbackForJob("Mage", 0));
+            int favoritePrice = DishConfig.GetPrice(DishType.HarvestFeastPlatter);
+            Assert.IsTrue(fallbackPrice < favoritePrice, "Test premise: fallback must be cheaper than favorite");
+
+            bool ok = PartyDiningService.TryPickHeroDishCore(
+                DishType.HarvestFeastPlatter, "Mage", fallbackPrice,
+                _ => true, out var dish, out var anyCoverable);
+
+            Assert.IsTrue(ok);
+            Assert.AreEqual(DishConfig.GetFallbackForJob("Mage", 0), dish);
+            Assert.IsTrue(anyCoverable);
+        }
+
+        [TestMethod]
+        [TestCategory("PartyDining")]
+        public void NullJobName_UsesDefaultFallbacks()
+        {
+            // Headless/no-hero contexts resolve jobName null → default fallback set.
+            bool ok = PartyDiningService.TryPickHeroDishCore(
+                DishType.CheesyMashedPotatoes, null, PlentyOfGold,
+                d => d != DishType.CheesyMashedPotatoes, out var dish, out _);
+
+            Assert.IsTrue(ok);
+            Assert.AreEqual(DishConfig.GetFallbackForJob(null, 0), dish);
+        }
+    }
+}

--- a/PitHero.Tests/KitchenServiceLoopTests.cs
+++ b/PitHero.Tests/KitchenServiceLoopTests.cs
@@ -979,13 +979,15 @@ namespace PitHero.Tests
         public void HasClosingWork_CrewDrainsOnlyWhenEverythingIsDone()
         {
             // The closing crew must stay for each kind of remaining work independently:
-            // an undelivered ticket, a seated guest still at their food, or a queued plate.
-            // Dropping any term strands dirty tables overnight (issue #392 follow-up).
-            Assert.IsTrue(KitchenTaskCoordinator.HasClosingWork(true, 0, 0), "undelivered ticket holds the crew");
-            Assert.IsTrue(KitchenTaskCoordinator.HasClosingWork(false, 1, 0), "queued plate holds the crew");
-            Assert.IsTrue(KitchenTaskCoordinator.HasClosingWork(false, 0, 1), "eating guest holds the crew");
-            Assert.IsFalse(KitchenTaskCoordinator.HasClosingWork(false, 0, 0),
-                "all tickets delivered, guests gone, plates bussed — crew goes home");
+            // an undelivered ticket, a seated guest still at their food, a queued plate, or an
+            // orphaned serving (cooked dish whose ticket was canceled at close). Dropping any
+            // term strands dirty tables or abandoned food overnight (issue #392 follow-ups).
+            Assert.IsTrue(KitchenTaskCoordinator.HasClosingWork(true, 0, 0, 0), "undelivered ticket holds the crew");
+            Assert.IsTrue(KitchenTaskCoordinator.HasClosingWork(false, 1, 0, 0), "queued plate holds the crew");
+            Assert.IsTrue(KitchenTaskCoordinator.HasClosingWork(false, 0, 1, 0), "eating guest holds the crew");
+            Assert.IsTrue(KitchenTaskCoordinator.HasClosingWork(false, 0, 0, 1), "orphaned serving holds the crew");
+            Assert.IsFalse(KitchenTaskCoordinator.HasClosingWork(false, 0, 0, 0),
+                "all tickets delivered, guests gone, plates bussed, orphans sunk — crew goes home");
         }
     }
 }

--- a/PitHero.Tests/KitchenServiceLoopTests.cs
+++ b/PitHero.Tests/KitchenServiceLoopTests.cs
@@ -974,5 +974,18 @@ namespace PitHero.Tests
             Assert.IsTrue(_coordinator.TryClaimBusJob(out var fresh));
             Assert.AreEqual(990f, fresh.EnqueuedTime);
         }
+
+        [TestMethod]
+        public void HasClosingWork_CrewDrainsOnlyWhenEverythingIsDone()
+        {
+            // The closing crew must stay for each kind of remaining work independently:
+            // an undelivered ticket, a seated guest still at their food, or a queued plate.
+            // Dropping any term strands dirty tables overnight (issue #392 follow-up).
+            Assert.IsTrue(KitchenTaskCoordinator.HasClosingWork(true, 0, 0), "undelivered ticket holds the crew");
+            Assert.IsTrue(KitchenTaskCoordinator.HasClosingWork(false, 1, 0), "queued plate holds the crew");
+            Assert.IsTrue(KitchenTaskCoordinator.HasClosingWork(false, 0, 1), "eating guest holds the crew");
+            Assert.IsFalse(KitchenTaskCoordinator.HasClosingWork(false, 0, 0),
+                "all tickets delivered, guests gone, plates bussed — crew goes home");
+        }
     }
 }

--- a/PitHero.Tests/MealBuffServiceExpiryTests.cs
+++ b/PitHero.Tests/MealBuffServiceExpiryTests.cs
@@ -1,0 +1,145 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Dining;
+using PitHero.Services;
+using RolePlayingFramework.Combat;
+using RolePlayingFramework.Heroes;
+using RolePlayingFramework.Jobs.Primary;
+using RolePlayingFramework.Stats;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Tests for MealBuffService expiry (issue #392): apply with expiry stamp, prune before/at/after,
+    /// inject-after-prune injects nothing, replace-record keeps latest expiry.
+    /// </summary>
+    [TestClass]
+    public class MealBuffServiceExpiryTests
+    {
+        private static Hero MakeHero() =>
+            new Hero("TestHero", new Knight(), level: 10, baseStats: new StatBlock(10, 10, 10, 10));
+
+        private const DishType Dish = DishType.RoastedOnionSkewers;
+        private const float Expiry = 500f;
+
+        // ── Apply + record present ───────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("MealBuff")]
+        public void ApplyMeal_WithExpiry_RecordIsPresent()
+        {
+            var service = new MealBuffService();
+            var hero = MakeHero();
+
+            service.ApplyMeal(hero, Dish, false, Expiry);
+
+            Assert.IsTrue(service.TryGetMeal(hero, out _, out _), "Record should be present after ApplyMeal");
+        }
+
+        // ── Prune before expiry ──────────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("MealBuff")]
+        public void Prune_BeforeExpiry_RecordKept()
+        {
+            var service = new MealBuffService();
+            var hero = MakeHero();
+            service.ApplyMeal(hero, Dish, false, Expiry);
+
+            service.Prune(Expiry - 1f); // one second before expiry
+
+            Assert.IsTrue(service.TryGetMeal(hero, out _, out _), "Record should survive a prune before expiry");
+        }
+
+        // ── Prune at expiry ──────────────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("MealBuff")]
+        public void Prune_AtExpiry_RecordRemoved()
+        {
+            var service = new MealBuffService();
+            var hero = MakeHero();
+            service.ApplyMeal(hero, Dish, false, Expiry);
+
+            service.Prune(Expiry); // exactly at expiry
+
+            Assert.IsFalse(service.TryGetMeal(hero, out _, out _), "Record should be pruned when now == expiry");
+        }
+
+        // ── Prune after expiry ───────────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("MealBuff")]
+        public void Prune_AfterExpiry_RecordRemoved()
+        {
+            var service = new MealBuffService();
+            var hero = MakeHero();
+            service.ApplyMeal(hero, Dish, false, Expiry);
+
+            service.Prune(Expiry + 100f);
+
+            Assert.IsFalse(service.TryGetMeal(hero, out _, out _), "Record should be pruned after expiry");
+        }
+
+        // ── InjectBuffsAtBattleStart after prune injects nothing ─────────────────
+
+        [TestMethod]
+        [TestCategory("MealBuff")]
+        public void InjectBuffsAtBattleStart_AfterPrune_InjectsNothing()
+        {
+            var service = new MealBuffService();
+            var hero = MakeHero();
+            // RoastedOnionSkewers gives AttackUp 1
+            service.ApplyMeal(hero, Dish, false, Expiry);
+            service.Prune(Expiry); // record removed
+
+            hero.ClearBattleState();
+            service.InjectBuffsAtBattleStart(hero);
+
+            // AttackUp stack from "meal" source should be zero
+            int attackUpFromMeal = hero.GetBuffStacks(MealBuffService.MealBuffSourceId, RolePlayingFramework.Combat.BuffType.AttackUp);
+            Assert.AreEqual(0, attackUpFromMeal, "No meal buffs should be injected after record is pruned");
+        }
+
+        // ── Re-ApplyMeal replaces record keeping latest expiry ───────────────────
+
+        [TestMethod]
+        [TestCategory("MealBuff")]
+        public void ApplyMeal_ReplacesRecord_KeepsLatestExpiry()
+        {
+            var service = new MealBuffService();
+            var hero = MakeHero();
+
+            service.ApplyMeal(hero, DishType.RoastedOnionSkewers, false, 200f);
+            service.ApplyMeal(hero, DishType.RoastedOnionSkewers, true,  700f); // replace with later expiry
+
+            // Should survive a prune at the earlier expiry
+            service.Prune(200f);
+            Assert.IsTrue(service.TryGetMeal(hero, out _, out _),
+                "Record with later expiry should survive a prune that would remove the earlier one");
+
+            // Should be removed at the later expiry
+            service.Prune(700f);
+            Assert.IsFalse(service.TryGetMeal(hero, out _, out _),
+                "Record should be pruned at its latest expiry");
+        }
+
+        // ── Multiple combatants: only expired ones pruned ────────────────────────
+
+        [TestMethod]
+        [TestCategory("MealBuff")]
+        public void Prune_OnlyExpiredCombatants_Removed()
+        {
+            var service = new MealBuffService();
+            var hero1 = MakeHero();
+            var hero2 = MakeHero();
+
+            service.ApplyMeal(hero1, Dish, false, 100f); // expires at 100
+            service.ApplyMeal(hero2, Dish, false, 800f); // expires at 800
+
+            service.Prune(100f); // hero1 expires, hero2 does not
+
+            Assert.IsFalse(service.TryGetMeal(hero1, out _, out _), "hero1 record should be pruned");
+            Assert.IsTrue(service.TryGetMeal(hero2, out _, out _),  "hero2 record should remain");
+        }
+    }
+}

--- a/PitHero.Tests/SaveLoadTests.cs
+++ b/PitHero.Tests/SaveLoadTests.cs
@@ -790,14 +790,15 @@ namespace PitHero.Tests
         }
 
         /// <summary>
-        /// The save format is a single version: any header other than CurrentVersion is rejected
-        /// with InvalidDataException, whether it is older or newer. Simulated by writing a
-        /// current-version binary and patching the version bytes.
+        /// Backwards compatibility policy: versions MinSupportedVersion..CurrentVersion load;
+        /// anything below MinSupportedVersion or above CurrentVersion is rejected with
+        /// InvalidDataException. Simulated by writing a current-version binary and patching the
+        /// version bytes.
         /// </summary>
         [TestMethod]
-        public void SaveData_ForeignVersionHeader_ThrowsInvalidData()
+        public void SaveData_UnsupportedVersionHeader_ThrowsInvalidData()
         {
-            AssertHeaderRejected(SaveData.CurrentVersion - 1, "An older save version must be rejected");
+            AssertHeaderRejected(SaveData.MinSupportedVersion - 1, "A version below MinSupportedVersion must be rejected");
             AssertHeaderRejected(SaveData.CurrentVersion + 1, "A newer save version must be rejected");
         }
 
@@ -824,6 +825,61 @@ namespace PitHero.Tests
             using (var rdr = new BinaryPersistableReader(new MemoryStream(bytes)))
             {
                 Assert.ThrowsException<InvalidDataException>(() => rdr.ReadPersistableInto(loaded), message);
+            }
+        }
+
+        /// <summary>
+        /// Backwards compatibility (issue #392): a v29 dining record (no MealExpiresAtSeconds)
+        /// must still read, defaulting the expiry to 0 so the pre-#392 buff is dropped cleanly.
+        /// </summary>
+        [TestMethod]
+        public void SaveData_V29DiningRecord_ReadsWithDefaultExpiry()
+        {
+            var ms = new MemoryStream();
+            using (var writer = new BinaryPersistableWriter(ms))
+            {
+                // v29 layout: OrderedDishId, HasPaid, HasEatenThisMeal, MealDishId, MealDeluxe
+                writer.Write(3);
+                writer.Write(true);
+                writer.Write(true);
+                writer.Write(5);
+                writer.Write(true);
+                // Trailing sentinel proves the v29 read consumed exactly the v29 bytes
+                writer.Write(42);
+            }
+
+            using (var rdr = new BinaryPersistableReader(new MemoryStream(ms.ToArray())))
+            {
+                var record = SaveData.ReadDiningRecord(rdr, 29);
+                Assert.AreEqual(3, record.OrderedDishId, "OrderedDishId should read from v29 layout");
+                Assert.AreEqual(true, record.HasPaid, "HasPaid should read from v29 layout");
+                Assert.AreEqual(true, record.HasEatenThisMeal, "HasEatenThisMeal should read from v29 layout");
+                Assert.AreEqual(5, record.MealDishId, "MealDishId should read from v29 layout");
+                Assert.AreEqual(true, record.MealDeluxe, "MealDeluxe should read from v29 layout");
+                Assert.AreEqual(0f, record.MealExpiresAtSeconds, "v29 records must default expiry to 0");
+                Assert.AreEqual(42, rdr.ReadInt(), "v29 read must not consume bytes past the record");
+            }
+        }
+
+        /// <summary>The v30 dining record layout reads its own expiry field back.</summary>
+        [TestMethod]
+        public void SaveData_V30DiningRecord_ReadsExpiry()
+        {
+            var ms = new MemoryStream();
+            using (var writer = new BinaryPersistableWriter(ms))
+            {
+                writer.Write(3);
+                writer.Write(true);
+                writer.Write(true);
+                writer.Write(5);
+                writer.Write(true);
+                writer.Write(1234.5f);
+            }
+
+            using (var rdr = new BinaryPersistableReader(new MemoryStream(ms.ToArray())))
+            {
+                var record = SaveData.ReadDiningRecord(rdr, 30);
+                Assert.AreEqual(1234.5f, record.MealExpiresAtSeconds, "v30 records must read the expiry stamp");
             }
         }
 
@@ -908,7 +964,7 @@ namespace PitHero.Tests
                 }
 
                 byte[] bytes = ms.ToArray();
-                bytes[0] = (byte)(SaveData.CurrentVersion - 1);
+                bytes[0] = (byte)(SaveData.MinSupportedVersion - 1);
                 bytes[1] = 0;
                 bytes[2] = 0;
                 bytes[3] = 0;

--- a/PitHero.Tests/SpeechBubbleShuffleBagTests.cs
+++ b/PitHero.Tests/SpeechBubbleShuffleBagTests.cs
@@ -148,6 +148,74 @@ namespace PitHero.Tests
             Assert.AreEqual(remainingBefore, bag.Bag.Remaining, "Bag must not advance when nothing is eligible");
         }
 
+        // ── Lunch and Dinner bags (issue #392) ───────────────────────────────────
+
+        [TestMethod]
+        public void SelectKey_LunchBag_TwoOptionsNoGate_EachKeyOncePerCycle()
+        {
+            // Mirrors the LunchOptions bag: 2 options, no gates
+            var bag = MakeBag(
+                new SpeechBubbleDialogue.Option("HeroLunchTime"),
+                new SpeechBubbleDialogue.Option("HeroLunchOptions"));
+            var rng = new System.Random(42);
+
+            for (int cycle = 0; cycle < 10; cycle++)
+            {
+                var seen = new HashSet<string>();
+                for (int i = 0; i < 2; i++)
+                {
+                    var key = SpeechBubbleDialogue.SelectKey(bag, hasMerc: false, tipPaid: null, rng);
+                    Assert.IsNotNull(key, "Ungated lunch bag must always yield a key");
+                    Assert.IsTrue(seen.Add(key), $"Key '{key}' repeated within cycle {cycle}");
+                }
+                Assert.AreEqual(2, seen.Count);
+            }
+        }
+
+        [TestMethod]
+        public void SelectKey_DinnerBag_TwoOptionsNoGate_EachKeyOncePerCycle()
+        {
+            // Mirrors the DinnerOptions bag: 2 options, no gates
+            var bag = MakeBag(
+                new SpeechBubbleDialogue.Option("HeroDinnerTime"),
+                new SpeechBubbleDialogue.Option("HeroDinnerServing"));
+            var rng = new System.Random(77);
+
+            for (int cycle = 0; cycle < 10; cycle++)
+            {
+                var seen = new HashSet<string>();
+                for (int i = 0; i < 2; i++)
+                {
+                    var key = SpeechBubbleDialogue.SelectKey(bag, hasMerc: false, tipPaid: null, rng);
+                    Assert.IsNotNull(key, "Ungated dinner bag must always yield a key");
+                    Assert.IsTrue(seen.Add(key), $"Key '{key}' repeated within cycle {cycle}");
+                }
+                Assert.AreEqual(2, seen.Count);
+            }
+        }
+
+        [TestMethod]
+        public void SelectKey_LunchBag_SameSeed_SameSequence()
+        {
+            var bag1 = MakeBag(
+                new SpeechBubbleDialogue.Option("HeroLunchTime"),
+                new SpeechBubbleDialogue.Option("HeroLunchOptions"));
+            var bag2 = MakeBag(
+                new SpeechBubbleDialogue.Option("HeroLunchTime"),
+                new SpeechBubbleDialogue.Option("HeroLunchOptions"));
+
+            var rng1 = new System.Random(2026);
+            var rng2 = new System.Random(2026);
+
+            for (int i = 0; i < 20; i++)
+            {
+                Assert.AreEqual(
+                    SpeechBubbleDialogue.SelectKey(bag1, false, null, rng1),
+                    SpeechBubbleDialogue.SelectKey(bag2, false, null, rng2),
+                    $"Lunch bag sequences diverged at draw {i}");
+            }
+        }
+
         [TestMethod]
         public void SelectKey_SameSeed_SameSequence()
         {

--- a/PitHero.Tests/TavernScheduleConfigTests.cs
+++ b/PitHero.Tests/TavernScheduleConfigTests.cs
@@ -61,15 +61,29 @@ namespace PitHero.Tests
 
         [TestMethod]
         [TestCategory("TavernSchedule")]
-        public void GetArrivalIntervalMultiplier_OffPeakHours_Return2f()
+        public void GetArrivalIntervalMultiplier_DaytimeOffPeakHours_Return2f()
         {
-            // Off-peak between rushes and overnight
-            int[] offPeak = { 0, 1, 2, 3, 4, 5, 8, 9, 10, 11, 14, 15, 16, 17, 21, 22, 23 };
+            // Off-peak between rushes while the kitchen is open
+            int[] offPeak = { 8, 9, 10, 11, 14, 15, 16, 17, 21 };
             for (int i = 0; i < offPeak.Length; i++)
             {
                 int hour = offPeak[i];
                 Assert.AreEqual(2f, TavernScheduleConfig.GetArrivalIntervalMultiplier(hour),
                     $"Hour {hour} should be off-peak (2x interval)");
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("TavernSchedule")]
+        public void GetArrivalIntervalMultiplier_OvernightHours_ReturnBaseRate()
+        {
+            // Kitchen-closed hours run at the base rate so the tavern keeps a night crowd
+            int[] overnight = { 22, 23, 0, 1, 2, 3, 4, 5 };
+            for (int i = 0; i < overnight.Length; i++)
+            {
+                int hour = overnight[i];
+                Assert.AreEqual(1f, TavernScheduleConfig.GetArrivalIntervalMultiplier(hour),
+                    $"Hour {hour} should be the overnight base rate (1x interval)");
             }
         }
 

--- a/PitHero.Tests/TavernScheduleConfigTests.cs
+++ b/PitHero.Tests/TavernScheduleConfigTests.cs
@@ -45,18 +45,18 @@ namespace PitHero.Tests
 
         [TestMethod]
         [TestCategory("TavernSchedule")]
-        public void GetArrivalIntervalMultiplier_RushWindows_Return1f()
+        public void GetArrivalIntervalMultiplier_RushWindows_ReturnHalf()
         {
             // Morning rush [6, 8)
-            Assert.AreEqual(1f, TavernScheduleConfig.GetArrivalIntervalMultiplier(6),  "6 AM is rush");
-            Assert.AreEqual(1f, TavernScheduleConfig.GetArrivalIntervalMultiplier(7),  "7 AM is rush");
+            Assert.AreEqual(0.5f, TavernScheduleConfig.GetArrivalIntervalMultiplier(6),  "6 AM is rush");
+            Assert.AreEqual(0.5f, TavernScheduleConfig.GetArrivalIntervalMultiplier(7),  "7 AM is rush");
             // Lunch rush [12, 14)
-            Assert.AreEqual(1f, TavernScheduleConfig.GetArrivalIntervalMultiplier(12), "12 PM is rush");
-            Assert.AreEqual(1f, TavernScheduleConfig.GetArrivalIntervalMultiplier(13), "1 PM is rush");
+            Assert.AreEqual(0.5f, TavernScheduleConfig.GetArrivalIntervalMultiplier(12), "12 PM is rush");
+            Assert.AreEqual(0.5f, TavernScheduleConfig.GetArrivalIntervalMultiplier(13), "1 PM is rush");
             // Dinner rush [18, 21)
-            Assert.AreEqual(1f, TavernScheduleConfig.GetArrivalIntervalMultiplier(18), "6 PM is rush");
-            Assert.AreEqual(1f, TavernScheduleConfig.GetArrivalIntervalMultiplier(19), "7 PM is rush");
-            Assert.AreEqual(1f, TavernScheduleConfig.GetArrivalIntervalMultiplier(20), "8 PM is rush");
+            Assert.AreEqual(0.5f, TavernScheduleConfig.GetArrivalIntervalMultiplier(18), "6 PM is rush");
+            Assert.AreEqual(0.5f, TavernScheduleConfig.GetArrivalIntervalMultiplier(19), "7 PM is rush");
+            Assert.AreEqual(0.5f, TavernScheduleConfig.GetArrivalIntervalMultiplier(20), "8 PM is rush");
         }
 
         [TestMethod]

--- a/PitHero.Tests/TavernScheduleConfigTests.cs
+++ b/PitHero.Tests/TavernScheduleConfigTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.Config;
+using PitHero.Dining;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Tests for TavernScheduleConfig (issue #392): kitchen-closed window, patron arrival
+    /// interval multipliers, and meal-period boundary detection.
+    /// </summary>
+    [TestClass]
+    public class TavernScheduleConfigTests
+    {
+        // ── IsKitchenClosed ──────────────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("TavernSchedule")]
+        public void IsKitchenClosed_AllHours_CorrectOpenAndClosedWindows()
+        {
+            // Open: hours 6 through 21 inclusive
+            for (int hour = 6; hour < 22; hour++)
+                Assert.IsFalse(TavernScheduleConfig.IsKitchenClosed(hour),
+                    $"Hour {hour} should be open");
+
+            // Closed: hours 22, 23, 0 through 5
+            for (int hour = 22; hour <= 23; hour++)
+                Assert.IsTrue(TavernScheduleConfig.IsKitchenClosed(hour),
+                    $"Hour {hour} should be closed");
+            for (int hour = 0; hour < 6; hour++)
+                Assert.IsTrue(TavernScheduleConfig.IsKitchenClosed(hour),
+                    $"Hour {hour} should be closed");
+        }
+
+        [TestMethod]
+        [TestCategory("TavernSchedule")]
+        public void IsKitchenClosed_BoundaryHours()
+        {
+            Assert.IsFalse(TavernScheduleConfig.IsKitchenClosed(6),  "6 AM is the open boundary");
+            Assert.IsFalse(TavernScheduleConfig.IsKitchenClosed(21), "9 PM is the last open hour");
+            Assert.IsTrue(TavernScheduleConfig.IsKitchenClosed(22),  "10 PM is the first closed hour");
+            Assert.IsTrue(TavernScheduleConfig.IsKitchenClosed(5),   "5 AM is still closed");
+        }
+
+        // ── GetArrivalIntervalMultiplier ─────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("TavernSchedule")]
+        public void GetArrivalIntervalMultiplier_RushWindows_Return1f()
+        {
+            // Morning rush [6, 8)
+            Assert.AreEqual(1f, TavernScheduleConfig.GetArrivalIntervalMultiplier(6),  "6 AM is rush");
+            Assert.AreEqual(1f, TavernScheduleConfig.GetArrivalIntervalMultiplier(7),  "7 AM is rush");
+            // Lunch rush [12, 14)
+            Assert.AreEqual(1f, TavernScheduleConfig.GetArrivalIntervalMultiplier(12), "12 PM is rush");
+            Assert.AreEqual(1f, TavernScheduleConfig.GetArrivalIntervalMultiplier(13), "1 PM is rush");
+            // Dinner rush [18, 21)
+            Assert.AreEqual(1f, TavernScheduleConfig.GetArrivalIntervalMultiplier(18), "6 PM is rush");
+            Assert.AreEqual(1f, TavernScheduleConfig.GetArrivalIntervalMultiplier(19), "7 PM is rush");
+            Assert.AreEqual(1f, TavernScheduleConfig.GetArrivalIntervalMultiplier(20), "8 PM is rush");
+        }
+
+        [TestMethod]
+        [TestCategory("TavernSchedule")]
+        public void GetArrivalIntervalMultiplier_OffPeakHours_Return2f()
+        {
+            // Off-peak between rushes and overnight
+            int[] offPeak = { 0, 1, 2, 3, 4, 5, 8, 9, 10, 11, 14, 15, 16, 17, 21, 22, 23 };
+            for (int i = 0; i < offPeak.Length; i++)
+            {
+                int hour = offPeak[i];
+                Assert.AreEqual(2f, TavernScheduleConfig.GetArrivalIntervalMultiplier(hour),
+                    $"Hour {hour} should be off-peak (2x interval)");
+            }
+        }
+
+        // ── TryGetMealAtHour ─────────────────────────────────────────────────────
+
+        [TestMethod]
+        [TestCategory("TavernSchedule")]
+        public void TryGetMealAtHour_BreakfastHour_ReturnsTrue()
+        {
+            bool result = TavernScheduleConfig.TryGetMealAtHour(6, out var meal);
+            Assert.IsTrue(result);
+            Assert.AreEqual(MealPeriod.Breakfast, meal);
+        }
+
+        [TestMethod]
+        [TestCategory("TavernSchedule")]
+        public void TryGetMealAtHour_LunchHour_ReturnsTrue()
+        {
+            bool result = TavernScheduleConfig.TryGetMealAtHour(12, out var meal);
+            Assert.IsTrue(result);
+            Assert.AreEqual(MealPeriod.Lunch, meal);
+        }
+
+        [TestMethod]
+        [TestCategory("TavernSchedule")]
+        public void TryGetMealAtHour_DinnerHour_ReturnsTrue()
+        {
+            bool result = TavernScheduleConfig.TryGetMealAtHour(18, out var meal);
+            Assert.IsTrue(result);
+            Assert.AreEqual(MealPeriod.Dinner, meal);
+        }
+
+        [TestMethod]
+        [TestCategory("TavernSchedule")]
+        public void TryGetMealAtHour_NonMealHours_ReturnsFalse()
+        {
+            int[] nonMeal = { 0, 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 19, 20, 21, 22, 23 };
+            for (int i = 0; i < nonMeal.Length; i++)
+            {
+                int hour = nonMeal[i];
+                bool result = TavernScheduleConfig.TryGetMealAtHour(hour, out _);
+                Assert.IsFalse(result, $"Hour {hour} should not be a meal boundary");
+            }
+        }
+    }
+}

--- a/PitHero/AI/SleepInBedAction.cs
+++ b/PitHero/AI/SleepInBedAction.cs
@@ -2,6 +2,7 @@ using Microsoft.Xna.Framework;
 using Nez;
 using PitHero;
 using PitHero.AI.Interfaces;
+using PitHero.Dining;
 using PitHero.ECS.Components;
 using PitHero.Services;
 using PitHero.Util;
@@ -751,7 +752,7 @@ namespace PitHero.AI
             // Morning breakfast trip (issue #319): if "Eat at tavern" is enabled and any party
             // member can actually order, enter Stop mode and head to the tavern
             if (isNightSleep)
-                Core.Services.GetService<Services.PartyDiningService>()?.BeginAutoDine();
+                Core.Services.GetService<Services.PartyDiningService>()?.BeginAutoDine(MealPeriod.Breakfast);
 
             Debug.Log("[SleepInBedAction] Sleep action completed, hero has left the inn");
         }

--- a/PitHero/Config/TavernScheduleConfig.cs
+++ b/PitHero/Config/TavernScheduleConfig.cs
@@ -1,0 +1,76 @@
+using PitHero.Dining;
+
+namespace PitHero.Config
+{
+    /// <summary>
+    /// Single source of truth for tavern schedule constants (issue #392):
+    /// kitchen hours, meal-period boundaries, and patron arrival-rate multipliers.
+    /// Pure static — no Nez or Core dependency, fully headless-testable.
+    /// </summary>
+    public static class TavernScheduleConfig
+    {
+        // ── Kitchen hours ────────────────────────────────────────────────────────
+
+        /// <summary>Hour at which the kitchen opens and begins taking orders (inclusive).</summary>
+        public const int KitchenOpenHour = 6;
+
+        /// <summary>Hour at which the kitchen stops taking new orders (inclusive at and above).</summary>
+        public const int KitchenCloseHour = 22;
+
+        // ── Meal-period start hours ──────────────────────────────────────────────
+
+        /// <summary>In-game hour that triggers the breakfast meal period.</summary>
+        public const int BreakfastHour = 6;
+
+        /// <summary>In-game hour that triggers the lunch meal period.</summary>
+        public const int LunchHour = 12;
+
+        /// <summary>In-game hour that triggers the dinner meal period.</summary>
+        public const int DinnerHour = 18;
+
+        // ── Queries ──────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Returns true when the kitchen is closed and should not accept new orders.
+        /// Closed window: 10 PM (22) through 5 AM (inclusive).
+        /// </summary>
+        public static bool IsKitchenClosed(int hour) => hour >= KitchenCloseHour || hour < KitchenOpenHour;
+
+        /// <summary>
+        /// Returns the patron-arrival interval multiplier for the given in-game hour.
+        /// Rush windows [6,8), [12,14), [18,21) receive the base rate (1×);
+        /// all other hours including overnight receive the slow-trickle rate (2×).
+        /// </summary>
+        public static float GetArrivalIntervalMultiplier(int hour)
+        {
+            if (hour >= 6  && hour < 8)  return 1f;
+            if (hour >= 12 && hour < 14) return 1f;
+            if (hour >= 18 && hour < 21) return 1f;
+            return 2f;
+        }
+
+        /// <summary>
+        /// Maps an in-game hour to its corresponding meal period.
+        /// Returns true at hours 6 (Breakfast), 12 (Lunch), and 18 (Dinner).
+        /// Returns false for all other hours.
+        /// </summary>
+        public static bool TryGetMealAtHour(int hour, out MealPeriod meal)
+        {
+            switch (hour)
+            {
+                case BreakfastHour:
+                    meal = MealPeriod.Breakfast;
+                    return true;
+                case LunchHour:
+                    meal = MealPeriod.Lunch;
+                    return true;
+                case DinnerHour:
+                    meal = MealPeriod.Dinner;
+                    return true;
+                default:
+                    meal = default;
+                    return false;
+            }
+        }
+    }
+}

--- a/PitHero/Config/TavernScheduleConfig.cs
+++ b/PitHero/Config/TavernScheduleConfig.cs
@@ -38,14 +38,14 @@ namespace PitHero.Config
 
         /// <summary>
         /// Returns the patron-arrival interval multiplier for the given in-game hour.
-        /// Rush windows [6,8), [12,14), [18,21) receive the base rate (1×);
-        /// all other hours including overnight receive the slow-trickle rate (2×).
+        /// Rush windows [6,8), [12,14), [18,21) receive double the base rate (0.5× interval);
+        /// all other hours including overnight receive the slow-trickle rate (2× interval).
         /// </summary>
         public static float GetArrivalIntervalMultiplier(int hour)
         {
-            if (hour >= 6  && hour < 8)  return 1f;
-            if (hour >= 12 && hour < 14) return 1f;
-            if (hour >= 18 && hour < 21) return 1f;
+            if (hour >= 6  && hour < 8)  return 0.5f;
+            if (hour >= 12 && hour < 14) return 0.5f;
+            if (hour >= 18 && hour < 21) return 0.5f;
             return 2f;
         }
 

--- a/PitHero/Config/TavernScheduleConfig.cs
+++ b/PitHero/Config/TavernScheduleConfig.cs
@@ -39,13 +39,17 @@ namespace PitHero.Config
         /// <summary>
         /// Returns the patron-arrival interval multiplier for the given in-game hour.
         /// Rush windows [6,8), [12,14), [18,21) receive double the base rate (0.5× interval);
-        /// all other hours including overnight receive the slow-trickle rate (2× interval).
+        /// daytime off-hours receive the slow-trickle rate (2× interval); overnight
+        /// (kitchen closed, 10 PM–6 AM) runs at the base rate (1×) so the tavern keeps a
+        /// steady night crowd for the future night phase — patrons sit ~2.5 game-hours on
+        /// reduced patience, so 1–2 game-hour arrival gaps hold one or two at a time.
         /// </summary>
         public static float GetArrivalIntervalMultiplier(int hour)
         {
             if (hour >= 6  && hour < 8)  return 0.5f;
             if (hour >= 12 && hour < 14) return 0.5f;
             if (hour >= 18 && hour < 21) return 0.5f;
+            if (IsKitchenClosed(hour))   return 1f;
             return 2f;
         }
 

--- a/PitHero/Content/Localization/en-us/Dialogue.txt
+++ b/PitHero/Content/Localization/en-us/Dialogue.txt
@@ -58,3 +58,8 @@ InnkeeperFarewellComeBackSoon,Come back soon!
 SecondChanceInterestedWares,Interested in my wares?
 SecondChanceBuyBackSomething,Perhaps you want to buy back something?
 SecondChanceMissSomething,Miss something you once had?
+
+HeroLunchTime,It's time for lunch
+HeroLunchOptions,Let's check out our lunch options
+HeroDinnerTime,Should be time for dinner
+HeroDinnerServing,They should be serving dinner now

--- a/PitHero/Content/Localization/en-us/Dialogue.txt
+++ b/PitHero/Content/Localization/en-us/Dialogue.txt
@@ -63,3 +63,5 @@ HeroLunchTime,It's time for lunch
 HeroLunchOptions,Let's check out our lunch options
 HeroDinnerTime,Should be time for dinner
 HeroDinnerServing,They should be serving dinner now
+HeroLunchSkipped,Looks like we'll have to skip lunch
+HeroDinnerSkipped,Looks like we'll have to skip dinner

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -298,6 +298,11 @@ ConsoleInnRest,Visiting inn to rest
 ConsoleNightSleep,Turning in for the night
 ConsoleBreakfastSkipped,The party skips breakfast - no ingredients for {0}
 ConsoleBreakfastSkippedGold,The party skips breakfast - not enough gold for {0}
+ConsoleLunchSkipped,The party skips lunch - no ingredients for {0}
+ConsoleLunchSkippedGold,The party skips lunch - not enough gold for {0}
+ConsoleDinnerSkipped,The party skips dinner - no ingredients for {0}
+ConsoleDinnerSkippedGold,The party skips dinner - not enough gold for {0}
+JobKitchenClosed,Kitchen closed
 ConsoleMercenaryHired,{0} {1} was hired
 ConsoleMonsterAttack,{0} attacks {1} for {2} damage!
 ConsoleItemFound,{0} found {1}.

--- a/PitHero/DialogueTextKey.cs
+++ b/PitHero/DialogueTextKey.cs
@@ -80,5 +80,11 @@ namespace PitHero
         public const string SecondChanceInterestedWares   = "SecondChanceInterestedWares";
         public const string SecondChanceBuyBackSomething  = "SecondChanceBuyBackSomething";
         public const string SecondChanceMissSomething     = "SecondChanceMissSomething";
+
+        // Issue #392 — lunch and dinner auto-dine dialogue
+        public const string HeroLunchTime                 = "HeroLunchTime";
+        public const string HeroLunchOptions              = "HeroLunchOptions";
+        public const string HeroDinnerTime                = "HeroDinnerTime";
+        public const string HeroDinnerServing             = "HeroDinnerServing";
     }
 }

--- a/PitHero/DialogueTextKey.cs
+++ b/PitHero/DialogueTextKey.cs
@@ -86,5 +86,7 @@ namespace PitHero
         public const string HeroLunchOptions              = "HeroLunchOptions";
         public const string HeroDinnerTime                = "HeroDinnerTime";
         public const string HeroDinnerServing             = "HeroDinnerServing";
+        public const string HeroLunchSkipped              = "HeroLunchSkipped";
+        public const string HeroDinnerSkipped             = "HeroDinnerSkipped";
     }
 }

--- a/PitHero/Dining/MealPeriod.cs
+++ b/PitHero/Dining/MealPeriod.cs
@@ -1,0 +1,14 @@
+namespace PitHero.Dining
+{
+    /// <summary>
+    /// The three scheduled meal periods the party can auto-dine during (issue #392).
+    /// Breakfast is triggered from SleepInBedAction after waking; Lunch and Dinner
+    /// are triggered by the in-game-hour edge watcher in MainGameScene.
+    /// </summary>
+    public enum MealPeriod
+    {
+        Breakfast,
+        Lunch,
+        Dinner,
+    }
+}

--- a/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
+++ b/PitHero/ECS/Components/KitchenMonsterStateMachine.cs
@@ -312,6 +312,11 @@ namespace PitHero.ECS.Components
             _targetPatron = null;
             _targetPartySlot = -1;
 
+            // No new orders while the kitchen is closed (10 PM – 6 AM).
+            var tsvc = Core.Instance != null ? Core.Services.GetService<InGameTimeService>() : null;
+            if (tsvc != null && TavernScheduleConfig.IsKitchenClosed(tsvc.Hour))
+                return false;
+
             if (!_coordinator.HasTicketCapacity)
                 return false;
 
@@ -639,7 +644,10 @@ namespace PitHero.ECS.Components
         private bool HasOrderWork(ServerZone zone)
         {
             // Mirrors TryPickNextOrderTarget's guards so wandering isn't interrupted for an
-            // order that could never be created (full board / empty pantry)
+            // order that could never be created (full board / empty pantry / kitchen closed).
+            var tsvcHOW = Core.Instance != null ? Core.Services.GetService<InGameTimeService>() : null;
+            if (tsvcHOW != null && TavernScheduleConfig.IsKitchenClosed(tsvcHOW.Hour))
+                return false;
             if (!_coordinator.HasTicketCapacity)
                 return false;
             var partyTable = TavernSeatConfig.GetTableTile(KitchenTaskCoordinator.GetPartySeatTile(0));
@@ -1296,11 +1304,14 @@ namespace PitHero.ECS.Components
                 Entity.Destroy();
                 return;
             }
-            // Only bubble on a real shift end (worker going to sleep, not a mid-shift role change)
+            // Only bubble on a real shift end (worker going to sleep or kitchen closing —
+            // not a mid-shift role change).
             var timeService = Core.Instance != null
                 ? Core.Services.GetService<InGameTimeService>()
                 : null;
-            if (timeService != null && MonsterScheduleConfig.IsAsleep(_monster.MonsterTypeName, timeService))
+            if (timeService != null
+                && (MonsterScheduleConfig.IsAsleep(_monster.MonsterTypeName, timeService)
+                    || TavernScheduleConfig.IsKitchenClosed(timeService.Hour)))
                 SpeechBubbleDialogue.SayWorkerShiftEnd(Entity);
         }
 

--- a/PitHero/ECS/Components/TavernPatronComponent.cs
+++ b/PitHero/ECS/Components/TavernPatronComponent.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.Xna.Framework;
 using Nez;
+using PitHero.Config;
 using PitHero.Dining;
 using PitHero.Services;
 using PitHero.Util;
@@ -106,13 +107,25 @@ namespace PitHero.ECS.Components
             switch (State)
             {
                 case PatronState.WaitingToOrder:
-                    // Kitchen needs to be open for orders — servers handle coming to us
-                    if (_elapsed >= GameConfig.PatronPatiencePreOrderSeconds)
+                {
+                    // Kitchen needs to be open for orders — servers handle coming to us.
+                    // When the kitchen is closed patrons who can't be served have reduced
+                    // patience (PatronClosedKitchenPatienceFactor × base) so overnight
+                    // arrivals linger for ambiance and then leave gracefully.
+                    var timeForPatience = Core.Instance != null
+                        ? Core.Services.GetService<InGameTimeService>()
+                        : null;
+                    int patronHour = timeForPatience?.Hour ?? 12; // null → open (headless tests)
+                    float patienceThreshold = TavernScheduleConfig.IsKitchenClosed(patronHour)
+                        ? GameConfig.PatronPatiencePreOrderSeconds * GameConfig.PatronClosedKitchenPatienceFactor
+                        : GameConfig.PatronPatiencePreOrderSeconds;
+                    if (_elapsed >= patienceThreshold)
                     {
                         // Patience expired — cancel and leave
                         LeaveOnPatienceExpiry();
                     }
                     break;
+                }
 
                 case PatronState.Ordered:
                     if (_elapsed >= GameConfig.PatronPatiencePostOrderSeconds)

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -8,6 +8,7 @@ using Nez.Tiled;
 using Nez.UI; // Added for Label
 using PitHero.AI;
 using PitHero.AI.Interfaces;
+using PitHero.Dining;
 using PitHero.ECS.Components;
 using PitHero.Services;
 using PitHero.Rendering;
@@ -2780,18 +2781,37 @@ namespace PitHero.ECS.Scenes
             // Tick party dining (eat timers, auto-resume, reload restart)
             Core.Services.GetService<Services.PartyDiningService>()?.Update();
 
-            // Morning reset: clear wet tiles and re-populate watering queue at 6AM
+            // Hour-edge triggers: 6 AM (morning reset), 12 PM (lunch), 6 PM (dinner)
             var timeService = Core.Services.GetService<InGameTimeService>();
             if (timeService != null)
             {
                 int currentHour = timeService.Hour;
-                if (currentHour == 6 && _lastInGameHour != 6 && _lastInGameHour != -1)
+                if (_lastInGameHour != -1)
                 {
-                    Core.Services.GetService<Services.WetTileService>()?.ClearAllWet();
-                    Core.Services.GetService<Services.FarmTaskCoordinator>()?.PopulateWaterQueue();
-                    // New day: yesterday's meal buffs expire and everyone may eat again (issue #319)
-                    Core.Services.GetService<Services.MealBuffService>()?.ClearAll();
-                    Core.Services.GetService<Services.PartyDiningService>()?.ResetDaily();
+                    if (currentHour == 6 && _lastInGameHour != 6)
+                    {
+                        // Morning reset: clear wet tiles, re-populate watering queue
+                        Core.Services.GetService<Services.WetTileService>()?.ClearAllWet();
+                        Core.Services.GetService<Services.FarmTaskCoordinator>()?.PopulateWaterQueue();
+                        // Belt-and-braces ClearAll (last dinner ~9:59 PM expires ~3:59 AM naturally)
+                        Core.Services.GetService<Services.MealBuffService>()?.ClearAll();
+                        // Reset so breakfast trip can fire (breakfast itself is wake-driven from SleepInBedAction)
+                        Core.Services.GetService<Services.PartyDiningService>()?.ResetForNewMealPeriod();
+                    }
+                    else if (currentHour == 12 && _lastInGameHour != 12)
+                    {
+                        // Lunch (issue #392)
+                        var partyDining = Core.Services.GetService<Services.PartyDiningService>();
+                        partyDining?.ResetForNewMealPeriod();
+                        partyDining?.BeginAutoDine(MealPeriod.Lunch);
+                    }
+                    else if (currentHour == 18 && _lastInGameHour != 18)
+                    {
+                        // Dinner (issue #392)
+                        var partyDining = Core.Services.GetService<Services.PartyDiningService>();
+                        partyDining?.ResetForNewMealPeriod();
+                        partyDining?.BeginAutoDine(MealPeriod.Dinner);
+                    }
                 }
                 _lastInGameHour = currentHour;
             }

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -280,6 +280,8 @@ namespace PitHero
         public const float PatronPatiencePreOrderSeconds = 600f;  // scaled seconds a patron waits for a server to take their order (10 min)
         public const float PatronPatiencePostOrderSeconds = 600f; // scaled seconds a patron waits for ordered food to arrive (10 min)
         public const float PatronLingerAfterEatingSeconds = 300f; // scaled seconds a patron sticks around after finishing their meal (5 min)
+        public const float MealBuffDurationSeconds = 360f;          // scaled seconds a food buff lasts (6 in-game hours, issue #392)
+        public const float PatronClosedKitchenPatienceFactor = 0.25f; // patience multiplier for patrons waiting to order while kitchen is closed (issue #392)
         public const float DishTipChance = 0.5f;                // chance an unhired merc tips on finishing a meal
         public const float DishTipMinPercent = 0.05f;           // tip is 5-15% of dish price, rounded up
         public const float DishTipMaxPercent = 0.15f;

--- a/PitHero/Services/Analytics/AnalyticsService.cs
+++ b/PitHero/Services/Analytics/AnalyticsService.cs
@@ -858,6 +858,25 @@ namespace PitHero.Services.Analytics
 #endif
         }
 
+        /// <summary>
+        /// Logs the outcome of an auto-dine trip decision at a meal edge: "started", or the
+        /// reason the whole trip was skipped (e.g. "no_ingredients", "kitchen_unstaffed").
+        /// One event per meal period — makes silent meal skips diagnosable from the session log.
+        /// </summary>
+        [Conditional("DEBUG")]
+        public static void LogPartyMealTrip(string meal, string outcome)
+        {
+#if DEBUG
+            if (!_enabled)
+                return;
+            if (!BeginEvent("party_meal_trip"))
+                return;
+            _json.Field("meal", meal);
+            _json.Field("outcome", outcome);
+            EndEvent();
+#endif
+        }
+
         /// <summary>Logs a party member skipped during a tavern seating (no order taken, no charge).</summary>
         [Conditional("DEBUG")]
         public static void LogPartyDineSkipped(int slot, string member, string dish, string reason)

--- a/PitHero/Services/AutoJob/FarmingJobDemandEvaluator.cs
+++ b/PitHero/Services/AutoJob/FarmingJobDemandEvaluator.cs
@@ -41,8 +41,10 @@ namespace PitHero.Services.AutoJob
         public void ResetPressure(float nowSeconds) => _tracker.Reset(nowSeconds);
 
         /// <inheritdoc/>
-        public JobDemandEntry EvaluateDemand(int rosterSize, int availableWorkers)
+        public JobDemandEntry EvaluateDemand(int rosterSize, int availableWorkers, bool nocturnal)
         {
+            // Farming demand is shift-agnostic: nocturnal farmers tend crops overnight just as
+            // day farmers do during daylight hours.  The param is ignored here.
             int outstanding = _coordinator != null ? _coordinator.OutstandingTaskCount : 0;
             int careLoad = (_cropGrowth != null ? _cropGrowth.CropCount : 0)
                 + (_cropPlanting != null ? _cropPlanting.PlanCount : 0);

--- a/PitHero/Services/AutoJob/IJobDemandEvaluator.cs
+++ b/PitHero/Services/AutoJob/IJobDemandEvaluator.cs
@@ -12,8 +12,10 @@ namespace PitHero.Services.AutoJob
         /// Computes how many workers this job wants right now. rosterSize is the full shift roster;
         /// availableWorkers is the roster minus the MinWorkers already reserved by higher-priority
         /// evaluators (registration order = priority), so lower-priority jobs only claim what's left.
+        /// nocturnal is true when this call evaluates the nocturnal shift (10 PM–6 AM); evaluators
+        /// that have no work on the night shift (e.g. kitchen) should return zero demand.
         /// </summary>
-        JobDemandEntry EvaluateDemand(int rosterSize, int availableWorkers);
+        JobDemandEntry EvaluateDemand(int rosterSize, int availableWorkers, bool nocturnal);
 
         /// <summary>
         /// Samples the live workload into the evaluator's backpressure tracker (issue #375).

--- a/PitHero/Services/AutoJob/KitchenJobDemandEvaluator.cs
+++ b/PitHero/Services/AutoJob/KitchenJobDemandEvaluator.cs
@@ -62,8 +62,21 @@ namespace PitHero.Services.AutoJob
         public void ResetPressure(float nowSeconds) => _tracker.Reset(nowSeconds);
 
         /// <inheritdoc/>
-        public JobDemandEntry EvaluateDemand(int rosterSize, int availableWorkers)
+        public JobDemandEntry EvaluateDemand(int rosterSize, int availableWorkers, bool nocturnal)
         {
+            // Kitchen only operates during the day shift (6 AM–10 PM).  On the nocturnal shift
+            // (10 PM–6 AM) workers go home once in-flight dishes are delivered; field no one new.
+            if (nocturnal)
+            {
+                return new JobDemandEntry
+                {
+                    Job = MonsterJob.Cooking,
+                    MinWorkers = 0,
+                    DesiredWorkers = 0,
+                    Sticky = true,
+                };
+            }
+
             bool anyDishOrderable = _coordinator == null || _coordinator.HasAnyOrderableDish();
             return ComputeDemand(LiveBacklog, _tracker.GrantedWorkers, rosterSize, availableWorkers,
                 anyDishOrderable, PatronWaitHigh);

--- a/PitHero/Services/AutoJobAssignmentService.cs
+++ b/PitHero/Services/AutoJobAssignmentService.cs
@@ -164,7 +164,7 @@ namespace PitHero.Services
                 int available = _snapshots.Count - reserved;
                 if (available < 0)
                     available = 0;
-                var demand = _evaluators[i].EvaluateDemand(_snapshots.Count, available);
+                var demand = _evaluators[i].EvaluateDemand(_snapshots.Count, available, nocturnal);
                 _demands.Add(demand);
                 reserved += demand.MinWorkers;
             }

--- a/PitHero/Services/KitchenTaskCoordinator.cs
+++ b/PitHero/Services/KitchenTaskCoordinator.cs
@@ -607,6 +607,26 @@ namespace PitHero.Services
             _wantedAssignments.Clear();
             _wantedRoles.Clear();
 
+            // Kitchen closure: at 10 PM stop wanting any new workers once all current tickets
+            // have been delivered.  Workers finishing in-flight dishes stay until done; then
+            // the existing reconcile path sends everyone home via RequestReturnHome().
+            // This is evaluated independently of IsAsleep (nocturnal workers are awake 10 PM–6 AM
+            // but must never be wanted while the kitchen is closed).
+            bool closed = timeService != null && TavernScheduleConfig.IsKitchenClosed(timeService.Hour);
+            bool hasUndeliveredTickets = false;
+            if (closed)
+            {
+                for (int ti = 0; ti < _tickets.Count; ti++)
+                {
+                    var ts = _tickets[ti].State;
+                    if (ts != TicketState.Delivered && ts != TicketState.Canceled)
+                    {
+                        hasUndeliveredTickets = true;
+                        break;
+                    }
+                }
+            }
+
             var roster = _alliedMonsters.AlliedMonsters;
             for (int i = 0; i < roster.Count; i++)
             {
@@ -614,6 +634,8 @@ namespace PitHero.Services
                 if (m.Job != MonsterJob.Cooking)
                     continue;
                 if (MonsterScheduleConfig.IsAsleep(m.MonsterTypeName, timeService))
+                    continue;
+                if (closed && !hasUndeliveredTickets)
                     continue;
 
                 int insertPos = _wantedAssignments.Count;
@@ -948,6 +970,14 @@ namespace PitHero.Services
             Entity patronEntity, Point seatTile)
         {
             if (_tickets.Count >= MaxOpenTickets)
+                return null;
+
+            // Belt-and-braces: reject new orders while the kitchen is closed (10 PM – 6 AM).
+            // The primary gate lives in KitchenMonsterStateMachine.TryPickNextOrderTarget; this
+            // guard catches any direct callers that bypass the FSM (e.g. future automation).
+            // CreateTicketPreReserved is explicitly exempted — it is the save-reload path only.
+            var timeForTicket = Core.Instance != null ? Core.Services.GetService<InGameTimeService>() : null;
+            if (timeForTicket != null && TavernScheduleConfig.IsKitchenClosed(timeForTicket.Hour))
                 return null;
 
             EnsureServices();

--- a/PitHero/Services/KitchenTaskCoordinator.cs
+++ b/PitHero/Services/KitchenTaskCoordinator.cs
@@ -144,11 +144,14 @@ namespace PitHero.Services
 
         /// <summary>
         /// After closing time, work that must finish before the crew drains home: undelivered
-        /// tickets, seated guests still eating (their plates are coming), and plates queued for
-        /// bussing. Pure — the closure gate in Update() feeds it live counts.
+        /// tickets, seated guests still eating (their plates are coming), plates queued for
+        /// bussing, and orphaned servings (a cooked dish whose ticket was canceled — patron left
+        /// or party departed for night sleep — sits on the serving table until a server sinks
+        /// it). Pure — the closure gate in Update() feeds it live counts.
         /// </summary>
-        public static bool HasClosingWork(bool hasUndeliveredTickets, int busJobCount, int diningPatrons)
-            => hasUndeliveredTickets || busJobCount > 0 || diningPatrons > 0;
+        public static bool HasClosingWork(bool hasUndeliveredTickets, int busJobCount,
+            int diningPatrons, int orphanedDishes)
+            => hasUndeliveredTickets || busJobCount > 0 || diningPatrons > 0 || orphanedDishes > 0;
 
         /// <summary>Total kitchen role posts — the cap on simultaneous kitchen workers.</summary>
         public static int MaxWorkerPosts =>
@@ -638,7 +641,8 @@ namespace PitHero.Services
                 }
                 EnsureServices();
                 hasClosingWork = HasClosingWork(hasUndeliveredTickets, _busJobs.Count,
-                    _mercenaryManager != null ? _mercenaryManager.CountPatronsDining() : 0);
+                    _mercenaryManager != null ? _mercenaryManager.CountPatronsDining() : 0,
+                    _orphanServing.Count);
             }
 
             var roster = _alliedMonsters.AlliedMonsters;

--- a/PitHero/Services/KitchenTaskCoordinator.cs
+++ b/PitHero/Services/KitchenTaskCoordinator.cs
@@ -142,6 +142,14 @@ namespace PitHero.Services
         /// </summary>
         public bool HasActiveRunner => _runner1WorkerIdx >= 0;
 
+        /// <summary>
+        /// After closing time, work that must finish before the crew drains home: undelivered
+        /// tickets, seated guests still eating (their plates are coming), and plates queued for
+        /// bussing. Pure — the closure gate in Update() feeds it live counts.
+        /// </summary>
+        public static bool HasClosingWork(bool hasUndeliveredTickets, int busJobCount, int diningPatrons)
+            => hasUndeliveredTickets || busJobCount > 0 || diningPatrons > 0;
+
         /// <summary>Total kitchen role posts — the cap on simultaneous kitchen workers.</summary>
         public static int MaxWorkerPosts =>
             GameConfig.MaxKitchenCooks + GameConfig.MaxKitchenServers + GameConfig.MaxKitchenRunners;
@@ -607,15 +615,18 @@ namespace PitHero.Services
             _wantedAssignments.Clear();
             _wantedRoles.Clear();
 
-            // Kitchen closure: at 10 PM stop wanting any new workers once all current tickets
-            // have been delivered.  Workers finishing in-flight dishes stay until done; then
-            // the existing reconcile path sends everyone home via RequestReturnHome().
+            // Kitchen closure: at 10 PM stop wanting any new workers once the closing work is
+            // done — every ticket delivered, every seated guest finished eating, and every
+            // plate bussed. Only then does the reconcile path send everyone home via
+            // RequestReturnHome(). Leaving before the last plates are cleared strands dirty
+            // tables all night (no runner) and overnight arrivals pile up at the door.
             // This is evaluated independently of IsAsleep (nocturnal workers are awake 10 PM–6 AM
             // but must never be wanted while the kitchen is closed).
             bool closed = timeService != null && TavernScheduleConfig.IsKitchenClosed(timeService.Hour);
-            bool hasUndeliveredTickets = false;
+            bool hasClosingWork = false;
             if (closed)
             {
+                bool hasUndeliveredTickets = false;
                 for (int ti = 0; ti < _tickets.Count; ti++)
                 {
                     var ts = _tickets[ti].State;
@@ -625,6 +636,9 @@ namespace PitHero.Services
                         break;
                     }
                 }
+                EnsureServices();
+                hasClosingWork = HasClosingWork(hasUndeliveredTickets, _busJobs.Count,
+                    _mercenaryManager != null ? _mercenaryManager.CountPatronsDining() : 0);
             }
 
             var roster = _alliedMonsters.AlliedMonsters;
@@ -635,7 +649,7 @@ namespace PitHero.Services
                     continue;
                 if (MonsterScheduleConfig.IsAsleep(m.MonsterTypeName, timeService))
                     continue;
-                if (closed && !hasUndeliveredTickets)
+                if (closed && !hasClosingWork)
                     continue;
 
                 int insertPos = _wantedAssignments.Count;

--- a/PitHero/Services/MealBuffService.cs
+++ b/PitHero/Services/MealBuffService.cs
@@ -5,10 +5,11 @@ using RolePlayingFramework.Combat;
 namespace PitHero.Services
 {
     /// <summary>
-    /// Holds each party member's active food buffs for the day (issue #319). Battle buffs are
-    /// cleared at every battle boundary, so this service re-injects meal buffs at each battle
-    /// start as BattleBuffs with RemainingTurns = -1 (until battle end). Records clear at the
-    /// 6 AM daily reset. Food grants buffs only — HP/MP recovery is the inn's job.
+    /// Holds each party member's active food buffs (issue #319, expiry added in #392). Battle
+    /// buffs are cleared at every battle boundary, so this service re-injects meal buffs at each
+    /// battle start as BattleBuffs with RemainingTurns = -1 (until battle end). Records expire
+    /// 6 in-game hours after eating (GameConfig.MealBuffDurationSeconds); the 6 AM ClearAll()
+    /// is kept as belt-and-braces. Food grants buffs only — HP/MP recovery is the inn's job.
     /// </summary>
     public sealed class MealBuffService
     {
@@ -20,32 +21,47 @@ namespace PitHero.Services
             public ICombatant Combatant;
             public DishType Dish;
             public bool Deluxe;
+            public float ExpiresAtSeconds; // absolute InGameTimeService.AccumulatedSeconds
         }
 
         private readonly List<MealRecord> _records = new List<MealRecord>(3);
 
         /// <summary>
         /// Applies a finished meal: records the dish's buffs for injection into every battle
-        /// until the next 6 AM reset.
+        /// until the buff expires or the next 6 AM reset.
         /// </summary>
-        public void ApplyMeal(ICombatant combatant, DishType dish, bool deluxe)
-            => RestoreRecord(combatant, dish, deluxe);
+        public void ApplyMeal(ICombatant combatant, DishType dish, bool deluxe, float expiresAtSeconds)
+            => RestoreRecord(combatant, dish, deluxe, expiresAtSeconds);
 
-        /// <summary>Records a meal's day-long buffs (also the save-load path).</summary>
-        public void RestoreRecord(ICombatant combatant, DishType dish, bool deluxe)
+        /// <summary>Records a meal's timed buffs (also the save-load path).</summary>
+        public void RestoreRecord(ICombatant combatant, DishType dish, bool deluxe, float expiresAtSeconds)
         {
             if (combatant == null) return;
 
-            // One meal per member per day — replace any existing record for this combatant
+            // One active meal per member — replace any existing record for this combatant,
+            // keeping the latest expiry stamp so back-to-back meals don't stack forever.
             for (int i = 0; i < _records.Count; i++)
             {
                 if (ReferenceEquals(_records[i].Combatant, combatant))
                 {
-                    _records[i] = new MealRecord { Combatant = combatant, Dish = dish, Deluxe = deluxe };
+                    _records[i] = new MealRecord { Combatant = combatant, Dish = dish, Deluxe = deluxe, ExpiresAtSeconds = expiresAtSeconds };
                     return;
                 }
             }
-            _records.Add(new MealRecord { Combatant = combatant, Dish = dish, Deluxe = deluxe });
+            _records.Add(new MealRecord { Combatant = combatant, Dish = dish, Deluxe = deluxe, ExpiresAtSeconds = expiresAtSeconds });
+        }
+
+        /// <summary>
+        /// Removes all records whose expiry has elapsed. Reverse-iterate so RemoveAt is safe.
+        /// No RNG, no LINQ, no allocation. Call every frame from PartyDiningService.Update().
+        /// </summary>
+        public void Prune(float nowSeconds)
+        {
+            for (int i = _records.Count - 1; i >= 0; i--)
+            {
+                if (_records[i].ExpiresAtSeconds <= nowSeconds)
+                    _records.RemoveAt(i);
+            }
         }
 
         /// <summary>Returns true and the active meal for the combatant, if any.</summary>

--- a/PitHero/Services/MercenaryManager.cs
+++ b/PitHero/Services/MercenaryManager.cs
@@ -85,7 +85,8 @@ namespace PitHero.Services
             // compare-time so a mid-wait hour flip adapts immediately without touching the timer.
             var timeService = Core.Services.GetService<InGameTimeService>();
             int hour = timeService?.Hour ?? 12;
-            float spawnThreshold = GetSpawnInterval() * TavernScheduleConfig.GetArrivalIntervalMultiplier(hour);
+            bool kitchenClosed = TavernScheduleConfig.IsKitchenClosed(hour);
+            float spawnThreshold = GetSpawnInterval(kitchenClosed) * TavernScheduleConfig.GetArrivalIntervalMultiplier(hour);
 
             if (_timeSinceLastSpawn >= spawnThreshold)
             {
@@ -104,10 +105,12 @@ namespace PitHero.Services
         /// <summary>
         /// Spawn cadence: an empty tavern gets its first patron quickly; after that a new
         /// patron arrives every 1-2 scaled minutes (rolled per arrival) whenever a seat is free.
+        /// The empty-tavern fast path only applies while the kitchen is open — overnight the
+        /// tavern is allowed to sit empty between slow-trickle arrivals (issue #392 follow-up).
         /// </summary>
-        private float GetSpawnInterval()
+        private float GetSpawnInterval(bool kitchenClosed)
         {
-            if (GetUnhiredMercenaries().Count == 0)
+            if (!kitchenClosed && GetUnhiredMercenaries().Count == 0)
                 return GameConfig.MercenaryMinSpawnIntervalSeconds;
             if (_nextSpawnInterval <= 0f)
                 _nextSpawnInterval = Nez.Random.Range(
@@ -132,6 +135,12 @@ namespace PitHero.Services
             var unhired = GetUnhiredMercenaries();
             if (unhired.Count >= MaxMercenariesInTavern)
             {
+                // While the kitchen is closed the tavern empties on its own (closing exodus) —
+                // never evict a finished patron just to seat a fresh face overnight.
+                var evictionTime = Core.Services.GetService<InGameTimeService>();
+                if (TavernScheduleConfig.IsKitchenClosed(evictionTime?.Hour ?? 12))
+                    return false;
+
                 // Fresh faces: the oldest patron who is done eating leaves right away
                 Entity doneEating = null;
                 int oldestSpawnId = int.MaxValue;
@@ -597,6 +606,18 @@ namespace PitHero.Services
             Debug.Log("[MercenaryManager] Waiting 2 seconds before spawning replacement mercenary");
             yield return Coroutine.WaitForSeconds(2.0f);
 
+            // While the kitchen is closed, departures are NOT replaced 1-for-1: restart the
+            // arrival timer so the next patron trickles in a full overnight interval later
+            // (issue #392 follow-up — the closing exodus used to spawn an instant replacement
+            // per leaver, and the replacements piled up at the door).
+            var replacementTime = Core.Services.GetService<InGameTimeService>();
+            if (TavernScheduleConfig.IsKitchenClosed(replacementTime?.Hour ?? 12))
+            {
+                _timeSinceLastSpawn = 0f;
+                _isRemovingMercenary = false;
+                yield break;
+            }
+
             _isRemovingMercenary = false;
 
             // Now that removal is complete and delay has passed, spawn the new mercenary
@@ -779,6 +800,34 @@ namespace PitHero.Services
                     continue;
                 var patron = entity.GetComponent<ECS.Components.TavernPatronComponent>();
                 if (patron != null && patron.State == ECS.Components.PatronState.WaitingToOrder)
+                    count++;
+            }
+            return count;
+        }
+
+        /// <summary>
+        /// Patrons with food on (or headed to) their table — FoodDelivered, Eating, or
+        /// FinishedEating. Their plates still need bussing, so the closing kitchen crew must
+        /// not drain home while any remain (issue #392 follow-up: un-bussed plates left all
+        /// nine tables dirty overnight and arrivals piled up at the door).
+        /// </summary>
+        public int CountPatronsDining()
+        {
+            int count = 0;
+            for (int i = 0; i < _mercenaryEntities.Count; i++)
+            {
+                var entity = _mercenaryEntities[i];
+                if (entity == null)
+                    continue;
+                var comp = entity.GetComponent<MercenaryComponent>();
+                if (comp == null || comp.IsHired)
+                    continue;
+                var patron = entity.GetComponent<ECS.Components.TavernPatronComponent>();
+                if (patron == null)
+                    continue;
+                if (patron.State == ECS.Components.PatronState.FoodDelivered
+                    || patron.State == ECS.Components.PatronState.Eating
+                    || patron.State == ECS.Components.PatronState.FinishedEating)
                     count++;
             }
             return count;

--- a/PitHero/Services/MercenaryManager.cs
+++ b/PitHero/Services/MercenaryManager.cs
@@ -39,6 +39,7 @@ namespace PitHero.Services
         private readonly HashSet<Point> _occupiedTavernPositions;
         private float _timeSinceLastSpawn;
         private float _nextSpawnInterval; // rolled 1-2 min per arrival; 0 = roll on first use
+        private bool _wasKitchenClosed;   // edge detector for the one-time arrival-timer reset at close
         private Scene _scene;
         private bool _hasSpawnedInitialMercenary;
         private int _nextSpawnId; // Global spawn ID counter
@@ -86,6 +87,16 @@ namespace PitHero.Services
             var timeService = Core.Services.GetService<InGameTimeService>();
             int hour = timeService?.Hour ?? 12;
             bool kitchenClosed = TavernScheduleConfig.IsKitchenClosed(hour);
+
+            // One-time reset at the 10 PM close: the tavern is typically full all evening, so
+            // the timer sits held at its threshold and the first freed seat would be refilled
+            // instantly. Resetting ONCE here starts the overnight trickle clock; individual
+            // departures during the closing exodus must NOT reset it again or the first night
+            // patron gets pushed back past dawn (each reset re-arms the full 2-4h interval).
+            if (kitchenClosed && !_wasKitchenClosed)
+                _timeSinceLastSpawn = 0f;
+            _wasKitchenClosed = kitchenClosed;
+
             float spawnThreshold = GetSpawnInterval(kitchenClosed) * TavernScheduleConfig.GetArrivalIntervalMultiplier(hour);
 
             if (_timeSinceLastSpawn >= spawnThreshold)
@@ -606,14 +617,13 @@ namespace PitHero.Services
             Debug.Log("[MercenaryManager] Waiting 2 seconds before spawning replacement mercenary");
             yield return Coroutine.WaitForSeconds(2.0f);
 
-            // While the kitchen is closed, departures are NOT replaced 1-for-1: restart the
-            // arrival timer so the next patron trickles in a full overnight interval later
-            // (issue #392 follow-up — the closing exodus used to spawn an instant replacement
-            // per leaver, and the replacements piled up at the door).
+            // While the kitchen is closed, departures are NOT replaced 1-for-1 — the overnight
+            // trickle is driven purely by the Update timer, which was reset once at the 10 PM
+            // transition. (Resetting it here per departure starved the whole night: the closing
+            // exodus stretches past midnight and every leaver re-armed the full 2-4h interval.)
             var replacementTime = Core.Services.GetService<InGameTimeService>();
             if (TavernScheduleConfig.IsKitchenClosed(replacementTime?.Hour ?? 12))
             {
-                _timeSinceLastSpawn = 0f;
                 _isRemovingMercenary = false;
                 yield break;
             }

--- a/PitHero/Services/MercenaryManager.cs
+++ b/PitHero/Services/MercenaryManager.cs
@@ -80,8 +80,8 @@ namespace PitHero.Services
             // Use scaled time for spawn timer
             _timeSinceLastSpawn += Time.DeltaTime;
 
-            // Arrival pacing: rush-hour windows use the base interval (1×); all other hours
-            // (including overnight) use a 2× slow-trickle rate.  The multiplier is applied at
+            // Arrival pacing: rush-hour windows use half the base interval (0.5×, double speed);
+            // all other hours (including overnight) use a 2× slow-trickle rate.  The multiplier is applied at
             // compare-time so a mid-wait hour flip adapts immediately without touching the timer.
             var timeService = Core.Services.GetService<InGameTimeService>();
             int hour = timeService?.Hour ?? 12;

--- a/PitHero/Services/MercenaryManager.cs
+++ b/PitHero/Services/MercenaryManager.cs
@@ -1,6 +1,7 @@
 using Microsoft.Xna.Framework;
 using Nez;
 using PitHero;
+using PitHero.Config;
 using PitHero.ECS.Components;
 using RolePlayingFramework.Balance;
 using RolePlayingFramework.Equipment;
@@ -79,7 +80,14 @@ namespace PitHero.Services
             // Use scaled time for spawn timer
             _timeSinceLastSpawn += Time.DeltaTime;
 
-            if (_timeSinceLastSpawn >= GetSpawnInterval())
+            // Arrival pacing: rush-hour windows use the base interval (1×); all other hours
+            // (including overnight) use a 2× slow-trickle rate.  The multiplier is applied at
+            // compare-time so a mid-wait hour flip adapts immediately without touching the timer.
+            var timeService = Core.Services.GetService<InGameTimeService>();
+            int hour = timeService?.Hour ?? 12;
+            float spawnThreshold = GetSpawnInterval() * TavernScheduleConfig.GetArrivalIntervalMultiplier(hour);
+
+            if (_timeSinceLastSpawn >= spawnThreshold)
             {
                 // Only reset the timer on a successful spawn — while the tavern is full the
                 // timer holds at the threshold so a patron walks in as soon as a seat frees.

--- a/PitHero/Services/PartyDiningService.cs
+++ b/PitHero/Services/PartyDiningService.cs
@@ -175,7 +175,9 @@ namespace PitHero.Services
         /// Auto-dine for the given meal period. Breakfast is called from SleepInBedAction after
         /// night sleep; Lunch and Dinner are called from the hour-edge watcher in MainGameScene.
         /// Enters Stop mode and walks the party to the tavern — skipped when the hero, who leads
-        /// the meal, can't order (gold, storage coverage, kitchen closed, or already ate).
+        /// the meal, can't order anything (favorite and job fallbacks all unmakeable or
+        /// unaffordable, kitchen closed, or already ate). Every outcome is logged to analytics
+        /// so a skipped meal is diagnosable from the session log.
         /// </summary>
         public void BeginAutoDine(MealPeriod meal)
         {
@@ -187,6 +189,7 @@ namespace PitHero.Services
             var heroComponent = GetHeroComponent();
             if (heroComponent == null || heroComponent.LinkedHero == null)
             {
+                Analytics.AnalyticsService.LogPartyMealTrip(meal.ToString(), "hero_not_present");
                 Debug.Log("[PartyDiningService] Skipping meal trip — hero not present");
                 return;
             }
@@ -195,6 +198,7 @@ namespace PitHero.Services
             {
                 // A player-stopped party returns to the table on its own (SeatedInTavern goal)
                 // and orders once seated; arming auto-resume here would cancel the player's stop.
+                Analytics.AnalyticsService.LogPartyMealTrip(meal.ToString(), "already_stopped");
                 Debug.Log($"[PartyDiningService] Skipping {meal} trip — party already stopped");
                 return;
             }
@@ -203,6 +207,7 @@ namespace PitHero.Services
             int hour = timeService?.Hour ?? TavernScheduleConfig.KitchenOpenHour;
             if (TavernScheduleConfig.IsKitchenClosed(hour))
             {
+                Analytics.AnalyticsService.LogPartyMealTrip(meal.ToString(), "kitchen_closed");
                 Debug.Log($"[PartyDiningService] Skipping {meal} trip — kitchen is closed");
                 return;
             }
@@ -210,14 +215,15 @@ namespace PitHero.Services
             var coordinator = Core.Services.GetService<KitchenTaskCoordinator>();
             if (coordinator == null || !coordinator.IsKitchenOpen)
             {
+                Analytics.AnalyticsService.LogPartyMealTrip(meal.ToString(), "kitchen_unstaffed");
                 Debug.Log($"[PartyDiningService] Skipping {meal} trip — kitchen cannot serve");
                 return;
             }
 
-            // The hero leads the meal — mercs eat free but only when he eats — so the trip
-            // hinges entirely on his favorite dish being makeable and affordable.
+            // The hero leads the meal — mercs eat free but only when he eats.
             if (_slots[0].HasEatenThisMeal || GetCombatant(0) == null)
             {
+                Analytics.AnalyticsService.LogPartyMealTrip(meal.ToString(), "already_ate");
                 Debug.Log($"[PartyDiningService] Skipping {meal} trip — hero already ate this meal");
                 return;
             }
@@ -225,36 +231,50 @@ namespace PitHero.Services
             var favorite = FavoriteDishId >= 0 && FavoriteDishId < DishTypeInfo.Count
                 ? (DishType)FavoriteDishId
                 : DishType.RoastedOnionSkewers;
-            if (!coordinator.CanCoverRecipe(favorite))
-            {
-                string noIngrKey = meal == MealPeriod.Breakfast ? UITextKey.ConsoleBreakfastSkipped
-                    : meal == MealPeriod.Lunch ? UITextKey.ConsoleLunchSkipped
-                    : UITextKey.ConsoleDinnerSkipped;
-                EmitMealSkipped(noIngrKey, favorite);
-                if (meal == MealPeriod.Breakfast)
-                    SpeechBubbleDialogue.SayBreakfastNoIngredients(Core.Scene?.FindEntity("hero"));
-                Debug.Log($"[PartyDiningService] Skipping {meal} trip — no ingredients for favorite dish");
-                return;
-            }
-
             var gameState = Core.Services.GetService<GameStateService>();
-            if (gameState == null || gameState.Funds < DishConfig.GetPrice(favorite))
+            bool anyCoverable = false;
+            if (gameState == null
+                || !TryPickHeroDish(coordinator, gameState, favorite, out _, out anyCoverable))
             {
-                string noGoldKey = meal == MealPeriod.Breakfast ? UITextKey.ConsoleBreakfastSkippedGold
-                    : meal == MealPeriod.Lunch ? UITextKey.ConsoleLunchSkippedGold
-                    : UITextKey.ConsoleDinnerSkippedGold;
-                EmitMealSkipped(noGoldKey, favorite);
-                Debug.Log($"[PartyDiningService] Skipping {meal} trip — not enough gold for favorite dish");
+                if (gameState != null && anyCoverable)
+                {
+                    string noGoldKey = meal == MealPeriod.Breakfast ? UITextKey.ConsoleBreakfastSkippedGold
+                        : meal == MealPeriod.Lunch ? UITextKey.ConsoleLunchSkippedGold
+                        : UITextKey.ConsoleDinnerSkippedGold;
+                    EmitMealSkipped(noGoldKey, favorite);
+                    Analytics.AnalyticsService.LogPartyMealTrip(meal.ToString(), "no_gold");
+                    Debug.Log($"[PartyDiningService] Skipping {meal} trip — not enough gold for any orderable dish");
+                }
+                else
+                {
+                    string noIngrKey = meal == MealPeriod.Breakfast ? UITextKey.ConsoleBreakfastSkipped
+                        : meal == MealPeriod.Lunch ? UITextKey.ConsoleLunchSkipped
+                        : UITextKey.ConsoleDinnerSkipped;
+                    EmitMealSkipped(noIngrKey, favorite);
+                    var heroEntity = Core.Scene?.FindEntity("hero");
+                    if (meal == MealPeriod.Breakfast)
+                        SpeechBubbleDialogue.SayBreakfastNoIngredients(heroEntity);
+                    else if (meal == MealPeriod.Lunch)
+                        SpeechBubbleDialogue.SayLunchSkipped(heroEntity);
+                    else
+                        SpeechBubbleDialogue.SayDinnerSkipped(heroEntity);
+                    Analytics.AnalyticsService.LogPartyMealTrip(meal.ToString(), "no_ingredients");
+                    Debug.Log($"[PartyDiningService] Skipping {meal} trip — no ingredients for any dish the hero can order");
+                }
                 return;
             }
 
             var stopUI = GetStopUI();
             if (stopUI == null)
+            {
+                Analytics.AnalyticsService.LogPartyMealTrip(meal.ToString(), "no_stop_ui");
                 return;
+            }
 
             _autoResumeWhenDone = true;
             stopUI.SetStopped(true);
             EmitMealBubble(meal);
+            Analytics.AnalyticsService.LogPartyMealTrip(meal.ToString(), "started");
             Debug.Log($"[PartyDiningService] Party heading to the tavern for {meal}");
         }
 
@@ -390,11 +410,12 @@ namespace PitHero.Services
 
         /// <summary>
         /// Next seated party member wanting to order. The hero leads the meal: he orders his
-        /// favorite dish only and pays for it; if it can't be made or afforded, the servers
-        /// skip the entire party — mercenaries never eat unless the hero eats. Mercenary meals
-        /// are free (job favorite, then the job's cheap fallbacks, ingredient-gated only).
-        /// Skips are re-evaluated on every poll, so the party is still served if ingredients
-        /// or gold appear while they remain seated.
+        /// favorite dish (falling back through his job's cheap fallbacks when it can't be made
+        /// or afforded) and pays for it; only when nothing he can order is available do the
+        /// servers skip the entire party — mercenaries never eat unless the hero eats.
+        /// Mercenary meals are free (job favorite, then the job's cheap fallbacks,
+        /// ingredient-gated only). Skips are re-evaluated on every poll, so the party is still
+        /// served if ingredients or gold appear while they remain seated.
         /// </summary>
         public bool TryGetNextPartyOrder(out int partySlot, out DishType dish)
         {
@@ -423,8 +444,7 @@ namespace PitHero.Services
                 if (heroCombatant == null || !TryGetFavorite(0, out var heroFavorite))
                     return false;
 
-                if (!coordinator.CanCoverRecipe(heroFavorite)
-                    || gameState.Funds < DishConfig.GetPrice(heroFavorite))
+                if (!TryPickHeroDish(coordinator, gameState, heroFavorite, out var heroDish, out _))
                 {
                     MarkPartySkippedByHero(coordinator, heroFavorite, heroCombatant.Name);
                     return false;
@@ -432,7 +452,7 @@ namespace PitHero.Services
 
                 _skippedThisSeating[0] = false;
                 partySlot = 0;
-                dish = heroFavorite;
+                dish = heroDish;
                 return true;
             }
 
@@ -637,6 +657,46 @@ namespace PitHero.Services
         /// it can't be made — the job class's two cheap fallback dishes, in order. Ingredient-
         /// gated only; mercenary meals never touch gold.
         /// </summary>
+        /// <summary>
+        /// Picks the dish the hero orders: his chosen favorite first, then his job's cheap
+        /// fallbacks — each candidate must be makeable AND affordable since the hero pays.
+        /// One missing crop no longer starves the whole party (issue #392 follow-up).
+        /// </summary>
+        private bool TryPickHeroDish(KitchenTaskCoordinator coordinator, GameStateService gameState,
+            DishType favorite, out DishType dish, out bool anyCoverable)
+        {
+            return TryPickHeroDishCore(favorite, GetJobName(0), gameState.Funds,
+                coordinator.CanCoverRecipe, out dish, out anyCoverable);
+        }
+
+        /// <summary>
+        /// Pure candidate ladder for the hero's order (public static for headless tests):
+        /// favorite → job fallback 0 → job fallback 1, first candidate that is coverable and
+        /// within <paramref name="funds"/> wins. <paramref name="anyCoverable"/> reports
+        /// whether any candidate had ingredients, so a full failure can be attributed to
+        /// ingredients vs gold.
+        /// </summary>
+        public static bool TryPickHeroDishCore(DishType favorite, string jobName, int funds,
+            System.Predicate<DishType> canCover, out DishType dish, out bool anyCoverable)
+        {
+            anyCoverable = false;
+            for (int c = 0; c < 3; c++)
+            {
+                var candidate = c == 0 ? favorite : DishConfig.GetFallbackForJob(jobName, c - 1);
+                if (c > 0 && candidate == favorite)
+                    continue; // favorite already failed — don't re-check it
+                if (!canCover(candidate))
+                    continue;
+                anyCoverable = true;
+                if (funds < DishConfig.GetPrice(candidate))
+                    continue;
+                dish = candidate;
+                return true;
+            }
+            dish = default;
+            return false;
+        }
+
         private bool TryPickMercDish(int slot, DishType favorite,
             KitchenTaskCoordinator coordinator, out DishType dish)
         {

--- a/PitHero/Services/PartyDiningService.cs
+++ b/PitHero/Services/PartyDiningService.cs
@@ -1,5 +1,6 @@
 using Microsoft.Xna.Framework;
 using Nez;
+using PitHero.Config;
 using PitHero.Dining;
 using PitHero.ECS.Components;
 using PitHero.UI;
@@ -10,21 +11,25 @@ using RolePlayingFramework.Combat;
 namespace PitHero.Services
 {
     /// <summary>
-    /// Orchestrates once-a-day party dining at the tavern (issue #319) on top of the existing
-    /// Stop mode — no new GOAP surface. Implements IPartyOrderSource so kitchen servers take
-    /// party orders with priority. Slot 0 = hero, slots 1/2 = hired mercenaries in
-    /// MercenaryManager.GetHiredMercenaries() order.
+    /// Orchestrates three-meals-a-day party dining at the tavern (issue #319, extended in #392)
+    /// on top of the existing Stop mode — no new GOAP surface. Implements IPartyOrderSource so
+    /// kitchen servers take party orders with priority. Slot 0 = hero, slots 1/2 = hired
+    /// mercenaries in MercenaryManager.GetHiredMercenaries() order.
+    /// Meal periods: Breakfast (6 AM, wake-driven), Lunch (12 PM, edge-driven), Dinner (6 PM,
+    /// edge-driven). Each meal resets HasEatenThisMeal; buff mirrors expire on their own 6-hour
+    /// clock and are cleared lazily in Update().
     /// </summary>
     public sealed class PartyDiningService : IPartyOrderSource
     {
-        /// <summary>One party member's dining state for the day (persisted in save section 33).</summary>
+        /// <summary>One party member's dining state for the current meal period (persisted in save section 33).</summary>
         public struct MemberDining
         {
-            public int OrderedDishId;   // -1 = none
+            public int OrderedDishId;       // -1 = none
             public bool HasPaid;
-            public bool HasEatenToday;
-            public int MealDishId;      // -1 = no active meal buffs
+            public bool HasEatenThisMeal;   // true once the member finishes eating in the current meal period
+            public int MealDishId;          // -1 = no active meal buffs
             public bool MealDeluxe;
+            public float MealExpiresAtSeconds; // absolute InGameTimeService.AccumulatedSeconds; 0 = none
         }
 
         private const int PartySlots = 3;
@@ -96,27 +101,36 @@ namespace PitHero.Services
                 return;
 
             var mealBuffs = Core.Services.GetService<MealBuffService>();
+            var timeService = Core.Services.GetService<InGameTimeService>();
+            float nowSeconds = timeService?.AccumulatedSeconds ?? 0f;
+
             bool anyOpenOrder = false;
             for (int slot = 0; slot < PartySlots && slot < data.PartyDining.Length; slot++)
             {
                 var saved = data.PartyDining[slot];
+
+                // Determine if the saved buff is still valid vs the restored clock
+                bool buffStillActive = saved.MealDishId >= 0
+                    && saved.MealExpiresAtSeconds > nowSeconds;
+
                 _slots[slot] = new MemberDining
                 {
                     OrderedDishId = saved.OrderedDishId,
                     HasPaid = saved.HasPaid,
-                    HasEatenToday = saved.HasEatenToday,
-                    MealDishId = saved.MealDishId,
-                    MealDeluxe = saved.MealDeluxe,
+                    HasEatenThisMeal = saved.HasEatenThisMeal,
+                    MealDishId = buffStillActive ? saved.MealDishId : -1,
+                    MealDeluxe = buffStillActive ? saved.MealDeluxe : false,
+                    MealExpiresAtSeconds = buffStillActive ? saved.MealExpiresAtSeconds : 0f,
                 };
 
-                if (saved.MealDishId >= 0 && saved.MealDishId < DishTypeInfo.Count)
+                if (buffStillActive && saved.MealDishId < DishTypeInfo.Count)
                 {
                     var combatant = GetCombatant(slot);
                     if (combatant != null)
-                        mealBuffs?.RestoreRecord(combatant, (DishType)saved.MealDishId, saved.MealDeluxe);
+                        mealBuffs?.RestoreRecord(combatant, (DishType)saved.MealDishId, saved.MealDeluxe, saved.MealExpiresAtSeconds);
                 }
 
-                if (saved.OrderedDishId >= 0 && !saved.HasEatenToday)
+                if (saved.OrderedDishId >= 0 && !saved.HasEatenThisMeal)
                     anyOpenOrder = true;
             }
 
@@ -124,16 +138,19 @@ namespace PitHero.Services
                 MarkPendingReloadDining();
         }
 
-        // ── Daily reset ─────────────────────────────────────────────────────────
+        // ── Meal-period reset ─────────────────────────────────────────────────────
 
-        /// <summary>6 AM reset: everyone may eat again; active meal records expire separately.</summary>
-        public void ResetDaily()
+        /// <summary>
+        /// Resets HasEatenThisMeal and skipped flags so everyone may eat the next meal period.
+        /// MealDishId/MealDeluxe/MealExpiresAtSeconds are deliberately NOT cleared here —
+        /// buff mirrors expire on their own clock (a 6:30 AM breakfast buff must survive the
+        /// 12 PM reset until 12:30 PM). Call before BeginAutoDine at each hour edge.
+        /// </summary>
+        public void ResetForNewMealPeriod()
         {
             for (int i = 0; i < PartySlots; i++)
             {
-                _slots[i].HasEatenToday = false;
-                _slots[i].MealDishId = -1;
-                _slots[i].MealDeluxe = false;
+                _slots[i].HasEatenThisMeal = false;
                 _skippedThisSeating[i] = false;
             }
         }
@@ -146,7 +163,7 @@ namespace PitHero.Services
             int count = 0;
             for (int slot = 0; slot < PartySlots; slot++)
             {
-                if (!_slots[slot].HasEatenToday && GetCombatant(slot) != null)
+                if (!_slots[slot].HasEatenThisMeal && GetCombatant(slot) != null)
                     count++;
             }
             return count;
@@ -155,36 +172,53 @@ namespace PitHero.Services
         // ── Entry points ────────────────────────────────────────────────────────
 
         /// <summary>
-        /// Morning auto-dine (called from SleepInBedAction after night sleep). Enters Stop mode
-        /// and walks the party to the tavern for breakfast — skipped entirely when the hero,
-        /// who leads the meal, can't order (gold, storage coverage, or the kitchen can't serve).
+        /// Auto-dine for the given meal period. Breakfast is called from SleepInBedAction after
+        /// night sleep; Lunch and Dinner are called from the hour-edge watcher in MainGameScene.
+        /// Enters Stop mode and walks the party to the tavern — skipped when the hero, who leads
+        /// the meal, can't order (gold, storage coverage, kitchen closed, or already ate).
         /// </summary>
-        public void BeginAutoDine()
+        public void BeginAutoDine(MealPeriod meal)
         {
             if (!EatAtTavern)
                 return;
 
+            // Dead-hero guard: GetCombatant(0) may still return the combatant object on a dead
+            // hero, so we check the hero component's alive state explicitly.
             var heroComponent = GetHeroComponent();
-            if (heroComponent != null && heroComponent.StoppedAdventure)
+            if (heroComponent == null || heroComponent.LinkedHero == null)
+            {
+                Debug.Log("[PartyDiningService] Skipping meal trip — hero not present");
+                return;
+            }
+
+            if (heroComponent.StoppedAdventure)
             {
                 // A player-stopped party returns to the table on its own (SeatedInTavern goal)
                 // and orders once seated; arming auto-resume here would cancel the player's stop.
-                Debug.Log("[PartyDiningService] Skipping breakfast trip — party already stopped");
+                Debug.Log($"[PartyDiningService] Skipping {meal} trip — party already stopped");
+                return;
+            }
+
+            var timeService = Core.Services.GetService<InGameTimeService>();
+            int hour = timeService?.Hour ?? TavernScheduleConfig.KitchenOpenHour;
+            if (TavernScheduleConfig.IsKitchenClosed(hour))
+            {
+                Debug.Log($"[PartyDiningService] Skipping {meal} trip — kitchen is closed");
                 return;
             }
 
             var coordinator = Core.Services.GetService<KitchenTaskCoordinator>();
             if (coordinator == null || !coordinator.IsKitchenOpen)
             {
-                Debug.Log("[PartyDiningService] Skipping breakfast trip — kitchen cannot serve");
+                Debug.Log($"[PartyDiningService] Skipping {meal} trip — kitchen cannot serve");
                 return;
             }
 
             // The hero leads the meal — mercs eat free but only when he eats — so the trip
             // hinges entirely on his favorite dish being makeable and affordable.
-            if (_slots[0].HasEatenToday || GetCombatant(0) == null)
+            if (_slots[0].HasEatenThisMeal || GetCombatant(0) == null)
             {
-                Debug.Log("[PartyDiningService] Skipping breakfast trip — hero already ate");
+                Debug.Log($"[PartyDiningService] Skipping {meal} trip — hero already ate this meal");
                 return;
             }
 
@@ -193,17 +227,24 @@ namespace PitHero.Services
                 : DishType.RoastedOnionSkewers;
             if (!coordinator.CanCoverRecipe(favorite))
             {
-                EmitBreakfastSkipped(UITextKey.ConsoleBreakfastSkipped, favorite);
-                SpeechBubbleDialogue.SayBreakfastNoIngredients(Core.Scene?.FindEntity("hero"));
-                Debug.Log("[PartyDiningService] Skipping breakfast trip — no ingredients for favorite dish");
+                string noIngrKey = meal == MealPeriod.Breakfast ? UITextKey.ConsoleBreakfastSkipped
+                    : meal == MealPeriod.Lunch ? UITextKey.ConsoleLunchSkipped
+                    : UITextKey.ConsoleDinnerSkipped;
+                EmitMealSkipped(noIngrKey, favorite);
+                if (meal == MealPeriod.Breakfast)
+                    SpeechBubbleDialogue.SayBreakfastNoIngredients(Core.Scene?.FindEntity("hero"));
+                Debug.Log($"[PartyDiningService] Skipping {meal} trip — no ingredients for favorite dish");
                 return;
             }
 
             var gameState = Core.Services.GetService<GameStateService>();
             if (gameState == null || gameState.Funds < DishConfig.GetPrice(favorite))
             {
-                EmitBreakfastSkipped(UITextKey.ConsoleBreakfastSkippedGold, favorite);
-                Debug.Log("[PartyDiningService] Skipping breakfast trip — not enough gold for favorite dish");
+                string noGoldKey = meal == MealPeriod.Breakfast ? UITextKey.ConsoleBreakfastSkippedGold
+                    : meal == MealPeriod.Lunch ? UITextKey.ConsoleLunchSkippedGold
+                    : UITextKey.ConsoleDinnerSkippedGold;
+                EmitMealSkipped(noGoldKey, favorite);
+                Debug.Log($"[PartyDiningService] Skipping {meal} trip — not enough gold for favorite dish");
                 return;
             }
 
@@ -213,8 +254,8 @@ namespace PitHero.Services
 
             _autoResumeWhenDone = true;
             stopUI.SetStopped(true);
-            EmitBreakfastBubble();
-            Debug.Log("[PartyDiningService] Party heading to the tavern for breakfast");
+            EmitMealBubble(meal);
+            Debug.Log($"[PartyDiningService] Party heading to the tavern for {meal}");
         }
 
         /// <summary>Called when Stop mode begins (player pressed Stop, or auto-dine).</summary>
@@ -277,7 +318,7 @@ namespace PitHero.Services
 
         // ── Per-frame update ────────────────────────────────────────────────────
 
-        /// <summary>Ticks eat timers and handles the deferred reload-mid-dining restart.</summary>
+        /// <summary>Ticks eat timers, prunes expired meal buffs, and handles the deferred reload-mid-dining restart.</summary>
         public void Update()
         {
             var pauseService = Core.Services.GetService<PauseService>();
@@ -286,6 +327,22 @@ namespace PitHero.Services
 
             if (_pendingReloadDining)
                 HandlePendingReload();
+
+            // Prune expired meal buff records and sync slot mirrors so save snapshots stay accurate
+            var timeService = Core.Services.GetService<InGameTimeService>();
+            float nowSeconds = timeService?.AccumulatedSeconds ?? 0f;
+            var mealBuffsForPrune = Core.Services.GetService<MealBuffService>();
+            mealBuffsForPrune?.Prune(nowSeconds);
+            for (int p = 0; p < PartySlots; p++)
+            {
+                if (_slots[p].MealDishId >= 0 && _slots[p].MealExpiresAtSeconds > 0f
+                    && _slots[p].MealExpiresAtSeconds <= nowSeconds)
+                {
+                    _slots[p].MealDishId = -1;
+                    _slots[p].MealDeluxe = false;
+                    _slots[p].MealExpiresAtSeconds = 0f;
+                }
+            }
 
             var hero = GetHeroComponent();
             bool seated = hero != null && hero.StoppedAdventure && hero.SeatedInTavern;
@@ -296,7 +353,7 @@ namespace PitHero.Services
                 var coordinator = Core.Services.GetService<KitchenTaskCoordinator>();
                 for (int slot = 0; slot < PartySlots; slot++)
                 {
-                    if (_slots[slot].OrderedDishId >= 0 && !_slots[slot].HasEatenToday && _tickets[slot] == null)
+                    if (_slots[slot].OrderedDishId >= 0 && !_slots[slot].HasEatenThisMeal && _tickets[slot] == null)
                         _tickets[slot] = coordinator?.CreateTicketPreReserved((DishType)_slots[slot].OrderedDishId, slot);
                 }
             }
@@ -359,7 +416,7 @@ namespace PitHero.Services
             if (coordinator == null || gameState == null)
                 return false;
 
-            bool heroLeads = _slots[0].OrderedDishId >= 0 || _slots[0].HasEatenToday;
+            bool heroLeads = _slots[0].OrderedDishId >= 0 || _slots[0].HasEatenThisMeal;
             if (!heroLeads)
             {
                 var heroCombatant = GetCombatant(0);
@@ -389,7 +446,7 @@ namespace PitHero.Services
                 if (!TryGetFavorite(slot, out var favorite))
                     continue;
 
-                if (_slots[slot].HasEatenToday)
+                if (_slots[slot].HasEatenThisMeal)
                 {
                     if (!_skippedThisSeating[slot])
                     {
@@ -456,21 +513,28 @@ namespace PitHero.Services
             if (ticket == null)
                 return;
 
+            var timeService = Core.Services.GetService<InGameTimeService>();
+            float nowSeconds = timeService?.AccumulatedSeconds ?? 0f;
+            float expiresAtSeconds = timeService != null
+                ? nowSeconds + GameConfig.MealBuffDurationSeconds
+                : float.MaxValue;
+
             var combatant = GetCombatant(slot);
             if (combatant != null)
             {
-                Core.Services.GetService<MealBuffService>()?.ApplyMeal(combatant, ticket.Dish, ticket.IsDeluxe);
+                Core.Services.GetService<MealBuffService>()?.ApplyMeal(combatant, ticket.Dish, ticket.IsDeluxe, expiresAtSeconds);
                 Debug.Log($"[PartyDiningService] Slot {slot} finished eating {ticket.Dish}");
             }
 
             Analytics.AnalyticsService.LogDishServed(
                 ticket.Dish.ToString(), DishConfig.GetPrice(ticket.Dish), 0, true, ticket.IsDeluxe);
 
-            _slots[slot].HasEatenToday = true;
+            _slots[slot].HasEatenThisMeal = true;
             _slots[slot].OrderedDishId = -1;
             _slots[slot].HasPaid = false;
             _slots[slot].MealDishId = (int)ticket.Dish;
             _slots[slot].MealDeluxe = ticket.IsDeluxe;
+            _slots[slot].MealExpiresAtSeconds = expiresAtSeconds;
             _eating[slot] = false;
             _tickets[slot] = null;
 
@@ -504,7 +568,7 @@ namespace PitHero.Services
             {
                 if (_tickets[slot] != null || _eating[slot])
                     return;
-                if (canStillServe && !_slots[slot].HasEatenToday && !_skippedThisSeating[slot]
+                if (canStillServe && !_slots[slot].HasEatenThisMeal && !_skippedThisSeating[slot]
                     && GetCombatant(slot) != null && TryGetFavorite(slot, out _))
                     return;
             }
@@ -517,14 +581,26 @@ namespace PitHero.Services
 
         // ── Helpers ─────────────────────────────────────────────────────────────
 
-        /// <summary>Shows the breakfast speech bubble on the hero entity.</summary>
-        private void EmitBreakfastBubble()
+        /// <summary>Shows the appropriate meal speech bubble on the hero entity.</summary>
+        private void EmitMealBubble(MealPeriod meal)
         {
-            SpeechBubbleDialogue.SayBreakfast(Core.Scene?.FindEntity("hero"));
+            var hero = Core.Scene?.FindEntity("hero");
+            switch (meal)
+            {
+                case MealPeriod.Breakfast:
+                    SpeechBubbleDialogue.SayBreakfast(hero);
+                    break;
+                case MealPeriod.Lunch:
+                    SpeechBubbleDialogue.SayLunch(hero);
+                    break;
+                case MealPeriod.Dinner:
+                    SpeechBubbleDialogue.SayDinner(hero);
+                    break;
+            }
         }
 
-        /// <summary>Session-log line explaining why the wake-up breakfast trip was skipped.</summary>
-        private void EmitBreakfastSkipped(string textKey, DishType favorite)
+        /// <summary>Session-log line explaining why the meal trip was skipped.</summary>
+        private void EmitMealSkipped(string textKey, DishType favorite)
         {
             var events = Core.Services.GetService<GameEventService>();
             if (events == null)
@@ -551,7 +627,7 @@ namespace PitHero.Services
 
             for (int slot = 0; slot < PartySlots; slot++)
             {
-                if (_slots[slot].OrderedDishId < 0 && !_slots[slot].HasEatenToday)
+                if (_slots[slot].OrderedDishId < 0 && !_slots[slot].HasEatenThisMeal)
                     _skippedThisSeating[slot] = true;
             }
         }

--- a/PitHero/Services/SaveData.cs
+++ b/PitHero/Services/SaveData.cs
@@ -249,14 +249,15 @@ namespace PitHero.Services
         public int AnchorY;
     }
 
-    /// <summary>One party member's tavern-dining state for the day (issue #319).</summary>
+    /// <summary>One party member's tavern-dining state per meal period (issue #319, expiry added in #392).</summary>
     public struct SavedDiningRecord
     {
-        public int OrderedDishId;   // -1 = no open order
+        public int OrderedDishId;       // -1 = no open order
         public bool HasPaid;
-        public bool HasEatenToday;
-        public int MealDishId;      // -1 = no active meal buffs
+        public bool HasEatenThisMeal;   // true once the member finishes eating in the current meal period
+        public int MealDishId;          // -1 = no active meal buffs
         public bool MealDeluxe;
+        public float MealExpiresAtSeconds; // absolute InGameTimeService.AccumulatedSeconds; 0 = none
     }
 
     /// <summary>Central save data container implementing IPersistable for binary persistence.</summary>
@@ -268,7 +269,7 @@ namespace PitHero.Services
         /// is rejected with InvalidDataException, and SaveLoadService treats that slot as empty.
         /// Bump it whenever the byte layout changes.
         /// </summary>
-        public const int CurrentVersion = 29;
+        public const int CurrentVersion = 30;
 
         // Total Time
         /// <summary>Total time played in seconds.</summary>
@@ -649,6 +650,7 @@ namespace PitHero.Services
             {
                 records[i].OrderedDishId = -1;
                 records[i].MealDishId = -1;
+                records[i].MealExpiresAtSeconds = 0f;
             }
             return records;
         }
@@ -1001,9 +1003,10 @@ namespace PitHero.Services
             {
                 writer.Write(PartyDining[i].OrderedDishId);
                 writer.Write(PartyDining[i].HasPaid);
-                writer.Write(PartyDining[i].HasEatenToday);
+                writer.Write(PartyDining[i].HasEatenThisMeal);
                 writer.Write(PartyDining[i].MealDishId);
                 writer.Write(PartyDining[i].MealDeluxe);
+                writer.Write(PartyDining[i].MealExpiresAtSeconds);
             }
 
             // 34. Automation (issue #321)
@@ -1481,9 +1484,10 @@ namespace PitHero.Services
                 {
                     OrderedDishId = reader.ReadInt(),
                     HasPaid = reader.ReadBool(),
-                    HasEatenToday = reader.ReadBool(),
+                    HasEatenThisMeal = reader.ReadBool(),
                     MealDishId = reader.ReadInt(),
                     MealDeluxe = reader.ReadBool(),
+                    MealExpiresAtSeconds = reader.ReadFloat(),
                 };
                 if (i < PartyDining.Length)
                     PartyDining[i] = record;

--- a/PitHero/Services/SaveData.cs
+++ b/PitHero/Services/SaveData.cs
@@ -264,12 +264,21 @@ namespace PitHero.Services
     public class SaveData : IPersistable
     {
         /// <summary>
-        /// The one and only save file version this build reads or writes. There is no migration
-        /// path and no reader for any other layout: a file whose header is not exactly this value
-        /// is rejected with InvalidDataException, and SaveLoadService treats that slot as empty.
-        /// Bump it whenever the byte layout changes.
+        /// The save file version this build writes. Bump it whenever the byte layout changes.
+        /// BACKWARDS COMPATIBILITY IS MANDATORY: every version from MinSupportedVersion up must
+        /// remain loadable — new fields are read conditionally on the file's version and given
+        /// safe defaults for older files. The v29 unification (issue #311/PR #391) was a one-time
+        /// periodic cleanup, not a policy of rejecting old saves; do not drop reader support for
+        /// a shipped version without the owner explicitly asking for a new unification.
         /// </summary>
         public const int CurrentVersion = 30;
+
+        /// <summary>
+        /// The oldest save file version this build can still load. Files below this (or above
+        /// CurrentVersion) are rejected with InvalidDataException and the slot reads as empty.
+        /// Only ever raised as part of an explicitly requested save unification.
+        /// </summary>
+        public const int MinSupportedVersion = 29;
 
         // Total Time
         /// <summary>Total time played in seconds.</summary>
@@ -1106,13 +1115,33 @@ namespace PitHero.Services
             writer.Write(RunnerCarryLevel);
         }
 
+        /// <summary>
+        /// Reads one SavedDiningRecord in the layout of the given file version. Public so the
+        /// backwards-compatibility path is unit-testable per version.
+        /// </summary>
+        public static SavedDiningRecord ReadDiningRecord(IPersistableReader reader, int fileVersion)
+        {
+            return new SavedDiningRecord
+            {
+                OrderedDishId = reader.ReadInt(),
+                HasPaid = reader.ReadBool(),
+                HasEatenThisMeal = reader.ReadBool(),
+                MealDishId = reader.ReadInt(),
+                MealDeluxe = reader.ReadBool(),
+                // Added in v30 (issue #392). v29 files default to 0 = no active buff, so a
+                // pre-#392 meal is simply dropped on load and the party re-eats next meal.
+                MealExpiresAtSeconds = fileVersion >= 30 ? reader.ReadFloat() : 0f,
+            };
+        }
+
         /// <summary>Reads all game state from the persistence reader.</summary>
         void IPersistable.Recover(IPersistableReader reader)
         {
-            // 1. File Version
+            // 1. File Version. Older supported versions load with safe defaults for fields they
+            // predate (see the versioned reads below); the next save rewrites at CurrentVersion.
             int fileVersion = reader.ReadInt();
-            if (fileVersion != CurrentVersion)
-                throw new System.IO.InvalidDataException($"Unsupported save file version {fileVersion} (expected {CurrentVersion})");
+            if (fileVersion < MinSupportedVersion || fileVersion > CurrentVersion)
+                throw new System.IO.InvalidDataException($"Unsupported save file version {fileVersion} (expected {MinSupportedVersion}-{CurrentVersion})");
 
             // 2. Total Time Played
             TotalTimePlayed = reader.ReadFloat();
@@ -1480,15 +1509,7 @@ namespace PitHero.Services
             int diningCount = reader.ReadInt();
             for (int i = 0; i < diningCount; i++)
             {
-                var record = new SavedDiningRecord
-                {
-                    OrderedDishId = reader.ReadInt(),
-                    HasPaid = reader.ReadBool(),
-                    HasEatenThisMeal = reader.ReadBool(),
-                    MealDishId = reader.ReadInt(),
-                    MealDeluxe = reader.ReadBool(),
-                    MealExpiresAtSeconds = reader.ReadFloat(),
-                };
+                var record = ReadDiningRecord(reader, fileVersion);
                 if (i < PartyDining.Length)
                     PartyDining[i] = record;
             }

--- a/PitHero/Services/SaveLoadService.cs
+++ b/PitHero/Services/SaveLoadService.cs
@@ -825,9 +825,10 @@ namespace PitHero.Services
                     {
                         OrderedDishId = slot.OrderedDishId,
                         HasPaid = slot.HasPaid,
-                        HasEatenToday = slot.HasEatenToday,
+                        HasEatenThisMeal = slot.HasEatenThisMeal,
                         MealDishId = slot.MealDishId,
                         MealDeluxe = slot.MealDeluxe,
+                        MealExpiresAtSeconds = slot.MealExpiresAtSeconds,
                     };
                 }
             }

--- a/PitHero/SpeechBubbleDialogue.cs
+++ b/PitHero/SpeechBubbleDialogue.cs
@@ -94,6 +94,20 @@ namespace PitHero
             new Option(DialogueTextKey.HeroBreakfastWhatsFor),
         });
 
+        // SayLunch — two variants, no gate (issue #392)
+        private static readonly OptionBag LunchOptions = new OptionBag(new Option[]
+        {
+            new Option(DialogueTextKey.HeroLunchTime),
+            new Option(DialogueTextKey.HeroLunchOptions),
+        });
+
+        // SayDinner — two variants, no gate (issue #392)
+        private static readonly OptionBag DinnerOptions = new OptionBag(new Option[]
+        {
+            new Option(DialogueTextKey.HeroDinnerTime),
+            new Option(DialogueTextKey.HeroDinnerServing),
+        });
+
         // SayPitAdventure — five variants, no gate
         private static readonly OptionBag PitAdventureOptions = new OptionBag(new Option[]
         {
@@ -234,6 +248,18 @@ namespace PitHero
         public static void SayBreakfast(Entity entity)
         {
             SayFromOptions(entity, BreakfastOptions);
+        }
+
+        /// <summary>Shows a randomly-picked lunch bubble (issue #392).</summary>
+        public static void SayLunch(Entity entity)
+        {
+            SayFromOptions(entity, LunchOptions);
+        }
+
+        /// <summary>Shows a randomly-picked dinner bubble (issue #392).</summary>
+        public static void SayDinner(Entity entity)
+        {
+            SayFromOptions(entity, DinnerOptions);
         }
 
         /// <summary>Shows a randomly-picked pit-adventure bubble (one-shot per trip).</summary>

--- a/PitHero/SpeechBubbleDialogue.cs
+++ b/PitHero/SpeechBubbleDialogue.cs
@@ -262,6 +262,24 @@ namespace PitHero
             SayFromOptions(entity, DinnerOptions);
         }
 
+        /// <summary>
+        /// Shows the skip-lunch bubble when lunch is skipped because no dish the hero
+        /// can order is makeable (not the no-gold path).
+        /// </summary>
+        public static void SayLunchSkipped(Entity entity)
+        {
+            SaySingle(entity, DialogueTextKey.HeroLunchSkipped);
+        }
+
+        /// <summary>
+        /// Shows the skip-dinner bubble when dinner is skipped because no dish the hero
+        /// can order is makeable (not the no-gold path).
+        /// </summary>
+        public static void SayDinnerSkipped(Entity entity)
+        {
+            SaySingle(entity, DialogueTextKey.HeroDinnerSkipped);
+        }
+
         /// <summary>Shows a randomly-picked pit-adventure bubble (one-shot per trip).</summary>
         public static void SayPitAdventure(Entity entity)
         {

--- a/PitHero/UI/MonsterUI.cs
+++ b/PitHero/UI/MonsterUI.cs
@@ -262,6 +262,9 @@ namespace PitHero.UI
             _monsterListTable.Clear();
             var manager = Core.Services.GetService<AlliedMonsterManager>();
             bool jobsAutomated = Core.Services.GetService<Services.AutoJobAssignmentService>()?.Enabled ?? false;
+            // One-shot: the monster window pauses the game so the clock can't cross 10 PM while open.
+            bool kitchenClosed = TavernScheduleConfig.IsKitchenClosed(
+                Core.Services?.GetService<Services.InGameTimeService>()?.Hour ?? 12);
 
             // One page per Monster House in the aggregate view; the per-house view is never paged.
             var houses = GetMonsterHouses();
@@ -442,13 +445,20 @@ namespace PitHero.UI
                             ImageUp = new SpriteDrawable(jobSprite)
                         };
                         var jobBtn = new HoverableImageButton(btnStyle, jobName);
+
+                        // Kitchen is closed 10 PM–6 AM in manual mode: dim and disable the button.
+                        // A monster already holding Cooking keeps its job (coordinator drains it;
+                        // it refields at 6 AM). Show the current selection at full brightness so
+                        // the player can see the active job, but don't allow clicking.
+                        bool disabledByClosure = kitchenClosed && jobValue == MonsterJob.Cooking && !jobsAutomated;
+
                         // With automation on, the system owns assignments: buttons stay visible
                         // (active job bright, others dimmed harder) but never accept clicks.
                         jobBtn.GetImage().SetColor(isSelected
                             ? Color.White
-                            : (jobsAutomated ? new Color(80, 80, 80, 140) : new Color(128, 128, 128, 200)));
+                            : (jobsAutomated || disabledByClosure ? new Color(80, 80, 80, 140) : new Color(128, 128, 128, 200)));
 
-                        if (!jobsAutomated)
+                        if (!jobsAutomated && !disabledByClosure)
                         {
                             var closuredMonster = capturedMonster;
                             var closuredJob = jobValue;
@@ -464,6 +474,9 @@ namespace PitHero.UI
                                 RefreshMonsterList();
                             };
                         }
+
+                        if (disabledByClosure)
+                            jobBtn.SetHoverText(GetText(TextType.UI, UITextKey.JobKitchenClosed));
 
                         buttonsTable.Add(jobBtn).Size(32f, 32f).Pad(1f);
                     }

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -309,6 +309,11 @@ namespace PitHero
         public const string ConsoleNightSleep = "ConsoleNightSleep";
         public const string ConsoleBreakfastSkipped = "ConsoleBreakfastSkipped";
         public const string ConsoleBreakfastSkippedGold = "ConsoleBreakfastSkippedGold";
+        public const string ConsoleLunchSkipped = "ConsoleLunchSkipped";
+        public const string ConsoleLunchSkippedGold = "ConsoleLunchSkippedGold";
+        public const string ConsoleDinnerSkipped = "ConsoleDinnerSkipped";
+        public const string ConsoleDinnerSkippedGold = "ConsoleDinnerSkippedGold";
+        public const string JobKitchenClosed = "JobKitchenClosed";
         public const string ConsoleMercenaryHired = "ConsoleMercenaryHired";
         public const string ConsoleMonsterAttack = "ConsoleMonsterAttack";
         public const string ConsoleItemFound = "ConsoleItemFound";

--- a/PitHero/docs/AutoJobAssignmentSystem.md
+++ b/PitHero/docs/AutoJobAssignmentSystem.md
@@ -22,7 +22,7 @@ The same gate covers kitchen role changes (the replacement waits for the old wor
 |---|---|---|
 | `AutoJobAssignmentService` | `PitHero/Services/AutoJobAssignmentService.cs` | Cadence + snapshot + apply loop. Registered/ticked/unloaded in `MainGameScene` (`Begin`, `Update` unpaused block, `Unload`). |
 | `JobAssignmentSolver` | `PitHero/Services/AutoJob/JobAssignmentSolver.cs` | Pure static solver. No service or ECS dependencies — fully unit-testable. |
-| `IJobDemandEvaluator` | `PitHero/Services/AutoJob/IJobDemandEvaluator.cs` | One per automatable job: reports how many workers the job wants right now (`EvaluateDemand`) and feeds its backpressure tracker (`SamplePressure`/`ResetPressure`). |
+| `IJobDemandEvaluator` | `PitHero/Services/AutoJob/IJobDemandEvaluator.cs` | One per automatable job: reports how many workers the job wants right now (`EvaluateDemand(rosterSize, availableWorkers, nocturnal)`) and feeds its backpressure tracker (`SamplePressure`/`ResetPressure`). |
 | `BackpressureTracker` | `PitHero/Services/AutoJob/BackpressureTracker.cs` | Per-job smoother: instant attack, EMA decay, one-worker-per-interval drain. Owned by each evaluator. |
 | `FarmingJobDemandEvaluator` | `PitHero/Services/AutoJob/FarmingJobDemandEvaluator.cs` | Farming demand (non-sticky). |
 | `KitchenJobDemandEvaluator` | `PitHero/Services/AutoJob/KitchenJobDemandEvaluator.cs` | Kitchen demand (sticky). |
@@ -89,9 +89,15 @@ Tracker state is transient (never persisted); it rebuilds within a few samples a
 Day monsters (work 6AM–10PM) and nocturnal monsters (10PM–6AM; see
 `MonsterScheduleConfig.IsNocturnal`) are **disjoint workforces that never work at the same time**.
 `ReassessNow()` partitions the roster by `IsNocturnal(MonsterTypeName)` and runs demand + solve
-separately per shift, so every job gets both a day crew and a night crew. Demand clamps
-(`rosterSize`) always refer to the *shift's* size, not the whole roster. Asleep monsters are
-assigned normally — the coordinators keep them home until their work window.
+separately per shift, passing `nocturnal` to each `IJobDemandEvaluator.EvaluateDemand(rosterSize,
+availableWorkers, nocturnal)`. Demand clamps (`rosterSize`) always refer to the *shift's* size,
+not the whole roster. Asleep monsters are assigned normally — the coordinators keep them home
+until their work window.
+
+**Kitchen night-shift demand (issue #392)**: `KitchenJobDemandEvaluator.EvaluateDemand` returns
+Min=0 / Desired=0 / Sticky=true when `nocturnal=true`. The kitchen only operates 6 AM–10 PM;
+nocturnal monsters are never assigned there by automation. `FarmingJobDemandEvaluator` accepts
+and ignores the `nocturnal` param — farming is shift-agnostic.
 
 ## The solver
 

--- a/PitHero/docs/AutomationSystem.md
+++ b/PitHero/docs/AutomationSystem.md
@@ -91,14 +91,19 @@ Two distinct patterns — pick deliberately:
 
 ## Persistence
 
-The save format is **a single version**. `SaveData.CurrentVersion` is the only header value the
-build reads or writes; `Recover` rejects anything else with `InvalidDataException` and
-`SaveLoadService` treats that slot as empty. There is no migration path, no `MinSupportedVersion`,
-and no version-gated branch anywhere in `Recover` — pre-launch, changing the layout means existing
-saves stop loading, which is the accepted cost.
+**Backwards compatibility is mandatory.** `SaveData.CurrentVersion` is the version the build
+writes; every version from `SaveData.MinSupportedVersion` up must remain loadable. `Recover`
+rejects only versions outside that range with `InvalidDataException` (and `SaveLoadService` treats
+that slot as empty). Fields added after `MinSupportedVersion` are read conditionally on the file's
+version with safe, gracefully degrading defaults (e.g. `fileVersion >= 30 ? reader.ReadFloat() :
+0f` — "no active buff"). Loads rewrite at `CurrentVersion` on the next save.
 
-Sections are still appended at the end and still numbered, because that keeps diffs and the
-Persist/Recover pairing readable — not because older files need to be prefixes of newer ones.
+Periodic **save unifications** (v17 via issue #311, v29 via PR #391) collapse the supported range
+back to a single version — they happen **only when the owner explicitly asks for one**, never as a
+side effect of a feature. See AGENTS.md "Save Format".
+
+Sections are appended at the end and numbered, because that keeps diffs and the Persist/Recover
+pairing readable.
 
 Removing a setting does **not** remove its bytes; reshaping a section in the middle is what forces
 a version bump. The v26 removal of the "Auto-Purchase Consumables" master flag left its bool as a
@@ -110,7 +115,9 @@ Adding a persisted setting means, in order:
 1. Add the field to `SaveData` with a default and a `// Feature name` comment.
 2. Append a **new numbered section at the very end** of `Persist`. Arrays are written as a count
    followed by the elements.
-3. Append the mirrored read at the very end of `Recover`, unconditionally. Clamp array reads with
+3. Append the mirrored read at the very end of `Recover`, gated on the file version when the
+   section postdates `MinSupportedVersion` (`if (fileVersion >= N)` with defaults pre-assigned for
+   older files). Clamp array reads with
    `if (i < arr.Length)` and **pre-fill the array's defaults before reading** — a saved count
    shorter than the current array leaves the tail at those defaults, which is how a rarity, gear
    category, or consumable added later behaves like a fresh enable. Scalars need no pre-assignment;
@@ -118,8 +125,9 @@ Adding a persisted setting means, in order:
 4. Bump `CurrentVersion`.
 5. Service → `SaveData` in `SaveLoadService` (the collect method); `SaveData` → service in
    `MainGameScene`'s load-apply path.
-6. Extend `SaveLoadTests` with a round-trip test *and* a defaults test (a null array persists a
-   zero count, which exercises the pre-fill path).
+6. Extend `SaveLoadTests` with a round-trip test, a defaults test (a null array persists a
+   zero count, which exercises the pre-fill path), *and* a previous-version layout test proving
+   the old byte layout still reads (pattern: `SaveData_V29DiningRecord_ReadsWithDefaultExpiry`).
 
 **Two indices are persisted identities and must stay append-only:**
 

--- a/PitHero/docs/SpeechBubbleSystem.md
+++ b/PitHero/docs/SpeechBubbleSystem.md
@@ -121,7 +121,9 @@ virtual/live run parity. See the comment block at the top of `SpeechBubbleDialog
 | Auto-purchase before pit jump | `AutoItemPurchaseService.TryPurchasePass` | Only when items were actually bought |
 | Lands in the pit | `JumpIntoPitAction` after `InsidePit = true` | [G] variant + silent |
 | Exits pit for night sleep / rest | `EmitPitIntentBubbles` | Discriminated at plan formation: `IsNighttime` → bedtime, else `HPCritical‖MPCritical` → rest set; **player-Stop exits never bubble**; `_pitExitBubbleEmitted` latch |
-| Breakfast commit / skipped (no ingredients) | `PartyDiningService` | Skip line only on the `CanCoverRecipe` failure branch, not no-gold |
+| Breakfast commit / skipped (no ingredients) | `PartyDiningService.BeginAutoDine(Breakfast)` | Keys `HeroBreakfastTime` / `HeroBreakfastOptions`; skip line only on the `CanCoverRecipe` failure branch, not no-gold |
+| Lunch commit | `PartyDiningService.BeginAutoDine(Lunch)` | Keys `HeroLunchTime` / `HeroLunchOptions` (shuffle-bag, 2 options); same guard ladder as breakfast; triggers at 12 PM hour-edge |
+| Dinner commit | `PartyDiningService.BeginAutoDine(Dinner)` | Keys `HeroDinnerTime` / `HeroDinnerServing` (shuffle-bag, 2 options); triggers at 6 PM hour-edge |
 | Boss defeated | `LiveBattleAdapter.OnEnemyDefeated` | Live layer only; `VirtualBattleSink` untouched |
 | Respawn after defeat | `WalkToStatueForCrystalAction.WalkToStatue` start | See the deferral trap above |
 | Crystal ceremony prayer | `HeroPromotionService.ExecuteHeroCrystalCeremony` top | The pre-lightning dwell was extended to 4.0s (0.5 + 3.5) specifically to fit this line's reveal+linger — don't shorten one without the other |
@@ -136,7 +138,7 @@ virtual/live run parity. See the comment block at the top of `SpeechBubbleDialog
 | Cook | Plates a dish on serving | `KitchenMonsterStateMachine.CookWalkToServing_Tick` | Capture `_cookTicket.Dish` before it's nulled; the carry-to-sink branch never bubbles |
 | Runner | Claims a fetch job | `KitchenMonsterStateMachine.RunnerIdle_Tick` | Not `RunnerWalkToStorage_Enter` — that re-enters per storage stop |
 | Farmer | Arrives at crop storage carrying a harvest | `FarmingMonsterStateMachine.CarryHarvestToStorage_Tick` | Before `DepositAndFinish()` (which hides the body); can fire twice on a split delivery |
-| Any worker | Shift end, heading home | `ReturnHome_Enter` (both FSMs) | Gated on `MonsterScheduleConfig.IsAsleep` so mid-shift role-change send-homes stay silent |
+| Any worker | Shift end, heading home | `ReturnHome_Enter` (both FSMs) | Gated on `IsAsleep OR TavernScheduleConfig.IsKitchenClosed` — kitchen closure also reads as a real shift end, so nocturnal kitchen workers' 10 PM send-home bubbles correctly |
 | Any worker | Emerges for a new shift/job | `EmergeFromHouse_Tick` (both FSMs) | At the transition out of the emerge state (worker is outside the house sprite) |
 
 **Worker-FSM hook rule:** the job coordinators call `RequestReturnHome()` **every frame** while

--- a/PitHero/docs/SpeechBubbleSystem.md
+++ b/PitHero/docs/SpeechBubbleSystem.md
@@ -122,8 +122,8 @@ virtual/live run parity. See the comment block at the top of `SpeechBubbleDialog
 | Lands in the pit | `JumpIntoPitAction` after `InsidePit = true` | [G] variant + silent |
 | Exits pit for night sleep / rest | `EmitPitIntentBubbles` | Discriminated at plan formation: `IsNighttime` → bedtime, else `HPCritical‖MPCritical` → rest set; **player-Stop exits never bubble**; `_pitExitBubbleEmitted` latch |
 | Breakfast commit / skipped (no ingredients) | `PartyDiningService.BeginAutoDine(Breakfast)` | Keys `HeroBreakfastTime` / `HeroBreakfastOptions`; skip line only on the `CanCoverRecipe` failure branch, not no-gold |
-| Lunch commit | `PartyDiningService.BeginAutoDine(Lunch)` | Keys `HeroLunchTime` / `HeroLunchOptions` (shuffle-bag, 2 options); same guard ladder as breakfast; triggers at 12 PM hour-edge |
-| Dinner commit | `PartyDiningService.BeginAutoDine(Dinner)` | Keys `HeroDinnerTime` / `HeroDinnerServing` (shuffle-bag, 2 options); triggers at 6 PM hour-edge |
+| Lunch commit / skipped (no ingredients) | `PartyDiningService.BeginAutoDine(Lunch)` | Keys `HeroLunchTime` / `HeroLunchOptions` (shuffle-bag, 2 options); skip key `HeroLunchSkipped` on the no-ingredients branch only, not no-gold; triggers at 12 PM hour-edge |
+| Dinner commit / skipped (no ingredients) | `PartyDiningService.BeginAutoDine(Dinner)` | Keys `HeroDinnerTime` / `HeroDinnerServing` (shuffle-bag, 2 options); skip key `HeroDinnerSkipped` on the no-ingredients branch only; triggers at 6 PM hour-edge |
 | Boss defeated | `LiveBattleAdapter.OnEnemyDefeated` | Live layer only; `VirtualBattleSink` untouched |
 | Respawn after defeat | `WalkToStatueForCrystalAction.WalkToStatue` start | See the deferral trap above |
 | Crystal ceremony prayer | `HeroPromotionService.ExecuteHeroCrystalCeremony` top | The pre-lightning dwell was extended to 4.0s (0.5 + 3.5) specifically to fit this line's reveal+linger — don't shorten one without the other |

--- a/PitHero/docs/TavernDiningSystem.md
+++ b/PitHero/docs/TavernDiningSystem.md
@@ -279,8 +279,17 @@ clear either way, which is all the seat gate cares about.
 | Off-hours / overnight | all other hours | 2× | 120–240s |
 
 The multiplier is applied **at compare-time** (not reset-time), so a mid-wait hour flip adapts
-immediately. The empty-tavern 5s fast path also scales (2.5s at rush, 10s off-hours). Patrons keep
-arriving overnight at the 2× slow-trickle rate — a night phase with stage/bar is planned later.
+immediately. The empty-tavern 5s fast path also scales (2.5s at rush, 10s off-hours) but is
+**suppressed entirely while the kitchen is closed** — overnight the tavern may sit empty between
+trickle arrivals. Patrons keep arriving overnight at the 2× slow-trickle rate — a night phase
+with stage/bar is planned later.
+
+**Closed-hours arrivals are purely timer-driven.** While the kitchen is open, a departing patron
+is replaced almost immediately (the walk-off coroutine calls `TrySpawnMercenary` directly after a
+2s beat, and a full tavern evicts the oldest `FinishedEating` patron for a fresh face). While the
+kitchen is **closed**, both paths are disabled: no fresh-face evictions, and each departure
+resets `_timeSinceLastSpawn` instead of spawning a replacement — so the closing exodus empties
+the tavern and the next patron trickles in a full overnight interval later.
 
 At the seat a `TavernPatronComponent` is added. **A patron never sits down at a table that still
 has an un-bussed plate.** `GetAvailableTavernPosition` prefers a free seat that is already
@@ -314,17 +323,22 @@ Issue #392. `TavernScheduleConfig.IsKitchenClosed(hour)` returns true for hours 
   return false when closed. `KitchenTaskCoordinator.CreateTicket` also returns null as a
   belt-and-braces guard. (`CreateTicketPreReserved` is exempted — it is the save-reload path.)
 - **Crew wind-down**: `KitchenTaskCoordinator.Update()` computes `closed` (from `timeService`,
-  null → open) and `hasUndeliveredTickets` (any ticket whose state is not `Delivered`/`Canceled`).
-  While closed and no undelivered tickets exist, workers are not added to `_wantedAssignments`,
-  so the existing reconcile sends everyone home via `RequestReturnHome`. Workers carrying or
-  plating an in-flight dish stay until the dish is delivered, then they go home. This is
-  independent of `IsAsleep`, which means nocturnal workers (Orc, Skeleton, GhostMiner — awake
-  10 PM–6 AM) are also excluded from kitchen duty overnight.
+  null → open) and `HasClosingWork(hasUndeliveredTickets, busJobCount, diningPatrons)` —
+  undelivered tickets (any state not `Delivered`/`Canceled`), plates queued for bussing, and
+  seated guests still at their food (`MercenaryManager.CountPatronsDining()`:
+  `FoodDelivered`/`Eating`/`FinishedEating`). While closed and no closing work remains, workers
+  are not added to `_wantedAssignments`, so the existing reconcile sends everyone home via
+  `RequestReturnHome`. The crew therefore delivers every in-flight dish, waits out the last
+  eaters, busses the final plates, and only then drains — leaving every table clean for
+  overnight arrivals (a crew that left at the last delivery stranded dirty tables all night and
+  door-waiters piled up). This is independent of `IsAsleep`, which means nocturnal workers
+  (Orc, Skeleton, GhostMiner — awake 10 PM–6 AM) are also excluded from kitchen duty overnight.
 - **Shift-end speech bubble**: `ReturnHome_Enter` now says the shift-end bubble when
   `IsAsleep(...) || IsKitchenClosed(hour)` (so nocturnal workers' closing-time departure looks
   like a real shift end, not a role change).
-- **Overnight leftovers**: bus jobs and orphan plates from patrons who finish after the crew
-  drains sit until the 6 AM crew arrives and clears them. This is acceptable and expected.
+- **Overnight leftovers**: rare — the crew now outlasts the last eater and busses their plates
+  before draining. A plate can still be orphaned by an edge case (e.g. a bus claim released by a
+  despawning worker after the drain decision); it sits until the 6 AM crew clears it.
 - **Auto job assignment**: `KitchenJobDemandEvaluator.EvaluateDemand` returns Min=0 / Desired=0 /
   Sticky=true when `nocturnal=true` — kitchen only operates on the day shift.
 - **Manual job window**: `MonsterUI.RefreshMonsterList` disables the Kitchen job button 10 PM–6 AM

--- a/PitHero/docs/TavernDiningSystem.md
+++ b/PitHero/docs/TavernDiningSystem.md
@@ -329,16 +329,19 @@ Issue #392. `TavernScheduleConfig.IsKitchenClosed(hour)` returns true for hours 
   return false when closed. `KitchenTaskCoordinator.CreateTicket` also returns null as a
   belt-and-braces guard. (`CreateTicketPreReserved` is exempted — it is the save-reload path.)
 - **Crew wind-down**: `KitchenTaskCoordinator.Update()` computes `closed` (from `timeService`,
-  null → open) and `HasClosingWork(hasUndeliveredTickets, busJobCount, diningPatrons)` —
-  undelivered tickets (any state not `Delivered`/`Canceled`), plates queued for bussing, and
-  seated guests still at their food (`MercenaryManager.CountPatronsDining()`:
-  `FoodDelivered`/`Eating`/`FinishedEating`). While closed and no closing work remains, workers
-  are not added to `_wantedAssignments`, so the existing reconcile sends everyone home via
-  `RequestReturnHome`. The crew therefore delivers every in-flight dish, waits out the last
-  eaters, busses the final plates, and only then drains — leaving every table clean for
-  overnight arrivals (a crew that left at the last delivery stranded dirty tables all night and
-  door-waiters piled up). This is independent of `IsAsleep`, which means nocturnal workers
-  (Orc, Skeleton, GhostMiner — awake 10 PM–6 AM) are also excluded from kitchen duty overnight.
+  null → open) and `HasClosingWork(hasUndeliveredTickets, busJobCount, diningPatrons,
+  orphanedDishes)` — undelivered tickets (any state not `Delivered`/`Canceled`), plates queued
+  for bussing, seated guests still at their food (`MercenaryManager.CountPatronsDining()`:
+  `FoodDelivered`/`Eating`/`FinishedEating`), and orphaned servings (`_orphanServing` — a
+  cooked dish whose ticket was canceled at close, e.g. the patron left on reduced patience or
+  the party departed for night sleep mid-order; a server sinks it). While closed and no closing
+  work remains, workers are not added to `_wantedAssignments`, so the existing reconcile sends
+  everyone home via `RequestReturnHome`. The crew therefore delivers every in-flight dish,
+  waits out the last eaters, busses the final plates, sinks any abandoned food, and only then
+  drains — leaving every table clean for overnight arrivals (a crew that left at the last
+  delivery stranded dirty tables all night and door-waiters piled up). This is independent of
+  `IsAsleep`, which means nocturnal workers (Orc, Skeleton, GhostMiner — awake 10 PM–6 AM) are
+  also excluded from kitchen duty overnight.
 - **Shift-end speech bubble**: `ReturnHome_Enter` now says the shift-end bubble when
   `IsAsleep(...) || IsKitchenClosed(hour)` (so nocturnal workers' closing-time departure looks
   like a real shift end, not a role change).

--- a/PitHero/docs/TavernDiningSystem.md
+++ b/PitHero/docs/TavernDiningSystem.md
@@ -273,13 +273,13 @@ clear either way, which is all the seat gate cares about.
 
 | Window | Hours | Multiplier | Effective interval |
 |---|---|---|---|
-| Morning rush | 6–8 AM | 1× | 60–120s rolled per arrival |
-| Lunch rush | 12–2 PM | 1× | 60–120s |
-| Dinner rush | 6–9 PM | 1× | 60–120s |
+| Morning rush | 6–8 AM | 0.5× | 30–60s rolled per arrival |
+| Lunch rush | 12–2 PM | 0.5× | 30–60s |
+| Dinner rush | 6–9 PM | 0.5× | 30–60s |
 | Off-hours / overnight | all other hours | 2× | 120–240s |
 
 The multiplier is applied **at compare-time** (not reset-time), so a mid-wait hour flip adapts
-immediately. The empty-tavern 5s fast path also doubles at off-hours (10s). Patrons keep
+immediately. The empty-tavern 5s fast path also scales (2.5s at rush, 10s off-hours). Patrons keep
 arriving overnight at the 2× slow-trickle rate — a night phase with stage/bar is planned later.
 
 At the seat a `TavernPatronComponent` is added. **A patron never sits down at a table that still

--- a/PitHero/docs/TavernDiningSystem.md
+++ b/PitHero/docs/TavernDiningSystem.md
@@ -287,9 +287,14 @@ with stage/bar is planned later.
 **Closed-hours arrivals are purely timer-driven.** While the kitchen is open, a departing patron
 is replaced almost immediately (the walk-off coroutine calls `TrySpawnMercenary` directly after a
 2s beat, and a full tavern evicts the oldest `FinishedEating` patron for a fresh face). While the
-kitchen is **closed**, both paths are disabled: no fresh-face evictions, and each departure
-resets `_timeSinceLastSpawn` instead of spawning a replacement — so the closing exodus empties
-the tavern and the next patron trickles in a full overnight interval later.
+kitchen is **closed**, both paths are disabled — no fresh-face evictions, no per-departure
+respawn — so the closing exodus empties the tavern on its own. The arrival timer is reset
+**exactly once**, at the 10 PM open→closed edge (`_wasKitchenClosed`): the evening tavern is
+usually full, so the timer sits held at its threshold and would otherwise refill the first freed
+seat instantly. Departures during the exodus must NOT reset it again — the exodus stretches past
+midnight, and re-arming the full 2–4 game-hour overnight interval per leaver starves the entire
+night of arrivals. Net effect: first night patron ~midnight–2 AM, then one every 2–4 game-hours,
+each sitting ~2.5 game-hours (1/4 patience) — a handful of night patrons for ambiance.
 
 At the seat a `TavernPatronComponent` is added. **A patron never sits down at a table that still
 has an un-bussed plate.** `GetAvailableTavernPosition` prefers a free seat that is already

--- a/PitHero/docs/TavernDiningSystem.md
+++ b/PitHero/docs/TavernDiningSystem.md
@@ -276,13 +276,14 @@ clear either way, which is all the seat gate cares about.
 | Morning rush | 6–8 AM | 0.5× | 30–60s rolled per arrival |
 | Lunch rush | 12–2 PM | 0.5× | 30–60s |
 | Dinner rush | 6–9 PM | 0.5× | 30–60s |
-| Off-hours / overnight | all other hours | 2× | 120–240s |
+| Daytime off-hours | 8–12 AM, 2–6 PM, 9–10 PM | 2× | 120–240s |
+| Overnight (kitchen closed) | 10 PM–6 AM | 1× | 60–120s |
 
 The multiplier is applied **at compare-time** (not reset-time), so a mid-wait hour flip adapts
 immediately. The empty-tavern 5s fast path also scales (2.5s at rush, 10s off-hours) but is
 **suppressed entirely while the kitchen is closed** — overnight the tavern may sit empty between
-trickle arrivals. Patrons keep arriving overnight at the 2× slow-trickle rate — a night phase
-with stage/bar is planned later.
+trickle arrivals. Overnight runs at the base rate (denser than daytime off-hours) so the tavern
+keeps a steady night crowd — a night phase with stage/bar is planned later.
 
 **Closed-hours arrivals are purely timer-driven.** While the kitchen is open, a departing patron
 is replaced almost immediately (the walk-off coroutine calls `TrySpawnMercenary` directly after a
@@ -292,9 +293,9 @@ respawn — so the closing exodus empties the tavern on its own. The arrival tim
 **exactly once**, at the 10 PM open→closed edge (`_wasKitchenClosed`): the evening tavern is
 usually full, so the timer sits held at its threshold and would otherwise refill the first freed
 seat instantly. Departures during the exodus must NOT reset it again — the exodus stretches past
-midnight, and re-arming the full 2–4 game-hour overnight interval per leaver starves the entire
-night of arrivals. Net effect: first night patron ~midnight–2 AM, then one every 2–4 game-hours,
-each sitting ~2.5 game-hours (1/4 patience) — a handful of night patrons for ambiance.
+midnight, and re-arming the full overnight interval per leaver starves the entire night of
+arrivals. Net effect: first night patron ~11 PM–midnight, then one every 1–2 game-hours,
+each sitting ~2.5 game-hours (1/4 patience) — one or two night patrons at a time for ambiance.
 
 At the seat a `TavernPatronComponent` is added. **A patron never sits down at a table that still
 has an un-bussed plate.** `GetAvailableTavernPosition` prefers a free seat that is already

--- a/PitHero/docs/TavernDiningSystem.md
+++ b/PitHero/docs/TavernDiningSystem.md
@@ -268,21 +268,68 @@ clear either way, which is all the seat gate cares about.
 
 ## Walk-in patrons
 
-`MercenaryManager` spawns unhired mercs on a 60–120s rolled interval (5s when the tavern is
-empty) into 9 fixed seats; at the seat a `TavernPatronComponent` is added. **A patron never sits
-down at a table that still has an un-bussed plate.** `GetAvailableTavernPosition` prefers a free
-seat that is already cleared, and `TryReseatToClearedSeat` re-checks (plates appear and get
-bussed during the walk in) — only when *every* free seat is dirty does the patron wait at the
-tavern door (100,6), retrying the reseat every 0.25s until a plate is cleared. Waiting patrons
-are unseated, so they add no ordering pressure while the backlog drains. When full, the
-oldest patron in `FinishedEating` is walked off to free a seat — never one still waiting or
-eating. `PatronState`: `WaitingToOrder → Ordered → FoodDelivered → Eating → FinishedEating`.
+`MercenaryManager` spawns unhired mercs into 9 fixed seats. The arrival interval is
+**time-of-day dependent** (issue #392, `TavernScheduleConfig.GetArrivalIntervalMultiplier`):
+
+| Window | Hours | Multiplier | Effective interval |
+|---|---|---|---|
+| Morning rush | 6–8 AM | 1× | 60–120s rolled per arrival |
+| Lunch rush | 12–2 PM | 1× | 60–120s |
+| Dinner rush | 6–9 PM | 1× | 60–120s |
+| Off-hours / overnight | all other hours | 2× | 120–240s |
+
+The multiplier is applied **at compare-time** (not reset-time), so a mid-wait hour flip adapts
+immediately. The empty-tavern 5s fast path also doubles at off-hours (10s). Patrons keep
+arriving overnight at the 2× slow-trickle rate — a night phase with stage/bar is planned later.
+
+At the seat a `TavernPatronComponent` is added. **A patron never sits down at a table that still
+has an un-bussed plate.** `GetAvailableTavernPosition` prefers a free seat that is already
+cleared, and `TryReseatToClearedSeat` re-checks (plates appear and get bussed during the walk
+in) — only when *every* free seat is dirty does the patron wait at the tavern door (100,6),
+retrying the reseat every 0.25s until a plate is cleared. Waiting patrons are unseated, so they
+add no ordering pressure while the backlog drains. When full, the oldest patron in
+`FinishedEating` is walked off to free a seat — never one still waiting or eating.
+
+`PatronState`: `WaitingToOrder → Ordered → FoodDelivered → Eating → FinishedEating`.
 Patience: 10 min pre-order and post-order (expiry cancels the ticket and leaves immediately);
-after eating they linger 5 min. On delivery the patron faces their table
-(`TavernSeatConfig.GetFacing`). On finishing: pays `DishConfig.GetPrice`, 50% chance of a
-5–15% tip (rounded up), logs `dish_served`. Hiring a patron mid-order calls
-`CancelTicketForPatron` before removing the component. Patrons order a random dish from
-`GetOrderableDishes` (= every dish whose recipe fridge+storage can cover).
+after eating they linger 5 min. **Closed-kitchen patience**: while the kitchen is closed
+(10 PM–6 AM) and the patron is still `WaitingToOrder`, the effective pre-order patience
+threshold drops to `PatronPatiencePreOrderSeconds × PatronClosedKitchenPatienceFactor`
+(600s × 0.25 = 150s ≈ 2.5 in-game hours, tunable via `GameConfig`). A patron seated before
+10 PM with accrued wait above that threshold leaves promptly at close; overnight arrivals sit
+for ambiance and then walk off via the normal `LeaveOnPatienceExpiry` path. Patrons in
+`Ordered` / `FoodDelivered` / `Eating` / `FinishedEating` keep their normal timers — the
+kitchen finishes serving them.
+
+On delivery the patron faces their table (`TavernSeatConfig.GetFacing`). On finishing: pays
+`DishConfig.GetPrice`, 50% chance of a 5–15% tip (rounded up), logs `dish_served`. Hiring a
+patron mid-order calls `CancelTicketForPatron` before removing the component. Patrons order a
+random dish from `GetOrderableDishes` (= every dish whose recipe fridge+storage can cover).
+
+## Kitchen hours (10 PM – 6 AM closure)
+
+Issue #392. `TavernScheduleConfig.IsKitchenClosed(hour)` returns true for hours ≥ 22 or < 6.
+
+- **No new orders**: `KitchenMonsterStateMachine.TryPickNextOrderTarget` and `HasOrderWork` both
+  return false when closed. `KitchenTaskCoordinator.CreateTicket` also returns null as a
+  belt-and-braces guard. (`CreateTicketPreReserved` is exempted — it is the save-reload path.)
+- **Crew wind-down**: `KitchenTaskCoordinator.Update()` computes `closed` (from `timeService`,
+  null → open) and `hasUndeliveredTickets` (any ticket whose state is not `Delivered`/`Canceled`).
+  While closed and no undelivered tickets exist, workers are not added to `_wantedAssignments`,
+  so the existing reconcile sends everyone home via `RequestReturnHome`. Workers carrying or
+  plating an in-flight dish stay until the dish is delivered, then they go home. This is
+  independent of `IsAsleep`, which means nocturnal workers (Orc, Skeleton, GhostMiner — awake
+  10 PM–6 AM) are also excluded from kitchen duty overnight.
+- **Shift-end speech bubble**: `ReturnHome_Enter` now says the shift-end bubble when
+  `IsAsleep(...) || IsKitchenClosed(hour)` (so nocturnal workers' closing-time departure looks
+  like a real shift end, not a role change).
+- **Overnight leftovers**: bus jobs and orphan plates from patrons who finish after the crew
+  drains sit until the 6 AM crew arrives and clears them. This is acceptable and expected.
+- **Auto job assignment**: `KitchenJobDemandEvaluator.EvaluateDemand` returns Min=0 / Desired=0 /
+  Sticky=true when `nocturnal=true` — kitchen only operates on the day shift.
+- **Manual job window**: `MonsterUI.RefreshMonsterList` disables the Kitchen job button 10 PM–6 AM
+  in manual mode: dimmed, unclickable, hover text "Kitchen closed" (`UITextKey.JobKitchenClosed`).
+  A monster already holding Cooking keeps the job; the coordinator drains it and refields at 6 AM.
 
 Patrons, servers, cooks, and runners emit random speech bubbles at key moments (order taken,
 payment — tip-gated variants, patron walk-off farewell via `KitchenTicket.ServerEntity`, dish
@@ -297,14 +344,20 @@ Rides **Stop mode** — no new GOAP surface. Entry paths:
   (`WalkToTavernForStopAction`, `HeroComponent.StoppedAdventure && SeatedInTavern`). The party
   sits regardless of the "Eat at tavern" checkbox; when it's off, servers ignore them entirely
   and focus on walk-in patrons.
-- **Morning auto-dine**: `SleepInBedAction` calls `BeginAutoDine()` after waking if the
-  Food-tab "Eat at tavern" checkbox is on (default **on** for new games), the kitchen is open,
-  and the hero can order (favorite makeable + affordable — an ingredient or gold shortfall
-  skips the trip with a session-console line); it force-stops, and `CheckAllDone()`
-  auto-resumes when everyone finishes. `BeginAutoDine` no-ops when the party is already
-  player-stopped so it can't cancel a manual stop. At 10 PM a stopped party leaves the table
-  for night sleep (`OnNightSleepDeparture` settles tickets like a resume) and returns after
-  waking — `StoppedAdventure` stays true throughout.
+- **Three auto-dine meals** (issue #392): `BeginAutoDine(MealPeriod meal)` fires three times
+  per in-game day:
+  - **Breakfast** (6 AM): `SleepInBedAction` calls `BeginAutoDine(MealPeriod.Breakfast)` after
+    the party wakes from night sleep.
+  - **Lunch** (12 PM): `MainGameScene` fires at the 12 PM hour-edge (`ResetForNewMealPeriod()`,
+    then `BeginAutoDine(MealPeriod.Lunch)`).
+  - **Dinner** (6 PM): same pattern with `MealPeriod.Dinner`.
+
+  Each call checks: "Eat at tavern" on → party not already player-stopped → kitchen open →
+  `HasEatenThisMeal` false → hero's favorite can be made and afforded. A shortfall skips the
+  trip with a session-console line (console keys: `ConsoleLunchSkipped` / `ConsoleDinnerSkipped`).
+  `BeginAutoDine` no-ops if the party is already player-stopped. `ResetForNewMealPeriod()` runs
+  **before** `BeginAutoDine` at every edge so `HasEatenThisMeal` is cleared for the new period.
+  At 10 PM a stopped party leaves the table for night sleep; `StoppedAdventure` stays true.
 
 `PartyDiningService` implements `IPartyOrderSource`; the coordinator polls
 `TryGetNextPartyOrder`. **The hero leads the meal**: he orders only the Food-tab favorite
@@ -314,8 +367,9 @@ gold in or out): job favorite via `DishConfig.GetFavoriteForJob(job)`, falling b
 two job-specific cheap dishes, ingredient-gated only. Skips log `party_dine_skipped`
 analytics once (reason `already_ate` / `no_ingredients` / `no_gold`) but are **re-evaluated
 every poll**, so a seated party is still served when ingredients/gold appear later. One meal
-per member per day (`HasEatenToday`, reset at the 6 AM daily tick along with
-`MealBuffService.ClearAll()`).
+per member per **meal period** (`HasEatenThisMeal`, reset by `ResetForNewMealPeriod()` at each
+6/12/18 AM/PM edge). `MealBuffService.ClearAll()` runs at the 6 AM edge as belt-and-braces
+(the last dinner buff expires ~4 AM; the 6 AM clear removes any stragglers).
 
 **The hero pays at order time** (`OnPartyOrderTaken`), unlike patrons who pay after eating.
 Eating runs on `GetEatSeconds` (5/7/10s by class); `FinishMember` applies the meal buff, logs
@@ -327,14 +381,20 @@ otherwise in-flight meals finish and the party resumes — no endless sitting.
 
 ## Meal buffs
 
-`MealBuffService` keeps one `(combatant, dish, deluxe)` record per member per day. Buffs are
-**not persistent battle state** — `BattleEngine` clears battle state at battle start and then
-calls `InjectBuffsAtBattleStart` for the hero and each merc (and for late-joining mercs),
-adding each dish buff as `BattleBuff(type, magnitude, -1, "meal")` — turns = -1 means "until
-battle end". Injection is pure list writes: **it consumes no battle RNG** (RNG call order is a
-contract — see `VirtualGameLogicLayer.md`). Deluxe meals scale magnitude ×1.5 rounded up.
-MagicUp feeds skill formulas via `ICombatant.GetSkillStats()`; HP/MP regen ticks at end of
-round. Food never restores HP/MP directly — that's the inn's job.
+`MealBuffService` keeps one `(combatant, dish, deluxe, expiresAtSeconds)` record per active
+meal per member. Buffs last **6 in-game hours** (`GameConfig.MealBuffDurationSeconds = 360f` ×
+1 real-second-per-in-game-minute time scale). Each `MealRecord` stores an absolute
+`ExpiresAtSeconds` stamp; `Prune(nowSeconds)` removes expired records every frame (reverse
+iteration, no allocation). Three meals per day means up to three active buff slots around
+dinner time if the player eats them close together.
+
+Buffs are **not persistent battle state** — `BattleEngine` clears battle state at battle start
+and then calls `InjectBuffsAtBattleStart` for the hero and each merc (and for late-joining
+mercs), adding each non-expired dish buff as `BattleBuff(type, magnitude, -1, "meal")` — turns
+= -1 means "until battle end". Injection is pure list writes: **it consumes no battle RNG**
+(RNG call order is a contract — see `VirtualGameLogicLayer.md`). Deluxe meals scale magnitude
+×1.5 rounded up. MagicUp feeds skill formulas via `ICombatant.GetSkillStats()`; HP/MP regen
+ticks at end of round. Food never restores HP/MP directly — that's the inn's job.
 
 ## Dish data
 
@@ -352,12 +412,15 @@ reprices the whole menu automatically (`DishPricingTests` guards this).
 
 ## Persistence (section 33)
 
-Persisted per party slot (`SavedDiningRecord`): `OrderedDishId`, `HasPaid`, `HasEatenToday`,
-`MealDishId`, `MealDeluxe`; plus `FavoriteDishId` and `EatAtTavern`. On load, meal buffs are
-rebuilt via `MealBuffService.RestoreRecord` (no HP/MP
-re-grant), and an open order forces Stop mode back on so the party returns to the table —
-crops were deducted pre-save and `HasPaid` prevents double payment
-(`CreateTicketPreReserved` recreates the ticket as `ReadyToCook` with full-recipe refund data).
+Save version **30** (issue #392). Persisted per party slot (`SavedDiningRecord`):
+`OrderedDishId`, `HasPaid`, `HasEatenThisMeal` (renamed from `HasEatenToday`),
+`MealDishId`, `MealDeluxe`, `MealExpiresAtSeconds`; plus `FavoriteDishId` and `EatAtTavern`.
+On load, meal buffs are rebuilt via `MealBuffService.RestoreRecord` only when
+`MealExpiresAtSeconds > InGameTimeService.AccumulatedSeconds` at load time (expired records
+are discarded and the slot mirrors cleared). An open order forces Stop mode back on so the
+party returns to the table — crops were deducted pre-save and `HasPaid` prevents double
+payment (`CreateTicketPreReserved` recreates the ticket as `ReadyToCook` with full-recipe
+refund data).
 
 Fridge contents and the Pre-Stock Stack Size slider persist separately (save v28, section 45:
 `FridgeSlots` + `FridgePreStockStackSize`, restored into `FridgeInventoryService` on load), as

--- a/PitHero/docs/TavernDiningSystem.md
+++ b/PitHero/docs/TavernDiningSystem.md
@@ -415,6 +415,9 @@ reprices the whole menu automatically (`DishPricingTests` guards this).
 Save version **30** (issue #392). Persisted per party slot (`SavedDiningRecord`):
 `OrderedDishId`, `HasPaid`, `HasEatenThisMeal` (renamed from `HasEatenToday`),
 `MealDishId`, `MealDeluxe`, `MealExpiresAtSeconds`; plus `FavoriteDishId` and `EatAtTavern`.
+v29 files still load (backwards compatibility is mandatory — see AGENTS.md "Save Format"):
+`MealExpiresAtSeconds` is read only when `fileVersion >= 30` and defaults to 0 for v29, so a
+pre-#392 meal buff is dropped cleanly and the party simply re-eats at the next meal period.
 On load, meal buffs are rebuilt via `MealBuffService.RestoreRecord` only when
 `MealExpiresAtSeconds > InGameTimeService.AccumulatedSeconds` at load time (expired records
 are discarded and the slot mirrors cleared). An open order forces Stop mode back on so the

--- a/PitHero/docs/TavernDiningSystem.md
+++ b/PitHero/docs/TavernDiningSystem.md
@@ -353,16 +353,27 @@ Rides **Stop mode** — no new GOAP surface. Entry paths:
   - **Dinner** (6 PM): same pattern with `MealPeriod.Dinner`.
 
   Each call checks: "Eat at tavern" on → party not already player-stopped → kitchen open →
-  `HasEatenThisMeal` false → hero's favorite can be made and afforded. A shortfall skips the
-  trip with a session-console line (console keys: `ConsoleLunchSkipped` / `ConsoleDinnerSkipped`).
+  `HasEatenThisMeal` false → **some dish the hero can order** exists (`TryPickHeroDish`:
+  Food-tab favorite first, then the hero's two job fallbacks via
+  `DishConfig.GetFallbackForJob`, each gated on `CanCoverRecipe` AND price — one missing crop
+  no longer starves the whole party). A full shortfall skips the trip with a session-console
+  line (console keys: `ConsoleLunchSkipped` / `ConsoleDinnerSkipped`) **and a hero skip
+  bubble** (`HeroLunchSkipped` / `HeroDinnerSkipped`, breakfast keeps
+  `HeroBreakfastNoIngredients`) on the no-ingredients branch only. Every `BeginAutoDine`
+  outcome logs a `party_meal_trip` analytics event (`started`, or the skip reason:
+  `hero_not_present` / `already_stopped` / `kitchen_closed` / `kitchen_unstaffed` /
+  `already_ate` / `no_ingredients` / `no_gold` / `no_stop_ui`) so a silently skipped meal is
+  diagnosable from the session log.
   `BeginAutoDine` no-ops if the party is already player-stopped. `ResetForNewMealPeriod()` runs
   **before** `BeginAutoDine` at every edge so `HasEatenThisMeal` is cleared for the new period.
   At 10 PM a stopped party leaves the table for night sleep; `StoppedAdventure` stays true.
 
 `PartyDiningService` implements `IPartyOrderSource`; the coordinator polls
-`TryGetNextPartyOrder`. **The hero leads the meal**: he orders only the Food-tab favorite
-(`FavoriteDishId`) and pays for it; if it can't be made or afforded, the servers skip the
-whole party — mercenaries never eat unless the hero eats. Mercenary meals are **free** (no
+`TryGetNextPartyOrder`. **The hero leads the meal**: he orders the Food-tab favorite
+(`FavoriteDishId`), falling back through his job's two cheap dishes when the favorite can't
+be made or afforded (`TryPickHeroDish` — the same ladder `BeginAutoDine` pre-checks), and
+pays for it; only when nothing he can order is available do the servers skip the whole
+party — mercenaries never eat unless the hero eats. Mercenary meals are **free** (no
 gold in or out): job favorite via `DishConfig.GetFavoriteForJob(job)`, falling back through
 two job-specific cheap dishes, ingredient-gated only. Skips log `party_dine_skipped`
 analytics once (reason `already_ate` / `no_ingredients` / `no_gold`) but are **re-evaluated


### PR DESCRIPTION
Implements #392.

## What changed

**Three meals a day, 6-hour food buffs**
- Meal buffs now expire 6 in-game hours after eating (`GameConfig.MealBuffDurationSeconds = 360f`). `MealBuffService` records carry an absolute expiry stamp and are pruned every frame; battle-start injection is untouched (RNG-free contract preserved).
- Party auto-dines at Breakfast (6 AM, wake-driven as before), Lunch (12 PM edge), and Dinner (6 PM edge) — the 12/18 hour edges reset the per-meal eaten flags and fire `BeginAutoDine(MealPeriod)`, which rides the existing Stop-mode flow (auto-stop → exit pit → tavern → eat → auto-resume), with the same guard ladder (Eat at Tavern setting, kitchen staffed, ingredients, gold).
- `HasEatenToday` → `HasEatenThisMeal`, reset each meal period. Buff mirrors survive meal-period resets and expire on their own clock.

**Hero dish fallback + meal-skip feedback** (playtest follow-up)
- Playtesting caught a silent lunch skip: the whole party's meal hinged on the hero's favorite dish, and patron orders had reserved the last potatoes at noon. The hero now falls back through his job's two cheap dishes like mercenaries do (`TryPickHeroDishCore`: favorite → fallback 0 → fallback 1, each gated on ingredients AND price) in both `BeginAutoDine` and the seated order poll.
- When nothing is orderable, lunch/dinner skips now show a hero bubble ("Looks like we'll have to skip lunch/dinner") alongside the console line, and every `BeginAutoDine` outcome logs a `party_meal_trip` analytics event (`started` or the skip reason) so silent skips are diagnosable from the session log.

**Save format v30 — with backwards compatibility**
- `SavedDiningRecord` gains `MealExpiresAtSeconds`; version bumps 29 → 30.
- **v29 saves still load**: `SaveData.MinSupportedVersion` (29) is reintroduced and `Recover` accepts the full supported range. The new field is read conditionally on the file version and defaults to 0 for v29 files (the pre-#392 buff is dropped cleanly; the party re-eats at the next meal). Backwards compatibility is now a documented hard rule (AGENTS.md "Save Format") — save unifications happen only when explicitly requested.

**New hero dialogue (shuffle bags)**
- Lunch: "It's time for lunch" / "Let's check out our lunch options"
- Dinner: "Should be time for dinner" / "They should be serving dinner now"
- Skip lines: "Looks like we'll have to skip lunch" / "Looks like we'll have to skip dinner"

**Time-varying tavern traffic**
- Rush hours 6–8 AM, 12–2 PM, 6–9 PM: **double** the base arrival rate (0.5× spawn interval, 30–60s). Daytime off-hours: 2× spawn interval (slow trickle). Overnight (10 PM–6 AM): base rate (1×, 60–120s) so the tavern keeps a steady night crowd for the future night phase. Applied at compare time via new `TavernScheduleConfig`. Departure pacing unchanged.

**Kitchen hours (10 PM – 6 AM closed)**
- No new orders: gated in the server FSM (`TryPickNextOrderTarget` + `HasOrderWork`, kept in sync) with a belt-and-braces gate in `CreateTicket` (save-reload `CreateTicketPreReserved` exempt).
- Crew stays through the full close-down: every ticket delivered, every seated guest finished eating, every plate bussed, and every orphaned serving sunk — a cooked dish whose ticket was canceled at close (patron left on reduced patience, hired mid-order, or the party departed for night sleep) no longer gets abandoned on the serving table (`HasClosingWork` + `CountPatronsDining` + `_orphanServing`). Then the crew drains home via the existing `RequestReturnHome` seams — including nocturnal monster types that previously kept the kitchen staffed all night. Shift-end bubble now also fires on closure. Tables are left clean for overnight arrivals.
- Closing exodus (playtest follow-ups): while closed, departing patrons are **not** replaced 1-for-1 — the departure coroutine's instant respawn and the full-tavern fresh-face eviction are disabled, and the empty-tavern fast-path interval is suppressed, so overnight arrivals are purely timer-driven (previously every leaver was instantly replaced and the replacements piled up at the door waiting for tables nobody would ever bus). The arrival timer resets exactly **once** at the 10 PM open→closed edge — the exodus stretches past midnight, and a per-departure reset re-armed the full interval each time, starving the whole night of arrivals. Net: first night patron ~11 PM–midnight, then one every 1–2 game-hours, each sitting ~2.5 game-hours — one or two night patrons at a time.
- Patrons still waiting to order while closed get 1/4 patience (`PatronClosedKitchenPatienceFactor`), so the tavern empties gracefully after close.
- Auto job assignment: `EvaluateDemand` gains a `nocturnal` param; kitchen demand is zero on the night shift.
- Manual job mode: the Kitchen job button is dimmed/unclickable 10 PM–6 AM with a "Kitchen closed" hover.

## Testing
- `dotnet build PitHero.sln` clean, `dotnet test`: **0 failed / 1993 passed** (baseline 1981; new `TavernScheduleConfigTests` incl. overnight tier, `MealBuffServiceExpiryTests`, lunch/dinner shuffle-bag tests, nocturnal kitchen-demand test, v29/v30 dining-record layout tests, `HeroDishFallbackTests`, `HasClosingWork` drain test incl. orphan term).
- Docs updated: `TavernDiningSystem.md`, `AutoJobAssignmentSystem.md`, `SpeechBubbleSystem.md`, `AutomationSystem.md` (persistence policy), AGENTS.md (new "Save Format" rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)