### PR TITLE
Monster Info card beside the aggregate Monsters window

### DIFF
--- a/PitHero.Tests/UI/MonsterInfoStatsTests.cs
+++ b/PitHero.Tests/UI/MonsterInfoStatsTests.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.UI;
+using RolePlayingFramework.AlliedMonsters;
+
+namespace PitHero.Tests.UI
+{
+    /// <summary>
+    /// Covers the workforce counts behind the Monster Info card (issue #394): roster totals split by
+    /// shift, and the farm/kitchen/idle headcount of whichever shift is awake.
+    /// </summary>
+    [TestClass]
+    public class MonsterInfoStatsTests
+    {
+        // "Slime" is a daytime type, "Orc" is nocturnal (MonsterScheduleConfig).
+        private static AlliedMonster Day(MonsterJob job) => Make("Slime", job);
+        private static AlliedMonster Night(MonsterJob job) => Make("Orc", job);
+
+        private static AlliedMonster Make(string typeName, MonsterJob job)
+        {
+            var monster = new AlliedMonster("Test", typeName, 5, 5, 5);
+            monster.Job = job;
+            return monster;
+        }
+
+        [TestMethod]
+        public void Compute_NullRoster_ReturnsZeros()
+        {
+            var stats = MonsterInfoStats.Compute(null, false);
+
+            Assert.AreEqual(0, stats.TotalDaytime);
+            Assert.AreEqual(0, stats.TotalNighttime);
+            Assert.AreEqual(0, stats.FarmWorkers);
+            Assert.AreEqual(0, stats.KitchenWorkers);
+            Assert.AreEqual(0, stats.IdleWorkers);
+        }
+
+        [TestMethod]
+        public void Compute_EmptyRoster_ReturnsZeros()
+        {
+            var stats = MonsterInfoStats.Compute(new List<AlliedMonster>(), true);
+
+            Assert.AreEqual(0, stats.TotalDaytime);
+            Assert.AreEqual(0, stats.TotalNighttime);
+            Assert.AreEqual(0, stats.IdleWorkers);
+        }
+
+        [TestMethod]
+        public void Compute_TotalsCountWholeRoster_RegardlessOfShift()
+        {
+            var roster = new List<AlliedMonster>
+            {
+                Day(MonsterJob.Farming), Day(MonsterJob.None), Night(MonsterJob.Cooking)
+            };
+
+            var day = MonsterInfoStats.Compute(roster, false);
+            var night = MonsterInfoStats.Compute(roster, true);
+
+            Assert.AreEqual(2, day.TotalDaytime);
+            Assert.AreEqual(1, day.TotalNighttime);
+            Assert.AreEqual(2, night.TotalDaytime, "totals must not depend on the current shift");
+            Assert.AreEqual(1, night.TotalNighttime);
+        }
+
+        [TestMethod]
+        public void Compute_TotalsAcceptLocalizedKeyForm()
+        {
+            var roster = new List<AlliedMonster> { Make("Monster_Orc", MonsterJob.None) };
+
+            var stats = MonsterInfoStats.Compute(roster, true);
+
+            Assert.AreEqual(0, stats.TotalDaytime);
+            Assert.AreEqual(1, stats.TotalNighttime);
+            Assert.AreEqual(1, stats.IdleWorkers, "the Monster_ prefix must not hide the night shift");
+        }
+
+        [TestMethod]
+        public void Compute_DayShift_CountsOnlyDaytimeMonstersAsWorkers()
+        {
+            var roster = new List<AlliedMonster>
+            {
+                Day(MonsterJob.Farming), Day(MonsterJob.Farming),
+                Day(MonsterJob.Cooking),
+                Day(MonsterJob.None),
+                Night(MonsterJob.Farming), Night(MonsterJob.None)
+            };
+
+            var stats = MonsterInfoStats.Compute(roster, false);
+
+            Assert.AreEqual(2, stats.FarmWorkers);
+            Assert.AreEqual(1, stats.KitchenWorkers);
+            Assert.AreEqual(1, stats.IdleWorkers);
+        }
+
+        [TestMethod]
+        public void Compute_NightShift_CountsOnlyNocturnalMonstersAsWorkers()
+        {
+            var roster = new List<AlliedMonster>
+            {
+                Day(MonsterJob.Farming), Day(MonsterJob.None),
+                Night(MonsterJob.Farming),
+                Night(MonsterJob.Cooking), Night(MonsterJob.Cooking),
+                Night(MonsterJob.None), Night(MonsterJob.None)
+            };
+
+            var stats = MonsterInfoStats.Compute(roster, true);
+
+            Assert.AreEqual(1, stats.FarmWorkers);
+            Assert.AreEqual(2, stats.KitchenWorkers);
+            Assert.AreEqual(2, stats.IdleWorkers);
+        }
+
+        [TestMethod]
+        public void Compute_AwakeFishingMonster_CountsInNoWorkerLine()
+        {
+            var roster = new List<AlliedMonster> { Day(MonsterJob.Fishing) };
+
+            var stats = MonsterInfoStats.Compute(roster, false);
+
+            Assert.AreEqual(1, stats.TotalDaytime);
+            Assert.AreEqual(0, stats.FarmWorkers);
+            Assert.AreEqual(0, stats.KitchenWorkers);
+            Assert.AreEqual(0, stats.IdleWorkers, "Fishing has no work loop, but it is still a job");
+        }
+    }
+}

