### PR TITLE
Configurable design height (296) and a UI space-reclaim pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file is the source of truth for project-wide development rules for any AI a
 
 ## Project Overview
 
-PitHero is a horizontal RPG strip game built in **C# (.NET 8.0)** with **FNA + Nez** (not MonoGame). The game runs as a borderless window at the bottom of the screen at a virtual resolution of **1920×360**. A single hero adventures in a single growing pit while the player interacts with other desktop apps.
+PitHero is a horizontal RPG strip game built in **C# (.NET 8.0)** with **FNA + Nez** (not MonoGame). The game runs as a borderless window at the bottom of the screen at a virtual resolution of **1920×`GameConfig.VirtualHeight`** (currently **296**; was 360 — the OS window height follows the constant). A single hero adventures in a single growing pit while the player interacts with other desktop apps.
 
 ## Commands
 
@@ -42,7 +42,7 @@ Game1 (Nez.Core)
 - **Single hero, single pit** — no multi-hero or multi-pit support
 - **`WorldState` is a struct** — always pass by `ref` to methods that mutate it
 - **`VirtualGame/VirtualGameSimulation.cs`** runs the full game loop without graphics; use it for testing game logic and balance without launching the game
-- Virtual resolution **1920×360**; game runs borderless, always-on-top, with optional click-through; maintain integer scaling for pixel-perfect rendering
+- Virtual resolution **1920×`GameConfig.VirtualHeight`** (currently **296**, flip the constant to compare heights; every tall UI window fits itself to `Stage.GetHeight()` at show time); game runs borderless, always-on-top, with optional click-through; maintain integer scaling for pixel-perfect rendering
 - Pit width grows every 10 pit levels (Pit Center X is dynamic); pit height is constant (Pit Center Y is constant)
 - Game continues running idle while the player interacts with other desktop apps
 

--- a/PitHero.Tests/StencilAutoSlotTests.cs
+++ b/PitHero.Tests/StencilAutoSlotTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Xna.Framework;
 using PitHero.Services;
+using PitHero.UI;
 using RolePlayingFramework.Equipment;
 using RolePlayingFramework.Inventory;
 using RolePlayingFramework.Stats;
@@ -122,13 +123,13 @@ namespace PitHero.Tests
 
         // ---- StencilBagSlotPreferenceProvider: anchor+offset → bagIndex ---------------
         //
-        // Grid layout (20 wide, rows 3-8 are bag-backed):
-        //   bagIndex = (gridY - 3) * 20 + gridX
+        // Grid layout (InventoryGrid.BagColumns wide, rows BagRowStart..+BagRows-1 are bag-backed):
+        //   bagIndex = (gridY - BagRowStart) * BagColumns + gridX
         //
         // ShieldMastery offsets: (0,0)=Sword at anchor; (1,0)=Shield at anchor+(1,0)
         // If anchor = (2, 3):
-        //   Sword cell: gridX=2, gridY=3 → bagIndex = (3-3)*20+2 = 2
-        //   Shield cell: gridX=3, gridY=3 → bagIndex = (3-3)*20+3 = 3
+        //   Sword cell: gridX=2, gridY=3 → bagIndex = 2
+        //   Shield cell: gridX=3, gridY=3 → bagIndex = 3
 
         [TestMethod]
         public void Provider_MatchingKind_ReturnsCorrectBagIndex()
@@ -187,26 +188,27 @@ namespace PitHero.Tests
             var sword = GearItems.ShortSword();
             bag.TryAdd(sword);
 
-            // Cell at row 0 is outside rows 3-8, so provider returns -1; item goes to first-empty = slot 0
+            // Row 0 is not a bag row, so the provider returns -1; item goes to first-empty = slot 0
             Assert.AreSame(sword, bag.GetSlotItem(0), "Out-of-range row must be skipped; sword falls to slot 0");
         }
 
         [TestMethod]
         public void Provider_OutOfRangeColumn_CellSkipped()
         {
-            // Place ShieldMastery at anchor (19, 3): Sword cell gridX=19 (ok), Shield cell gridX=20 (out of range col 0-19)
-            var svc = MakeServiceWithStencil(ShieldMasteryId, anchorX: 19, anchorY: 3);
+            // Anchor on the last column: the Sword cell is still on the grid, the Shield cell is not
+            int lastCol = InventoryGrid.BagColumns - 1;
+            var svc = MakeServiceWithStencil(ShieldMasteryId, anchorX: lastCol, anchorY: InventoryGrid.BagRowStart);
             var bag = MakeBagWithProvider(120, svc);
 
-            // Sword at (19,3) → bagIndex = (3-3)*20+19 = 19 (valid)
+            // Sword on the first bag row lands at bagIndex == its column
             var sword = GearItems.ShortSword();
             bag.TryAdd(sword);
-            Assert.AreSame(sword, bag.GetSlotItem(19), "Sword at valid col 19 should land at bagIndex 19");
+            Assert.AreSame(sword, bag.GetSlotItem(lastCol), $"Sword at valid col {lastCol} should land at that bagIndex");
 
-            // Shield at (20,3) → col 20 is out of range; falls to first-empty non-19 slot = slot 0
+            // Shield would be one column past the grid; it falls back to the first empty slot
             var shield = GearItems.IronShield();
             bag.TryAdd(shield);
-            Assert.AreSame(shield, bag.GetSlotItem(0), "Shield cell col 20 is out of range; falls to first empty");
+            Assert.AreSame(shield, bag.GetSlotItem(0), "Shield cell past the last column is out of range; falls to first empty");
         }
 
         [TestMethod]

--- a/PitHero.Tests/SynergyPatternFitTests.cs
+++ b/PitHero.Tests/SynergyPatternFitTests.cs
@@ -1,0 +1,58 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.UI;
+using RolePlayingFramework.Synergies;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Every registered synergy stencil has to be placeable in the bag area of the inventory grid.
+    /// The grid is deliberately wide and short, so a tall pattern would be impossible to place.
+    /// </summary>
+    [TestClass]
+    public class SynergyPatternFitTests
+    {
+        [TestMethod]
+        public void EveryPattern_FitsTheBagArea()
+        {
+            var patterns = SynergyPatternRegistry.All;
+            Assert.IsTrue(patterns.Count > 0, "registry should not be empty");
+
+            for (int i = 0; i < patterns.Count; i++)
+            {
+                var pattern = patterns[i];
+                var offsets = pattern.GridOffsets;
+                Assert.IsTrue(offsets.Count > 0, $"{pattern.Id} has no cells");
+
+                int minX = offsets[0].X, maxX = offsets[0].X;
+                int minY = offsets[0].Y, maxY = offsets[0].Y;
+                for (int c = 1; c < offsets.Count; c++)
+                {
+                    if (offsets[c].X < minX) minX = offsets[c].X;
+                    if (offsets[c].X > maxX) maxX = offsets[c].X;
+                    if (offsets[c].Y < minY) minY = offsets[c].Y;
+                    if (offsets[c].Y > maxY) maxY = offsets[c].Y;
+                }
+
+                int width = maxX - minX + 1;
+                int height = maxY - minY + 1;
+
+                Assert.IsTrue(height <= InventoryGrid.BagRows,
+                    $"{pattern.Id} is {width}x{height}; the bag is only {InventoryGrid.BagRows} rows tall");
+                Assert.IsTrue(width <= InventoryGrid.BagColumns,
+                    $"{pattern.Id} is {width}x{height}; the bag is only {InventoryGrid.BagColumns} columns wide");
+            }
+        }
+
+        [TestMethod]
+        public void EveryPattern_HasOneRequiredKindPerCell()
+        {
+            var patterns = SynergyPatternRegistry.All;
+            for (int i = 0; i < patterns.Count; i++)
+            {
+                var pattern = patterns[i];
+                Assert.AreEqual(pattern.GridOffsets.Count, pattern.RequiredKinds.Count,
+                    $"{pattern.Id} has {pattern.GridOffsets.Count} cells but {pattern.RequiredKinds.Count} required kinds");
+            }
+        }
+    }
+}

--- a/PitHero.Tests/UI/InventoryGridLayoutTests.cs
+++ b/PitHero.Tests/UI/InventoryGridLayoutTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero;
+using PitHero.UI;
+
+namespace PitHero.Tests.UI
+{
+    /// <summary>
+    /// Layout guards for the wide, non-scrolling inventory grid: 24 columns x 5 bag rows keeps the
+    /// old 120-slot capacity while fitting the configured design height.
+    /// </summary>
+    [TestClass]
+    public class InventoryGridLayoutTests
+    {
+        [TestMethod]
+        public void BagCapacity_MatchesTheOldTallLayout()
+        {
+            Assert.AreEqual(120, InventoryGrid.BagCapacity);
+        }
+
+        [TestMethod]
+        public void Grid_SizesItselfToItsContent()
+        {
+            var grid = new InventoryGrid();
+
+            Assert.AreEqual(InventoryGrid.ContentWidth, grid.GetWidth());
+            Assert.AreEqual(InventoryGrid.ContentHeight, grid.GetHeight());
+        }
+
+        [TestMethod]
+        public void GridHeight_FitsTheHeroWindowTabArea()
+        {
+            // The Party window spans the full design height (flush top and bottom) and the tab strip
+            // comes off the top. The grid must fit what is left, since nothing scrolls.
+            const float tabStripHeight = 37f;
+            float tabArea = GameConfig.VirtualHeight - tabStripHeight;
+
+            Assert.IsTrue(InventoryGrid.ContentHeight <= tabArea,
+                $"grid is {InventoryGrid.ContentHeight}px but only {tabArea}px of tab area exists");
+        }
+
+        [TestMethod]
+        public void GridWidth_FitsTheSecondChanceHeroPanel()
+        {
+            Assert.IsTrue(InventoryGrid.ContentWidth + 8f <= GameConfig.SecondChanceHeroPanelWidth,
+                "the shop's hero panel must show every column");
+        }
+
+        [TestMethod]
+        public void SecondChanceComposition_StaysOnTheReferenceStage()
+        {
+            Assert.AreEqual(GameConfig.VirtualWidth,
+                GameConfig.SecondChanceHeroPanelX + GameConfig.SecondChanceHeroPanelWidth,
+                "hero panel stays flush with the right edge of the 1920 reference stage");
+            Assert.IsTrue(GameConfig.SecondChanceShopWindowX + GameConfig.SecondChanceShopWindowWidth
+                          < GameConfig.SecondChanceHeroPanelX,
+                "the two windows must not overlap each other");
+        }
+
+        [TestMethod]
+        public void Merchant_IsCenteredBetweenTheShopAndHeroPanels()
+        {
+            const float spriteSize = 256f;
+            float shopRight = GameConfig.SecondChanceShopWindowX + GameConfig.SecondChanceShopWindowWidth;
+            float spriteCenter = GameConfig.SecondChanceMerchantSpriteX + spriteSize / 2f;
+            float spanCenter = (shopRight + GameConfig.SecondChanceHeroPanelX) / 2f;
+
+            // The sprite X is a whole pixel, so allow the half-pixel rounding
+            Assert.IsTrue(System.Math.Abs(spriteCenter - spanCenter) <= 0.5f,
+                $"merchant center {spriteCenter} should sit at the span center {spanCenter}");
+        }
+    }
+}

--- a/PitHero.Tests/UILayoutTests.cs
+++ b/PitHero.Tests/UILayoutTests.cs
@@ -1,0 +1,98 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero;
+using PitHero.UI;
+
+namespace PitHero.Tests
+{
+    /// <summary>
+    /// Tests for the pure layout math behind the configurable design height
+    /// (WindowManager.GetStripHeight and UILayout). Windows themselves need a Skin, so only the
+    /// math is covered here.
+    /// </summary>
+    [TestClass]
+    public class UILayoutTests
+    {
+        [TestMethod]
+        public void GetStripHeight_IsOneToOneAtReferenceDisplayHeight()
+        {
+            Assert.AreEqual(GameConfig.VirtualHeight, WindowManager.GetStripHeight(GameConfig.ReferenceDisplayHeight));
+        }
+
+        [TestMethod]
+        public void GetStripHeight_DoublesOnA4KMonitor()
+        {
+            Assert.AreEqual(GameConfig.VirtualHeight * 2, WindowManager.GetStripHeight(2 * GameConfig.ReferenceDisplayHeight));
+        }
+
+        [TestMethod]
+        public void GetStripHeight_ScalesProportionallyOnA1440pMonitor()
+        {
+            int expected = 1440 * GameConfig.VirtualHeight / GameConfig.ReferenceDisplayHeight;
+            Assert.AreEqual(expected, WindowManager.GetStripHeight(1440));
+        }
+
+        [TestMethod]
+        public void FitHeight_KeepsPreferredHeightWhenItFits()
+        {
+            Assert.AreEqual(200f, UILayout.FitHeight(200f, 360f, 6f, 4f));
+        }
+
+        [TestMethod]
+        public void FitHeight_ShrinksToTheAvailableBudget()
+        {
+            // 296 tall stage, window starts at y=6 and must end 4px above the bottom
+            Assert.AreEqual(286f, UILayout.FitHeight(350f, 296f, 6f, 4f));
+        }
+
+        [TestMethod]
+        public void FitHeight_NeverGoesBelowTheFloor()
+        {
+            Assert.AreEqual(UILayout.MinWindowHeight, UILayout.FitHeight(350f, 40f, 30f, 20f));
+        }
+
+        [TestMethod]
+        public void ClampY_LeavesAWindowThatAlreadyFits()
+        {
+            Assert.AreEqual(50f, UILayout.ClampY(50f, 100f, 296f));
+        }
+
+        [TestMethod]
+        public void ClampY_PushesAWindowUpOffTheBottomEdge()
+        {
+            Assert.AreEqual(196f, UILayout.ClampY(250f, 100f, 296f));
+        }
+
+        [TestMethod]
+        public void ClampY_KeepsTheTitleBarWhenTheWindowIsTallerThanTheStage()
+        {
+            Assert.AreEqual(0f, UILayout.ClampY(10f, 400f, 296f));
+        }
+
+        [TestMethod]
+        public void CenterY_CentersWithoutBias()
+        {
+            Assert.AreEqual(98f, UILayout.CenterY(100f, 296f, 0f));
+        }
+
+        [TestMethod]
+        public void CenterY_AppliesTheUpwardBias()
+        {
+            Assert.AreEqual(68f, UILayout.CenterY(100f, 296f, 30f));
+        }
+
+        [TestMethod]
+        public void CenterY_ClampsWhenTheBiasWouldPushThePanelOffTheTop()
+        {
+            Assert.AreEqual(0f, UILayout.CenterY(280f, 296f, 30f));
+        }
+
+        [TestMethod]
+        public void SecondChanceHeroPanel_FitsTheConfiguredDesignHeight()
+        {
+            float h = UILayout.FitHeight(GameConfig.SecondChanceHeroPanelHeight, GameConfig.VirtualHeight,
+                GameConfig.UIStageMargin, GameConfig.UIStageMargin);
+            Assert.IsTrue(h + 2f * GameConfig.UIStageMargin <= GameConfig.VirtualHeight,
+                "Fitted hero panel must leave both stage margins intact");
+        }
+    }
+}

--- a/PitHero/ECS/Components/CameraControllerComponent.cs
+++ b/PitHero/ECS/Components/CameraControllerComponent.cs
@@ -64,8 +64,11 @@ namespace PitHero.ECS.Components
                 _camera.SetMinimumZoom(_currentMinimumZoom);
                 _camera.SetMaximumZoom(_currentMaximumZoom);
                 _camera.RawZoom = GameConfig.CameraDefaultZoom;
+                // Vertically centre on the pit's centre row (statue / rim-walk row) rather than on
+                // half the design height, so the whole pit is framed at any GameConfig.VirtualHeight
                 _defaultCameraPosition = ConstrainCameraPosition(new Vector2(
-                    _tileMapBounds.X + _tileMapBounds.Width / 2f, GameConfig.VirtualHeight / 2f));
+                    _tileMapBounds.X + _tileMapBounds.Width / 2f,
+                    (GameConfig.MapCenterTileY + 0.5f) * GameConfig.TileSize));
                 // A centre requested during scene setup (before this deferred init) wins over the default
                 _camera.Position = _hasPendingCenter ? ConstrainCameraPosition(_pendingCenter) : _defaultCameraPosition;
                 _hasPendingCenter = false;
@@ -144,6 +147,11 @@ namespace PitHero.ECS.Components
                     WindowManager.RestoreOriginalSize(Core.Instance);
 
                 _camera.RawZoom = GameConfig.CameraDefaultZoom;
