### PR TITLE
New-game intro: hero falls from the sky at the hero statue

### DIFF
--- a/PitHero.Tests/NewGameIntroTests.cs
+++ b/PitHero.Tests/NewGameIntroTests.cs
@@ -1,0 +1,80 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.ECS.Components;
+using PitHero.Services;
+
+namespace PitHero.Tests
+{
+    /// <summary>Pure-math coverage for the new-game intro drop (issue #396).</summary>
+    [TestClass]
+    public class NewGameIntroTests
+    {
+        [TestMethod]
+        public void ComputeFallHeight_AtStart_ReturnsStartHeight()
+        {
+            Assert.AreEqual(290f, NewGameIntroService.ComputeFallHeight(290f, 0f), 0.0001f);
+        }
+
+        [TestMethod]
+        public void ComputeFallHeight_AtEnd_ReturnsZero()
+        {
+            Assert.AreEqual(0f, NewGameIntroService.ComputeFallHeight(290f, 1f), 0.0001f);
+        }
+
+        [TestMethod]
+        public void ComputeFallHeight_ClampsTimeOutsideUnitRange()
+        {
+            Assert.AreEqual(290f, NewGameIntroService.ComputeFallHeight(290f, -0.5f), 0.0001f);
+            Assert.AreEqual(0f, NewGameIntroService.ComputeFallHeight(290f, 1.5f), 0.0001f);
+        }
+
+        [TestMethod]
+        public void ComputeFallHeight_IsNonIncreasingAndGravityEased()
+        {
+            float previous = NewGameIntroService.ComputeFallHeight(100f, 0f);
+            for (int i = 1; i <= 20; i++)
+            {
+                float t = i / 20f;
+                float height = NewGameIntroService.ComputeFallHeight(100f, t);
+                Assert.IsTrue(height <= previous, $"height increased at t={t}");
+                previous = height;
+            }
+
+            // Ease-in: the first half of the drop covers less distance than the second half
+            float atHalf = NewGameIntroService.ComputeFallHeight(100f, 0.5f);
+            Assert.IsTrue(100f - atHalf < atHalf, "expected a gravity-style ease-in");
+        }
+
+        [TestMethod]
+        public void ComputeFallStartHeight_StatueTileAtDefaultZoom()
+        {
+            // Hero at world Y 208 (tile 6), visible top at 12 (camera Y 192, 360px render target, 1x zoom),
+            // 46px composite sprite, 48px margin
+            Assert.AreEqual(290f, NewGameIntroService.ComputeFallStartHeight(208f, 12f, 46f, 48f), 0.0001f);
+        }
+
+        [TestMethod]
+        public void ComputeFallStartHeight_NeverBelowSpritePlusMargin()
+        {
+            // Hero already above the visible top edge: still drop at least sprite + margin
+            Assert.AreEqual(94f, NewGameIntroService.ComputeFallStartHeight(0f, 400f, 46f, 48f), 0.0001f);
+        }
+
+        [TestMethod]
+        public void ComputeVisibleWorldTop_DefaultZoom()
+        {
+            Assert.AreEqual(12f, CameraControllerComponent.ComputeVisibleWorldTop(192f, 360, 1f), 0.0001f);
+        }
+
+        [TestMethod]
+        public void ComputeVisibleWorldTop_ZoomedOutShowsMoreWorldAbove()
+        {
+            Assert.AreEqual(-528f, CameraControllerComponent.ComputeVisibleWorldTop(192f, 360, 0.25f), 0.0001f);
+        }
+
+        [TestMethod]
+        public void ComputeVisibleWorldTop_ZeroZoomFallsBackToOne()
+        {
+            Assert.AreEqual(12f, CameraControllerComponent.ComputeVisibleWorldTop(192f, 360, 0f), 0.0001f);
+        }
+    }
+}

--- a/PitHero/AI/WalkToStatueForCrystalAction.cs
+++ b/PitHero/AI/WalkToStatueForCrystalAction.cs
@@ -13,8 +13,8 @@ namespace PitHero.AI
     /// </summary>
     public class WalkToStatueForCrystalAction : HeroActionBase
     {
-        private const int StatueTileX = 112;
-        private const int StatueTileY = 6;
+        private const int StatueTileX = GameConfig.HeroStatueStandTileX;
+        private const int StatueTileY = GameConfig.HeroStatueStandTileY;
         private ICoroutine _walkCoroutine;
 
         public WalkToStatueForCrystalAction() : base(GoapConstants.WalkToStatueForCrystalAction, 1)

--- a/PitHero/Content/Localization/en-us/Dialogue.txt
+++ b/PitHero/Content/Localization/en-us/Dialogue.txt
@@ -24,6 +24,7 @@ HeroRespawnStronger,Each defeat makes me stronger.
 HeroRespawnOuch,Ouch! That'll leave a mark!
 HeroRespawnNotAsPlanned,That didn't go as planned...
 HeroCeremonyGrantStrength,Guardian Spirit, show me a new path!
+HeroIntroDestiny,Guardian Spirit, help me fulfill my destiny!
 PatronOrderIllHave,I'll have a {0}
 PatronOrderOnePlease,One {0} please
 PatronPaidDelicious,That was delicious!

--- a/PitHero/DialogueTextKey.cs
+++ b/PitHero/DialogueTextKey.cs
@@ -30,6 +30,7 @@ namespace PitHero
         public const string HeroRespawnOuch               = "HeroRespawnOuch";
         public const string HeroRespawnNotAsPlanned       = "HeroRespawnNotAsPlanned";
         public const string HeroCeremonyGrantStrength     = "HeroCeremonyGrantStrength";
+        public const string HeroIntroDestiny              = "HeroIntroDestiny";
 
         // Wave 3 — patron
         public const string PatronOrderIllHave            = "PatronOrderIllHave";

--- a/PitHero/ECS/Components/CameraControllerComponent.cs
+++ b/PitHero/ECS/Components/CameraControllerComponent.cs
@@ -26,6 +26,14 @@ namespace PitHero.ECS.Components
         private float _keyboardPanHeldTime = 0f; // continuous seconds arrow/WASD pan keys have been held
         private Vector2 _keyboardPanRemainder; // banked sub-pixel movement released in whole-pixel steps
         private Entity _heroEntity; // cached reference to hero entity
+        private bool _hasPendingCenter; // CenterOnWorldPosition called before OnAddedToEntity initialised the camera
+        private Vector2 _pendingCenter;
+
+        /// <summary>
+        /// While true every input path (zoom, pan, quadrant/keyboard pan, hero following) is skipped;
+        /// the camera stays wherever it was put. Used by the new-game intro (issue #396).
+        /// </summary>
+        public bool InputSuspended { get; set; }
 
         /// <summary>
         /// Optional hook set by the scene; returns true when the pointer is over a UI element.
@@ -58,7 +66,9 @@ namespace PitHero.ECS.Components
                 _camera.RawZoom = GameConfig.CameraDefaultZoom;
                 _defaultCameraPosition = ConstrainCameraPosition(new Vector2(
                     _tileMapBounds.X + _tileMapBounds.Width / 2f, GameConfig.VirtualHeight / 2f));
-                _camera.Position = _defaultCameraPosition;
+                // A centre requested during scene setup (before this deferred init) wins over the default
+                _camera.Position = _hasPendingCenter ? ConstrainCameraPosition(_pendingCenter) : _defaultCameraPosition;
+                _hasPendingCenter = false;
                 QuantizeCameraPosition();
             }
         }