--- a/PitHero/Content/Localization/en-us/UI.txt
+++ b/PitHero/Content/Localization/en-us/UI.txt
@@ -322,7 +322,7 @@ ButtonAddMonsters,Add Monsters
 AddMonsterWindowTitle,Add Monsters
 AddMonsterRemainingSpace,Remaining Space: {0}
 AddMonsterDaytimeLabel,Daytime
-AddMonsterNocturnalLabel,Nocturnal
+AddMonsterNighttimeLabel,Nighttime
 TabAutomation,Automation
 SettingsAutomateMonsterJobs,Automate monster jobs
 SettingsAutomateMonsterJobsTooltip,Monster job assignments are handled automatically.  Player can't assign monster jobs when this is enabled
@@ -450,3 +450,11 @@ WindowRefrigerator,Refrigerator
 FridgePreStockStackSize,Pre-Stock Stack Size: {0}
 FridgePreStockStackSizeTooltip,Maintain this many stacks of each available crop for use in cooking
 ButtonSendToCropStorage,Send to Crop Storage
+
+# Monster Info (issue #394)
+WindowMonsterInfo,Monster Info
+MonsterInfoTotalDaytime,Total Daytime Monsters:
+MonsterInfoTotalNighttime,Total Nighttime Monsters:
+MonsterInfoFarmWorkers,Current Farm Workers:
+MonsterInfoKitchenWorkers,Current Kitchen Workers:
+MonsterInfoIdleWorkers,Current Idle Workers:

--- a/PitHero/UI/AddMonsterDialog.cs
+++ b/PitHero/UI/AddMonsterDialog.cs
@@ -135,7 +135,7 @@ namespace PitHero.UI
             var actorsAtlas = TryLoadActorsAtlas();
 
             AddSection(GetText(UITextKey.AddMonsterDaytimeLabel), daytime, actorsAtlas, remaining);
-            AddSection(GetText(UITextKey.AddMonsterNocturnalLabel), nocturnal, actorsAtlas, remaining);
+            AddSection(GetText(UITextKey.AddMonsterNighttimeLabel), nocturnal, actorsAtlas, remaining);
         }
 
         private void AddSection(string header, List<IEnemy> monsters, Nez.Sprites.SpriteAtlas actorsAtlas, int remaining)