+                // Vertically centre on the pit's centre row (statue / rim-walk row) rather than on
+                // half the design height, so the whole pit is framed at any GameConfig.VirtualHeight
+                _defaultCameraPosition = ConstrainCameraPosition(new Vector2(
+                    _tileMapBounds.X + _tileMapBounds.Width / 2f,
+                    (GameConfig.MapCenterTileY + 0.5f) * GameConfig.TileSize));
                 _camera.Position = ConstrainCameraPosition(_defaultCameraPosition);
                 QuantizeCameraPosition();
                 Debug.Log($"[CameraController] SHIFT+RightClick reset zoom={_camera.RawZoom} positionX={_camera.Position.X} positionY={_camera.Position.Y}");

--- a/PitHero/ECS/Scenes/MainGameScene.cs
+++ b/PitHero/ECS/Scenes/MainGameScene.cs
@@ -94,11 +94,9 @@ namespace PitHero.ECS.Scenes
 
         // Cached base positions for top-left anchored UI (so offsets are relative and centralized)
         private const float PitLabelBaseX = 10f; // X position for Pit Lv label (bottom-left)
-        private const float PitLabelBaseY = 350f; // Y position for Pit Lv label (bottom-left, ~30px from bottom at 360px height)
         private const float FundsLabelGapX = 16f; // Gap between the measured Pit Lv label text and the Funds label
         private const float ClockLabelRightPadding = 32f; // Pixels from right edge for clock label
         private const float ClockLabelBaseY = 16f; // Y position for clock label (top area, offset to avoid cutoff)
-        private const float FundsLabelBaseY = 350f; // Y position for Funds label (same as Pit Lv)
         private const float GraphicalHudBaseX = 10f; // Base X position for graphical HUD (shifted left to fill space)
         private const float GraphicalHudBaseY = 4f; // Base Y position for graphical HUD
         private const float GraphicalHudHalfModeXOffset = 0f; // No additional X offset needed since Pit Lv is at bottom
@@ -1996,7 +1994,7 @@ namespace PitHero.ECS.Scenes
             // Pit level label (bottom-left, always visible, no scaling)
             _pitLevelLabel = uiCanvas.Stage.AddElement(new Label("Pit Lv. 1", _hudFontNormal));
             _pitLevelLabel.SetStyle(_pitLevelStyleNormal);
-            _pitLevelLabel.SetPosition(PitLabelBaseX, PitLabelBaseY);
+            _pitLevelLabel.SetPosition(PitLabelBaseX, HudBottomLabelY());
 
             // Funds label (bottom-left next to Pit Lv, always visible, no scaling)
             _fundsLabel = uiCanvas.Stage.AddElement(new Label("Gold: 0", _hudFontNormal));
@@ -2162,6 +2160,26 @@ namespace PitHero.ECS.Scenes
         }
 
         /// <summary>
+        /// Y for the bottom-left HUD labels, derived from the live stage height so they follow the
+        /// configured design height (GameConfig.VirtualHeight) and every window/dock mode.
+        /// </summary>
+        private float HudBottomLabelY()
+        {
+            float stageH = _uiStage != null ? _uiStage.GetHeight() : GameConfig.VirtualHeight;
+            return stageH - GameConfig.HudBottomLabelOffsetY;
+        }
+
+        /// <summary>
+        /// Re-anchor the bottom-left HUD labels (Pit Lv / Gold) after a stage size change
+        /// </summary>
+        private void RepositionBottomLabels()
+        {
+            if (_pitLevelLabel != null)
+                _pitLevelLabel.SetPosition(PitLabelBaseX, HudBottomLabelY());
+            RepositionFundsLabel();
+        }
+
+        /// <summary>
         /// Position the Funds label just right of the Pit Lv label based on its measured text width
         /// </summary>
         private void RepositionFundsLabel()
@@ -2170,7 +2188,7 @@ namespace PitHero.ECS.Scenes
                 return;
 
             float pitLabelWidth = _hudFontNormal.MeasureString(_pitLevelLabel.GetText()).X;
-            _fundsLabel.SetPosition(PitLabelBaseX + pitLabelWidth + FundsLabelGapX, FundsLabelBaseY);
+            _fundsLabel.SetPosition(PitLabelBaseX + pitLabelWidth + FundsLabelGapX, HudBottomLabelY());
         }
 
         /// <summary>
@@ -2690,6 +2708,7 @@ namespace PitHero.ECS.Scenes
                     _lastStageWidth = stageW;
                     _lastStageHeight = stageH;
                     PositionShortcutBar();
+                    RepositionBottomLabels();
                     PositionEventConsolePanel();
                     if (_pauseOverlayRenderer != null)
                     {

--- a/PitHero/Game1.cs
+++ b/PitHero/Game1.cs
@@ -106,10 +106,7 @@ namespace PitHero
             base.LoadContent();
 
             // Configure window as horizontal strip docked at bottom
-            //WindowManager.ConfigureHorizontalStrip(this,
-            //    alwaysOnTop: GameConfig.AlwaysOnTop,
-            //    clickThrough: GameConfig.ClickThrough);
-            WindowManager.ConfigureHorizontalStripOneThird(this,
+            WindowManager.ConfigureHorizontalStrip(this,
                 alwaysOnTop: GameConfig.AlwaysOnTop);
         }
 

--- a/PitHero/GameConfig.cs
+++ b/PitHero/GameConfig.cs
@@ -13,10 +13,24 @@ namespace PitHero
         // while the render-target width grows with the window aspect (ultrawide sees more world).
         // VirtualWidth is only a reference width (initial backbuffer, minimum-layout reference) —
         // runtime layout/camera code must use Stage.GetWidth()/Scene.SceneRenderTargetSize instead.
+        // VirtualHeight is the single knob for the strip's height: the OS window height follows it
+        // (WindowManager.GetStripHeight scales it by the monitor height), and every tall UI window
+        // fits itself to Stage.GetHeight() at show time, so it can be flipped (e.g. 360 <-> 296).
         public const int VirtualWidth = 1920;
-        public const int VirtualHeight = 360;
+        public const int VirtualHeight = 296;
         public const int InternalWorldWidth = 1920;
         public const int InternalWorldHeight = 800;
+
+        /// <summary>Monitor height at which the strip renders 1:1 (window height = VirtualHeight).</summary>
+        public const int ReferenceDisplayHeight = 1080;
+
+        // UI layout budget (all UI windows fit themselves to Stage.GetHeight() at show time)
+        /// <summary>Gap kept between a stage-fitted window and the top/bottom stage edges.</summary>
+        public const float UIStageMargin = 4f;
+        /// <summary>Gap between a top-bar button and the window opened beneath it.</summary>
+        public const float UIWindowBelowBarGap = 4f;
+        /// <summary>Distance from the bottom of the stage to the baseline HUD labels (Pit Lv / Gold).</summary>
+        public const float HudBottomLabelOffsetY = 10f;
 
         // Window Configuration
         public const bool AlwaysOnTop = true;
@@ -501,24 +515,28 @@ namespace PitHero
         public const float UIBarProximityY = 48f;     // Mouse Y <= this (stage coords) triggers proximity-unhide
 
         // Second Chance Shop layout positions
-        // Composed for a 1920-wide stage; SecondChanceShopUI centers the whole composition on
-        // wider stages by shifting all X positions right by (stageWidth - VirtualWidth) / 2.
+        // Composed for a 1920x360 stage; SecondChanceShopUI centers the whole composition on
+        // wider stages by shifting all X positions right by (stageWidth - VirtualWidth) / 2, and fits
+        // the panel heights/Y to the live stage height when VirtualHeight is shorter than 360.
         // Shop window (vault grid + tabs) positioned near left-center
-        public const float SecondChanceShopWindowX = 573f;
+        public const float SecondChanceShopWindowX = 509f;
         public const float SecondChanceShopWindowY = 12f;
         public const float SecondChanceShopWindowWidth = 350f;
         public const float SecondChanceShopWindowHeight = 310f;
 
-        // Hero panel (inventory/crystal) positioned to fill right side of screen
-        public const float SecondChanceHeroPanelX = 1200f;
+        // Hero panel (inventory/crystal) sized around the 824px inventory grid and right-aligned to
+        // the 1920 reference stage (1068 + 852 = 1920); the shop and merchant shift left to match.
+        public const float SecondChanceHeroPanelX = 1068f;
         public const float SecondChanceHeroPanelY = 12f;
-        public const float SecondChanceHeroPanelWidth = 720f;
+        public const float SecondChanceHeroPanelWidth = 852f;
         public const float SecondChanceHeroPanelHeight = 340f;
 
-        // Merchant sprite positioned between shop window and hero panel
-        // Sprite is 256x256; Y=50 places it within the 360px stage height (50 to 306)
-        public const float SecondChanceMerchantSpriteX = 935f;
-        public const float SecondChanceMerchantSpriteY = 50f;
+        // Merchant sprite centered in the span between the shop window and the hero panel:
+        // (509 + 350 + 1068) / 2 - 128 = 835.5, snapped to a whole pixel so the art stays crisp.
+        // The 256px frame is wider than that span, so its transparent margins overlap both windows.
+        // The sprite Y is derived at show time: SecondChanceShopUI stands the merchant on the bottom
+        // edge of the panels, so it follows the fitted panel height at any design height.
+        public const float SecondChanceMerchantSpriteX = 836f;
 
         // Merchant greeting bubble tail-tip anchor, relative to the sprite's top-left (issue #385).
         // X centers on the 256px art; Y sits at the top of the merchant's head within the frame.

--- a/PitHero/RolePlayingFramework/Synergies/CrossClassSynergyPatterns.cs
+++ b/PitHero/RolePlayingFramework/Synergies/CrossClassSynergyPatterns.cs
@@ -137,24 +137,22 @@ namespace RolePlayingFramework.Synergies
         /// <summary>Dragon Bolt - Monk+Mage draconic magic.</summary>
         public static SynergyPattern CreateDragonBolt()
         {
+            // 6 wide x 4 tall: the old 4x6 block transposed so it fits the 5-row bag. Same 24 cells
+            // and the same required kinds — each old row is now a column.
             var offsets = new List<Point>
             {
-                new Point(0, 0), new Point(1, 0), new Point(2, 0), new Point(3, 0),
-                new Point(0, 1), new Point(1, 1), new Point(2, 1), new Point(3, 1),
-                new Point(0, 2), new Point(1, 2), new Point(2, 2), new Point(3, 2),
-                new Point(0, 3), new Point(1, 3), new Point(2, 3), new Point(3, 3),
-                new Point(0, 4), new Point(1, 4), new Point(2, 4), new Point(3, 4),
-                new Point(0, 5), new Point(1, 5), new Point(2, 5), new Point(3, 5)
+                new Point(0, 0), new Point(1, 0), new Point(2, 0), new Point(3, 0), new Point(4, 0), new Point(5, 0),
+                new Point(0, 1), new Point(1, 1), new Point(2, 1), new Point(3, 1), new Point(4, 1), new Point(5, 1),
+                new Point(0, 2), new Point(1, 2), new Point(2, 2), new Point(3, 2), new Point(4, 2), new Point(5, 2),
+                new Point(0, 3), new Point(1, 3), new Point(2, 3), new Point(3, 3), new Point(4, 3), new Point(5, 3)
             };
 
             var requiredKinds = new List<ItemKind>
             {
-                ItemKind.WeaponKnuckle, ItemKind.Accessory, ItemKind.WeaponRod, ItemKind.Accessory,
-                ItemKind.Accessory, ItemKind.ArmorGi, ItemKind.Accessory, ItemKind.ArmorRobe,
-                ItemKind.WeaponKnuckle, ItemKind.Accessory, ItemKind.HatWizard, ItemKind.Accessory,
-                ItemKind.Accessory, ItemKind.ArmorGi, ItemKind.Accessory, ItemKind.HatHeadband,
-                ItemKind.WeaponKnuckle, ItemKind.Accessory, ItemKind.WeaponRod, ItemKind.Accessory,
-                ItemKind.Accessory, ItemKind.ArmorRobe, ItemKind.Accessory, ItemKind.Accessory
+                ItemKind.WeaponKnuckle, ItemKind.Accessory, ItemKind.WeaponKnuckle, ItemKind.Accessory, ItemKind.WeaponKnuckle, ItemKind.Accessory,
+                ItemKind.Accessory, ItemKind.ArmorGi, ItemKind.Accessory, ItemKind.ArmorGi, ItemKind.Accessory, ItemKind.ArmorRobe,
+                ItemKind.WeaponRod, ItemKind.Accessory, ItemKind.HatWizard, ItemKind.Accessory, ItemKind.WeaponRod, ItemKind.Accessory,
+                ItemKind.Accessory, ItemKind.ArmorRobe, ItemKind.Accessory, ItemKind.HatHeadband, ItemKind.Accessory, ItemKind.Accessory
             };
 
             var effects = new List<ISynergyEffect>
@@ -379,24 +377,26 @@ namespace RolePlayingFramework.Synergies
         /// <summary>Elemental Champion - All equipment types ultimate pattern.</summary>
         public static SynergyPattern CreateElementalChampion()
         {
+            // 9 wide x 4 tall: the old 6x6 block reflowed so it fits the 5-row bag. Same 36 cells and
+            // the same required kinds — the two all-accessory rows are folded into the themed rows.
             var offsets = new List<Point>
             {
-                new Point(0, 0), new Point(1, 0), new Point(2, 0), new Point(3, 0), new Point(4, 0), new Point(5, 0),
-                new Point(0, 1), new Point(1, 1), new Point(2, 1), new Point(3, 1), new Point(4, 1), new Point(5, 1),
-                new Point(0, 2), new Point(1, 2), new Point(2, 2), new Point(3, 2), new Point(4, 2), new Point(5, 2),
-                new Point(0, 3), new Point(1, 3), new Point(2, 3), new Point(3, 3), new Point(4, 3), new Point(5, 3),
-                new Point(0, 4), new Point(1, 4), new Point(2, 4), new Point(3, 4), new Point(4, 4), new Point(5, 4),
-                new Point(0, 5), new Point(1, 5), new Point(2, 5), new Point(3, 5), new Point(4, 5), new Point(5, 5)
+                new Point(0, 0), new Point(1, 0), new Point(2, 0), new Point(3, 0), new Point(4, 0), new Point(5, 0), new Point(6, 0), new Point(7, 0), new Point(8, 0),
+                new Point(0, 1), new Point(1, 1), new Point(2, 1), new Point(3, 1), new Point(4, 1), new Point(5, 1), new Point(6, 1), new Point(7, 1), new Point(8, 1),
+                new Point(0, 2), new Point(1, 2), new Point(2, 2), new Point(3, 2), new Point(4, 2), new Point(5, 2), new Point(6, 2), new Point(7, 2), new Point(8, 2),
+                new Point(0, 3), new Point(1, 3), new Point(2, 3), new Point(3, 3), new Point(4, 3), new Point(5, 3), new Point(6, 3), new Point(7, 3), new Point(8, 3)
             };
 
             var requiredKinds = new List<ItemKind>
             {
-                ItemKind.WeaponSword, ItemKind.WeaponKnuckle, ItemKind.WeaponRod, ItemKind.WeaponStaff, ItemKind.Accessory, ItemKind.Accessory,
-                ItemKind.ArmorMail, ItemKind.ArmorGi, ItemKind.ArmorRobe, ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory,
-                ItemKind.Shield, ItemKind.HatHelm, ItemKind.HatHeadband, ItemKind.HatWizard, ItemKind.HatPriest, ItemKind.Accessory,
-                ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory,
-                ItemKind.WeaponSword, ItemKind.WeaponKnuckle, ItemKind.Accessory, ItemKind.ArmorMail, ItemKind.Shield, ItemKind.Accessory,
-                ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory
+                // Weapons
+                ItemKind.WeaponSword, ItemKind.WeaponKnuckle, ItemKind.WeaponRod, ItemKind.WeaponStaff, ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory,
+                // Armor
+                ItemKind.ArmorMail, ItemKind.ArmorGi, ItemKind.ArmorRobe, ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory,
+                // Shield and hats
+                ItemKind.Shield, ItemKind.HatHelm, ItemKind.HatHeadband, ItemKind.HatWizard, ItemKind.HatPriest, ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory,
+                // Second set of the heavy pieces
+                ItemKind.WeaponSword, ItemKind.WeaponKnuckle, ItemKind.ArmorMail, ItemKind.Shield, ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory, ItemKind.Accessory
             };
 
             var effects = new List<ISynergyEffect>

--- a/PitHero/Services/StencilBagSlotPreferenceProvider.cs
+++ b/PitHero/Services/StencilBagSlotPreferenceProvider.cs
@@ -1,4 +1,5 @@
 using Nez;
+using PitHero.UI;
 using RolePlayingFramework.Equipment;
 using RolePlayingFramework.Inventory;
 using RolePlayingFramework.Synergies;
@@ -11,14 +12,13 @@ namespace PitHero.Services
     /// </summary>
     public sealed class StencilBagSlotPreferenceProvider : IBagSlotPreferenceProvider
     {
-        // Grid-layout constants — must stay in sync with InventoryGrid.UpdateBagSlots.
-        // Rows 3-8 (inclusive) of the 20-wide grid back the 120 bag slots.
-        // bagIndex = (gridY - GridBagRowStart) * GridWidth + gridX
-        private const int GridWidth        = 20;
-        private const int GridBagRowStart  = 3;   // first grid row that is bag-backed
-        private const int GridBagRowEnd    = 8;   // last  grid row that is bag-backed (inclusive)
+        // Grid layout, taken straight from InventoryGrid so a resize of the grid can never leave this
+        // mapping behind: bagIndex = (gridY - GridBagRowStart) * GridWidth + gridX
+        private const int GridWidth        = InventoryGrid.BagColumns;
+        private const int GridBagRowStart  = InventoryGrid.BagRowStart;                          // first bag-backed row
+        private const int GridBagRowEnd    = InventoryGrid.BagRowStart + InventoryGrid.BagRows - 1; // last, inclusive
         private const int GridColMin       = 0;
-        private const int GridColMax       = 19;
+        private const int GridColMax       = InventoryGrid.BagColumns - 1;
 
         private readonly GameStateService _gameStateService;
 
@@ -60,7 +60,7 @@ namespace PitHero.Services
                     int gridX = record.AnchorX + offsets[i].X;
                     int gridY = record.AnchorY + offsets[i].Y;
 
-                    // Only rows 3-8 map to bag slots; discard out-of-bounds coordinates.
+                    // Only the bag rows map to bag slots; discard out-of-bounds coordinates.
                     if (gridY < GridBagRowStart || gridY > GridBagRowEnd) continue;
                     if (gridX < GridColMin      || gridX > GridColMax)    continue;
 

--- a/PitHero/UI/AddMonsterDialog.cs
+++ b/PitHero/UI/AddMonsterDialog.cs
@@ -29,6 +29,8 @@ namespace PitHero.UI
 
         private const float SlotSize = 64f;
         private const int Columns = 6;
+        private const float DialogWidth = 460f;
+        private const float DialogDesignHeight = 340f; // design height at GameConfig.VirtualHeight = 360
         private static readonly Color BrownColor = new Color(71, 36, 7);
 
         /// <summary>Whether the dialog is currently visible.</summary>
@@ -40,7 +42,7 @@ namespace PitHero.UI
             _stage = stage;
             SetMovable(false);
             SetResizable(false);
-            SetSize(460f, 340f);
+            SetSize(DialogWidth, DialogDesignHeight);
 
             GetTitleLabel().SetText(GetText(UITextKey.AddMonsterWindowTitle));
 
@@ -95,11 +97,16 @@ namespace PitHero.UI
             Core.Services.GetService<PauseService>()?.Unpause();
         }
 
+        /// <summary>Fits the dialog to the live stage height and centers it.</summary>
         private void CenterOnStage()
         {
             var stage = _stage ?? GetStage();
             if (stage == null) return;
-            SetPosition((stage.GetWidth() - GetWidth()) / 2f, (stage.GetHeight() - GetHeight()) / 2f);
+            float stageH = stage.GetHeight();
+            float h = UILayout.FitHeight(DialogDesignHeight, stageH, GameConfig.UIStageMargin, GameConfig.UIStageMargin);
+            SetSize(DialogWidth, h);
+            Validate();
+            SetPosition((stage.GetWidth() - GetWidth()) / 2f, UILayout.CenterY(h, stageH, 0f));
         }
 
         private void Rebuild()

--- a/PitHero/UI/AutoSellCropTypesDialog.cs
+++ b/PitHero/UI/AutoSellCropTypesDialog.cs
@@ -134,7 +134,7 @@ namespace PitHero.UI
             _window.Pack();
             _window.SetPosition(
                 (_stage.GetWidth() - _window.GetWidth()) / 2f,
-                (_stage.GetHeight() - _window.GetHeight()) / 2f);
+                UILayout.CenterY(_window.GetHeight(), _stage.GetHeight(), 0f));
             _window.SetVisible(true);
             _window.ToFront();
             _shownFrame = Time.FrameCount;

--- a/PitHero/UI/BuildingModeOverlay.cs
+++ b/PitHero/UI/BuildingModeOverlay.cs
@@ -60,6 +60,11 @@ namespace PitHero.UI
         private const float FallStartOffset = -600f;
         private const float SlotSize = 100f;
         private const float WinPad = 16f;
+        // Upward nudge off centre so the window clears the bottom UI bars.
+        private const float CenterYBias = 30f;
+        
+        // Gap between the Buildings window and the description card.
+        private const float DescWindowGap = 8f;
 
         private TextService _textService;
 
@@ -281,9 +286,10 @@ namespace PitHero.UI
             _inventoryWindow.Pack();
             float w = _inventoryWindow.GetWidth();
             float h = _inventoryWindow.GetHeight();
+            float stageH = _stage.GetHeight();
             _inventoryWindow.SetPosition(
                 (_stage.GetWidth()  - w) / 2f,
-                (_stage.GetHeight() - h) / 2f - 30f);
+                UILayout.CenterY(h, stageH, CenterYBias));
             _inventoryWindow.SetVisible(true);
         }
 