@@ -77,6 +87,10 @@ namespace PitHero.ECS.Components
                 _camera.Position = ConstrainCameraPosition(_camera.Position);
                 QuantizeCameraPosition();
             }
+
+            // Scripted sequences (new-game intro) own the camera: no input, no hero following
+            if (InputSuspended)
+                return;
 
             // Only the manual (menu) pause freezes the camera; the farm-mode pause keeps camera
             // controls live so the player can right-mouse pan while planning crops.
@@ -574,6 +588,44 @@ namespace PitHero.ECS.Components
                 desiredPosition.Y = MathHelper.Clamp(desiredPosition.Y, minY, maxY);
 
             return desiredPosition;
+        }
+
+        /// <summary>
+        /// Centers the camera on a world position (clamped to the map). Safe to call during scene
+        /// setup before the camera is initialised: the request is latched and applied in
+        /// OnAddedToEntity instead of the default map-center position. Does not switch to manual
+        /// control, so hero auto-follow (if enabled) resumes seamlessly afterwards.
+        /// </summary>
+        public void CenterOnWorldPosition(Vector2 worldPosition)
+        {
+            if (_camera == null)
+            {
+                _pendingCenter = worldPosition;
+                _hasPendingCenter = true;
+                return;
+            }
+
+            _camera.Position = ConstrainCameraPosition(worldPosition);
+            QuantizeCameraPosition();
+        }
+
+        /// <summary>
+        /// World-space Y of the top edge of the visible area, computed from the scene render target
+        /// (not Camera.Bounds, which reads the backbuffer viewport when called outside Scene.Update).
+        /// </summary>
+        public float GetVisibleWorldTop()
+        {
+            if (_camera == null)
+                return _tileMapBounds.Y;
+            return ComputeVisibleWorldTop(_camera.Position.Y, GetSceneRenderTargetSize().Y, _camera.RawZoom);
+        }
+
+        /// <summary>Pure helper: visible top edge for a camera centre Y, render-target height and zoom</summary>
+        public static float ComputeVisibleWorldTop(float cameraY, int renderTargetHeight, float zoom)
+        {
+            if (zoom <= 0f)
+                zoom = 1f;
+            return cameraY - (renderTargetHeight / zoom) * 0.5f;
         }
 
         /// <summary>

--- a/PitHero/ECS/Components/HeroJumpComponent.cs
+++ b/PitHero/ECS/Components/HeroJumpComponent.cs
@@ -116,16 +116,31 @@ namespace PitHero.ECS.Components
                 return;
             }
 
-            UpdateJumpVerticalOffset(progress);
+            if (progress < 0f) progress = 0f;
+            var heightFactor = 4f * progress * (1f - progress);
+            SetAirborneHeight(MAX_JUMP_HEIGHT_PX * heightFactor);
         }
 
         /// <summary>Starts a jump in a direction for duration</summary>
         public void StartJump(Direction direction, float duration)
         {
-            _jumpDirection = direction;
             _jumpDuration = duration;
             _jumpStartTime = Time.TotalTime;
             _isJumping = true;
+
+            if (BeginAirbornePose(direction))
+                Debug.Log($"[HeroJumpComponent] Started jump animation for direction {direction} with duration {duration}s");
+        }
+
+        /// <summary>
+        /// Puts the hero into the airborne look without any timing: faces the direction, plays the
+        /// per-layer jump pose, shows the ground shadow and records the rest offset that
+        /// <see cref="SetAirborneHeight"/> lifts from. Returns false when graphics are unavailable
+        /// (headless tests). Used by StartJump and by scripted drops such as the new-game intro.
+        /// </summary>
+        public bool BeginAirbornePose(Direction direction)
+        {
+            _jumpDirection = direction;
 
             // Update facing
             var facing = Entity.GetComponent<ActorFacingComponent>();
@@ -139,8 +154,8 @@ namespace PitHero.ECS.Components
 
             if (_multiSpriteAnimator == null && (_heroAnimators.Count == 0 || _actorsAtlas == null))
             {
-                Debug.Warn("[HeroJumpComponent] StartJump called but graphics components not available (this is normal in tests)");
-                return;
+                Debug.Warn("[HeroJumpComponent] BeginAirbornePose called but graphics components not available (this is normal in tests)");
+                return false;
             }
 
             // Arc offset lives on the composite's LocalOffset when present; otherwise per-layer.
@@ -148,21 +163,48 @@ namespace PitHero.ECS.Components
                 ? _multiSpriteAnimator.LocalOffset.Y
                 : (_heroAnimators.Count > 0 ? _heroAnimators[0].LocalOffset.Y : 0f);
 
-            foreach (var animator in _heroAnimators)
-                animator?.PlayJumpAnimation(direction);
+            for (int i = 0; i < _heroAnimators.Count; i++)
+                _heroAnimators[i]?.PlayJumpAnimation(direction);
 
             if (_shadowRenderer != null)
                 _shadowRenderer.SetEnabled(true);
 
-            Debug.Log($"[HeroJumpComponent] Started jump animation for direction {direction} with duration {duration}s");
+            return true;
         }
 