--- a/PitHero/UI/MonsterInfoPanel.cs
+++ b/PitHero/UI/MonsterInfoPanel.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Nez;
+using Nez.UI;
+using PitHero.Services;
+using RolePlayingFramework.AlliedMonsters;
+
+namespace PitHero.UI
+{
+    /// <summary>
+    /// Compact "Monster Info" card docked to the right of the aggregate Monsters window (issue #394).
+    /// Shows the roster's daytime/nighttime totals plus the farm/kitchen/idle split of the shift that
+    /// is currently awake.
+    /// </summary>
+    public class MonsterInfoPanel : Window
+    {
+        private const float ContentPadding = 6f;
+        private const float CaptionGap = 12f;
+
+        private static readonly Color BrownColor = new Color(71, 36, 7);
+
+        private readonly Table _contentTable;
+        private readonly Label _daytimeValue;
+        private readonly Label _nighttimeValue;
+        private readonly Label _farmValue;
+        private readonly Label _kitchenValue;
+        private readonly Label _idleValue;
+
+        private TextService _textService;
+
+        public MonsterInfoPanel(Skin skin) : base("", skin)
+        {
+            SetMovable(false);
+            SetResizable(false);
+            SetKeepWithinStage(false);
+
+            GetTitleLabel().SetText(GetText(UITextKey.WindowMonsterInfo));
+
+            _contentTable = new Table();
+            _contentTable.Top().Left();
+
+            _daytimeValue   = AddStatRow(UITextKey.MonsterInfoTotalDaytime);
+            _nighttimeValue = AddStatRow(UITextKey.MonsterInfoTotalNighttime);
+            _farmValue      = AddStatRow(UITextKey.MonsterInfoFarmWorkers);
+            _kitchenValue   = AddStatRow(UITextKey.MonsterInfoKitchenWorkers);
+            _idleValue      = AddStatRow(UITextKey.MonsterInfoIdleWorkers);
+
+            Add(_contentTable).Expand().Fill().Pad(ContentPadding);
+            SetVisible(false);
+            Pack();
+        }
+
+        /// <summary>Recomputes the counts from the roster and resizes the card to fit.</summary>
+        public void Refresh(IReadOnlyList<AlliedMonster> roster, bool isNighttime)
+        {
+            var stats = MonsterInfoStats.Compute(roster, isNighttime);
+            _daytimeValue.SetText(stats.TotalDaytime.ToString());
+            _nighttimeValue.SetText(stats.TotalNighttime.ToString());
+            _farmValue.SetText(stats.FarmWorkers.ToString());
+            _kitchenValue.SetText(stats.KitchenWorkers.ToString());
+            _idleValue.SetText(stats.IdleWorkers.ToString());
+            Pack();
+        }
+
+        /// <summary>Adds a caption/value row and returns the value label for later updates.</summary>
+        private Label AddStatRow(string captionKey)
+        {
+            var valueLabel = new Label("0", BrownStyle());
+            _contentTable.Add(new Label(GetText(captionKey), BrownStyle())).Left().SetPadRight(CaptionGap);
+            _contentTable.Add(valueLabel).Right().SetExpandX();
+            _contentTable.Row();
+            return valueLabel;
+        }
+
+        private static LabelStyle BrownStyle() =>
+            new LabelStyle { Font = Graphics.Instance.BitmapFont, FontColor = BrownColor };
+
+        private string GetText(string key)
+        {
+            if (_textService == null && Core.Services != null)
+                _textService = Core.Services.GetService<TextService>();
+            return _textService?.DisplayText(TextType.UI, key) ?? key;
+        }
+    }
+}