@@ -333,10 +339,30 @@ namespace PitHero.UI
 
             _descWindow.Pack();
 
+            // Below the Buildings window when there is room; otherwise beside it, so the card is never
+            // pushed off the bottom at short design heights.
             float invX = _inventoryWindow.GetX();
             float invY = _inventoryWindow.GetY();
+            float invW = _inventoryWindow.GetWidth();
             float invH = _inventoryWindow.GetHeight();
-            _descWindow.SetPosition(invX, invY + invH + 8f);
+            float stageW = _stage.GetWidth();
+            float stageH = _stage.GetHeight();
+            float descW = _descWindow.GetWidth();
+            float descH = _descWindow.GetHeight();
+
+            if (invY + invH + DescWindowGap + descH <= stageH - GameConfig.UIStageMargin)
+            {
+                _descWindow.SetPosition(invX, invY + invH + DescWindowGap);
+            }
+            else
+            {
+                float descX = invX + invW + DescWindowGap;
+                if (descX + descW > stageW)
+                    descX = invX - DescWindowGap - descW;
+                if (descX < 0f)
+                    descX = 0f;
+                _descWindow.SetPosition(descX, UILayout.ClampY(invY, descH, stageH));
+            }
             _descWindow.SetVisible(true);
         }
 

--- a/PitHero/UI/ConfirmationDialog.cs
+++ b/PitHero/UI/ConfirmationDialog.cs
@@ -103,7 +103,7 @@ namespace PitHero.UI
             // Center the dialog
             var stageWidth = stage.GetWidth();
             var stageHeight = stage.GetHeight();
-            SetPosition((stageWidth - GetWidth()) / 2f, (stageHeight - GetHeight()) / 2f);
+            SetPosition((stageWidth - GetWidth()) / 2f, UILayout.CenterY(GetHeight(), stageHeight, 0f));
 
             stage.AddElement(this);
             SetVisible(true);

--- a/PitHero/UI/ConsumablePurchaseOptionsDialog.cs
+++ b/PitHero/UI/ConsumablePurchaseOptionsDialog.cs
@@ -20,6 +20,9 @@ namespace PitHero.UI
         private const float SpriteSize = 32f;
         private const float WinPad = 16f;
         private const float GridMaxHeight = 200f;
+        // Window chrome around the grid (title bar, label, button row, padding) — the grid cap is the
+        // stage height minus this, so the dialog always fits the configured design height.
+        private const float GridChromeHeight = 109f;
         private const float SliderWidth = 120f;
 
         private readonly Stage _stage;
@@ -28,6 +31,8 @@ namespace PitHero.UI
         private readonly HoverableLabel[] _stackLabels = new HoverableLabel[ConsumableCatalog.Count];
         private readonly EnhancedSlider[] _stackSliders = new EnhancedSlider[ConsumableCatalog.Count];
 
+        private Table _contentTable;
+        private Cell _gridCell;
         private Window _window;
         private uint _shownFrame;
         private TextService _textService;
@@ -55,6 +60,7 @@ namespace PitHero.UI
             _window.SetResizable(false);
 
             var content = new Table();
+            _contentTable = content;
             content.Pad(WinPad);
 
             content.Add(new Label(GetText(UITextKey.LabelConsumablesAutoPurchased), skin, "ph-default")).Left().SetPadBottom(8f);
@@ -124,7 +130,7 @@ namespace PitHero.UI
             var scrollPane = new ScrollPane(grid, skin, "ph-default");
             scrollPane.SetScrollingDisabled(true, false);
             scrollPane.SetFadeScrollBars(false);
-            content.Add(scrollPane).SetMaxHeight(GridMaxHeight).Expand().Fill();
+            _gridCell = content.Add(scrollPane).SetMaxHeight(GridMaxHeight).Expand().Fill();
             content.Row();
 
             var buttonRow = new Table();
@@ -152,10 +158,17 @@ namespace PitHero.UI
         public void Show()
         {
             SyncFromService();
+            // Cap the grid so title bar, button row and padding still fit the configured design height
+            float stageH = _stage.GetHeight();
+            float gridMax = stageH - 2f * GameConfig.UIStageMargin - GridChromeHeight;
+            if (gridMax > GridMaxHeight) gridMax = GridMaxHeight;
+            if (gridMax < UILayout.MinScrollCellHeight) gridMax = UILayout.MinScrollCellHeight;
+            _gridCell.SetMaxHeight(gridMax);
+            _contentTable.InvalidateHierarchy();
             _window.Pack();
             _window.SetPosition(
                 (_stage.GetWidth() - _window.GetWidth()) / 2f,
-                (_stage.GetHeight() - _window.GetHeight()) / 2f);
+                UILayout.CenterY(_window.GetHeight(), stageH, 0f));
             _window.SetVisible(true);
             _window.ToFront();
             _shownFrame = Time.FrameCount;

--- a/PitHero/UI/ConsumableSellOptionsDialog.cs
+++ b/PitHero/UI/ConsumableSellOptionsDialog.cs
@@ -21,6 +21,9 @@ namespace PitHero.UI
         private const float SpriteSize = 32f;
         private const float WinPad = 16f;
         private const float GridMaxHeight = 200f;
+        // Window chrome around the grid (title bar, label, button row, padding) — the grid cap is the
+        // stage height minus this, so the dialog always fits the configured design height.
+        private const float GridChromeHeight = 109f;
         private const float SliderWidth = 120f;
 
         private readonly Stage _stage;
@@ -29,6 +32,8 @@ namespace PitHero.UI
         private readonly HoverableLabel[] _stackLabels = new HoverableLabel[ConsumableCatalog.Count];
         private readonly EnhancedSlider[] _stackSliders = new EnhancedSlider[ConsumableCatalog.Count];
 
+        private Table _contentTable;
+        private Cell _gridCell;
         private Window _window;
         private uint _shownFrame;
         private TextService _textService;
@@ -56,6 +61,7 @@ namespace PitHero.UI
             _window.SetResizable(false);
 
             var content = new Table();
+            _contentTable = content;
             content.Pad(WinPad);
 
             content.Add(new Label(GetText(UITextKey.LabelConsumablesAutoSold), skin, "ph-default")).Left().SetPadBottom(8f);
@@ -122,7 +128,7 @@ namespace PitHero.UI
             var scrollPane = new ScrollPane(grid, skin, "ph-default");
             scrollPane.SetScrollingDisabled(true, false);
             scrollPane.SetFadeScrollBars(false);
-            content.Add(scrollPane).SetMaxHeight(GridMaxHeight).Expand().Fill();
+            _gridCell = content.Add(scrollPane).SetMaxHeight(GridMaxHeight).Expand().Fill();
             content.Row();
 
             var buttonRow = new Table();
@@ -150,10 +156,17 @@ namespace PitHero.UI
         public void Show()
         {
             SyncFromService();
+            // Cap the grid so title bar, button row and padding still fit the configured design height
+            float stageH = _stage.GetHeight();
+            float gridMax = stageH - 2f * GameConfig.UIStageMargin - GridChromeHeight;
+            if (gridMax > GridMaxHeight) gridMax = GridMaxHeight;
+            if (gridMax < UILayout.MinScrollCellHeight) gridMax = UILayout.MinScrollCellHeight;
+            _gridCell.SetMaxHeight(gridMax);
+            _contentTable.InvalidateHierarchy();
             _window.Pack();
             _window.SetPosition(
                 (_stage.GetWidth() - _window.GetWidth()) / 2f,
-                (_stage.GetHeight() - _window.GetHeight()) / 2f);
+                UILayout.CenterY(_window.GetHeight(), stageH, 0f));
             _window.SetVisible(true);
             _window.ToFront();
             _shownFrame = Time.FrameCount;

--- a/PitHero/UI/CrystalCreationDialog.cs
+++ b/PitHero/UI/CrystalCreationDialog.cs
@@ -187,7 +187,7 @@ namespace PitHero.UI
             float dialogH = GetHeight();
             SetPosition(
                 (_stage.GetWidth()  - dialogW) / 2f,
-                (_stage.GetHeight() - dialogH) / 2f
+                UILayout.CenterY(dialogH, _stage.GetHeight(), 0f)
             );
 
             _skillTooltip = new SkillTooltip(this, skin);

--- a/PitHero/UI/CrystalsTab.cs
+++ b/PitHero/UI/CrystalsTab.cs
@@ -9,8 +9,10 @@ namespace PitHero.UI
     /// <summary>The main content of the Crystals collection tab.</summary>
     public class CrystalsTab
     {
-        private const int INVENTORY_COLS = 8;
-        private const int INVENTORY_ROWS = 5;
+        // Wide and short: 40 slots either way, but one row less costs 34px of height. The queue column
+        // is the next cell of the same table row, so it shifts right with the extra columns on its own.
+        private const int INVENTORY_COLS = 10;
+        private const int INVENTORY_ROWS = 4;
         private const int INVENTORY_TOTAL = INVENTORY_COLS * INVENTORY_ROWS; // 40 slots
         private const int QUEUE_SLOTS = 5;
         private const float SLOT_SIZE = 32f;
@@ -86,7 +88,7 @@ namespace PitHero.UI
 
             // ── Forge section (spans both columns) ───────────────────────────────
             var forgeSection = new Table();
-            forgeSection.Add(new HoverableLabel(GetText(UITextKey.CrystalForgeTitle), skin, "ph-default", GetText(UITextKey.CrystalForgeTitleTooltip), _stage)).Left().Pad(5);
+            forgeSection.Add(new HoverableLabel(GetText(UITextKey.CrystalForgeTitle), skin, "ph-default", GetText(UITextKey.CrystalForgeTitleTooltip), _stage)).Left().Pad(2);
             forgeSection.Row();
 
             var forgeRow = new Table();
@@ -151,7 +153,7 @@ namespace PitHero.UI
 
             // ── Inventory section (left) ──────────────────────────────────────────
             var invCol = new Table();
-            invCol.Add(new Label(GetText(UITextKey.CrystalInventoryTitle), skin, "ph-default")).Left().Pad(5);
+            invCol.Add(new Label(GetText(UITextKey.CrystalInventoryTitle), skin, "ph-default")).Left().Pad(2);
             invCol.Row();
 
             var invGrid = new Table();
@@ -176,11 +178,11 @@ namespace PitHero.UI
             _createButton = new HoverableTextButton(GetText(UITextKey.CrystalCreateButton), skin, "ph-default", GetText(UITextKey.CrystalCreateButtonTooltip), _stage);
             _createButton.OnClicked += OnCreateClicked;
             _createButton.OnClicked += (_) => _createButton.HideTooltip();
-            invCol.Add(_createButton).Height(24).Left().Pad(5);
+            invCol.Add(_createButton).Height(24).Left().Pad(2);
 
             // ── Queue section (right) ─────────────────────────────────────────────
             var queueCol = new Table();
-            queueCol.Add(new HoverableLabel(GetText(UITextKey.CrystalQueueTitle), skin, "ph-default", GetText(UITextKey.CrystalQueueTitleTooltip), _stage)).Left().Pad(5);
+            queueCol.Add(new HoverableLabel(GetText(UITextKey.CrystalQueueTitle), skin, "ph-default", GetText(UITextKey.CrystalQueueTitleTooltip), _stage)).Left().Pad(2);
             queueCol.Row();
 
             _queueSlots = new CrystalSlotElement[QUEUE_SLOTS];

--- a/PitHero/UI/GearFilterOptionsDialog.cs
+++ b/PitHero/UI/GearFilterOptionsDialog.cs
@@ -153,7 +153,7 @@ namespace PitHero.UI
             _window.Pack();
             _window.SetPosition(
                 (_stage.GetWidth() - _window.GetWidth()) / 2f,
-                (_stage.GetHeight() - _window.GetHeight()) / 2f);
+                UILayout.CenterY(_window.GetHeight(), _stage.GetHeight(), 0f));
             _window.SetVisible(true);
             _window.ToFront();
             _shownFrame = Time.FrameCount;