-        /// <summary>Ends current jump</summary>
-        public void EndJump()
+        /// <summary>
+        /// Lifts the hero sprite heightPx above its rest offset. Render-only: the entity (collider,
+        /// pathfinding, bubble anchor) does not move.
+        /// </summary>
+        public void SetAirborneHeight(float heightPx)
         {
-            if (!_isJumping) return;
-            _isJumping = false;
+            if (_heroAnimators == null)
+                InitializeAnimators();
 
+            if (heightPx < 0f) heightPx = 0f;
+            var yOffset = _initialYOffset - heightPx;
+
+            if (_multiSpriteAnimator != null)
+            {
+                _multiSpriteAnimator.LocalOffset = new Vector2(0f, yOffset);
+            }
+            else
+            {
+                for (int i = 0; i < _heroAnimators.Count; i++)
+                {
+                    var animator = _heroAnimators[i];
+                    if (animator != null)
+                        animator.SetLocalOffset(new Vector2(animator.LocalOffset.X, yOffset));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Restores the grounded look: rest offset, walking animation for the airborne direction,
+        /// shadow hidden.
+        /// </summary>
+        public void EndAirbornePose()
+        {
             // Initialize _heroAnimators if null (may happen in tests)
             if (_heroAnimators == null)
             {
@@ -171,14 +213,22 @@ namespace PitHero.ECS.Components
 
             // Reset the arc offset — on the composite when present, per-layer in legacy path.
             if (_multiSpriteAnimator != null)
+            {
                 _multiSpriteAnimator.LocalOffset = new Vector2(0f, _initialYOffset);
+            }
             else
-                foreach (var animator in _heroAnimators)
+            {
+                for (int i = 0; i < _heroAnimators.Count; i++)
+                {
+                    var animator = _heroAnimators[i];
                     if (animator != null)
                         animator.SetLocalOffset(new Vector2(animator.LocalOffset.X, _initialYOffset));
+                }
+            }
 
-            foreach (var animator in _heroAnimators)
+            for (int i = 0; i < _heroAnimators.Count; i++)
             {
+                var animator = _heroAnimators[i];
                 if (animator != null)
                 {
                     animator.UpdateAnimationForDirection(_jumpDirection);
@@ -188,35 +238,17 @@ namespace PitHero.ECS.Components
 
             if (_shadowRenderer != null)
                 _shadowRenderer.SetEnabled(false);
-
-            Debug.Log("[HeroJumpComponent] Ended jump animation");
         }
 
-        /// <summary>Updates vertical offset along parabolic arc</summary>
-        private void UpdateJumpVerticalOffset(float progress)
+        /// <summary>Ends current jump</summary>
+        public void EndJump()
         {
-            if (_heroAnimators == null)
-                InitializeAnimators();
+            if (!_isJumping) return;
+            _isJumping = false;
 
-            if (progress < 0f) progress = 0f;
-            if (progress > 1f) progress = 1f;
+            EndAirbornePose();
 
-            var heightFactor = 4f * progress * (1f - progress);
-            var yOffset = _initialYOffset - (MAX_JUMP_HEIGHT_PX * heightFactor);
-
-            if (_multiSpriteAnimator != null)
-            {
-                _multiSpriteAnimator.LocalOffset = new Vector2(0f, yOffset);
-            }
-            else
-            {
-                if (_heroAnimators.Count == 0) return;
-                foreach (var animator in _heroAnimators)
-                {
-                    if (animator != null)
-                        animator.SetLocalOffset(new Vector2(animator.LocalOffset.X, yOffset));
-                }
-            }
+            Debug.Log("[HeroJumpComponent] Ended jump animation");
         }
 
         /// <summary>Returns true if jumping</summary>

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -52,6 +52,7 @@ namespace PitHero.ECS.Scenes
         private Entity _mercenarySelectBoxEntity; // Entity for rendering SelectBox over hovered mercenary
         private Entity _mercenaryNameLabelEntity; // Entity for rendering name above hovered mercenary
         private Services.HeroPromotionService _heroPromotionService; // Manages hero crystal promotion after death
+        private Services.NewGameIntroService _newGameIntroService; // Scripted new-game opening at the hero statue (issue #396)
         private EventConsolePanel _eventConsolePanel; // MMO-style event log panel in the lower-right corner
         private Rendering.ColorGradingController _colorGrading;
         private TillModeOverlay _tillModeOverlay;
@@ -264,6 +265,9 @@ namespace PitHero.ECS.Scenes
             if (_isInitializationComplete)
                 return;
 
+            // Captured up front: ApplyPendingLoadData() below clears PendingLoadData
+            bool isNewGame = SaveLoadService.PendingLoadData == null;
+
             LoadMap();
             SpawnPit();
 
@@ -272,7 +276,7 @@ namespace PitHero.ECS.Scenes
             // saved level.  Generating here first would create deferred entities that
             // ClearExistingPitEntities cannot find, producing a conflicting dual-state pit.
             var pitWidthManager = Core.Services.GetService<PitWidthManager>();
-            if (pitWidthManager != null && SaveLoadService.PendingLoadData == null)
+            if (pitWidthManager != null && isNewGame)
             {
                 // New game — ensure tier state is clean before setting the initial level.
                 pitWidthManager.SetPitTier(1);
@@ -280,7 +284,7 @@ namespace PitHero.ECS.Scenes
                 pitWidthManager.SetPitLevel(1);
             }
 
-            SpawnHero();
+            var hero = SpawnHero(isNewGame);
             SpawnHeroStatue();
             SpawnInnkeeper();
 
@@ -399,6 +403,11 @@ namespace PitHero.ECS.Scenes
             // scene swap never run their close path) and re-apply the persistent window size —
             // otherwise the deferred size restore never fires again after loading a save.
             UI.UIWindowManager.ResetForNewScene();
+
+            // A brand-new game opens with the hero dropping in at the statue (issue #396). Started
+            // last so the window size above is settled and every UI element exists.
+            if (isNewGame)
+                StartNewGameIntro(hero);
 
             _isInitializationComplete = true;
         }
@@ -1402,11 +1411,72 @@ namespace PitHero.ECS.Scenes
         }
 
         /// <summary>
-        /// Spawns the initial hero at tile (62, 6)
+        /// Spawns the initial hero. A new game starts at the hero statue's feet without a state
+        /// machine (the intro adds it when it ends); a loaded game spawns at tile (62, 6) as before.
         /// </summary>
-        private void SpawnHero()
+        private Entity SpawnHero(bool isNewGame)
         {
-            CreateHeroEntity(62, 6);
+            if (isNewGame)
+                return CreateHeroEntity(GameConfig.HeroStatueStandTileX, GameConfig.HeroStatueStandTileY, addStateMachine: false);
+            return CreateHeroEntity(62, 6);
+        }
+
+        /// <summary>True while the new-game intro sequence owns the HUD, input and hero</summary>
+        public bool IsIntroActive => _newGameIntroService != null && _newGameIntroService.IsActive;
+
+        /// <summary>
+        /// Kicks off the new-game intro: hides the hero until the drop is posed, locks the
+        /// presentation and launches the sequence coroutine.
+        /// </summary>
+        private void StartNewGameIntro(Entity hero)
+        {
+            if (hero == null)
+                return;
+
+            hero.GetComponent<MultiSpriteAnimator>()?.SetEnabled(false);
+            BeginIntroPresentation();
+            _newGameIntroService = new Services.NewGameIntroService(this, _cameraController);
+            _newGameIntroService.Start(hero);
+        }
+
+        /// <summary>
+        /// Hides every HUD element, locks input and parks the camera on the statue for the intro.
+        /// The camera centre is latched and applied by the controller's deferred init.
+        /// </summary>
+        private void BeginIntroPresentation()
+        {
+            _graphicalHUD?.SetEnabled(false);
+            _heroActionQueueViz?.SetEnabled(false);
+            _pitLevelLabel?.SetVisible(false);
+            _fundsLabel?.SetVisible(false);
+            _clockLabel?.SetVisible(false);
+            _settingsUI?.EnterIntroMode();
+
+            if (_cameraController != null)
+            {
+                _cameraController.InputSuspended = true;
+                _cameraController.CenterOnWorldPosition(new Vector2(
+                    GameConfig.HeroStatueStandTileX * GameConfig.TileSize + GameConfig.TileSize / 2f,
+                    GameConfig.HeroStatueStandTileY * GameConfig.TileSize + GameConfig.TileSize / 2f));
+            }
+        }
+
+        /// <summary>
+        /// Ends the intro presentation: restores the HUD and input, and gives the hero its GOAP state
+        /// machine so it plans its first pit trip from the statue (the pit-adventure bubble fires
+        /// naturally — the speech bubble component is long initialised by now).
+        /// </summary>
+        public void EndIntroPresentation(Entity hero)
+        {
+            _pitLevelLabel?.SetVisible(true);
+            _fundsLabel?.SetVisible(true);
+            _clockLabel?.SetVisible(true);
+            _settingsUI?.ExitIntroMode();
+            if (_cameraController != null)
+                _cameraController.InputSuspended = false;
+
+            if (hero != null && !hero.IsDestroyed && hero.GetComponent<HeroStateMachine>() == null)
+                hero.AddComponent(new HeroStateMachine());
         }
 
         /// <summary>
@@ -1494,7 +1564,7 @@ namespace PitHero.ECS.Scenes
         /// Creates a hero entity at the specified tile coordinates using HeroDesign for appearance.
         /// When needsCrystal is true, the hero spawns without a crystal and waits for the promotion ceremony.
         /// </summary>
-        private Entity CreateHeroEntity(int tileX, int tileY, bool needsCrystal = false)
+        private Entity CreateHeroEntity(int tileX, int tileY, bool needsCrystal = false, bool addStateMachine = true)
         {
             var designService = Core.Services.GetService<HeroDesignService>();
             var design = designService.GetDesign();
@@ -1611,7 +1681,10 @@ namespace PitHero.ECS.Scenes
             heroBouncyText.SetEnabled(false);
 
             hero.AddComponent(new Historian());
-            hero.AddComponent(new HeroStateMachine());
+            // The new-game intro adds the state machine when it ends: adding it here would plan the
+            // first pit trip immediately (Idle_Enter runs inside the deferred OnAddedToEntity).
+            if (addStateMachine)
+                hero.AddComponent(new HeroStateMachine());
             hero.AddComponent(new SpeechBubbleComponent());
             hero.AddComponent(new CharacterSelectorComponent());
 
@@ -1775,12 +1848,13 @@ namespace PitHero.ECS.Scenes
         }
 
         /// <summary>
-        /// Spawn the hero statue at tile coordinate (112, 6)
+        /// Spawn the hero statue sprite anchored at GameConfig.HeroStatueTileX/Y (112, 3). The
+        /// 181px-tall sprite's base lands on row 6, so heroes stand at HeroStatueStandTileX/Y (112, 6).
         /// </summary>
         private void SpawnHeroStatue()
         {
-            var tileX = 112;
-            var tileY = 3;
+            var tileX = GameConfig.HeroStatueTileX;
+            var tileY = GameConfig.HeroStatueTileY;
 
             var worldPos = new Vector2(
                 tileX * GameConfig.TileSize + GameConfig.TileSize / 2,
@@ -2760,7 +2834,9 @@ namespace PitHero.ECS.Scenes
 
             UpdatePlantingCropsLabel();
 
-            UpdateHeroHUD();
+            // The intro keeps the graphical HUD hidden; UpdateHeroHUD would re-enable it every frame
+            if (!IsIntroActive)
+                UpdateHeroHUD();
             UpdateHudFontMode();
 
             // Update shortcut bar position (handles offset when inventory open)
@@ -2769,18 +2845,21 @@ namespace PitHero.ECS.Scenes
             // Refresh shortcut bar to keep it in sync with inventory
             _shortcutBar?.RefreshItems();
 
-            // Handle keyboard shortcuts via shortcut bar
-            _shortcutBar?.HandleKeyboardShortcuts();
+            // Handle keyboard shortcuts via shortcut bar (suspended during the new-game intro)
+            if (!IsIntroActive)
+                _shortcutBar?.HandleKeyboardShortcuts();
 
             // Update mercenary manager
             var mercenaryManager = Core.Services.GetService<MercenaryManager>();
             mercenaryManager?.Update();
 
-            // Sync farming monster workers with job assignments
-            Core.Services.GetService<Services.FarmTaskCoordinator>()?.Update();
-
-            // Sync kitchen/tavern workers and ticket queue
-            Core.Services.GetService<Services.KitchenTaskCoordinator>()?.Update();
+            // Sync farming / kitchen workers with job assignments. Held during the new-game intro so
+            // the starter Slime stays inside its house until the hero has arrived (issue #396).
+            if (!IsIntroActive)
+            {
+                Core.Services.GetService<Services.FarmTaskCoordinator>()?.Update();
+                Core.Services.GetService<Services.KitchenTaskCoordinator>()?.Update();
+            }
 
             // Tick party dining (eat timers, auto-resume, reload restart)
             Core.Services.GetService<Services.PartyDiningService>()?.Update();

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -403,6 +403,20 @@ namespace PitHero
         public const int NewGameStarterSlimeFishingProficiency = 3;
         public const int NewGameStarterSlimeCookingProficiency = 3;
 
+        // Hero statue (issue #396): sprite anchor tile and the ground tile the hero stands on to pray
+        public const int HeroStatueTileX = 112;
+        public const int HeroStatueTileY = 3;
+        public const int HeroStatueStandTileX = 112;
+        public const int HeroStatueStandTileY = 6;
+
+        // New-game intro (issue #396): fall from the sky onto the statue tile, pray, lightning
+        public const float IntroFallDurationSeconds = 1.0f; // Gravity-eased drop from above the screen to the ground
+        public const float IntroPostLandingDelaySeconds = 0.5f; // Beat between touchdown and turning to the statue
+        public const float IntroPrayerDwellSeconds = 4.5f; // Must cover the HeroIntroDestiny bubble: 44 chars @ SpeechBubbleCharsPerSecond (20) = 2.2 s + SpeechBubbleLingerSeconds (2) = 4.2 s — change together
+        public const float IntroPostLightningDelaySeconds = 0.5f; // Beat after the strike before the HUD returns
+        public const float IntroFallOffscreenMarginPx = 48f; // Extra lift above the visible top edge (render target may still resize a few frames after a window restore)
+        public const int IntroAnimatorReadyMaxFrames = 10; // Frames to wait for the paperdoll animators to load (mirrors ApplySpawnSleepPoses)
+
         // Render Layers (the lower the number, the higher the layer)
 
         public const int RenderLayerLowest = 0; // Lowest possible layer

--- a/PitHero/Services/HeroPromotionService.cs
+++ b/PitHero/Services/HeroPromotionService.cs
@@ -103,7 +103,7 @@ namespace PitHero.Services
             yield return Coroutine.WaitForSeconds(3.5f);
 
             // Play lightning strike animation on the hero entity
-            yield return PlayLightningStrikeAtHero(heroEntity);
+            yield return Util.LightningStrikeEffect.PlayAt(_scene, heroEntity.Transform.Position);
 
             Debug.Log("[HeroPromotionService] Crystal ceremony lightning complete — granting crystal to hero");
 
@@ -212,41 +212,6 @@ namespace PitHero.Services
             // New job, new cycle: shrink the pit back to level 1 (waits for any mercenaries
             // still inside; the party followed the hero out, so this is normally immediate)
             (_scene as MainGameScene)?.StartPitResetForNewCycle();
-        }
-
-        /// <summary>
-        /// Plays the lightning strike animation centered on the hero entity
-        /// </summary>
-        private IEnumerator PlayLightningStrikeAtHero(Entity heroEntity)
-        {
-            Debug.Log("[HeroPromotionService] Playing lightning strike on hero");
-
-            var lightningEntity = _scene.CreateEntity("lightning-strike-hero");
-            lightningEntity.SetPosition(heroEntity.Transform.Position);
-
-            var actorsAtlas = Core.Content.LoadSpriteAtlas("Content/Atlases/Actors.atlas");
-            if (actorsAtlas == null)
-            {
-                Debug.Error("[HeroPromotionService] Failed to load Actors.atlas for hero lightning strike");
-                yield break;
-            }
-
-            var animator = lightningEntity.AddComponent<PausableSpriteAnimator>();
-            animator.AddAnimationsFromAtlas(actorsAtlas);
-            animator.SetRenderLayer(GameConfig.RenderLayerTop);
-
-            animator.Play("LightningStrike", Nez.Sprites.SpriteAnimator.LoopMode.Once);
-
-            float timeout = 5.0f;
-            float elapsed = 0f;
-            while (animator.IsRunning && elapsed < timeout)
-            {
-                yield return null;
-                elapsed += Time.DeltaTime;
-            }
-
-            lightningEntity.Destroy();
-            Debug.Log("[HeroPromotionService] Hero lightning strike complete");
         }
 
         /// <summary>

--- a/PitHero/Services/NewGameIntroService.cs
+++ b/PitHero/Services/NewGameIntroService.cs
@@ -1,0 +1,151 @@
+using System.Collections;
+using Nez;
+using PitHero.ECS.Components;
+using PitHero.ECS.Scenes;
+using PitHero.Util;
+using PitHero.Util.SoundEffectTypes;
+
+namespace PitHero.Services
+{
+    /// <summary>
+    /// Scripted new-game opening (issue #396): the hero drops from above the screen onto the tile at
+    /// the hero statue's feet, turns to the statue, prays, and is struck by the ceremony lightning.
+    /// The scene hides the HUD and blocks input for the duration (see
+    /// <see cref="MainGameScene.BeginIntroPresentation"/>) and adds the hero's GOAP state machine only
+    /// when the sequence ends, so the first pit trip starts from the statue.
+    /// Timing uses scaled time like the crystal ceremony; the sequence is not pause-aware (nothing
+    /// can pause the game while the HUD is locked).
+    /// </summary>
+    public class NewGameIntroService
+    {
+        private readonly MainGameScene _scene;
+        private readonly CameraControllerComponent _cameraController;
+
+        public NewGameIntroService(MainGameScene scene, CameraControllerComponent cameraController)
+        {
+            _scene = scene;
+            _cameraController = cameraController;
+        }
+
+        /// <summary>True from Start() until the sequence has handed control back to the scene</summary>
+        public bool IsActive { get; private set; }
+
+        /// <summary>
+        /// Launches the intro coroutine for the freshly spawned hero. The scene must already have
+        /// disabled the hero's MultiSpriteAnimator so no standing frame renders before the drop.
+        /// </summary>
+        public void Start(Entity hero)
+        {
+            if (IsActive || hero == null)
+                return;
+
+            IsActive = true;
+            Core.StartCoroutine(Run(hero));
+        }
+
+        /// <summary>
+        /// Gravity-style drop: remaining height above the ground at normalized time t (clamped to [0,1]).
+        /// </summary>
+        public static float ComputeFallHeight(float startHeight, float t)
+        {
+            if (t < 0f) t = 0f;
+            if (t > 1f) t = 1f;
+            return startHeight * (1f - t * t);
+        }
+
+        /// <summary>
+        /// Lift that starts the sprite fully above the visible top edge. Never less than
+        /// spriteHeightPx + marginPx so the drop reads even when the hero is already near the top.
+        /// </summary>
+        public static float ComputeFallStartHeight(float heroWorldY, float visibleWorldTop, float spriteHeightPx, float marginPx)
+        {
+            float height = heroWorldY - visibleWorldTop + spriteHeightPx + marginPx;
+            float minimum = spriteHeightPx + marginPx;
+            return height < minimum ? minimum : height;
+        }
+
+        private IEnumerator Run(Entity hero)
+        {
+            // Components initialise on the first scene update after creation; wait for the paperdoll
+            // animators (and the jump component's atlas/shadow) before posing. The camera controller
+            // also finishes its deferred init during this wait, so the visible-top query below is valid.
+            for (int frame = 0; frame < GameConfig.IntroAnimatorReadyMaxFrames; frame++)
+            {
+                yield return null;
+                if (hero.IsDestroyed)
+                    break;
+                var anim = hero.GetComponent<HeroAnimationComponent>();
+                if (anim != null && anim.Animations != null && anim.Animations.Count > 0)
+                    break;
+            }
+
+            if (hero.IsDestroyed)
+            {
+                Finish(hero);
+                yield break;
+            }
+
+            var jump = hero.GetComponent<HeroJumpComponent>();
+            var multiAnimator = hero.GetComponent<MultiSpriteAnimator>();
+            float heroY = hero.Transform.Position.Y;
+            float visibleTop = _cameraController != null ? _cameraController.GetVisibleWorldTop() : heroY;
+            float startHeight = ComputeFallStartHeight(heroY, visibleTop, MultiSpriteAnimator.RT_HEIGHT, GameConfig.IntroFallOffscreenMarginPx);
+
+            // Pose, lift off-screen and reveal in the same tick so no frame shows the hero standing
+            bool posed = jump != null && jump.BeginAirbornePose(Direction.Down);
+            if (posed)
+                jump.SetAirborneHeight(startHeight);
+            multiAnimator?.SetEnabled(true);
+
+            if (posed)
+            {
+                float elapsed = 0f;
+                while (elapsed < GameConfig.IntroFallDurationSeconds)
+                {
+                    yield return null;
+                    if (hero.IsDestroyed)
+                    {
+                        Finish(hero);
+                        yield break;
+                    }
+                    elapsed += Time.DeltaTime;
+                    jump.SetAirborneHeight(ComputeFallHeight(startHeight, elapsed / GameConfig.IntroFallDurationSeconds));
+                }
+                jump.EndAirbornePose();
+            }
+
+            Core.GetGlobalManager<SoundEffectManager>()?.PlaySoundAt(SoundEffectType.Land, hero.Transform.Position);
+
+            yield return Coroutine.WaitForSeconds(GameConfig.IntroPostLandingDelaySeconds);
+            if (hero.IsDestroyed)
+            {
+                Finish(hero);
+                yield break;
+            }
+
+            // Face the statue and pray. IntroPrayerDwellSeconds is sized to the line's reveal + linger
+            // (44 chars @ 20 cps ≈ 2.2 s + 2 s linger = 4.2 s) so the bubble finishes before the strike.
+            hero.GetComponent<ActorFacingComponent>()?.SetFacing(Direction.Up);
+            SpeechBubbleDialogue.SayIntro(hero);
+            yield return Coroutine.WaitForSeconds(GameConfig.IntroPrayerDwellSeconds);
+            if (hero.IsDestroyed)
+            {
+                Finish(hero);
+                yield break;
+            }
+
+            // Purely for show — the hero already has its crystal
+            yield return LightningStrikeEffect.PlayAt(_scene, hero.Transform.Position);
+            yield return Coroutine.WaitForSeconds(GameConfig.IntroPostLightningDelaySeconds);
+
+            Finish(hero);
+        }
+
+        private void Finish(Entity hero)
+        {
+            IsActive = false;
+            _scene.EndIntroPresentation(hero);
+            Debug.Log("[NewGameIntroService] New-game intro complete — hero AI enabled");
+        }
+    }
+}

--- a/PitHero/SpeechBubbleDialogue.cs
+++ b/PitHero/SpeechBubbleDialogue.cs
@@ -348,6 +348,12 @@ namespace PitHero
             SaySingle(entity, DialogueTextKey.HeroCeremonyGrantStrength);
         }
 
+        /// <summary>Shows the new-game intro prayer bubble at the hero statue (issue #396).</summary>
+        public static void SayIntro(Entity entity)
+        {
+            SaySingle(entity, DialogueTextKey.HeroIntroDestiny);
+        }
+
         /// <summary>
         /// Shows a randomly-picked patron-order bubble formatted with the localized dish name.
         /// </summary>

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -131,6 +131,10 @@ namespace PitHero.UI
         private int _freeMoveDragStartWindowY;
         private FreeMoveInputBlocker _freeMoveBlocker;
         private TextButton _freeMoveExitButton;
+
+        // New-game intro mode (issue #396): HUD snapped off-screen + transparent full-stage blocker
+        private bool _isIntroModeActive;
+        private FreeMoveInputBlocker _introBlocker;
         private TextButton _freeMoveButton;
 
         private Game _game;
@@ -2201,6 +2205,13 @@ namespace PitHero.UI
         /// </summary>
         public void Update()
         {
+            // New-game intro owns the HUD: keep everything pinned off-screen and swallow all input
+            if (_isIntroModeActive)
+            {
+                SnapHudHiddenForIntro();
+                return;
+            }
+
             // Free-move mode suspends shortcuts, farm modes, auto-hide and smooth scrolling for its duration
             if (_isFreeMoveModeActive)
             {
@@ -2576,13 +2587,19 @@ namespace PitHero.UI
         /// </summary>
         private class FreeMoveInputBlocker : Element, IInputListener
         {
-            public FreeMoveInputBlocker()
+            private readonly bool _drawDim;
+
+            /// <param name="drawDim">False for an invisible blocker (new-game intro); true draws the pause dim.</param>
+            public FreeMoveInputBlocker(bool drawDim = true)
             {
+                _drawDim = drawDim;
                 SetTouchable(Touchable.Enabled);
             }
 
             public override void Draw(Batcher batcher, float parentAlpha)
             {
+                if (!_drawDim)
+                    return;
                 batcher.DrawRect(GetX(), GetY(), GetWidth(), GetHeight(), new Color(0, 0, 0, 100));
             }
 
@@ -2601,6 +2618,118 @@ namespace PitHero.UI
             void IInputListener.OnRightMouseUp(Vector2 mousePos) { }
 
             bool IInputListener.OnMouseScrolled(int mouseWheelDelta) => true;
+        }
+
+        // ── New-game intro mode (issue #396) ─────────────────────────────────────
+
+        /// <summary>Returns true while the new-game intro sequence owns the HUD and input</summary>
+        public bool IsIntroModeActive => _isIntroModeActive;
+
+        /// <summary>
+        /// Enters intro mode: snaps the top bar, shortcut bar and event console off-screen (no slide,
+        /// so nothing flashes on the first frame), hides the auto-hide markers and raises a transparent
+        /// full-stage blocker so every stage hit-test succeeds — which closes all world-interaction
+        /// gates and the camera's pointer-over-UI zoom. Update() early-returns for the duration, so
+        /// hotkeys, farm modes and auto-hide are suspended too.
+        /// </summary>
+        public void EnterIntroMode()
+        {
+            if (_isIntroModeActive)
+                return;
+
+            if (_introBlocker == null)
+            {
+                _introBlocker = new FreeMoveInputBlocker(drawDim: false);
+                _stage.AddElement(_introBlocker);
+            }
+
+            _introBlocker.SetVisible(true);
+            _introBlocker.ToFront();
+            _isIntroModeActive = true;
+            SnapHudHiddenForIntro();
+        }
+
+        /// <summary>Exits intro mode: drops the blocker and slides the bars back into view</summary>
+        public void ExitIntroMode()
+        {
+            if (!_isIntroModeActive)
+                return;
+
+            _isIntroModeActive = false;
+            _introBlocker?.SetVisible(false);
+            ShowUIBar();
+            ShowShortcutBar();
+            ShowEventConsole();
+        }
+
+        /// <summary>
+        /// Pins every bar at its hidden offset and the blocker at full-stage. Idempotent and re-run
+        /// every intro frame: the stage reports Screen dimensions until the UICanvas is initialised
+        /// and the window may still be resized during scene start, so offsets computed once inside
+        /// Begin() can be stale by the first rendered frame.
+        /// </summary>
+        private void SnapHudHiddenForIntro()
+        {
+            _uiBarHidden = true;
+            _uiBarAnimating = false;
+            _uiBarIdleTimer = 0f;
+            _uiBarSlideY = -GetUIBarHideOffset();
+            _farmUI?.DismissSubButtons();
+            _constructionUI?.DismissSubButtons();
+            SetTopBarButtonsTouchable(false);
+            PositionUI();
+
+            if (_shortcutBar != null)
+            {
+                _shortcutBarHidden = true;
+                _shortcutBarAnimating = false;
+                _shortcutBarSlideY = GetShortcutBarHideOffset(WindowManager.IsHalfHeightMode());
+                _shortcutBar.SetSlideOffsetY(_shortcutBarSlideY);
+            }
+
+            if (_eventConsolePanel != null)
+            {
+                _consoleHidden = true;
+                _consoleAnimating = false;
+                _consoleSlideY = GetConsoleHideOffset();
+                _eventConsolePanel.SetSlideOffsetY(_consoleSlideY);
+            }
+
+            _topBarMarker?.SetVisible(false);
+            _shortcutBarMarker?.SetVisible(false);
+            _consoleMarker?.SetVisible(false);
+
+            _introBlocker?.SetBounds(0, 0, _stage.GetWidth(), _stage.GetHeight());
+        }
+
+        /// <summary>
+        /// Slide distance that parks the top bar fully above the window. Derived from the live button
+        /// height so half-size (2x sprite) mode clears the screen edge too.
+        /// </summary>
+        private float GetUIBarHideOffset()
+        {
+            return _gearButton != null ? (_gearButton.GetHeight() + 4f) : GameConfig.UIBarHideOffset;
+        }
+
+        /// <summary>
+        /// Slide distance that parks the shortcut bar fully below the window. Mirrors the
+        /// PositionShortcutBar formula: bottomY = stageH - barHeight - 16 + yOffset, so the distance
+        /// from bottomY to stageH is barHeight + 16 - yOffset (+4 margin).
+        /// </summary>
+        private static float GetShortcutBarHideOffset(bool isHalfMode)
+        {
+            float sbScale = isHalfMode ? 2f : 1f;
+            float sbBarHeight = 32f * sbScale;
+            float sbYOffset = isHalfMode ? -16f : 0f;
+            return sbBarHeight + 16f - sbYOffset + 4f;
+        }
+
+        /// <summary>Slide distance that pushes the event console fully below the bottom edge</summary>
+        private float GetConsoleHideOffset()
+        {
+            if (_eventConsolePanel == null)
+                return 0f;
+            return (_stage.GetHeight() - _eventConsolePanel.BaseY) + 4f;
         }
 
         /// <summary>
@@ -2800,7 +2929,7 @@ namespace PitHero.UI
 
             // Derive the hide offset from the actual button height so half-size (2x sprite) mode
             // moves the bar far enough to fully clear the screen edge.
-            float hideOffset = _gearButton != null ? (_gearButton.GetHeight() + 4f) : GameConfig.UIBarHideOffset;
+            float hideOffset = GetUIBarHideOffset();
             float targetY = _uiBarHidden ? -hideOffset : 0f;
             float delta = targetY - _uiBarSlideY;
             float step = GameConfig.UIBarSlideSpeed * Time.UnscaledDeltaTime;
@@ -2929,13 +3058,9 @@ namespace PitHero.UI
 
             if (!_shortcutBarAnimating) return;
 
-            // Mirror the PositionShortcutBar formula to compute how far the bar must slide
-            // before its top edge clears the bottom of the stage.
-            // PositionShortcutBar: bottomY = stageH - barHeight - 16 + yOffset
-            //   => distance from bottomY to stageH = barHeight + 16 - yOffset
-            float sbBarHeight = 32f * sbScale;
-            float sbYOffset = isHalfMode ? -16f : 0f;
-            float sbHideOffset = sbBarHeight + 16f - sbYOffset + 4f; // +4 margin
+            // How far the bar must slide before its top edge clears the bottom of the stage
+            // (shared with the intro-mode snap so the two can't drift apart).
+            float sbHideOffset = GetShortcutBarHideOffset(isHalfMode);
             float targetOffsetY = _shortcutBarHidden ? sbHideOffset : 0f;
             float sbDelta = targetOffsetY - _shortcutBarSlideY;
             float sbStep = GameConfig.UIBarSlideSpeed * Time.UnscaledDeltaTime;
@@ -3037,10 +3162,8 @@ namespace PitHero.UI
             // Marker is only shown once the panel has fully slid off-screen, and never during farm modes.
             _consoleMarker?.SetVisible(_consoleHidden && !_consoleAnimating && !ecFarmActive);
 
-            float stageH = _stage.GetHeight();
-            float consolePanelBaseY = _eventConsolePanel.BaseY;
             // Push the panel far enough below the bottom edge to fully clear it.
-            float hideOffset = (stageH - consolePanelBaseY) + 4f;
+            float hideOffset = GetConsoleHideOffset();
 
             if (!_consoleAnimating)
             {

--- a/PitHero/Util/LightningStrikeEffect.cs
+++ b/PitHero/Util/LightningStrikeEffect.cs
@@ -1,0 +1,53 @@
+using System.Collections;
+using Microsoft.Xna.Framework;
+using Nez;
+using Nez.Sprites;
+using PitHero.ECS.Components;
+
+namespace PitHero.Util
+{
+    /// <summary>
+    /// Cosmetic lightning strike: plays the Actors.atlas "LightningStrike" animation once at a world
+    /// position on RenderLayerTop, then destroys it. Silent. Shared by the crystal ceremony and the
+    /// new-game intro (issue #396).
+    /// </summary>
+    public static class LightningStrikeEffect
+    {
+        private const string EntityName = "lightning-strike";
+        private const string AtlasPath = "Content/Atlases/Actors.atlas";
+        private const string AnimationName = "LightningStrike";
+        private const float SafetyTimeoutSeconds = 5f;
+
+        /// <summary>
+        /// Coroutine that plays the strike centered on worldPosition and completes when the
+        /// animation finishes (5 s safety timeout).
+        /// </summary>
+        public static IEnumerator PlayAt(Scene scene, Vector2 worldPosition)
+        {
+            var lightningEntity = scene.CreateEntity(EntityName);
+            lightningEntity.SetPosition(worldPosition);
+
+            var actorsAtlas = Core.Content.LoadSpriteAtlas(AtlasPath);
+            if (actorsAtlas == null)
+            {
+                Debug.Error("[LightningStrikeEffect] Failed to load Actors.atlas for lightning strike");
+                lightningEntity.Destroy();
+                yield break;
+            }
+
+            var animator = lightningEntity.AddComponent<PausableSpriteAnimator>();
+            animator.AddAnimationsFromAtlas(actorsAtlas);
+            animator.SetRenderLayer(GameConfig.RenderLayerTop);
+            animator.Play(AnimationName, SpriteAnimator.LoopMode.Once);
+
+            float elapsed = 0f;
+            while (animator.IsRunning && elapsed < SafetyTimeoutSeconds)
+            {
+                yield return null;
+                elapsed += Time.DeltaTime;
+            }
+
+            lightningEntity.Destroy();
+        }
+    }
+}

--- a/PitHero/docs/CrystalCeremony.md
+++ b/PitHero/docs/CrystalCeremony.md
@@ -21,20 +21,37 @@ When a hero dies (see [Permadeath.md](Permadeath.md) for the death animation and
 
 ## Hero Statue
 
-**Location:** statue sprite at tile (112, 3); hero destination tile (112, 6)
+**Location:** statue sprite anchored at `GameConfig.HeroStatueTileX/Y` (112, 3); the 181px-tall sprite's base lands on row 6, so heroes stand at `GameConfig.HeroStatueStandTileX/Y` (112, 6)
 **Sprite:** "HeroStatue" from Actors.atlas
 **Render Layer:** `GameConfig.RenderLayerActors`
 
 ## Lightning Strike Animation
 
+**Helper:** `Util/LightningStrikeEffect.PlayAt(scene, worldPosition)` — a coroutine shared by the ceremony and the new-game intro
 **Animation:** "LightningStrike" from Actors.atlas
 **Play Mode:** Once (`LoopMode.Once`), 5-second safety timeout
 **Render Layer:** `GameConfig.RenderLayerTop`
+**Sound:** none (cosmetic only)
+
+## New-Game Intro (issue #396)
+
+A brand-new game (`SaveLoadService.PendingLoadData == null`, captured at the top of `MainGameScene.Begin()` because `ApplyPendingLoadData` clears it) opens with a scripted sequence run by `Services/NewGameIntroService`:
+
+1. The hero is created at the statue's feet (`HeroStatueStandTileX/Y`) **without** a `HeroStateMachine` — Nez's `SimpleStateMachine.InitialState` setter runs `Idle_Enter` synchronously inside the deferred `OnAddedToEntity`, which would plan the first pit trip (and burn the one-shot pit bubble) immediately. Its `MultiSpriteAnimator` is disabled so no standing frame renders.
+2. `MainGameScene.BeginIntroPresentation` hides the labels and graphical HUD, `SettingsUI.EnterIntroMode()` snaps the top bar / shortcut bar / event console off-screen (re-pinned every frame while active) and raises a transparent full-stage blocker (every stage hit-test succeeds → all world-interaction gates close), and `CameraControllerComponent.InputSuspended` + `CenterOnWorldPosition` park the camera on the statue (the centre is latched until the controller's deferred init). The farm/kitchen coordinator ticks are also held while `IsIntroActive`, so the starter Slime stays inside its Monster House and emerges only after the intro.
+3. Once the paperdoll animators are loaded, the hero is posed with `HeroJumpComponent.BeginAirbornePose(Down)` and lifted above the visible top edge (`ComputeFallStartHeight` from the controller's render-target math — not `Camera.Bounds`, which reads the backbuffer from a coroutine), then dropped with a gravity ease (`ComputeFallHeight`, `GameConfig.IntroFallDurationSeconds`) and the Land sound.
+4. `SetFacing(Up)`, `SpeechBubbleDialogue.SayIntro` (`HeroIntroDestiny`), and a dwell of `GameConfig.IntroPrayerDwellSeconds` sized to the bubble's reveal + linger (change them together), then `LightningStrikeEffect.PlayAt` — purely for show, the hero already has its crystal.
+5. `MainGameScene.EndIntroPresentation` restores the HUD (bars slide back in), re-enables camera input and adds the `HeroStateMachine`, whose first plan is the normal pit trip from the statue.
+
+No save-format change (the intro never applies to a loaded game) and no virtual-layer counterpart (presentation only).
 
 ## Related Files
 
 - `PitHero/Services/HeroPromotionService.cs` — `CheckAndPromoteHeroIfNeeded`, `ExecuteHeroCrystalCeremony`, `GetNextCrystalForHero`
+- `PitHero/Util/LightningStrikeEffect.cs` — shared lightning strike coroutine
+- `PitHero/Services/NewGameIntroService.cs` — new-game intro sequence
 - `PitHero/AI/WalkToStatueForCrystalAction.cs` — GOAP walk-to-statue action
-- `PitHero/ECS/Scenes/MainGameScene.cs` — `RespawnHero`, `ReconnectUIToHero`, per-frame ceremony check
+- `PitHero/ECS/Scenes/MainGameScene.cs` — `RespawnHero`, `ReconnectUIToHero`, per-frame ceremony check, `BeginIntroPresentation` / `EndIntroPresentation`
 - `PitHero/ECS/Components/HeroComponent.cs` — `NeedsCrystal`, `HasArrivedAtStatueForCrystal`
+- `PitHero/ECS/Components/HeroJumpComponent.cs` — `BeginAirbornePose` / `SetAirborneHeight` / `EndAirbornePose` (airborne look without the jump timing)
 - `PitHero/docs/Permadeath.md` — the death animation and crystal-vault half of the death→respawn cycle

--- a/PitHero/docs/SpeechBubbleSystem.md
+++ b/PitHero/docs/SpeechBubbleSystem.md
@@ -127,6 +127,7 @@ virtual/live run parity. See the comment block at the top of `SpeechBubbleDialog
 | Boss defeated | `LiveBattleAdapter.OnEnemyDefeated` | Live layer only; `VirtualBattleSink` untouched |
 | Respawn after defeat | `WalkToStatueForCrystalAction.WalkToStatue` start | See the deferral trap above |
 | Crystal ceremony prayer | `HeroPromotionService.ExecuteHeroCrystalCeremony` top | The pre-lightning dwell was extended to 4.0s (0.5 + 3.5) specifically to fit this line's reveal+linger — don't shorten one without the other |
+| New-game intro prayer | `NewGameIntroService.Run` after touchdown (issue #396) | Key `HeroIntroDestiny`; `GameConfig.IntroPrayerDwellSeconds` (4.5 s) is sized to 44 chars @ 20 cps + 2 s linger = 4.2 s — change them together. Fires well after the hero's creation frame, so the deferral trap above doesn't apply |
 
 ### Tavern & workers
 


### PR DESCRIPTION
Closes #396

## Summary
A brand-new game now opens in an **Intro** state:
- Camera starts centered on the hero statue; top bar, shortcut bar, event console, markers, labels and graphical HUD are hidden; map interaction and camera scroll/zoom are blocked.
- The hero falls from above the screen onto the ground tile beneath the statue (112,6) with shadow + Land sound, faces the statue and says *"Guardian Spirit, help me fulfill my destiny!"*.
- The crystal-ceremony lightning strikes (cosmetic only), then the intro is dismissed: bars slide back in, input unlocks, and the hero plans its first pit trip as usual.
- The starter Slime stays inside its Monster House until the intro ends.

## Implementation notes
- `Services/NewGameIntroService` runs the sequence; `MainGameScene.Begin/EndIntroPresentation` own the HUD/camera/FSM hand-off.
- `HeroStateMachine` is added only when the intro ends — Nez's `SimpleStateMachine.InitialState` setter runs `Idle_Enter` synchronously, which would plan the pit trip immediately.
- Camera centering is latched until the controller's deferred `OnAddedToEntity`; visible-top uses render-target math, not `Camera.Bounds`.
- `SettingsUI.EnterIntroMode` reuses the free-move blocker pattern (transparent) and re-snaps bar offsets every frame.
- Lightning extracted to `Util/LightningStrikeEffect`, shared with the ceremony; `HeroJumpComponent` exposes the airborne pose without jump timing (pit jump behaviour unchanged).
- Statue tiles moved to `GameConfig`; no save-format or virtual-layer changes (presentation only).

## Test plan
- [x] `dotnet build PitHero.sln` clean
- [x] `dotnet test` — 2009 passed, 0 failed (9 new tests for fall curve / start height / visible top)
- [x] Playtested new game: intro plays, HUD returns, hero heads to the pit; Slime emerges after the intro
- [ ] Load game unaffected; death → respawn ceremony still shows lightning

🤖 Generated with [Claude Code](https://claude.com/claude-code)