--- a/PitHero/UI/MonsterInfoStats.cs
+++ b/PitHero/UI/MonsterInfoStats.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using PitHero.Config;
+using RolePlayingFramework.AlliedMonsters;
+
+namespace PitHero.UI
+{
+    /// <summary>
+    /// Aggregate headcounts for the Monster Info card (issue #394): roster totals per shift plus the
+    /// farm/kitchen/idle split of whichever shift is currently awake. Pure and Core-free so it can be
+    /// unit tested headless.
+    /// </summary>
+    public struct MonsterInfoStats
+    {
+        /// <summary>Monsters whose type works the day shift (6AM-10PM), asleep ones included.</summary>
+        public int TotalDaytime;
+
+        /// <summary>Monsters whose type works the night shift (10PM-6AM), asleep ones included.</summary>
+        public int TotalNighttime;
+
+        /// <summary>Awake monsters currently assigned to farming.</summary>
+        public int FarmWorkers;
+
+        /// <summary>Awake monsters currently assigned to the kitchen.</summary>
+        public int KitchenWorkers;
+
+        /// <summary>Awake monsters holding no job at all.</summary>
+        public int IdleWorkers;
+
+        /// <summary>
+        /// Counts the roster. Totals span the whole roster; the three worker counts only cover the
+        /// shift that is awake at <paramref name="isNighttime"/>. A monster assigned to Fishing (no
+        /// work loop yet) counts in none of the three worker lines.
+        /// </summary>
+        public static MonsterInfoStats Compute(IReadOnlyList<AlliedMonster> roster, bool isNighttime)
+        {
+            var stats = new MonsterInfoStats();
+            if (roster == null)
+                return stats;
+
+            for (int i = 0; i < roster.Count; i++)
+            {
+                var monster = roster[i];
+                if (monster == null)
+                    continue;
+
+                bool nocturnal = MonsterScheduleConfig.IsNocturnal(monster.MonsterTypeName);
+                if (nocturnal)
+                    stats.TotalNighttime++;
+                else
+                    stats.TotalDaytime++;
+
+                // Mirrors MonsterScheduleConfig.IsAsleep without needing an InGameTimeService.
+                if (nocturnal != isNighttime)
+                    continue;
+
+                switch (monster.Job)
+                {
+                    case MonsterJob.Farming: stats.FarmWorkers++; break;
+                    case MonsterJob.Cooking: stats.KitchenWorkers++; break;
+                    case MonsterJob.None:    stats.IdleWorkers++;   break;
+                }
+            }
+
+            return stats;
+        }
+    }
+}

--- a/PitHero/UI/MonsterUI.cs
+++ b/PitHero/UI/MonsterUI.cs
@@ -41,7 +41,14 @@ namespace PitHero.UI
         // Aggregate view only: one page per Monster House. Empty in the per-house view.
         private PagerRow _pagerRow;
 
+        // Aggregate view only: workforce summary card docked to the right of the roster window.
+        private MonsterInfoPanel _infoPanel;
+        // Pre-allocated so the per-frame dismissal poll never allocates.
+        private System.Collections.Generic.List<Element> _dismissEnvelope;
+
         private const float SpriteSize = 32f;
+        // Gap between the roster window and the info card, matching HeroCrystalCard's dock spacing.
+        private const float InfoPanelGap = 10f;
         private static readonly Color BrownColor = new Color(71, 36, 7);
         private static LabelStyle BrownStyle() => new LabelStyle { Font = Graphics.Instance.BitmapFont, FontColor = BrownColor };
 
@@ -182,6 +189,9 @@ namespace PitHero.UI
 
             _monsterWindow.Add(content).Expand().Fill();
             _monsterWindow.SetVisible(false);
+
+            _infoPanel = new MonsterInfoPanel(skin);
+            _dismissEnvelope = new System.Collections.Generic.List<Element>(2) { _monsterWindow, _infoPanel };
         }
 
         private void ToggleMonsterWindow()
@@ -194,6 +204,9 @@ namespace PitHero.UI
                 _stage.AddElement(_monsterWindow);
                 _monsterWindow.SetVisible(true);
                 _monsterWindow.ToFront();
+                // Added after the roster window so the card sits above it when the two overlap.
+                _stage.AddElement(_infoPanel);
+                _infoPanel.ToFront();
                 PositionWindow();
                 var pauseService = Core.Services.GetService<PauseService>();
                 if (pauseService != null)
@@ -206,6 +219,8 @@ namespace PitHero.UI
                 UIWindowManager.OnUIWindowClosing();
                 _monsterWindow.SetVisible(false);
                 _monsterWindow.Remove();
+                _infoPanel.SetVisible(false);
+                _infoPanel.Remove();
                 var pauseService = Core.Services.GetService<PauseService>();
                 if (pauseService != null)
                     pauseService.IsPaused = false;
@@ -263,8 +278,15 @@ namespace PitHero.UI
             var manager = Core.Services.GetService<AlliedMonsterManager>();
             bool jobsAutomated = Core.Services.GetService<Services.AutoJobAssignmentService>()?.Enabled ?? false;
             // One-shot: the monster window pauses the game so the clock can't cross 10 PM while open.