--- a/PitHero/UI/HarvestedCropsModeOverlay.cs
+++ b/PitHero/UI/HarvestedCropsModeOverlay.cs
@@ -24,6 +24,8 @@ namespace PitHero.UI
 
         private Window _inventoryWindow;
         private Table _slotTable;
+        private Table _outerTable;
+        private Cell _scrollCell;
 
         private Window _descWindow;
         private Label _descNameLabel;
@@ -51,8 +53,9 @@ namespace PitHero.UI
         private const int   Columns      = 8;
         private const float ButtonWidth  = 110f;
         private const float ButtonHeight = 16f;
-        // One page is 4 rows of 44px (40px slot + 2px pad each side), so 224 fits a full storage
-        // without scrolling while keeping the window clear of the top of the screen.
+        // One page is 4 rows of 44px (40px slot + 2px pad each side), so 224 fits a full storage at the
+        // 360px design height without scrolling. ShowInventoryWindow shrinks it when the configured
+        // GameConfig.VirtualHeight is shorter (the grid then scrolls).
         private const float ScrollHeight = 224f;
         // Upward nudge off centre so the window clears the bottom UI bars.
         private const float CenterYBias  = 30f;
@@ -334,12 +337,13 @@ namespace PitHero.UI
             _inventoryWindow.SetResizable(false);
 
             var outer = new Table();
+            _outerTable = outer;
             outer.Pad(WinPad);
 
             _slotTable = new Table();
             var scroll = new ScrollPane(_slotTable, skin, "ph-default");
             scroll.SetScrollingDisabled(true, false);
-            outer.Add(scroll).Width(SlotSize * Columns + 48f).Height(ScrollHeight);
+            _scrollCell = outer.Add(scroll).Width(SlotSize * Columns + 48f).Height(ScrollHeight);
             outer.Row();
 
             _pagerRow = new PagerRow(skin);
@@ -412,20 +416,16 @@ namespace PitHero.UI
         private void ShowInventoryWindow()
         {
             _descWindow?.SetVisible(false);
-            _inventoryWindow.Pack();
-            float w = _inventoryWindow.GetWidth();
-            float h = _inventoryWindow.GetHeight();
             float stageW = _stage.GetWidth();
             float stageH = _stage.GetHeight();
 
-            // Sits slightly above centre to clear the bottom UI bars, then is clamped to the stage so a
-            // taller window — an extra button row, a larger slot grid — can never run off the top.
+            // Shrink the slot grid when the configured design height cannot fit the full window, then
+            // sit slightly above centre to clear the bottom UI bars (clamped to the stage).
+            UILayout.FitScrollCellToStage(_inventoryWindow, _outerTable, _scrollCell, ScrollHeight, stageH, GameConfig.UIStageMargin);
+            float w = _inventoryWindow.GetWidth();
+            float h = _inventoryWindow.GetHeight();
             float x = (stageW - w) / 2f;
-            float y = (stageH - h) / 2f - CenterYBias;
-            if (y + h > stageH)
-                y = stageH - h;
-            if (y < 0f)
-                y = 0f;
+            float y = UILayout.CenterY(h, stageH, CenterYBias);
             if (x < 0f)
                 x = 0f;
 

--- a/PitHero/UI/HeroCreationUI.cs
+++ b/PitHero/UI/HeroCreationUI.cs
@@ -32,7 +32,7 @@ namespace PitHero.UI
 
         // Shared layout constants for the Appearance + Job Info window pair
         private const float AppearanceWindowWidth = 560f;
-        private const float CreationWindowHeight = 340f;
+        private const float CreationWindowHeight = 340f; // design height at GameConfig.VirtualHeight = 360
         private const float CreationWindowGap = 10f;
         private const float JobInfoWindowWidth = 350f;
 
@@ -108,6 +108,12 @@ namespace PitHero.UI
             RebuildPreviewAppearance();
         }
 
+        /// <summary>Height of the Appearance / Job Info windows, fitted to the live stage height.</summary>
+        private static float FittedCreationHeight(float stageH)
+        {
+            return UILayout.FitHeight(CreationWindowHeight, stageH, GameConfig.UIStageMargin, GameConfig.UIStageMargin);
+        }
+
         /// <summary>Creates the controls window with appearance options and hero preview</summary>
         private void CreateControlsWindow(Skin skin)
         {
@@ -116,14 +122,15 @@ namespace PitHero.UI
             _controlsWindow = window;
 
             const float windowWidth = AppearanceWindowWidth;
-            const float windowHeight = CreationWindowHeight;
             const float gap = CreationWindowGap;
             const float jobInfoWidth = JobInfoWindowWidth;
             float totalWidth = windowWidth + gap + jobInfoWidth;
             float startX = (_stage.GetWidth() - totalWidth) / 2f;
 
-            window.SetSize(windowWidth, windowHeight);
-            window.SetPosition(startX, (_stage.GetHeight() - windowHeight) / 2f);
+            float stageH = _stage.GetHeight();
+            float fittedHeight = FittedCreationHeight(stageH);
+            window.SetSize(windowWidth, fittedHeight);
+            window.SetPosition(startX, UILayout.CenterY(fittedHeight, stageH, 0f));
 
             // Main layout: top row (controls + preview), bottom row (buttons)
             var mainTable = new Table();
@@ -134,10 +141,10 @@ namespace PitHero.UI
 
             // Left: controls table
             var controlsTable = new Table();
-            controlsTable.Defaults().SetPadBottom(8f);
+            controlsTable.Defaults().SetPadBottom(3f); // tight rows so the Appearance content fits short design heights
 
             const float arrowWidth = 40f;
-            const float arrowHeight = 30f;
+            const float arrowHeight = 26f;
             const float labelWidth = 160f;
 
             // --- Name row ---
@@ -324,10 +331,10 @@ namespace PitHero.UI
             cancelButton.OnClicked += (btn) => OnCancel();
 
             var buttonsTable = new Table();
-            buttonsTable.Add(createButton).Size(160f, 40f).SetPadRight(10f);
-            buttonsTable.Add(cancelButton).Size(140f, 40f);
+            buttonsTable.Add(createButton).Size(160f, 34f).SetPadRight(10f);
+            buttonsTable.Add(cancelButton).Size(140f, 34f);
 
-            mainTable.Add(buttonsTable).Left().SetPadTop(10f);
+            mainTable.Add(buttonsTable).Left().SetPadTop(6f);
 
             window.Add(mainTable).Expand().Fill();
             _stage.AddElement(window);
@@ -431,13 +438,14 @@ namespace PitHero.UI
 
             const float windowWidth = AppearanceWindowWidth;
             const float jobInfoWidth = JobInfoWindowWidth;
-            const float windowHeight = CreationWindowHeight;
             const float gap = CreationWindowGap;
             float totalWidth = windowWidth + gap + jobInfoWidth;
             float startX = (_stage.GetWidth() - totalWidth) / 2f;
 
-            jobInfoWindow.SetSize(jobInfoWidth, windowHeight);
-            jobInfoWindow.SetPosition(startX + windowWidth + gap, (_stage.GetHeight() - windowHeight) / 2f);
+            float stageH = _stage.GetHeight();
+            float fittedHeight = FittedCreationHeight(stageH);
+            jobInfoWindow.SetSize(jobInfoWidth, fittedHeight);
+            jobInfoWindow.SetPosition(startX + windowWidth + gap, UILayout.CenterY(fittedHeight, stageH, 0f));
 
             _jobInfoContentTable = new Table();
             _jobInfoContentTable.Pad(10f);
@@ -599,9 +607,12 @@ namespace PitHero.UI
 
                 float totalWidth = AppearanceWindowWidth + CreationWindowGap + JobInfoWindowWidth;
                 float startX = (stageW - totalWidth) / 2f;
-                float windowY = (stageH - CreationWindowHeight) / 2f;
+                float fittedHeight = FittedCreationHeight(stageH);
+                float windowY = UILayout.CenterY(fittedHeight, stageH, 0f);
 
+                _controlsWindow?.SetSize(AppearanceWindowWidth, fittedHeight);
                 _controlsWindow?.SetPosition(startX, windowY);
+                _jobInfoWindow?.SetSize(JobInfoWindowWidth, fittedHeight);
                 _jobInfoWindow?.SetPosition(startX + AppearanceWindowWidth + CreationWindowGap, windowY);
                 // Preview sits above the direction buttons on the right side of the Appearance window
                 _previewEntity?.SetPosition(startX + AppearanceWindowWidth - 128f, stageH * 0.48f);

--- a/PitHero/UI/HeroCrystalTab.cs
+++ b/PitHero/UI/HeroCrystalTab.cs
@@ -17,6 +17,13 @@ namespace PitHero.UI
     /// </summary>
     public class HeroCrystalTab
     {
+        // Skill icons are 32px with 2px padding, so eight columns take 288px of the ~490px window —
+        // twice as many skills per row as before, which lifts the sections below out of dead space.
+        private const int SkillGridColumns = 8;
+
+        /// <summary>Vertical gap between the info label rows (Name/Job/Level, JP/stats).</summary>
+        private const float InfoRowSpacing = 2f;
+
         private Table _mainContainer;
         private HeroComponent _heroComponent;
 
@@ -76,7 +83,8 @@ namespace PitHero.UI
 
             // Middle section: Three skill grids in scroll pane
             var skillGridsPane = CreateSkillGrids(skin);
-            _mainContainer.Add(skillGridsPane).Expand().Fill().Pad(20f);
+            // Modest padding so the skill grids keep as much of the window as possible at short design heights
+            _mainContainer.Add(skillGridsPane).Expand().Fill().Pad(10f);
 
             // Create confirmation dialog (hidden initially)
             CreateConfirmationDialog(skin);
@@ -108,8 +116,10 @@ namespace PitHero.UI
         {
             var infoTable = new Table();
 
-            // Left column: Name, Job and Level info
+            // Left column: Name, Job and Level info. The label rows breathe by InfoRowSpacing so they
+            // are not crammed together; the Change Job button keeps its own larger gap below them.
             var leftCol = new Table();
+            leftCol.Defaults().SetPadBottom(InfoRowSpacing);
             _heroNameLabel = new Label(GetText(TextType.UI, UITextKey.HeroNameLabel), skin, "ph-default");
             leftCol.Add(_heroNameLabel).Left();
             leftCol.Row();
@@ -138,8 +148,9 @@ namespace PitHero.UI
             // Middle column: Hero sprite preview
             _heroPreviewContainer = new Table();
 
-            // Right column: JP info and stats
+            // Right column: JP info and stats, spaced to match the left column
             var rightCol = new Table();
+            rightCol.Defaults().SetPadBottom(InfoRowSpacing);
             _currentJPLabel = new Label(GetText(TextType.UI, UITextKey.HeroCurrentJpLabel), skin, "ph-default");
             rightCol.Add(_currentJPLabel).Left();
             rightCol.Row();
@@ -151,9 +162,11 @@ namespace PitHero.UI
             _statsLabel = new Label(GetText(TextType.UI, UITextKey.HeroStatsLabel), skin, "ph-default");
             rightCol.Add(_statsLabel).Left();
 
-            infoTable.Add(leftCol).Left().Expand().Pad(5f);
+            // Both label columns are top-aligned so Current JP lines up with Name; without this the
+            // shorter right column is centered against the taller left one and sits lower.
+            infoTable.Add(leftCol).Left().Top().Expand().Pad(5f);
             infoTable.Add(_heroPreviewContainer).Center().Pad(5f);
-            infoTable.Add(rightCol).Right().Expand().Pad(5f);
+            infoTable.Add(rightCol).Right().Top().Expand().Pad(5f);
 
             return infoTable;
         }
@@ -287,7 +300,7 @@ namespace PitHero.UI
                 return;
             }
 
-            const int columns = 4;
+            const int columns = SkillGridColumns;
             int col = 0;
 
             for (int i = 0; i < jobSkills.Count; i++)
@@ -366,7 +379,7 @@ namespace PitHero.UI
                 return;
             }
 
-            const int columns = 4;
+            const int columns = SkillGridColumns;
             int col = 0;
 
             for (int i = 0; i < synergySkills.Count; i++)
@@ -412,7 +425,7 @@ namespace PitHero.UI
                 return;
             }
 
-            const int columns = 4;
+            const int columns = SkillGridColumns;
             int col = 0;
 
             for (int i = 0; i < activeSynergyGroups.Count; i++)

--- a/PitHero/UI/HeroUI.cs
+++ b/PitHero/UI/HeroUI.cs
@@ -93,8 +93,10 @@ namespace PitHero.UI
         private MercenariesTab _mercenariesTabComponent;
         private FoodTab _foodTabComponent;
 
-        private const float HERO_WINDOW_WIDTH = 870f;
+        // Inventory tab width: the grid cell plus the stencil button column and its padding
+        private const float HERO_WINDOW_WIDTH = InventoryGrid.ContentWidth + 178f; // 1002
         private const float COMPACT_WINDOW_WIDTH = 490f;
+        private const float HERO_WINDOW_HEIGHT = GameConfig.VirtualHeight; // full stage height: the window is flush with the top and bottom edges
         private const float TAB_STRIP_MARGIN = 24f; // breathing room beside the tab button strip
         private float _minTabStripWidth; // computed from the real tab buttons so new tabs can't overflow
 
@@ -183,9 +185,9 @@ namespace PitHero.UI
         {
             _heroWindow = new Window("", skin); // Empty title since tabs provide context
             _heroWindow.Pad(0); // Remove all window padding so tabs are flush with edges
-            // Start with inventory tab width (850px)
-            // Width will be adjusted dynamically when tabs change
-            _heroWindow.SetSize(HERO_WINDOW_WIDTH, 350f);
+            // Start at the inventory tab width; the width follows the active tab and the height is
+            // fitted to the live stage in PositionHeroWindow.
+            _heroWindow.SetSize(HERO_WINDOW_WIDTH, HERO_WINDOW_HEIGHT);
             var tabWindowStyle = skin.Get<TabWindowStyle>(); // Use skin's tab window style
             _tabPane = new TabPane(tabWindowStyle);
             var tabStyle = CreateTabStyle(skin);
@@ -264,7 +266,7 @@ namespace PitHero.UI
             if (newWidth < _minTabStripWidth)
                 newWidth = _minTabStripWidth;
 
-            _heroWindow.SetSize(newWidth, 350f);
+            _heroWindow.SetWidth(newWidth); // PositionHeroWindow fits the height to the stage
             PositionHeroWindow(); // Reposition after resize to keep it on screen
         }
 
@@ -316,9 +318,10 @@ namespace PitHero.UI
             var scrollPane = new ScrollPane(_inventoryGrid, skin);
             scrollPane.SetScrollingDisabled(true, false);
 
-            // Add scroll pane to left side with explicit width to ensure rightmost column is clickable
-            // Grid is 692px wide (20 columns � 33px + 32px left padding)
-            inventoryContainer.Add(scrollPane).Width(700f).Expand().Fill().Pad(0f);
+            // Add scroll pane to left side with explicit width to ensure rightmost column is clickable.
+            // The grid never scrolls: it is 824px wide and 248px tall (24 columns x 5 bag rows), which
+            // fits the window, which spans the full design height (see PositionHeroWindow).
+            inventoryContainer.Add(scrollPane).Width(InventoryGrid.ContentWidth + 8f).Expand().Fill().Pad(0f);
 
             // Add stencil control buttons vertically on the right
             var buttonTable = new Table();
@@ -400,6 +403,7 @@ namespace PitHero.UI
                 }
 
                 _stencilLibraryPanel.ResetSelection();
+                _stencilLibraryPanel.FitToStage(_stage.GetHeight());
                 // Dock flush against the Hero window's left edge so the two never overlap;
                 // fall back to its right edge when there is no room on the left
                 float panelX = _heroWindow.GetX() - _stencilLibraryPanel.GetWidth();
@@ -713,7 +717,10 @@ namespace PitHero.UI
         {
             _crystalsTabComponent = new CrystalsTab();
             var content = _crystalsTabComponent.CreateContent(skin, _stage, _heroWindow);
-            tab.Add(content).Expand().Fill();
+            // The card list is taller than the window at short design heights, so it scrolls vertically
+            var scrollPane = new ScrollPane(content, skin, "ph-default");
+            scrollPane.SetScrollingDisabled(true, false);
+            tab.Add(scrollPane).Expand().Fill();
         }
 
         private void PopulateMercenariesTab(Tab mercenariesTab, Skin skin)
@@ -908,20 +915,31 @@ namespace PitHero.UI
             }
         }
 
+        /// <summary>
+        /// Sizes the hero window to the full stage height — flush with the top and bottom edges, so the
+        /// tabs and grid read as one panel — and places it beside the Party button.
+        /// </summary>
         private void PositionHeroWindow()
         {
             if (_heroWindow == null || _heroButton == null) return;
-            _heroWindow.Validate();
             float heroX = _heroButton.GetX();
-            float heroY = _heroButton.GetY();
             float heroW = _heroButton.GetWidth();
-            float winW = _heroWindow.GetWidth();
-            float winH = _heroWindow.GetHeight();
-            const float padding = 4f; float targetX = heroX + heroW + padding; float targetY = heroY + padding;
-            float stageW = _stage.GetWidth(); float stageH = _stage.GetHeight();
-            if (targetX + winW > stageW) targetX = heroX - padding - winW;
-            if (targetX < 0) targetX = 0; if (targetY < 0) targetY = 0; if (targetY + winH > stageH) targetY = stageH - winH;
-            _heroWindow.SetPosition(targetX, targetY);
+            float stageW = _stage.GetWidth();
+            float stageH = _stage.GetHeight();
+
+            float winH = stageH;
+            _heroWindow.SetSize(_heroWindow.GetWidth(), winH);
+            _heroWindow.Validate();
+
+            // Anchor to the right of the Party button, sliding left only as far as it takes to fit on
+            // stage — it stays under its button instead of jumping to the opposite side of the screen.
+            // The fit is always measured against the widest tab (inventory), so narrower tabs keep the
+            // same left edge and only their right edge moves; switching tabs never shifts the window.
+            float targetX = heroX + heroW + GameConfig.UIWindowBelowBarGap;
+            float maxX = stageW - HERO_WINDOW_WIDTH - GameConfig.UIStageMargin;
+            if (targetX > maxX) targetX = maxX;
+            if (targetX < 0) targetX = 0;
+            _heroWindow.SetPosition(targetX, 0f);
         }
 
         private HeroComponent GetHeroComponent()

--- a/PitHero/UI/InventoryGrid.cs
+++ b/PitHero/UI/InventoryGrid.cs
@@ -19,17 +19,42 @@ namespace PitHero.UI
     /// <summary>Grid layout container for inventory slots with interaction logic (single linear buffer version).</summary>
     public class InventoryGrid : Group
     {
-        private const int GRID_WIDTH = 20;
-        private const int GRID_HEIGHT = 9;  // 1 row for hero name space + 2 rows for equipment area + 6 rows for inventory
+        private const int GRID_WIDTH = 24;
+        private const int GRID_HEIGHT = 8;  // 1 row for hero name space + 2 rows for equipment area + 5 rows for inventory
         private const int CELL_COUNT = GRID_WIDTH * GRID_HEIGHT;
         private const float SLOT_SIZE = 32f;
         private const float SLOT_PADDING = 1f;
         private const float HOVER_OFFSET_Y = -16f; // Offset in pixels when hovering over a slot while another is selected
         private const float SWAP_TWEEN_DURATION = 0.2f; // Duration in seconds for swap animation
 
-        // Mercenary equip slot column positions (3 columns each, matching hero layout)
-        private const int MERC0_COL_START = 4;   // First mercenary: columns 4-6 (left of hero)
-        private const int MERC1_COL_START = 12;  // Second mercenary: columns 12-14 (right of hero)
+        // Pixel geometry of the grid. It is deliberately wide and short — 24 columns x 5 bag rows is
+        // the same 120 bag slots the old 20 x 6 layout had, but one row shorter so the whole grid
+        // fits the design height (GameConfig.VirtualHeight) without scrolling.
+        private const int BAG_START_ROW = 3;                                            // rows 0-2 are names + equipment
+        private const int BAG_ROW_COUNT = GRID_HEIGHT - BAG_START_ROW;                  // 5
+        private const float ROW_PITCH = SLOT_SIZE + SLOT_PADDING;                       // 33
+        private const float X_OFFSET = 32f;                                             // left padding before column 0
+        private const float Y_OFFSET = -16f;                                            // grid sits 16px higher (half the name row)
+
+        /// <summary>Bag columns — also the widest a synergy stencil may be.</summary>
+        public const int BagColumns = GRID_WIDTH;                                       // 24
+        /// <summary>Bag rows — also the tallest a synergy stencil may be.</summary>
+        public const int BagRows = BAG_ROW_COUNT;                                       // 5
+        /// <summary>First grid row backed by a bag slot (rows above it are names and equipment).</summary>
+        public const int BagRowStart = BAG_START_ROW;                                   // 3
+        /// <summary>Bag slot count (rows 3..7 across every column).</summary>
+        public const int BagCapacity = GRID_WIDTH * BAG_ROW_COUNT;                      // 120
+        /// <summary>Width of the whole grid, which a host must give it in full.</summary>
+        public const float ContentWidth = GRID_WIDTH * ROW_PITCH + X_OFFSET;            // 824
+        /// <summary>Height of the whole grid, which a host must give it in full.</summary>
+        public const float ContentHeight = GRID_HEIGHT * ROW_PITCH + Y_OFFSET;          // 248
+
+        // Equipment block: mercenary / hero / mercenary, three columns each with a one-column gap,
+        // centered over the grid width (11 = 3 + 1 + 3 + 1 + 3).
+        private const int EQUIP_BLOCK_START = (GRID_WIDTH - 11) / 2;
+        private const int MERC0_COL_START = EQUIP_BLOCK_START;      // First mercenary (left of hero)
+        private const int HERO_COL_START = EQUIP_BLOCK_START + 4;   // Hero equipment columns
+        private const int MERC1_COL_START = EQUIP_BLOCK_START + 8;  // Second mercenary (right of hero)
         private const int MAX_MERCENARY_SLOTS = 2;
 
         private readonly FastList<InventorySlot> _slots;   // Row-major, may contain nulls for Null slots or capacity-disabled slots
@@ -218,19 +243,19 @@ namespace PitHero.UI
             // Rows 1-2 (y=1,2) are for equipment display (hero + mercenaries)
             if (y >= 1 && y <= 2)
             {
-                // Hero equipment slots (columns 8-10)
-                if (y == 1 && x == 8) return new InventorySlotData(x, y, InventorySlotType.Equipment) { EquipmentSlot = EquipmentSlot.WeaponShield1 };
-                if (y == 1 && x == 9) return new InventorySlotData(x, y, InventorySlotType.Equipment) { EquipmentSlot = EquipmentSlot.Hat };
-                if (y == 1 && x == 10) return new InventorySlotData(x, y, InventorySlotType.Equipment) { EquipmentSlot = EquipmentSlot.WeaponShield2 };
-                if (y == 2 && x == 8) return new InventorySlotData(x, y, InventorySlotType.Equipment) { EquipmentSlot = EquipmentSlot.Accessory1 };
-                if (y == 2 && x == 9) return new InventorySlotData(x, y, InventorySlotType.Equipment) { EquipmentSlot = EquipmentSlot.Armor };
-                if (y == 2 && x == 10) return new InventorySlotData(x, y, InventorySlotType.Equipment) { EquipmentSlot = EquipmentSlot.Accessory2 };
+                // Hero equipment slots (three columns starting at HERO_COL_START)
+                if (y == 1 && x == HERO_COL_START) return new InventorySlotData(x, y, InventorySlotType.Equipment) { EquipmentSlot = EquipmentSlot.WeaponShield1 };
+                if (y == 1 && x == HERO_COL_START + 1) return new InventorySlotData(x, y, InventorySlotType.Equipment) { EquipmentSlot = EquipmentSlot.Hat };
+                if (y == 1 && x == HERO_COL_START + 2) return new InventorySlotData(x, y, InventorySlotType.Equipment) { EquipmentSlot = EquipmentSlot.WeaponShield2 };
+                if (y == 2 && x == HERO_COL_START) return new InventorySlotData(x, y, InventorySlotType.Equipment) { EquipmentSlot = EquipmentSlot.Accessory1 };
+                if (y == 2 && x == HERO_COL_START + 1) return new InventorySlotData(x, y, InventorySlotType.Equipment) { EquipmentSlot = EquipmentSlot.Armor };
+                if (y == 2 && x == HERO_COL_START + 2) return new InventorySlotData(x, y, InventorySlotType.Equipment) { EquipmentSlot = EquipmentSlot.Accessory2 };
 
-                // Mercenary 0 equipment slots (columns 4-6, left of hero)
+                // Mercenary 0 equipment slots (left of hero)
                 var merc0Data = TryCreateMercenarySlotData(x, y, MERC0_COL_START, 0);
                 if (merc0Data != null) return merc0Data;
 
-                // Mercenary 1 equipment slots (columns 12-14, right of hero)
+                // Mercenary 1 equipment slots (right of hero)
                 var merc1Data = TryCreateMercenarySlotData(x, y, MERC1_COL_START, 1);
                 if (merc1Data != null) return merc1Data;
 
@@ -238,7 +263,7 @@ namespace PitHero.UI
                 return new InventorySlotData(x, y, InventorySlotType.Null);
             }
 
-            // Rows 3-8: Pure inventory (6 rows × 20 columns = 120 inventory slots)
+            // Rows 3-7: Pure inventory (5 rows × 24 columns = 120 inventory slots)
             return new InventorySlotData(x, y, InventorySlotType.Inventory);
         }
 