-            bool kitchenClosed = TavernScheduleConfig.IsKitchenClosed(
-                Core.Services?.GetService<Services.InGameTimeService>()?.Hour ?? 12);
+            var timeService = Core.Services?.GetService<InGameTimeService>();
+            bool kitchenClosed = TavernScheduleConfig.IsKitchenClosed(timeService?.Hour ?? 12);
+
+            // The workforce summary belongs to the aggregate view only; the per-house view lists a
+            // subset that the roster-wide totals would not describe.
+            bool aggregateView = _houseFilterId < 0;
+            _infoPanel.SetVisible(aggregateView);
+            if (aggregateView)
+                _infoPanel.Refresh(manager?.AlliedMonsters, timeService?.IsNighttime ?? false);
 
             // One page per Monster House in the aggregate view; the per-house view is never paged.
             var houses = GetMonsterHouses();
@@ -388,7 +410,6 @@ namespace PitHero.UI
                 textTable.Add(statsLabel).Left();
 
                 // Show a red, waving "Sleeping" label when the monster is outside its work window.
-                var timeService = Core.Services?.GetService<InGameTimeService>();
                 if (MonsterScheduleConfig.IsAsleep(monster.MonsterTypeName, timeService))
                 {
                     var sleepStyle = (_skin?.Get<LabelStyle>("ph-sleeping"))
@@ -506,8 +527,13 @@ namespace PitHero.UI
             float stageW = _stage.GetWidth();
             float stageH = _stage.GetHeight();
 
+            // The info card docks to the right of the roster window, so the pair is placed as one
+            // block — otherwise the flip-to-the-left fallback would still leave the card off-stage.
+            bool infoShown = _infoPanel != null && _infoPanel.IsVisible();
+            float blockW = winW + (infoShown ? InfoPanelGap + _infoPanel.GetWidth() : 0f);
+
             float winX = btnX + btnW + 4f;
-            if (winX + winW > stageW) winX = btnX - 4f - winW;
+            if (winX + blockW > stageW) winX = btnX - 4f - blockW;
             if (winX < 0) winX = 0;
 
             float winY = _monsterButton.GetY() + 4f;
@@ -515,6 +541,15 @@ namespace PitHero.UI
             if (winY < 0) winY = 0;
 
             _monsterWindow.SetPosition(winX, winY);
+
+            if (infoShown)
+            {
+                float infoY = winY;
+                float infoH = _infoPanel.GetHeight();
+                if (infoY + infoH > stageH) infoY = stageH - infoH;
+                if (infoY < 0) infoY = 0;
+                _infoPanel.SetPosition(winX + winW + InfoPanelGap, infoY);
+            }
         }
 
         /// <summary>Sets the position of the monster icon button.</summary>
@@ -539,6 +574,8 @@ namespace PitHero.UI
                 UIWindowManager.OnUIWindowClosing();
                 _monsterWindow?.SetVisible(false);
                 _monsterWindow?.Remove();
+                _infoPanel?.SetVisible(false);
+                _infoPanel?.Remove();
                 var pauseService = Core.Services.GetService<PauseService>();
                 if (pauseService != null)
                     pauseService.IsPaused = false;
@@ -620,7 +657,9 @@ namespace PitHero.UI
             if (ConfirmationDialog.AnyVisible) return;
             // Clicks on the window's own top-bar button are the toggle handler's job, not ours
             if (OutsideClickDismissal.IsMouseInside(_monsterButton, _stage)) return;
-            if (OutsideClickDismissal.ShouldDismiss(_monsterWindow, _stage, _windowShownFrame))
+            // Envelope of the roster window plus the info card: a click on the card, or in the gap
+            // between the two, is inside this UI and must not close it.
+            if (OutsideClickDismissal.ShouldDismiss(_dismissEnvelope, _stage, _windowShownFrame))
                 ToggleMonsterWindow();
         }
     }

--- a/PitHero/UITextKey.cs
+++ b/PitHero/UITextKey.cs
@@ -330,8 +330,14 @@ namespace PitHero
         public const string AddMonsterWindowTitle = "AddMonsterWindowTitle";
         public const string AddMonsterRemainingSpace = "AddMonsterRemainingSpace";
         public const string AddMonsterDaytimeLabel = "AddMonsterDaytimeLabel";