@@ -317,15 +342,60 @@ namespace PitHero.UI
                 {
                     _stencilManager.ClearAll();
                     var records = gameState.PlacedStencils;
-                    for (int i = 0; i < records.Count; i++)
+                    // Backwards: a record whose pattern can no longer fit is removed as we go
+                    for (int i = records.Count - 1; i >= 0; i--)
                     {
                         var record = records[i];
                         var pattern = SynergyPatternRegistry.GetById(record.PatternId);
                         if (pattern == null) continue;
-                        _stencilManager.PlaceStencil(pattern, new Point(record.AnchorX, record.AnchorY));
+
+                        var anchor = new Point(record.AnchorX, record.AnchorY);
+                        if (!TryFitStencilAnchor(pattern, ref anchor))
+                        {
+                            gameState.RemovePlacedStencil(record.PatternId);
+                            continue;
+                        }
+
+                        _stencilManager.PlaceStencil(pattern, anchor);
+                        if (anchor.X != record.AnchorX || anchor.Y != record.AnchorY)
+                            gameState.SetPlacedStencil(record.PatternId, anchor.X, anchor.Y);
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Clamps a restored stencil anchor so the whole pattern lands on bag slots. Saves written for
+        /// the older, taller grid (20 columns x 6 bag rows) can carry anchors on a row that no longer
+        /// exists. Returns false when the pattern cannot fit the bag area at all.
+        /// </summary>
+        private static bool TryFitStencilAnchor(SynergyPattern pattern, ref Point anchor)
+        {
+            var offsets = pattern.GridOffsets;
+            if (offsets.Count == 0) return false;
+
+            int minOffX = offsets[0].X, maxOffX = offsets[0].X;
+            int minOffY = offsets[0].Y, maxOffY = offsets[0].Y;
+            for (int i = 1; i < offsets.Count; i++)
+            {
+                if (offsets[i].X < minOffX) minOffX = offsets[i].X;
+                if (offsets[i].X > maxOffX) maxOffX = offsets[i].X;
+                if (offsets[i].Y < minOffY) minOffY = offsets[i].Y;
+                if (offsets[i].Y > maxOffY) maxOffY = offsets[i].Y;
+            }
+
+            int minAnchorX = -minOffX;
+            int maxAnchorX = GRID_WIDTH - 1 - maxOffX;
+            int minAnchorY = BAG_START_ROW - minOffY;
+            int maxAnchorY = GRID_HEIGHT - 1 - maxOffY;
+            if (minAnchorX > maxAnchorX || minAnchorY > maxAnchorY)
+                return false;
+
+            if (anchor.X < minAnchorX) anchor.X = minAnchorX;
+            else if (anchor.X > maxAnchorX) anchor.X = maxAnchorX;
+            if (anchor.Y < minAnchorY) anchor.Y = minAnchorY;
+            else if (anchor.Y > maxAnchorY) anchor.Y = maxAnchorY;
+            return true;
         }
 
         /// <summary>Updates mercenary equip slots with the current set of hired mercenaries.</summary>
@@ -599,30 +669,21 @@ namespace PitHero.UI
         /// <summary>Positions slot components based on grid coordinates.</summary>
         private void LayoutSlots()
         {
-            const float X_OFFSET = 32f; // Move grid right by 32 pixels for left padding
-            const float Y_OFFSET = -16f; // Move grid up by 16 pixels
             for (int i = 0; i < _slots.Length; i++)
             {
                 var slot = _slots.Buffer[i];
                 if (slot == null) continue;
                 var data = slot.SlotData;
-                slot.SetPosition(data.X * (SLOT_SIZE + SLOT_PADDING) + X_OFFSET, data.Y * (SLOT_SIZE + SLOT_PADDING) + Y_OFFSET);
+                slot.SetPosition(data.X * ROW_PITCH + X_OFFSET, data.Y * ROW_PITCH + Y_OFFSET);
             }
         }
 
-        /// <summary>Sets the explicit size of the grid to account for offsets and ensure all slots are clickable.</summary>
+        /// <summary>Sets the explicit size of the grid so every slot is drawn and clickable.</summary>
         private void SetGridSize()
         {
-            const float X_OFFSET = 32f; // Left padding
-            const float Y_OFFSET = -16f; // Top offset (negative means moving up)
-            
-            // Calculate total grid dimensions including offsets
-            // Width: (20 columns * 33px per slot) + 32px left padding = 692px
-            // Height: (9 rows * 33px per slot) - 16px top offset = 281px (but we use absolute value for size)
-            float gridWidth = (GRID_WIDTH * (SLOT_SIZE + SLOT_PADDING)) + X_OFFSET;
-            float gridHeight = (GRID_HEIGHT * (SLOT_SIZE + SLOT_PADDING)) + System.Math.Abs(Y_OFFSET);
-            
-            SetSize(gridWidth, gridHeight);
+            // Width:  (24 columns * 33px per slot) + 32px left padding = 824px
+            // Height: (8 rows * 33px per slot) - 16px top offset = 248px, the real content extent
+            SetSize(ContentWidth, ContentHeight);
         }
 
         /// <summary>Routes slot clicks to stencil-mode handling. No item movement on click — drag-and-drop only.</summary>
@@ -1136,8 +1197,7 @@ namespace PitHero.UI
         {
             if (_nameFont == null) return;
 
-            const float X_OFFSET = 32f;
-            const float Y_OFFSET = 8f;
+            const float NAME_Y = 8f; // baseline inside the name row
             int[] colStarts = { MERC0_COL_START, MERC1_COL_START };
 
             for (int m = 0; m < MAX_MERCENARY_SLOTS; m++)
@@ -1146,10 +1206,10 @@ namespace PitHero.UI
                 if (merc == null) continue;
 
                 // Center name above the 3 equip columns (colStart to colStart+2)
-                float leftX = colStarts[m] * (SLOT_SIZE + SLOT_PADDING) + X_OFFSET;
-                float rightX = (colStarts[m] + 3) * (SLOT_SIZE + SLOT_PADDING) + X_OFFSET;
+                float leftX = colStarts[m] * ROW_PITCH + X_OFFSET;
+                float rightX = (colStarts[m] + 3) * ROW_PITCH + X_OFFSET;
                 float centerX = (leftX + rightX) / 2f;
-                float nameY = 0f * (SLOT_SIZE + SLOT_PADDING) + Y_OFFSET;
+                float nameY = NAME_Y;
 
                 var nameText = merc.Name;
                 var textSize = _nameFont.MeasureString(nameText);
@@ -1158,14 +1218,13 @@ namespace PitHero.UI
                 batcher.DrawString(_nameFont, nameText, new Vector2(textX, nameY), MercenaryNameFontColor, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
             }
 
-            // Draw hero name at the same Y position, centered above hero equip columns (8-10)
+            // Draw hero name at the same Y position, centered above the hero equip columns
             if (_heroComponent?.LinkedHero != null)
             {
-                const int HERO_COL_START = 8;
-                float heroLeftX = HERO_COL_START * (SLOT_SIZE + SLOT_PADDING) + X_OFFSET;
-                float heroRightX = (HERO_COL_START + 3) * (SLOT_SIZE + SLOT_PADDING) + X_OFFSET;
+                float heroLeftX = HERO_COL_START * ROW_PITCH + X_OFFSET;
+                float heroRightX = (HERO_COL_START + 3) * ROW_PITCH + X_OFFSET;
                 float heroCenterX = (heroLeftX + heroRightX) / 2f;
-                float heroNameY = 0f * (SLOT_SIZE + SLOT_PADDING) + Y_OFFSET;
+                float heroNameY = NAME_Y;
 
                 var heroNameText = _heroComponent.LinkedHero.Name ?? "Hero";
                 var heroTextSize = _nameFont.MeasureString(heroNameText);

--- a/PitHero/UI/MercenariesTab.cs
+++ b/PitHero/UI/MercenariesTab.cs
@@ -28,6 +28,7 @@ namespace PitHero.UI
         private readonly Label[] _jobLabels = new Label[2];
         private readonly Label[] _statsLabels = new Label[2];
         private readonly Table[] _skillGrids = new Table[2];
+        private readonly Label[] _skillsSectionLabels = new Label[2];
         private readonly Label[] _noMercLabels = new Label[2];
 
         // Per-mercenary sprite preview containers
@@ -133,23 +134,25 @@ namespace PitHero.UI
             leftCol.Row();
             leftCol.Add(_statsLabels[index]).Left();
 
-            infoSection.Add(leftCol).Left().Expand().Pad(5f);
-            infoSection.Add(_previewContainers[index]).Center().Pad(5f).SetPadRight(64f);
+            infoSection.Add(leftCol).Left().Top().Expand().Pad(5f);
+
+            // Middle column: a mercenary only ever has four skills, so the label and icons fit beside
+            // the info labels instead of costing two more rows underneath them
+            _skillsSectionLabels[index] = new Label(_textService.DisplayText(TextType.UI, UITextKey.LabelJobSkills), skin, "ph-default");
+            var skillsCol = new Table();
+            skillsCol.Add(_skillsSectionLabels[index]).Center();
+            skillsCol.Row();
+            skillsCol.Add(_skillGrids[index]).Center().SetPadTop(2f);
+            infoSection.Add(skillsCol).Center().Expand().Pad(5f);
+
+            // Right column: sprite preview with the Dismiss button tucked 8px beneath it
+            var previewCol = new Table();
+            previewCol.Add(_previewContainers[index]).Center();
+            previewCol.Row();
+            previewCol.Add(_dismissButtons[index]).Center().SetPadTop(8f).SetMinWidth(80f).SetMinHeight(28f);
+            infoSection.Add(previewCol).Center().Pad(5f).SetPadRight(64f);
 
             row.Add(infoSection).Expand().Fill();
-            row.Row();
-
-            // Row: "Job Skills" label
-            var skillsSectionLabel = new Label(_textService.DisplayText(TextType.UI, UITextKey.LabelJobSkills), skin, "ph-default");
-            row.Add(skillsSectionLabel).Left().SetPadTop(4f);
-            row.Row();
-
-            // Row: Skill icon grid
-            row.Add(_skillGrids[index]).Left().SetPadTop(2f);
-            row.Row();
-
-            // Row: Dismiss button (right-aligned)
-            row.Add(_dismissButtons[index]).Right().SetPadTop(6f).SetMinWidth(80f).SetMinHeight(28f);
             row.Row();
 
             // The no-merc label is shown/hidden via SetVisible on the row
@@ -181,6 +184,8 @@ namespace PitHero.UI
                     _statsLabels[m].SetText("");
                     _mercRows[m].SetVisible(m == 0);
                     _dismissButtons[m].SetVisible(false);
+                    // The header would otherwise sit above the "no mercenaries" placeholder
+                    _skillsSectionLabels[m].SetVisible(false);
                     if (m == 0)
                     {
                         _skillGrids[m].Add(_noMercLabels[m]).Center();
@@ -190,6 +195,7 @@ namespace PitHero.UI
 
                 _mercRows[m].SetVisible(true);
                 _dismissButtons[m].SetVisible(true);
+                _skillsSectionLabels[m].SetVisible(true);
 
                 // Update info labels
                 _nameLabels[m].SetText(merc.Name);

--- a/PitHero/UI/MercenaryHireDialog.cs
+++ b/PitHero/UI/MercenaryHireDialog.cs
@@ -211,7 +211,7 @@ namespace PitHero.UI
                 Pack();
                 SetPosition(
                     (stage.GetWidth() - GetWidth()) / 2f,
-                    (stage.GetHeight() - GetHeight()) / 2f
+                    UILayout.CenterY(GetHeight(), stage.GetHeight(), 0f)
                 );
             }
         }

--- a/PitHero/UI/MessageDialog.cs
+++ b/PitHero/UI/MessageDialog.cs
@@ -42,7 +42,7 @@ namespace PitHero.UI
         {
             var stageWidth = stage.GetWidth();
             var stageHeight = stage.GetHeight();
-            SetPosition((stageWidth - GetWidth()) / 2f, (stageHeight - GetHeight()) / 2f);
+            SetPosition((stageWidth - GetWidth()) / 2f, UILayout.CenterY(GetHeight(), stageHeight, 0f));
 
             stage.AddElement(this);
             SetVisible(true);

--- a/PitHero/UI/MonsterUI.cs
+++ b/PitHero/UI/MonsterUI.cs
@@ -49,6 +49,8 @@ namespace PitHero.UI
         private const float SpriteSize = 32f;
         // Gap between the roster window and the info card, matching HeroCrystalCard's dock spacing.
         private const float InfoPanelGap = 10f;
+        private const float MonsterWindowWidth = 460f;
+        private const float MonsterWindowHeight = 340f; // design height at GameConfig.VirtualHeight = 360
         private static readonly Color BrownColor = new Color(71, 36, 7);
         private static LabelStyle BrownStyle() => new LabelStyle { Font = Graphics.Instance.BitmapFont, FontColor = BrownColor };
 
@@ -167,8 +169,9 @@ namespace PitHero.UI
         private void CreateMonsterWindow(Skin skin)
         {
             _monsterWindow = new Window(GetText(TextType.UI, UITextKey.WindowMonsters), skin);
-            // Nearly the full 360px virtual stage height, so the roster list fills the window.
-            _monsterWindow.SetSize(460f, 340f);
+            // Design height at GameConfig.VirtualHeight = 360; PositionWindow fits it to the live stage
+            // so the roster list fills the window at any configured design height.
+            _monsterWindow.SetSize(MonsterWindowWidth, MonsterWindowHeight);
 
             _monsterListTable = new Table();
             _monsterListTable.Top().Left();
@@ -517,39 +520,41 @@ namespace PitHero.UI
             }
         }
 
+        /// <summary>
+        /// Sizes the roster window to fit the live stage height and places it (with the info card
+        /// docked beside it) under the Monsters button.
+        /// </summary>
         private void PositionWindow()
         {
             if (_monsterButton == null || _monsterWindow == null) return;
             float btnX = _monsterButton.GetX();
             float btnW = _monsterButton.GetWidth();
-            float winW = _monsterWindow.GetWidth();
-            float winH = _monsterWindow.GetHeight();
             float stageW = _stage.GetWidth();
             float stageH = _stage.GetHeight();
+
+            float winY = _monsterButton.GetY() + GameConfig.UIWindowBelowBarGap;
+            float winH = UILayout.FitHeight(MonsterWindowHeight, stageH, winY, GameConfig.UIStageMargin);
+            if (winH != _monsterWindow.GetHeight())
+            {
+                _monsterWindow.SetSize(MonsterWindowWidth, winH);
+                _monsterWindow.Validate();
+            }
+            float winW = _monsterWindow.GetWidth();
 
             // The info card docks to the right of the roster window, so the pair is placed as one
             // block — otherwise the flip-to-the-left fallback would still leave the card off-stage.
             bool infoShown = _infoPanel != null && _infoPanel.IsVisible();
             float blockW = winW + (infoShown ? InfoPanelGap + _infoPanel.GetWidth() : 0f);
 
-            float winX = btnX + btnW + 4f;
-            if (winX + blockW > stageW) winX = btnX - 4f - blockW;
+            float winX = btnX + btnW + GameConfig.UIWindowBelowBarGap;
+            if (winX + blockW > stageW) winX = btnX - GameConfig.UIWindowBelowBarGap - blockW;
             if (winX < 0) winX = 0;
 
-            float winY = _monsterButton.GetY() + 4f;
-            if (winY + winH > stageH) winY = stageH - winH;
-            if (winY < 0) winY = 0;
-
+            winY = UILayout.ClampY(winY, winH, stageH);
             _monsterWindow.SetPosition(winX, winY);
 
             if (infoShown)
-            {
-                float infoY = winY;
-                float infoH = _infoPanel.GetHeight();
-                if (infoY + infoH > stageH) infoY = stageH - infoH;
-                if (infoY < 0) infoY = 0;
-                _infoPanel.SetPosition(winX + winW + InfoPanelGap, infoY);
-            }
+                _infoPanel.SetPosition(winX + winW + InfoPanelGap, UILayout.ClampY(winY, _infoPanel.GetHeight(), stageH));
         }
 
         /// <summary>Sets the position of the monster icon button.</summary>

--- a/PitHero/UI/RefrigeratorDialog.cs
+++ b/PitHero/UI/RefrigeratorDialog.cs
@@ -30,6 +30,8 @@ namespace PitHero.UI
 
         private Window _window;
         private Table _slotTable;
+        private Table _outerTable;
+        private Cell _scrollCell;
         private HoverableLabel _preStockLabel;
         private EnhancedSlider _preStockSlider;
         private uint _shownFrame;
@@ -79,12 +81,13 @@ namespace PitHero.UI
             _window.SetResizable(false);
 
             var outer = new Table();
+            _outerTable = outer;
             outer.Pad(WinPad);
 
             _slotTable = new Table();
             var scroll = new ScrollPane(_slotTable, _skin, "ph-default");
             scroll.SetScrollingDisabled(true, false);
-            outer.Add(scroll).Width(SlotSize * Columns + 48f).Height(ScrollHeight);
+            _scrollCell = outer.Add(scroll).Width(SlotSize * Columns + 48f).Height(ScrollHeight);
             outer.Row();
 
             var sliderRow = new Table();
@@ -169,10 +172,12 @@ namespace PitHero.UI
                 _preStockLabel.SetText(string.Format(GetText(UITextKey.FridgePreStockStackSize), svc.PreStockStackSize));
             }
             RebuildSlots();
-            _window.Pack();
+            // Shrink the slot grid when the configured design height cannot fit the full window
+            float stageH = _stage.GetHeight();
+            UILayout.FitScrollCellToStage(_window, _outerTable, _scrollCell, ScrollHeight, stageH, GameConfig.UIStageMargin);
             _window.SetPosition(
                 (_stage.GetWidth() - _window.GetWidth()) / 2f,
-                (_stage.GetHeight() - _window.GetHeight()) / 2f);
+                UILayout.CenterY(_window.GetHeight(), stageH, 0f));
             _window.SetVisible(true);
             _window.ToFront();
             _shownFrame = Time.FrameCount;
@@ -267,7 +272,7 @@ namespace PitHero.UI
             _descWindow.Pack();
             _descWindow.SetPosition(
                 (_stage.GetWidth() - _descWindow.GetWidth()) / 2f,
-                (_stage.GetHeight() - _descWindow.GetHeight()) / 2f);
+                UILayout.CenterY(_descWindow.GetHeight(), _stage.GetHeight(), 0f));
             _descWindow.SetVisible(true);
             _descWindow.ToFront();
         }

--- a/PitHero/UI/SaveLoadUI.cs
+++ b/PitHero/UI/SaveLoadUI.cs
@@ -40,7 +40,7 @@ namespace PitHero.UI
         }
 
         private const float WindowWidth = 500f;
-        private const float WindowHeight = 300f;
+        private const float WindowHeight = 300f; // design height at GameConfig.VirtualHeight = 360; fitted to the stage at show time
         private const float SlotRowHeight = 50f;
         private const float SlotPadding = 4f;
 
@@ -90,7 +90,9 @@ namespace PitHero.UI
                 ? GetText(TextType.UI, UITextKey.WindowSaveGame) 
                 : GetText(TextType.UI, UITextKey.WindowLoadGame);
             _window = new Window(title, windowStyle);
-            _window.SetSize(WindowWidth, WindowHeight);
+            float stageH = _stage.GetHeight();
+            float windowH = UILayout.FitHeight(WindowHeight, stageH, GameConfig.UIStageMargin, GameConfig.UIStageMargin);
+            _window.SetSize(WindowWidth, windowH);
             _window.SetMovable(false);
 
             var contentTable = new Table();
@@ -137,7 +139,7 @@ namespace PitHero.UI
             // Center the window on stage
             _window.SetPosition(
                 (_stage.GetWidth() - WindowWidth) / 2f,
-                (_stage.GetHeight() - WindowHeight) / 2f
+                UILayout.CenterY(windowH, stageH, 0f)
             );
 
             _stage.AddElement(_window);

--- a/PitHero/UI/SecondChanceHeroCrystalPanel.cs
+++ b/PitHero/UI/SecondChanceHeroCrystalPanel.cs
@@ -20,15 +20,25 @@ namespace PitHero.UI
         private const float SLOT_SIZE = 32f;
         private const float SLOT_PAD = 1f;
 
+        /// <summary>Gap between the window's left edge and the Crystal Inventory column.</summary>
+        public const float LeftMargin = 16f;
+        /// <summary>Gap the host leaves between the Crystal Queue column and the window's right edge.</summary>
+        public const float RightMargin = 16f;
+
         // Pre-allocated slot number strings to avoid dynamic allocation (AOT compliance)
         private static readonly string[] QueueSlotNumbers = { "1", "2", "3", "4", "5" };
 
         private CrystalSlotElement[] _inventorySlots;
         private CrystalSlotElement[] _queueSlots;
 
+        private Table _mainTable;
         private Stage _stage;
         private Skin _skin;
         private CrystalCollectionService _crystalService;
+        private TextService _textService;
+
+        /// <summary>Width the content actually needs, including the left margin but not the right one.</summary>
+        public float ContentWidth => _mainTable != null ? _mainTable.PreferredWidth : 0f;
 
         // Hover tooltip
         private Window _hoverTooltip;
@@ -43,6 +53,14 @@ namespace PitHero.UI
 
         /// <summary>Fired when a hero crystal slot is clicked and has a crystal.</summary>
         public event System.Action<HeroCrystal> OnCrystalSlotClicked;
+
+        /// <summary>Gets localized text, falling back to the key when Core is not initialized.</summary>
+        private string GetText(string key)
+        {
+            if (_textService == null && Core.Services != null)
+                _textService = Core.Services.GetService<TextService>();
+            return _textService?.DisplayText(TextType.UI, key) ?? key;
+        }
 
         /// <summary>Creates the panel content and returns the root Table.</summary>
         public Table CreateContent(Skin skin, Stage stage)
@@ -62,11 +80,13 @@ namespace PitHero.UI
             _hoverTooltip.SetVisible(false);
 
             var mainTable = new Table();
-            mainTable.Top().Left().PadLeft(4f);
+            _mainTable = mainTable;
+            // The window's left edge sits flush against this, so the inset is the panel's left margin
+            mainTable.Top().Left().PadLeft(LeftMargin);
 
             // ── Inventory section (left column) ─────────────────────────────────
             var invCol = new Table();
-            invCol.Add(new Label("Crystal Inventory:", skin, "ph-default")).Left().Pad(5);
+            invCol.Add(new Label(GetText(UITextKey.CrystalInventoryTitle), skin, "ph-default")).Left().Pad(5);
             invCol.Row();
 
             _inventorySlots = new CrystalSlotElement[INV_TOTAL];
@@ -87,7 +107,7 @@ namespace PitHero.UI
 
             // ── Queue section (right column, slots stacked vertically) ─────────
             var queueCol = new Table();
-            queueCol.Add(new Label("Queue:", skin, "ph-default")).Left().Pad(5);
+            queueCol.Add(new Label(GetText(UITextKey.CrystalQueueTitle), skin, "ph-default")).Left().Pad(5);
             queueCol.Row();
 
             _queueSlots = new CrystalSlotElement[QUEUE_SLOTS];
@@ -108,9 +128,10 @@ namespace PitHero.UI
                 queueCol.Row();
             }
 
-            // Side-by-side: inventory left, queue right (mirrors CrystalsTab layout)
-            mainTable.Add(invCol).Top().Left().Pad(2);
-            mainTable.Add(queueCol).Top().Left().Pad(2, 16, 2, 5);
+            // Side-by-side: inventory left, queue right (mirrors CrystalsTab layout). The queue cell
+            // carries no right padding so the host can put exactly RightMargin past it.
+            mainTable.Add(invCol).Top().Left().Pad(2, 0, 2, 2);
+            mainTable.Add(queueCol).Top().Left().Pad(2, 16, 2, 0);
 
             RefreshAll();
             return mainTable;

--- a/PitHero/UI/SecondChanceShopUI.cs
+++ b/PitHero/UI/SecondChanceShopUI.cs
@@ -18,6 +18,8 @@ namespace PitHero.UI
     /// <summary>UI shell for the Second Chance Shop - provides a button, a vault window, and a separate hero panel for purchasing items and crystals.</summary>
     public class SecondChanceShopUI
     {
+        private const float MerchantSpriteSize = 256f; // merchant art is 256x256
+
         private Stage _stage;
         private HoverableImageButton _shopButton;
 
@@ -202,11 +204,10 @@ namespace PitHero.UI
             var scrollPane = new ScrollPane(_heroInventoryGrid, skin, "ph-default");
             scrollPane.SetScrollingDisabled(true, false);
 
-            // Use Expand().Fill() to match HeroUI's PopulateInventoryTab layout so the
-            // ScrollPane gets an explicit height (without Fill, InventoryGrid reports 0
-            // preferred height and the ScrollPane collapses to nothing)
+            // Use Expand().Fill() to match HeroUI's PopulateInventoryTab layout so the pane gets an
+            // explicit height. The grid never scrolls — the panel is sized to show all 824x248 of it.
             var content = new Table();
-            content.Add(scrollPane).Width(700f).Expand().Fill().Pad(0f);
+            content.Add(scrollPane).Width(InventoryGrid.ContentWidth + 8f).Expand().Fill().Pad(0f);
 
             _heroInventoryWindow.Add(content).Expand().Fill();
             _heroInventoryWindow.SetVisible(false);
@@ -225,8 +226,10 @@ namespace PitHero.UI
 
             var heroPanel = _heroCrystalPanel.CreateContent(skin, _stage);
 
+            // No left/right padding here: the panel owns its own margins, and the window is sized to
+            // the content so the crystal panel is only as wide as it needs to be.
             var content = new Table();
-            content.Add(heroPanel).Top().Left().Pad(4f);
+            content.Add(heroPanel).Top().Left().Pad(4f, 0f, 4f, 0f);
 
             _heroCrystalWindow.Add(content).Expand().Fill();
             _heroCrystalWindow.SetVisible(false);
@@ -452,19 +455,31 @@ namespace PitHero.UI
             {
                 UIWindowManager.OnUIWindowOpening();
 
-                // The layout constants compose a full-strip arrangement designed for a 1920-wide
-                // stage; center the intact composition on wider stages (FixedHeight policy).
+                // The layout constants compose a full-strip arrangement designed for a 1920x360
+                // stage; center the intact composition on wider stages (FixedHeight policy) and fit
+                // the panel heights to the configured design height (GameConfig.VirtualHeight).
                 float xOffset = System.Math.Max(0f, (_stage.GetWidth() - GameConfig.VirtualWidth) / 2f);
+                float stageH = _stage.GetHeight();
+                const float margin = GameConfig.UIStageMargin;
 
                 // Shop (left panel)
+                float shopH = UILayout.FitHeight(GameConfig.SecondChanceShopWindowHeight, stageH, margin, margin);
+                float shopY = System.Math.Min(GameConfig.SecondChanceShopWindowY, stageH - shopH - margin);
+                _shopWindow.SetSize(GameConfig.SecondChanceShopWindowWidth, shopH);
                 _stage.AddElement(_shopWindow);
                 _shopWindow.SetVisible(true);
-                _shopWindow.SetPosition(GameConfig.SecondChanceShopWindowX + xOffset, GameConfig.SecondChanceShopWindowY);
+                _shopWindow.SetPosition(GameConfig.SecondChanceShopWindowX + xOffset, UILayout.ClampY(shopY, shopH, stageH));
                 _shopWindow.ToFront();
 
-                // Merchant sprite (between panels)
+                // Hero panel geometry, needed here because the merchant stands on its baseline
+                float heroH = UILayout.FitHeight(GameConfig.SecondChanceHeroPanelHeight, stageH, margin, margin);
+                float heroY = UILayout.ClampY(System.Math.Min(GameConfig.SecondChanceHeroPanelY, stageH - heroH - margin), heroH, stageH);
+
+                // Merchant sprite (between panels) — his feet land on the bottom edge of the panels
+                float spriteY = heroY + heroH - MerchantSpriteSize;
+                if (spriteY < 0f) spriteY = 0f;
                 _stage.AddElement(_merchantSprite);
-                _merchantSprite.SetPosition(GameConfig.SecondChanceMerchantSpriteX + xOffset, GameConfig.SecondChanceMerchantSpriteY);
+                _merchantSprite.SetPosition(GameConfig.SecondChanceMerchantSpriteX + xOffset, spriteY);
                 _merchantSprite.ToFront();
 
                 // Greeting bubble above the merchant's head; persists until the shop closes
@@ -474,16 +489,22 @@ namespace PitHero.UI
                     _stage.AddElement(_merchantBubble);
                     _merchantBubble.SetTailAnchor(
                         GameConfig.SecondChanceMerchantSpriteX + xOffset + GameConfig.SecondChanceMerchantBubbleAnchorX,
-                        GameConfig.SecondChanceMerchantSpriteY + GameConfig.SecondChanceMerchantBubbleAnchorY);
+                        spriteY + GameConfig.SecondChanceMerchantBubbleAnchorY);
                     _merchantBubble.Show(greeting);
                     _merchantBubble.ToFront();
                 }
 
-                // Hero panel (right) — show the one matching the active tab
+                // Hero panel (right) — show the one matching the active tab. The crystal panel is much
+                // narrower than the inventory grid, so it only takes the width its columns need.
+                float crystalW = _heroCrystalPanel != null
+                    ? _heroCrystalPanel.ContentWidth + SecondChanceHeroCrystalPanel.RightMargin
+                    : GameConfig.SecondChanceHeroPanelWidth;
+                _heroInventoryWindow.SetSize(GameConfig.SecondChanceHeroPanelWidth, heroH);
+                _heroCrystalWindow.SetSize(crystalW, heroH);
                 _stage.AddElement(_heroInventoryWindow);
                 _stage.AddElement(_heroCrystalWindow);
-                _heroInventoryWindow.SetPosition(GameConfig.SecondChanceHeroPanelX + xOffset, GameConfig.SecondChanceHeroPanelY);
-                _heroCrystalWindow.SetPosition(GameConfig.SecondChanceHeroPanelX + xOffset, GameConfig.SecondChanceHeroPanelY);
+                _heroInventoryWindow.SetPosition(GameConfig.SecondChanceHeroPanelX + xOffset, heroY);
+                _heroCrystalWindow.SetPosition(GameConfig.SecondChanceHeroPanelX + xOffset, heroY);
 
                 if (_activeTabIndex == 0)
                 {

--- a/PitHero/UI/SeedPlantingModeOverlay.cs
+++ b/PitHero/UI/SeedPlantingModeOverlay.cs
@@ -51,6 +51,11 @@ namespace PitHero.UI
         // ── Constants ─────────────────────────────────────────────────────────────
         private const float SlotSize   = 40f;
         private const float WinPad     = 16f;
+        // Slot-grid height at the 360px design height; ShowInventoryWindow shrinks it (and the grid
+        // scrolls) when the configured GameConfig.VirtualHeight is shorter.
+        private const float ScrollHeight = 200f;
+        // Upward nudge off centre so the window clears the bottom UI bars.
+        private const float CenterYBias = 30f;
         private const int   CropsPerRow = 4;
 
         // ── Localization ──────────────────────────────────────────────────────────
@@ -353,6 +358,8 @@ namespace PitHero.UI
         // ── Inventory window ──────────────────────────────────────────────────────
 
         private Table _slotTable;
+        private Table _outerTable;
+        private Cell _scrollCell;
 
         private void CreateInventoryWindow()
         {
@@ -362,12 +369,13 @@ namespace PitHero.UI
             _inventoryWindow.SetResizable(false);
 
             var outer = new Table();
+            _outerTable = outer;
             outer.Pad(WinPad);
 
             _slotTable = new Table();
             var scroll = new ScrollPane(_slotTable, skin, "ph-default");
             scroll.SetScrollingDisabled(true, false);
-            outer.Add(scroll).Width(SlotSize * CropsPerRow + 16f).Height(200f);
+            _scrollCell = outer.Add(scroll).Width(SlotSize * CropsPerRow + 16f).Height(ScrollHeight);
             outer.Row();
 
             var cancelButton = new TextButton(GetText(UITextKey.ButtonCancel), skin, "ph-default");
@@ -403,12 +411,15 @@ namespace PitHero.UI
                     _slotTable.Row();
             }
 
-            _inventoryWindow.Pack();
+            // Shrink the slot grid when the configured design height cannot fit the full window, then
+            // sit slightly above centre to clear the bottom UI bars (clamped to the stage).
+            float stageH = _stage.GetHeight();
+            UILayout.FitScrollCellToStage(_inventoryWindow, _outerTable, _scrollCell, ScrollHeight, stageH, GameConfig.UIStageMargin);
             float w = _inventoryWindow.GetWidth();
             float h = _inventoryWindow.GetHeight();
             _inventoryWindow.SetPosition(
                 (_stage.GetWidth()  - w) / 2f,
-                (_stage.GetHeight() - h) / 2f - 30f);
+                UILayout.CenterY(h, stageH, CenterYBias));
             _inventoryWindow.SetVisible(true);
         }
 

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -19,6 +19,8 @@ namespace PitHero.UI
         private Stage _stage;
         private Table _mainTable;
         private HoverableImageButton _gearButton;
+        private const float SettingsWindowWidth = 450f;
+        private const float SettingsWindowHeight = 350f; // design height at GameConfig.VirtualHeight = 360; fitted to the stage in PositionUI
         private Window _settingsWindow;
         private bool _isVisible = false;
 
@@ -578,7 +580,7 @@ namespace PitHero.UI
             var windowStyle = skin.Get<WindowStyle>("ph-default");
             _settingsWindow = new Window("", windowStyle); // Empty title since tabs provide context
             _settingsWindow.Pad(0); // Remove all window padding so tabs are flush with edges
-            _settingsWindow.SetSize(450, 350);
+            _settingsWindow.SetSize(SettingsWindowWidth, SettingsWindowHeight);
 
             // Create TabPane with proper styling
             var tabWindowStyle = skin.Get<TabWindowStyle>("ph-default"); // Use PitHero's custom tab window style
@@ -1931,21 +1933,20 @@ namespace PitHero.UI
 
             if (_isVisible)
             {
-                const float padding = 4f;
+                // Fit the window to the stage first: the design height may exceed the configured
+                // GameConfig.VirtualHeight, and KeepWithinStage would otherwise clip the tab strip.
+                float winY = buttonY + GameConfig.UIWindowBelowBarGap;
+                float winH = UILayout.FitHeight(SettingsWindowHeight, stageH, winY, GameConfig.UIStageMargin);
+                _settingsWindow.SetSize(SettingsWindowWidth, winH);
+                _settingsWindow.Validate();
+
                 float winW = _settingsWindow.GetWidth();
-                float winH = _settingsWindow.GetHeight();
-
-                float winX = gearX + gearW + padding;
-                float winY = buttonY + padding;
-
+                float winX = gearX + gearW + GameConfig.UIWindowBelowBarGap;
                 if (winX + winW > stageW)
-                    winX = gearX - padding - winW;
-
+                    winX = gearX - GameConfig.UIWindowBelowBarGap - winW;
                 if (winX < 0) winX = 0;
-                if (winY < 0) winY = 0;
-                if (winY + winH > stageH) winY = stageH - winH;
 
-                _settingsWindow.SetPosition(winX, winY);
+                _settingsWindow.SetPosition(winX, UILayout.ClampY(winY, winH, stageH));
             }
 
             _lastStageW = stageW;

--- a/PitHero/UI/StencilLibraryPanel.cs
+++ b/PitHero/UI/StencilLibraryPanel.cs
@@ -16,6 +16,7 @@ namespace PitHero.UI
         private const int TOTAL_SLOTS = GRID_COLUMNS * GRID_ROWS;
         private const float SLOT_SIZE = 32f;
         private const float SLOT_PADDING = 2f;
+        private const float ScrollCellDesignHeight = 200f; // slot-grid height at the 360px design height
 
         private GameStateService _gameStateService;
         private List<SynergyPattern> _allPatterns;
@@ -27,6 +28,7 @@ namespace PitHero.UI
         private SynergyPattern _selectedPattern;
         private TextService _textService;
         private SkillTooltip _hoverTooltip;
+        private Cell _scrollCell;
 
         public event System.Action<SynergyPattern> OnStencilActivated;
 
@@ -41,10 +43,21 @@ namespace PitHero.UI
             _hoverTooltip = new SkillTooltip(this, skin);
             BuildUI(skin);
 
-            // Size the window to exactly fit its rows — the stage is only ~360 tall,
-            // so any slack height pushes the title bar off-screen.
+            // Size the window to exactly fit its rows — the stage is only as tall as
+            // GameConfig.VirtualHeight, so any slack height pushes the title bar off-screen.
+            // FitToStage shrinks the slot grid further when the design height is short.
             Pack();
         }
+
+        /// <summary>
+        /// Shrinks the slot grid until the whole panel fits the stage, then re-packs. Called before the
+        /// panel is docked beside the hero window so it never runs past the top or bottom edge.
+        /// </summary>
+        public void FitToStage(float stageH)
+        {
+            UILayout.FitScrollCellToStage(this, this, _scrollCell, ScrollCellDesignHeight, stageH, GameConfig.UIStageMargin);
+        }
+
         /// <summary>
         /// Safely retrieves TextService. Returns null if Core is not initialized (e.g., in unit tests).
         /// </summary>
@@ -93,7 +106,7 @@ namespace PitHero.UI
             var scrollPane = new ScrollPane(_gridTable, skin, "ph-default");
             scrollPane.SetScrollingDisabled(true, false);
             scrollPane.SetFadeScrollBars(false);
-            Add(scrollPane).Height(200f).Width(420f).Pad(5f).Top();
+            _scrollCell = Add(scrollPane).Height(ScrollCellDesignHeight).Width(420f).Pad(5f).Top();
             Row();
 
             _detailsLabel = new Label(GetText(TextType.UI, UITextKey.StencilSelectPrompt), skin);