-        public const string AddMonsterNocturnalLabel = "AddMonsterNocturnalLabel";
+        public const string AddMonsterNighttimeLabel = "AddMonsterNighttimeLabel";
         public const string AddMonsterConfirmPrompt = "AddMonsterConfirmPrompt";
+        public const string WindowMonsterInfo = "WindowMonsterInfo";
+        public const string MonsterInfoTotalDaytime = "MonsterInfoTotalDaytime";
+        public const string MonsterInfoTotalNighttime = "MonsterInfoTotalNighttime";
+        public const string MonsterInfoFarmWorkers = "MonsterInfoFarmWorkers";
+        public const string MonsterInfoKitchenWorkers = "MonsterInfoKitchenWorkers";
+        public const string MonsterInfoIdleWorkers = "MonsterInfoIdleWorkers";
         public const string ConsoleTrapTriggered = "ConsoleTrapTriggered";
         public const string ConsoleTrapDisarmed = "ConsoleTrapDisarmed";
         public const string TabAutomation = "TabAutomation";


### PR DESCRIPTION
Closes #394.

## What

Adds a compact **Monster Info** card docked to the right of the Monsters window when it is opened from the top bar, and renames the Add Monsters section header **Nocturnal** → **Nighttime**.

The card shows:

- Total Daytime Monsters
- Total Nighttime Monsters
- Current Farm Workers
- Current Kitchen Workers
- Current Idle Workers

## Design notes

- **Totals span the whole roster** (asleep monsters included); only the three worker lines are scoped to the shift that is awake at the current hour.
- **Idle means `Job == MonsterJob.None`.** A monster assigned to `Fishing` counts in none of the three worker lines — the enum value exists but has no work loop yet — so the three lines deliberately do not sum to the awake headcount.
- **Aggregate view only.** The card is hidden in the per-house view reached from a Monster House's "Show" action, which lists a subset that roster-wide totals would not describe.
- **The roster window and the card are positioned as one block.** `PositionWindow` already flips the roster window to the *left* of the top-bar button when it would overflow the stage, and stage width varies per monitor, so docking the card independently would strand it off-screen after that flip.
- **Dismissal** moves to the existing multi-window `OutsideClickDismissal.ShouldDismiss(List<Element>, …)` overload (built for the paired shop panels). It tests the bounding envelope, so a click on the card, or in the gap between the two windows, no longer closes the roster.
- The "Nocturnal" → "Nighttime" change is display-only: `MonsterScheduleConfig.IsNocturnal` and `GameConfig.NocturnalMonsterAddCostGold` keep their names.

No save-format change and no gameplay logic change.

## Files

| File | |
|---|---|
| `PitHero/UI/MonsterInfoStats.cs` | new — pure, Core-free count; one `for` loop, no LINQ, no allocation |
| `PitHero/UI/MonsterInfoPanel.cs` | new — `Window` card, built on the `HeroCrystalCard` dock pattern |
| `PitHero/UI/MonsterUI.cs` | owns, positions and dismisses the card; hoists the per-row `InGameTimeService` lookup out of the loop |
| `PitHero/UI/AddMonsterDialog.cs`, `UITextKey.cs`, `Content/Localization/en-us/UI.txt` | six new keys + the Nighttime rename |
| `PitHero.Tests/UI/MonsterInfoStatsTests.cs` | new — 7 tests |

## Testing

- `dotnet build PitHero.sln` — 0 errors (warning count unchanged).
- `dotnet test` — **2000 passed, 0 failed**, 6 skipped. New coverage: shift-independent totals, the `Monster_` prefixed type-name form, day/night worker splits, Fishing excluded from all three lines, null/empty roster.

**Not verified in-game.** Reaching `MainGameScene` needs mouse input on the title menu, so the card's on-screen appearance and behavior still want a manual pass: open the Monsters window (top-bar icon or `M`) and check the card sits flush right with matching top edges, click a job button to see the counts move, and confirm "Show" from a Monster House hides it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)