--- a/PitHero/UI/UILayout.cs
+++ b/PitHero/UI/UILayout.cs
@@ -1,0 +1,80 @@
+using Nez.UI;
+
+namespace PitHero.UI
+{
+    /// <summary>
+    /// Pure layout math shared by every tall UI window. The strip's design height
+    /// (GameConfig.VirtualHeight) is configurable, so windows size and position themselves against
+    /// Stage.GetHeight() at show time instead of hard-coding the height they were designed at.
+    /// </summary>
+    public static class UILayout
+    {
+        /// <summary>Smallest height a fitted window is allowed to shrink to.</summary>
+        public const float MinWindowHeight = 32f;
+
+        /// <summary>Smallest height a fitted scroll cell is allowed to shrink to (one row plus chrome).</summary>
+        public const float MinScrollCellHeight = 44f;
+
+        /// <summary>
+        /// Height for a window that starts at topY: its design height, capped so the window still ends
+        /// bottomMargin above the bottom of the stage.
+        /// </summary>
+        public static float FitHeight(float preferred, float stageH, float topY, float bottomMargin)
+        {
+            var available = stageH - topY - bottomMargin;
+            var height = preferred < available ? preferred : available;
+            if (height < MinWindowHeight)
+                height = MinWindowHeight;
+            return height;
+        }
+
+        /// <summary>
+        /// Keeps a window of the given height on the stage: pushed up off the bottom edge first, then
+        /// pinned to the top (the title bar wins when the window is taller than the stage).
+        /// </summary>
+        public static float ClampY(float y, float h, float stageH)
+        {
+            if (y + h > stageH)
+                y = stageH - h;
+            if (y < 0f)
+                y = 0f;
+            return y;
+        }
+
+        /// <summary>
+        /// Vertically centers a window of the given height, shifted up by bias, clamped to the stage.
+        /// </summary>
+        public static float CenterY(float h, float stageH, float bias)
+        {
+            return ClampY((stageH - h) / 2f - bias, h, stageH);
+        }
+
+        /// <summary>
+        /// Shrinks a packed window's scroll cell until the whole window fits the stage. Cell.Height does
+        /// not invalidate the layout, so the owning table is invalidated and the window re-packed.
+        /// Returns the cell height that ended up applied.
+        /// </summary>
+        public static float FitScrollCellToStage(Window window, Table owner, Cell scrollCell, float designCellHeight, float stageH, float margin)
+        {
+            if (window == null || owner == null || scrollCell == null)
+                return designCellHeight;
+
+            scrollCell.Height(designCellHeight);
+            owner.InvalidateHierarchy();
+            window.Pack();
+
+            var overflow = window.GetHeight() - (stageH - 2f * margin);
+            if (overflow <= 0f)
+                return designCellHeight;
+
+            var fitted = designCellHeight - overflow;
+            if (fitted < MinScrollCellHeight)
+                fitted = MinScrollCellHeight;
+
+            scrollCell.Height(fitted);
+            owner.InvalidateHierarchy();
+            window.Pack();
+            return fitted;
+        }
+    }
+}

--- a/PitHero/UI/VaultBuyQuantityDialog.cs
+++ b/PitHero/UI/VaultBuyQuantityDialog.cs
@@ -209,7 +209,7 @@ namespace PitHero.UI
         {
             var w = stage.GetWidth();
             var h = stage.GetHeight();
-            SetPosition((w - GetWidth()) / 2f, (h - GetHeight()) / 2f);
+            SetPosition((w - GetWidth()) / 2f, UILayout.CenterY(GetHeight(), h, 0f));
             stage.AddElement(this);
             SetVisible(true);
         }

--- a/PitHero/WindowManager.cs
+++ b/PitHero/WindowManager.cs
@@ -189,52 +189,20 @@ namespace PitHero
         }
 
         /// <summary>
-        /// Configures the game window as a horizontal strip docked at the bottom of the screen.
+        /// Physical window height for the strip on a monitor of the given height. The design height
+        /// (GameConfig.VirtualHeight) is 1:1 at GameConfig.ReferenceDisplayHeight and scales from there,
+        /// so the FixedHeight render target always maps to whole pixels (1080 -> 1x, 2160 -> 2x).
         /// </summary>
-        public static void ConfigureHorizontalStrip(Game game, bool alwaysOnTop = true)
+        public static int GetStripHeight(int displayHeight)
         {
-            var window = game.Window;
-            IntPtr sdlWindow = window.Handle;
-            if (sdlWindow == IntPtr.Zero)
-            {
-                Debug.Log("Could not get SDL window handle.");
-                return;
-            }
-
-            int windowWidth = GameConfig.VirtualWidth;
-            int windowHeight = GameConfig.VirtualHeight;
-
-            // Clamp to current display
-            var displayMode = GraphicsAdapter.DefaultAdapter.CurrentDisplayMode;
-            windowWidth = Math.Min(windowWidth, displayMode.Width);
-            windowHeight = Math.Min(windowHeight, displayMode.Height);
-
-            int x = Math.Max(0, (displayMode.Width - windowWidth) / 2);
-            int y = Math.Max(0, displayMode.Height - windowHeight);
-
-            if (y + windowHeight > displayMode.Height)
-                y = displayMode.Height - windowHeight;
-            if (y < 0)
-                y = 0;
-
-            // Borderless
-            if (window is Microsoft.Xna.Framework.GameWindow gw)
-                gw.IsBorderlessEXT = true;
-
-            SDL.SDL_SetWindowPosition(sdlWindow, x, y);
-            SDL.SDL_SetWindowAlwaysOnTop(sdlWindow, alwaysOnTop ? true : false);
-
-            _currentDockMode = DockMode.Bottom; // treat initial configuration as bottom dock
-            _currentDockYOffset = 0;
-
-            Debug.Log($"Window configured as horizontal strip at ({x},{y}) - Always on top: {alwaysOnTop}");
+            return displayHeight * GameConfig.VirtualHeight / GameConfig.ReferenceDisplayHeight;
         }
 
         /// <summary>
         /// Configures the game window as a horizontal strip docked at the bottom of the screen,
-        /// taking up 1/3 of the screen height.
+        /// sized by GetStripHeight (the design height scaled to the monitor).
         /// </summary>
-        public static void ConfigureHorizontalStripOneThird(Game game, bool alwaysOnTop = true)
+        public static void ConfigureHorizontalStrip(Game game, bool alwaysOnTop = true)
         {
             var window = game.Window;
             IntPtr sdlWindow = window.Handle;
@@ -249,7 +217,7 @@ namespace PitHero
             int displayHeight = displayMode.Height;
 
             int windowWidth = displayWidth;
-            int windowHeight = (int)(displayHeight / 3);
+            int windowHeight = GetStripHeight(displayHeight);
 
             int x = 0;
             int y = displayHeight - windowHeight;
@@ -367,7 +335,7 @@ namespace PitHero
             EnsureCurrentDisplay(sdlWindow);
 
             int windowWidth = _currentDisplayBounds.w;
-            int windowHeight = _currentDisplayBounds.h / 3;
+            int windowHeight = GetStripHeight(_currentDisplayBounds.h);
 
             int x = _currentDisplayBounds.x;
             int y = _currentDisplayBounds.y + Math.Max(0, Math.Min(yOffset, _currentDisplayBounds.h - 100));
@@ -391,7 +359,7 @@ namespace PitHero
             EnsureCurrentDisplay(sdlWindow);
 
             int windowWidth = _currentDisplayBounds.w;
-            int windowHeight = _currentDisplayBounds.h / 3;
+            int windowHeight = GetStripHeight(_currentDisplayBounds.h);
 
             int baseY = _currentDisplayBounds.y + _currentDisplayBounds.h - windowHeight;
             int y = Math.Max(_currentDisplayBounds.y + 100, Math.Min(baseY + yOffset, _currentDisplayBounds.y + _currentDisplayBounds.h - 100));
@@ -416,7 +384,7 @@ namespace PitHero
             EnsureCurrentDisplay(sdlWindow);
 
             int windowWidth = _currentDisplayBounds.w;
-            int windowHeight = _currentDisplayBounds.h / 3;
+            int windowHeight = GetStripHeight(_currentDisplayBounds.h);
 
             int centerY = _currentDisplayBounds.y + (_currentDisplayBounds.h - windowHeight) / 2;
             int y = Math.Max(_currentDisplayBounds.y + 100, Math.Min(centerY + yOffset, _currentDisplayBounds.y + _currentDisplayBounds.h - 100));
@@ -483,7 +451,7 @@ namespace PitHero
 
             // Use docking mode to decide target position/size
             int targetWidth = nextBounds.w;
-            int targetHeight = nextBounds.h / 3;
+            int targetHeight = GetStripHeight(nextBounds.h);
             int targetX = nextBounds.x;
             int targetY;
             switch (_currentDockMode)

--- a/PitHero/docs/SynergySystem.md
+++ b/PitHero/docs/SynergySystem.md
@@ -136,13 +136,13 @@ var pattern = new SynergyPattern(
 var detector = new SynergyDetector();
 detector.RegisterPattern(pattern);
 
-// Create inventory grid (8x7 in PitHero)
-var grid = new IItem[8, 7];
+// Create inventory grid (24 wide x 8 tall in PitHero; rows 3-7 are the 120 bag slots)
+var grid = new IItem[24, 8];
 grid[0, 3] = GearItems.ShortSword();
 grid[1, 3] = GearItems.WoodenShield();
 
 // Detect active synergies
-var synergies = detector.DetectSynergies(grid, 8, 7);
+var synergies = detector.DetectSynergies(grid, 24, 8);
 
 // Apply to hero
 hero.UpdateActiveSynergies(synergies);
@@ -163,6 +163,10 @@ hero.EarnSynergyPoints(10);
 ### 1. Pattern Size
 - Keep patterns compact (2-4 items typically)
 - Larger patterns = more powerful effects but harder to achieve
+- **Hard limit:** a pattern must fit the bag area — at most `InventoryGrid.BagRows` tall (5) and
+  `InventoryGrid.BagColumns` wide (24). The bag is wide and short, so grow patterns sideways, not
+  down: the two biggest ones are Dragon Bolt (6×4) and Elemental Champion (9×4).
+  `SynergyPatternFitTests` fails the build if a pattern stops fitting.
 
 ### 2. Item Requirements
 - Use job-specific equipment for thematic synergies
@@ -433,8 +437,10 @@ bag items toward the first empty stencil cell whose `RequiredKind` matches the i
 2. **First matching empty cell wins.** The provider iterates `PlacedStencils` in list order
    (placement order). Within each stencil, it iterates the pattern's offsets in definition order.
    The first cell whose kind matches and whose bag slot is empty is returned.
-3. **Out-of-bounds cells are skipped.** Only cells in grid rows 3–8 (the 120 bag slots,
-   `bagIndex = (gridY-3)*20 + gridX`) and columns 0–19 are valid.
+3. **Out-of-bounds cells are skipped.** Only cells in the bag rows (the 120 bag slots,
+   `bagIndex = (gridY - InventoryGrid.BagRowStart) * InventoryGrid.BagColumns + gridX`) and
+   columns `0 .. BagColumns-1` are valid. The grid is currently 24 columns × 5 bag rows (rows 3–7);
+   `StencilBagSlotPreferenceProvider` reads those constants, so resizing the grid cannot desync it.
 4. **Occupied cells are skipped.** If the preferred slot is already taken the provider returns -1
    for that candidate and the next valid candidate is tried.
 5. **Fallback to first-empty.** A return value of -1 from the provider causes `ItemBag.TryAdd`

--- a/PitHero/docs/WindowManagement.md
+++ b/PitHero/docs/WindowManagement.md
@@ -5,7 +5,7 @@ This document describes the window management features that configure PitHero as
 ## Features
 
 ### Horizontal Strip Display
-- **Resolution**: 1920×360 virtual resolution as specified in game requirements
+- **Resolution**: 1920×`GameConfig.VirtualHeight` virtual resolution (currently 296). `WindowManager.GetStripHeight` scales the design height to the monitor (1:1 at 1080p, 2x at 4K) so the FixedHeight render target maps to whole pixels
 - **Position**: Automatically positioned at the bottom center of the screen
 - **Borderless**: Removes window border, title bar, and system controls
 - **Always on Top**: Stays above other applications (configurable)
@@ -32,10 +32,9 @@ public const bool BorderlessWindow = true; // Remove window decorations
 The window is automatically configured when the game starts:
 
 ```csharp
-// In Game1.Initialize()
-WindowManager.ConfigureHorizontalStrip(this, 
-    alwaysOnTop: GameConfig.AlwaysOnTop, 
-    clickThrough: GameConfig.ClickThrough);
+// In Game1.LoadContent()
+WindowManager.ConfigureHorizontalStrip(this,
+    alwaysOnTop: GameConfig.AlwaysOnTop);
 ```
 
 ### Manual Control
@@ -59,7 +58,8 @@ WindowManager.UpdatePosition(game);
 
 The `WindowManager` class provides static methods for window manipulation:
 
-- `ConfigureHorizontalStrip()`: Main setup method
+- `ConfigureHorizontalStrip()`: Main setup method (full-width strip, `GetStripHeight` tall, docked bottom)
+- `GetStripHeight()`: Physical window height for a monitor height, derived from `GameConfig.VirtualHeight`
 - `SetAlwaysOnTop()`: Control topmost behavior
 - `SetClickThrough()`: Control mouse transparency
 - `UpdatePosition()`: Reposition after screen changes
@@ -84,5 +84,5 @@ This implementation fulfills the Copilot instruction requirements:
 - ✅ Borderless window
 - ✅ Always-on-top capability
 - ✅ Optional click-through
-- ✅ 1920×600 virtual resolution
+- ✅ 1920×`GameConfig.VirtualHeight` virtual resolution (single configurable knob)
 - ✅ Continues running while user interacts with other apps


### PR DESCRIPTION
## Summary

`GameConfig.VirtualHeight` is now the single knob for the strip's height, set to **296** (two tiles shorter than 360 — flip the constant to compare). The OS window follows it via `WindowManager.GetStripHeight(displayHeight)`, which scales the design height by the monitor height at all five sizing sites, so the `FixedHeight` render target keeps whole-pixel scaling (1080 → 1x, 2160 → 2x). Changing the design height without the window height would have blurred the render target.

On top of that, a pass over the tabs that wasted the most vertical space.

## Layout plumbing

- New `PitHero/UI/UILayout.cs` — `FitHeight` / `ClampY` / `CenterY` / `FitScrollCellToStage`. Every tall window now sizes and positions itself from `Stage.GetHeight()` at show time instead of hard-coding the height it was designed at (`Element.Pack()` overrides `SetSize`, so packed windows resize via a cell height + `InvalidateHierarchy()` + re-`Pack()`).
- HUD Pit Lv / Gold labels derive their Y from the stage and re-anchor on a stage-size change (the old `PitLabelBaseY = 350f` ran off-screen at 296).
- Camera default centers on `MapCenterTileY` rather than half the design height, so the whole pit is framed on frame one.
- The Party window spans the full stage height (flush top and bottom) and keeps the same left edge across every tab.

## Inventory grid

Wide and short: **24 columns × 5 bag rows** — still 120 slots, 248px tall — so it fits without scrolling. The equipment block derives from `EQUIP_BLOCK_START` and stays centered over the wider grid.

`BagColumns` / `BagRows` / `BagRowStart` are public and `StencilBagSlotPreferenceProvider` now reads them. **Bug fix:** that provider had hard-coded the old 20-wide, rows-3-8 mapping, so after the resize it would have auto-slotted items into the wrong bag slots and rejected stencil cells in the new columns. Loading a save clamps stencil anchors into the bag rows (`TryFitStencilAnchor`).

Dragon Bolt (4×6 → 6×4) and Elemental Champion (6×6 → 9×4) were reshaped to fit the five bag rows, with their required-kind multisets unchanged.

## Space reclaimed per tab

- **Hero Info** — skill grids 8 columns wide (16 skills go from 4 rows to 2), 2px spacing between the info label rows, both label columns top-aligned.
- **Mercenaries** — each row collapsed into one band: labels | skills | sprite with Dismiss 8px beneath. Both mercenaries now fit without scrolling.
- **Crystals** — inventory 10×4 (same 40 slots).
- **Second Chance shop** — recomposed around the wider hero panel; merchant centered between the two windows and standing on their baseline; the crystal panel is sized to its own content and uses the localized "Crystal Inventory" / "Crystal Queue" strings instead of hard-coded English.

## Docs and tests

- `AGENTS.md` + `WindowManagement.md` for the height knob; `SynergySystem.md` for the bag-index mapping, the `DetectSynergies` example (which was wrong before this change) and the pattern size limit.
- New `UILayoutTests`, `InventoryGridLayoutTests`, `SynergyPatternFitTests` (the last one fails the build if a pattern stops fitting the bag).

## Verification

`dotnet build PitHero.sln` clean; `dotnet test` **2030 passed / 0 failed**. Still wants a play-through at 296: every window, dock top/centre/bottom, monitor swap, and CTRL+wheel half-size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015L32sRmmMst38niW5cZbwZ