### PR TITLE
Add graphical close button to UI windows (#399)

### DIFF
--- a/PitHero.Tests/UI/WindowCloseButtonLayoutTests.cs
+++ b/PitHero.Tests/UI/WindowCloseButtonLayoutTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PitHero.UI;
+
+namespace PitHero.Tests.UI
+{
+    /// <summary>
+    /// Anchor guards for the graphical close button (issue #399): it hangs fully outside a window's
+    /// left edge and flush against it, centered on the window, and never leaves the stage.
+    /// </summary>
+    [TestClass]
+    public class WindowCloseButtonLayoutTests
+    {
+        private const float BtnW = 32f;
+        private const float BtnH = 32f;
+
+        [TestMethod]
+        public void Anchor_SitsFlushAgainstTheLeftEdge()
+        {
+            var pos = WindowCloseButton.AnchorLeftOf(500f, 20f, 300f, BtnW, BtnH, 296f);
+
+            // The button's right edge touches the window's left border - no gap
+            Assert.AreEqual(500f, pos.X + BtnW);
+        }
+
+        [TestMethod]
+        public void Anchor_CentersOnTheWindow()
+        {
+            var pos = WindowCloseButton.AnchorLeftOf(500f, 20f, 300f, BtnW, BtnH, 400f);
+
+            // Button center matches the window center: 20 + 300/2 = 170
+            Assert.AreEqual(170f, pos.Y + BtnH / 2f);
+        }
+
+        [TestMethod]
+        public void Anchor_ClampsToTheStageWhenTheWindowIsFlushLeft()
+        {
+            var pos = WindowCloseButton.AnchorLeftOf(0f, 0f, 200f, BtnW, BtnH, 296f);
+
+            Assert.AreEqual(0f, pos.X);
+        }
+
+        [TestMethod]
+        public void Anchor_ClampsYWhenTheWindowOverflowsTheStage()
+        {
+            // Window taller than the stage: centering would push the button off the bottom
+            var pos = WindowCloseButton.AnchorLeftOf(500f, 0f, 600f, BtnW, BtnH, 296f);
+
+            Assert.IsTrue(pos.Y >= 0f, "button must not sit above the stage");
+            Assert.IsTrue(pos.Y + BtnH <= 296f, "button must not sit below the stage");
+        }
+    }
+}

--- a/PitHero/UI/AutoSellCropTypesDialog.cs
+++ b/PitHero/UI/AutoSellCropTypesDialog.cs
@@ -109,16 +109,16 @@ namespace PitHero.UI
             var buttonRow = new Table();
             var selectAllButton = new TextButton(GetText(UITextKey.ButtonSelectAll), skin, "ph-default");
             selectAllButton.OnClicked += (_) => SetAllDesignations(true);
-            buttonRow.Add(selectAllButton).Width(110f).SetPadRight(8f);
+            buttonRow.Add(selectAllButton).Width(110f).SetMinHeight(GameConfig.DialogButtonMinHeight).SetPadRight(8f);
 
             var deselectAllButton = new TextButton(GetText(UITextKey.ButtonDeselectAll), skin, "ph-default");
             deselectAllButton.OnClicked += (_) => SetAllDesignations(false);
-            buttonRow.Add(deselectAllButton).Width(110f).SetPadRight(8f);
+            buttonRow.Add(deselectAllButton).Width(110f).SetMinHeight(GameConfig.DialogButtonMinHeight).SetPadRight(8f);
 
             var closeButton = new TextButton(GetText(UITextKey.ButtonClose), skin, "ph-default");
             closeButton.ClickSoundCategory = ButtonClickCategory.Cancel;
             closeButton.OnClicked += (_) => Hide();
-            buttonRow.Add(closeButton).Width(100f);
+            buttonRow.Add(closeButton).Width(100f).SetMinHeight(GameConfig.DialogButtonMinHeight);
 
             content.Add(buttonRow).SetPadTop(12f);
 

--- a/PitHero/UI/BuildingModeOverlay.cs
+++ b/PitHero/UI/BuildingModeOverlay.cs
@@ -273,7 +273,7 @@ namespace PitHero.UI
             var cancelButton = new TextButton(GetText(UITextKey.ButtonCancel), skin, "ph-default");
             cancelButton.ClickSoundCategory = ButtonClickCategory.Cancel;
             cancelButton.OnClicked += (_) => RequestExitBuildingMode?.Invoke();
-            content.Add(cancelButton).SetColspan(2).Width(100f).SetPadTop(8f);
+            content.Add(cancelButton).SetColspan(2).Width(100f).SetMinHeight(GameConfig.DialogButtonMinHeight).SetPadTop(8f);
 
             _inventoryWindow.Add(content).Expand().Fill();
             _inventoryWindow.Pack();
@@ -320,7 +320,7 @@ namespace PitHero.UI
 
             _buildButton = new TextButton(GetText(UITextKey.ButtonBuild), skin, "ph-default");
             _buildButton.OnClicked += (_) => { if (!_buildButton.GetDisabled()) OnBuildClicked(); };
-            content.Add(_buildButton).Width(80f);
+            content.Add(_buildButton).Width(80f).SetMinHeight(GameConfig.DialogButtonMinHeight);
 
             _descWindow.Add(content).Expand().Fill();
             _descWindow.Pack();

--- a/PitHero/UI/ConsumablePurchaseOptionsDialog.cs
+++ b/PitHero/UI/ConsumablePurchaseOptionsDialog.cs
@@ -136,16 +136,16 @@ namespace PitHero.UI
             var buttonRow = new Table();
             var selectAllButton = new TextButton(GetText(UITextKey.ButtonSelectAll), skin, "ph-default");
             selectAllButton.OnClicked += (_) => SetAllSelected(true);
-            buttonRow.Add(selectAllButton).Width(110f).SetMinHeight(16f).SetPadRight(8f);
+            buttonRow.Add(selectAllButton).Width(110f).SetMinHeight(GameConfig.DialogButtonMinHeight).SetPadRight(8f);
 
             var deselectAllButton = new TextButton(GetText(UITextKey.ButtonDeselectAll), skin, "ph-default");
             deselectAllButton.OnClicked += (_) => SetAllSelected(false);
-            buttonRow.Add(deselectAllButton).Width(110f).SetMinHeight(16f).SetPadRight(8f);
+            buttonRow.Add(deselectAllButton).Width(110f).SetMinHeight(GameConfig.DialogButtonMinHeight).SetPadRight(8f);
 
             var closeButton = new TextButton(GetText(UITextKey.ButtonClose), skin, "ph-default");
             closeButton.ClickSoundCategory = ButtonClickCategory.Cancel;
             closeButton.OnClicked += (_) => Hide();
-            buttonRow.Add(closeButton).Width(100f).SetMinHeight(16f);
+            buttonRow.Add(closeButton).Width(100f).SetMinHeight(GameConfig.DialogButtonMinHeight);
 
             content.Add(buttonRow).SetPadTop(12f);
 

--- a/PitHero/UI/ConsumableSellOptionsDialog.cs
+++ b/PitHero/UI/ConsumableSellOptionsDialog.cs
@@ -134,16 +134,16 @@ namespace PitHero.UI
             var buttonRow = new Table();
             var selectAllButton = new TextButton(GetText(UITextKey.ButtonSelectAll), skin, "ph-default");
             selectAllButton.OnClicked += (_) => SetAllSelected(true);
-            buttonRow.Add(selectAllButton).Width(110f).SetMinHeight(16f).SetPadRight(8f);
+            buttonRow.Add(selectAllButton).Width(110f).SetMinHeight(GameConfig.DialogButtonMinHeight).SetPadRight(8f);
 
             var deselectAllButton = new TextButton(GetText(UITextKey.ButtonDeselectAll), skin, "ph-default");
             deselectAllButton.OnClicked += (_) => SetAllSelected(false);
-            buttonRow.Add(deselectAllButton).Width(110f).SetMinHeight(16f).SetPadRight(8f);
+            buttonRow.Add(deselectAllButton).Width(110f).SetMinHeight(GameConfig.DialogButtonMinHeight).SetPadRight(8f);
 
             var closeButton = new TextButton(GetText(UITextKey.ButtonClose), skin, "ph-default");
             closeButton.ClickSoundCategory = ButtonClickCategory.Cancel;
             closeButton.OnClicked += (_) => Hide();
-            buttonRow.Add(closeButton).Width(100f).SetMinHeight(16f);
+            buttonRow.Add(closeButton).Width(100f).SetMinHeight(GameConfig.DialogButtonMinHeight);
 
             content.Add(buttonRow).SetPadTop(12f);
 

--- a/PitHero/UI/GearFilterOptionsDialog.cs
+++ b/PitHero/UI/GearFilterOptionsDialog.cs
@@ -128,16 +128,16 @@ namespace PitHero.UI
             var buttonRow = new Table();
             var selectAllButton = new TextButton(GetText(UITextKey.ButtonSelectAll), skin, "ph-default");
             selectAllButton.OnClicked += (_) => SetAll(true);
-            buttonRow.Add(selectAllButton).Width(110f).SetPadRight(8f);
+            buttonRow.Add(selectAllButton).Width(110f).SetMinHeight(GameConfig.DialogButtonMinHeight).SetPadRight(8f);
 
             var deselectAllButton = new TextButton(GetText(UITextKey.ButtonDeselectAll), skin, "ph-default");
             deselectAllButton.OnClicked += (_) => SetAll(false);
-            buttonRow.Add(deselectAllButton).Width(110f).SetPadRight(8f);
+            buttonRow.Add(deselectAllButton).Width(110f).SetMinHeight(GameConfig.DialogButtonMinHeight).SetPadRight(8f);
 
             var closeButton = new TextButton(GetText(UITextKey.ButtonClose), skin, "ph-default");
             closeButton.ClickSoundCategory = ButtonClickCategory.Cancel;
             closeButton.OnClicked += (_) => Hide();
-            buttonRow.Add(closeButton).Width(100f);
+            buttonRow.Add(closeButton).Width(100f).SetMinHeight(GameConfig.DialogButtonMinHeight);
 
             content.Add(buttonRow).SetPadTop(12f);
 

--- a/PitHero/UI/HarvestedCropsModeOverlay.cs
+++ b/PitHero/UI/HarvestedCropsModeOverlay.cs
@@ -52,7 +52,6 @@ namespace PitHero.UI
         private const float WinPad       = 16f;
         private const int   Columns      = 8;
         private const float ButtonWidth  = 110f;
-        private const float ButtonHeight = 16f;
         // One page is 4 rows of 44px (40px slot + 2px pad each side), so 224 fits a full storage at the
         // 360px design height without scrolling. ShowInventoryWindow shrinks it when the configured
         // GameConfig.VirtualHeight is shorter (the grid then scrolls).
@@ -134,18 +133,18 @@ namespace PitHero.UI
             var buildingService = Core.Services.GetService<BuildingService>();
 
             if (_filterBuildingId < 0 && AnyStorageHasCrops(storage, buildingService))
-                _buttonRow.Add(_sellAllButton).Width(ButtonWidth).SetMinHeight(ButtonHeight).SetPadRight(8f);
+                _buttonRow.Add(_sellAllButton).Width(ButtonWidth).SetMinHeight(GameConfig.DialogButtonMinHeight).SetPadRight(8f);
 
             int shownId = CurrentPageBuildingId;
             bool hasCrops = storage != null && shownId >= 0 && storage.HasAvailableCrops(shownId);
             bool otherStorageExists = (buildingService?.CropStorageCount ?? 0) > 1;
 
             if (hasCrops && otherStorageExists)
-                _buttonRow.Add(_moveAllButton).Width(ButtonWidth).SetMinHeight(ButtonHeight).SetPadRight(8f);
+                _buttonRow.Add(_moveAllButton).Width(ButtonWidth).SetMinHeight(GameConfig.DialogButtonMinHeight).SetPadRight(8f);
             if (hasCrops)
-                _buttonRow.Add(_sellStorageButton).Width(ButtonWidth).SetMinHeight(ButtonHeight).SetPadRight(8f);
+                _buttonRow.Add(_sellStorageButton).Width(ButtonWidth).SetMinHeight(GameConfig.DialogButtonMinHeight).SetPadRight(8f);
 
-            _buttonRow.Add(_closeButton).Width(100f).SetMinHeight(ButtonHeight);
+            _buttonRow.Add(_closeButton).Width(100f).SetMinHeight(GameConfig.DialogButtonMinHeight);
         }
 
         /// <summary>
@@ -456,13 +455,13 @@ namespace PitHero.UI
 
             var sellButton = new TextButton(GetText(UITextKey.ButtonSell), skin, "ph-default");
             sellButton.OnClicked += (_) => OnSellStackClicked();
-            content.Add(sellButton).Width(80f).SetPadBottom(4f);
+            content.Add(sellButton).Width(80f).SetMinHeight(GameConfig.DialogButtonMinHeight).SetPadBottom(4f);
             content.Row();
 
             var closeButton = new TextButton(GetText(UITextKey.ButtonClose), skin, "ph-default");
             closeButton.ClickSoundCategory = ButtonClickCategory.Cancel;
             closeButton.OnClicked += (_) => _descWindow.SetVisible(false);
-            content.Add(closeButton).Width(80f);
+            content.Add(closeButton).Width(80f).SetMinHeight(GameConfig.DialogButtonMinHeight);
 
             _descWindow.Add(content).Expand().Fill();
             _descWindow.Pack();

--- a/PitHero/UI/HeroUI.cs
+++ b/PitHero/UI/HeroUI.cs
@@ -33,6 +33,9 @@ namespace PitHero.UI
         private Tab _foodTab;
         private bool _windowVisible = false;
 
+        // Graphical close button anchored outside the hero window's left edge (issue #399).
+        private WindowCloseButton _closeButton;
+
         // References for single window policy enforcement
         private SettingsUI _settingsUI;
         private SecondChanceShopUI _secondChanceShopUI;
@@ -229,6 +232,10 @@ namespace PitHero.UI
             
             _heroWindow.Add(_tabPane).Expand().Fill().Pad(0); // No cell padding - tabs flush with window edges
             _heroWindow.SetVisible(false);
+
+            // Anchored to the window as a whole, so switching tabs never moves it
+            _closeButton = WindowCloseButton.Create(_heroWindow,
+                GetText(TextType.UI, UITextKey.ButtonClose), ToggleHeroWindow);
         }
 
         /// <summary>Adjusts window width when tabs are changed.</summary>
@@ -895,6 +902,7 @@ namespace PitHero.UI
                 _stage.AddElement(_heroWindow);
                 _heroWindow.SetVisible(true);
                 _heroWindow.ToFront();
+                _closeButton.ShowOn(_stage);
                 var pauseService = Core.Services.GetService<PauseService>();
                 if (pauseService != null) pauseService.IsPaused = true;
                 // Stamp the frame so the click that opened the window can't also dismiss it
@@ -910,6 +918,7 @@ namespace PitHero.UI
                 ClearHoverVisuals();
                 _heroWindow.SetVisible(false);
                 _heroWindow.Remove();
+                _closeButton.HideAndDetach();
                 var pauseService = Core.Services.GetService<PauseService>();
                 if (pauseService != null) pauseService.IsPaused = false;
                 Debug.Log("Hero window closed and game unpaused");
@@ -941,6 +950,8 @@ namespace PitHero.UI
             if (targetX > maxX) targetX = maxX;
             if (targetX < 0) targetX = 0;
             _heroWindow.SetPosition(targetX, 0f);
+
+            _closeButton?.SyncPosition(_stage);
         }
 
         private HeroComponent GetHeroComponent()
@@ -1210,9 +1221,12 @@ namespace PitHero.UI
         private List<Element> GetWindowBoundsElements()
         {
             if (_windowBoundsElements == null)
-                _windowBoundsElements = new List<Element>(4);
+                _windowBoundsElements = new List<Element>(5);
             _windowBoundsElements.Clear();
             _windowBoundsElements.Add(_heroWindow);
+            // The close button hangs outside the window, so it must widen the envelope or a click on
+            // it would also register as an outside click.
+            _windowBoundsElements.Add(_closeButton);
             _windowBoundsElements.Add(_stencilLibraryPanel);
             _windowBoundsElements.Add(_selectedItemCard);
             _windowBoundsElements.Add(_crystalsTabComponent?.CrystalCardElement);
@@ -1270,7 +1284,7 @@ namespace PitHero.UI
         {
             if (_windowVisible)
             {
-                _windowVisible = false; UIWindowManager.OnUIWindowClosing(); _selectedItemCard?.Hide(); _crystalsTabComponent?.Cleanup(); _stencilLibraryPanel?.SetVisible(false); ClearHoverVisuals(); _heroWindow?.SetVisible(false); _heroWindow?.Remove(); var pauseService = Core.Services.GetService<PauseService>(); if (pauseService != null) pauseService.IsPaused = false; Debug.Log("[HeroUI] Hero window force closed by single window policy");
+                _windowVisible = false; UIWindowManager.OnUIWindowClosing(); _selectedItemCard?.Hide(); _crystalsTabComponent?.Cleanup(); _stencilLibraryPanel?.SetVisible(false); ClearHoverVisuals(); _heroWindow?.SetVisible(false); _heroWindow?.Remove(); _closeButton?.HideAndDetach(); var pauseService = Core.Services.GetService<PauseService>(); if (pauseService != null) pauseService.IsPaused = false; Debug.Log("[HeroUI] Hero window force closed by single window policy");
             }
         }
 

--- a/PitHero/UI/HoverableImageButton.cs
+++ b/PitHero/UI/HoverableImageButton.cs
@@ -39,6 +39,15 @@ namespace PitHero.UI
 
         public override void Draw(Batcher batcher, float parentAlpha)
         {
+            // Correct the hover flag before base.Draw picks a style from it. Nez only clears
+            // _mouseOver from OnMouseExit, which fires solely on a mouse-move where the hit-tested
+            // element changed. Any way the cursor stops being "on" the button without such a move -
+            // a window opening over it, the top bar becoming untouchable, the button sliding away
+            // under a stationary cursor, the element being detached and re-added - strands the flag
+            // and the button comes back stuck in its Over (highlight) sprite.
+            if (_mouseOver && !MouseIsInsideBounds())
+                _mouseOver = _mouseDown = false;
+
             // Call base draw first
             base.Draw(batcher, parentAlpha);
 
@@ -64,6 +73,23 @@ namespace PitHero.UI
             }
 
             _wasMouseOver = isMouseOver;
+        }
+
+        /// <summary>
+        /// True when the cursor is genuinely within this button's current stage bounds. Used to
+        /// self-heal a stranded hover flag; returns true when there is no stage to measure against so
+        /// the flag is left alone rather than cleared on a guess.
+        /// </summary>
+        private bool MouseIsInsideBounds()
+        {
+            var stage = GetStage();
+            if (stage == null)
+                return true;
+
+            var mouse = stage.GetMousePosition();
+            var pos = GetStagePosition();
+            return mouse.X >= pos.X && mouse.X <= pos.X + GetWidth()
+                && mouse.Y >= pos.Y && mouse.Y <= pos.Y + GetHeight();
         }
 
         /// <summary>

--- a/PitHero/UI/MonsterUI.cs
+++ b/PitHero/UI/MonsterUI.cs
@@ -43,6 +43,10 @@ namespace PitHero.UI
 
         // Aggregate view only: workforce summary card docked to the right of the roster window.
         private MonsterInfoPanel _infoPanel;
+
+        // Graphical close button anchored outside the roster window's left edge (issue #399).
+        private WindowCloseButton _closeButton;
+
         // Pre-allocated so the per-frame dismissal poll never allocates.
         private System.Collections.Generic.List<Element> _dismissEnvelope;
 
@@ -194,7 +198,12 @@ namespace PitHero.UI
             _monsterWindow.SetVisible(false);
 
             _infoPanel = new MonsterInfoPanel(skin);
-            _dismissEnvelope = new System.Collections.Generic.List<Element>(2) { _monsterWindow, _infoPanel };
+
+            _closeButton = WindowCloseButton.Create(_monsterWindow,
+                GetText(TextType.UI, UITextKey.ButtonClose), ToggleMonsterWindow);
+
+            // The close button joins the envelope so a click on it is not also read as an outside click.
+            _dismissEnvelope = new System.Collections.Generic.List<Element>(3) { _monsterWindow, _infoPanel, _closeButton };
         }
 
         private void ToggleMonsterWindow()
@@ -210,6 +219,7 @@ namespace PitHero.UI
                 // Added after the roster window so the card sits above it when the two overlap.
                 _stage.AddElement(_infoPanel);
                 _infoPanel.ToFront();
+                _closeButton.ShowOn(_stage);
                 PositionWindow();
                 var pauseService = Core.Services.GetService<PauseService>();
                 if (pauseService != null)
@@ -224,6 +234,7 @@ namespace PitHero.UI
                 _monsterWindow.Remove();
                 _infoPanel.SetVisible(false);
                 _infoPanel.Remove();
+                _closeButton.HideAndDetach();
                 var pauseService = Core.Services.GetService<PauseService>();
                 if (pauseService != null)
                     pauseService.IsPaused = false;
@@ -555,6 +566,8 @@ namespace PitHero.UI
 
             if (infoShown)
                 _infoPanel.SetPosition(winX + winW + InfoPanelGap, UILayout.ClampY(winY, _infoPanel.GetHeight(), stageH));
+
+            _closeButton?.SyncPosition(_stage);
         }
 
         /// <summary>Sets the position of the monster icon button.</summary>
@@ -581,6 +594,7 @@ namespace PitHero.UI
                 _monsterWindow?.Remove();
                 _infoPanel?.SetVisible(false);
                 _infoPanel?.Remove();
+                _closeButton?.HideAndDetach();
                 var pauseService = Core.Services.GetService<PauseService>();
                 if (pauseService != null)
                     pauseService.IsPaused = false;

--- a/PitHero/UI/SecondChanceShopUI.cs
+++ b/PitHero/UI/SecondChanceShopUI.cs
@@ -28,6 +28,9 @@ namespace PitHero.UI
         private Tab _crystalsTab;
         private Tab _seedsTab;
 
+        // Graphical close button anchored outside the shop window's left edge (issue #399)
+        private WindowCloseButton _closeButton;
+
         // Right panel: separate windows for hero inventory and crystal panel
         private Window _heroInventoryWindow;
         private Window _heroCrystalWindow;
@@ -171,6 +174,10 @@ namespace PitHero.UI
 
             _shopWindow.Add(_tabPane).Expand().Fill().Pad(0);
             _shopWindow.SetVisible(false);
+
+            // Anchored to the left panel as a whole, so switching tabs never moves it
+            _closeButton = WindowCloseButton.Create(_shopWindow,
+                GetText(TextType.UI, UITextKey.ButtonClose), ToggleShopWindow);
         }
 
         /// <summary>Creates the hero inventory window (right panel for the Items tab).</summary>
@@ -470,6 +477,8 @@ namespace PitHero.UI
                 _shopWindow.SetPosition(GameConfig.SecondChanceShopWindowX + xOffset, UILayout.ClampY(shopY, shopH, stageH));
                 _shopWindow.ToFront();
 
+                _closeButton.ShowOn(_stage);
+
                 // Hero panel geometry, needed here because the merchant stands on its baseline
                 float heroH = UILayout.FitHeight(GameConfig.SecondChanceHeroPanelHeight, stageH, margin, margin);
                 float heroY = UILayout.ClampY(System.Math.Min(GameConfig.SecondChanceHeroPanelY, stageH - heroH - margin), heroH, stageH);
@@ -543,6 +552,7 @@ namespace PitHero.UI
                 UIWindowManager.OnUIWindowClosing();
                 _shopWindow.SetVisible(false);
                 _shopWindow.Remove();
+                _closeButton.HideAndDetach();
                 _merchantSprite.Remove();
                 RemoveMerchantBubble();
                 _heroInventoryWindow.SetVisible(false);
@@ -575,6 +585,7 @@ namespace PitHero.UI
                 UIWindowManager.OnUIWindowClosing();
                 _shopWindow?.SetVisible(false);
                 _shopWindow?.Remove();
+                _closeButton?.HideAndDetach();
                 _merchantSprite?.Remove();
                 RemoveMerchantBubble();
                 _heroInventoryWindow?.SetVisible(false);
@@ -711,9 +722,12 @@ namespace PitHero.UI
         private List<Nez.UI.Element> GetWindowBoundsElements()
         {
             if (_windowBoundsElements == null)
-                _windowBoundsElements = new List<Nez.UI.Element>(6);
+                _windowBoundsElements = new List<Nez.UI.Element>(7);
             _windowBoundsElements.Clear();
             _windowBoundsElements.Add(_shopWindow);
+            // The close button hangs outside the left panel, so it must widen the envelope or a click
+            // on it would also register as an outside click.
+            _windowBoundsElements.Add(_closeButton);
             _windowBoundsElements.Add(_merchantSprite);
             _windowBoundsElements.Add(_merchantBubble);
             _windowBoundsElements.Add(_heroInventoryWindow);

--- a/PitHero/UI/SettingsUI.cs
+++ b/PitHero/UI/SettingsUI.cs
@@ -24,6 +24,9 @@ namespace PitHero.UI
         private Window _settingsWindow;
         private bool _isVisible = false;
 
+        // Graphical close button anchored outside the settings window's left edge (issue #399).
+        private WindowCloseButton _closeButton;
+
         // Tab management using actual TabPane
         private TabPane _tabPane;
         private Tab _windowTab;
@@ -614,6 +617,11 @@ namespace PitHero.UI
 
             // Initially hidden
             _settingsWindow.SetVisible(false);
+
+            // Anchored to the window as a whole, so switching tabs never moves it. LayoutUI keeps its
+            // stage membership and visibility in lockstep with the window.
+            _closeButton = WindowCloseButton.Create(_settingsWindow,
+                GetText(TextType.UI, UITextKey.ButtonClose), ToggleSettingsVisibility);
 
             // Create confirmation dialogs (initially hidden)
             CreateConfirmationDialogs(skin);
@@ -1851,6 +1859,12 @@ namespace PitHero.UI
                 _stage.AddElement(_settingsWindow);
 
             _settingsWindow.SetVisible(_isVisible);
+
+            if (_isVisible)
+                _closeButton?.ShowOn(_stage);
+            else
+                _closeButton?.HideAndDetach();
+
             PositionUI();
         }
 
@@ -1947,6 +1961,8 @@ namespace PitHero.UI
                 if (winX < 0) winX = 0;
 
                 _settingsWindow.SetPosition(winX, UILayout.ClampY(winY, winH, stageH));
+
+                _closeButton?.SyncPosition(_stage);
             }
 
             _lastStageW = stageW;

--- a/PitHero/UI/WindowCloseButton.cs
+++ b/PitHero/UI/WindowCloseButton.cs
@@ -1,0 +1,115 @@
+using Microsoft.Xna.Framework;
+using Nez;
+using Nez.Textures;
+using Nez.UI;
+
+namespace PitHero.UI
+{
+    /// <summary>
+    /// The graphical close button (issue #399). Anchors flush against the outside of a UI window's left
+    /// edge, vertically centered on it, and gives the player a visible way out of any window. It is purely
+    /// additive - the top-bar toggle, ESC and outside-click paths are unchanged, and clicking this
+    /// button routes into the owning UI's normal close method so the pause/window-size bookkeeping in
+    /// UIWindowManager still runs.
+    /// </summary>
+    public class WindowCloseButton : HoverableImageButton
+    {
+        private readonly Element _target;
+
+        private WindowCloseButton(ImageButtonStyle style, string hoverText, Element target)
+            : base(style, hoverText)
+        {
+            _target = target;
+        }
+
+        /// <summary>
+        /// Builds a close button for the given window. The Up/Down/Over triple follows the atlas
+        /// naming convention used by every other icon button (base / Inverse / Highlight), and the
+        /// size is read off the art so swapping in a differently sized icon needs no code change.
+        /// Only the 1x sprite is needed: UIWindowManager.OnUIWindowOpening restores the OS window to
+        /// Normal size before any of these windows shows, so the half-height 2x art never applies.
+        /// </summary>
+        public static WindowCloseButton Create(Element target, string hoverText, System.Action onClose)
+        {
+            var uiAtlas = Core.Content.LoadSpriteAtlas("Content/Atlases/UI.atlas");
+            var sprite    = uiAtlas.GetSprite("UIClose");
+            var highlight = uiAtlas.GetSprite("UICloseHighlight");
+            var inverse   = uiAtlas.GetSprite("UICloseInverse");
+
+            var style = new ImageButtonStyle
+            {
+                ImageUp   = new SpriteDrawable(sprite),
+                ImageDown = new SpriteDrawable(inverse),
+                ImageOver = new SpriteDrawable(highlight)
+            };
+
+            var button = new WindowCloseButton(style, hoverText, target);
+            button.ClickSoundCategory = ButtonClickCategory.Cancel;
+            button.SetSize(sprite.SourceRect.Width, sprite.SourceRect.Height);
+            // The owning UI's close path is expected to end in HideAndDetach, which is what dismisses
+            // the hover text the cursor left showing.
+            button.OnClicked += (_) => onClose?.Invoke();
+            return button;
+        }
+
+        /// <summary>
+        /// Attaches the button to the stage (if it is not already there), shows it and anchors it.
+        /// Deliberately does NOT call ToFront: a freshly added element is already on top of everything
+        /// currently on the stage, and re-raising an already-attached button would lift it above
+        /// overlays that were raised after it (the free-move blocker, confirmation dialogs).
+        /// </summary>
+        public void ShowOn(Stage stage)
+        {
+            if (stage == null) return;
+            // Parent, not GetStage(): Group.RemoveElement clears the parent but leaves the element's
+            // cached stage set, so GetStage() stays non-null forever after the first add and would
+            // skip every re-attach after the first close.
+            if (GetParent() == null)
+                stage.AddElement(this);
+            SetVisible(true);
+            SyncPosition(stage);
+        }
+
+        /// <summary>
+        /// Hides and detaches the button. Dismisses the hover text first: closing pulls the button out
+        /// from under the cursor, so Draw never runs the hover-exit path and "Close" would be stranded
+        /// over the game world. This covers every close path, not just a click on the button itself.
+        /// </summary>
+        public void HideAndDetach()
+        {
+            DismissHoverText();
+
+            // Closing pulls the button out from under the cursor, so OnMouseExit never fires and Nez's
+            // Button keeps _mouseOver set. Without this reset the button comes back drawn in its Over
+            // (highlight) state the next time the window opens.
+            _mouseOver = false;
+            _mouseDown = false;
+
+            SetVisible(false);
+            Remove();
+        }
+
+        /// <summary>Re-anchors to the target window's current bounds. Cheap; safe to call every frame.</summary>
+        public void SyncPosition(Stage stage)
+        {
+            if (_target == null || stage == null) return;
+            var pos = AnchorLeftOf(_target.GetX(), _target.GetY(), _target.GetHeight(),
+                GetWidth(), GetHeight(), stage.GetHeight());
+            SetPosition(pos.X, pos.Y);
+        }
+
+        /// <summary>
+        /// Pure anchor math: fully outside the target's left edge and flush against it (the button's
+        /// right edge touches the window's left border), vertically centered on the target, clamped so
+        /// the button never leaves the stage.
+        /// </summary>
+        public static Vector2 AnchorLeftOf(float targetX, float targetY, float targetH,
+            float btnW, float btnH, float stageH)
+        {
+            float x = targetX - btnW;
+            if (x < 0f) x = 0f;
+            float y = UILayout.ClampY(targetY + (targetH - btnH) * 0.5f, btnH, stageH);
+            return new Vector2(x, y);
+        }
+    }
+}


### PR DESCRIPTION
Closes #399.

## Graphical close button

Adds `PitHero/UI/WindowCloseButton.cs`, a `HoverableImageButton` built from the `UIClose` / `UICloseHighlight` / `UICloseInverse` atlas triple that had been shipping unused since 162200e. It anchors flush against the **outside** of a window's left edge, vertically centered and clamped to the stage, and shows "Close" on hover (the `ButtonClose` key already existed — no localization additions).

Wired into:

| UI | Window | Routes to |
|---|---|---|
| Settings | `_settingsWindow` | `ToggleSettingsVisibility()` |
| Party (`HeroUI`) | `_heroWindow` | `ToggleHeroWindow()` |
| Monsters | `_monsterWindow` | `ToggleMonsterWindow()` |
| Second Chance Shop | `_shopWindow` (left panel) | `ToggleShopWindow()` |

The Monster House → "Show Monsters" view reuses `_monsterWindow` via `ShowForHouse`, so it is covered by the same wiring.

It is purely additive — the top-bar toggle, ESC and outside-click paths are unchanged. Each click routes into that UI's **existing** close method so `UIWindowManager.OnUIWindowClosing()` and the unpause still run. Because the button hangs outside the window it also joins each outside-click envelope, or a click on it would register as an outside click too.

Anchoring is done by a pure static `AnchorLeftOf`, covered by `PitHero.Tests/UI/WindowCloseButtonLayoutTests.cs` (no graphics device needed).

## Two Nez pitfalls fixed along the way

Both surfaced as bugs during review and are worth knowing about beyond this PR:

- **`Group.RemoveElement` clears an element's parent but leaves its cached stage set.** So an `if (GetStage() == null) AddElement(...)` guard silently skips every re-attach after the first close — the element is "visible" with no parent and never draws. `ShowOn` guards on `GetParent()` instead.
- **`Button` clears `_mouseOver` only from `OnMouseExit`,** which fires solely on a mouse-move where the hit-tested element changed. Any way the cursor stops being on a button without such a move (a window opening over it, the bar going untouchable, the button sliding away under a stationary cursor, detach/re-attach) strands the highlight. `HoverableImageButton.Draw` now self-heals the flag against the button's real stage bounds — this fixes stuck highlights on **every** top-bar icon button, not just the close button.

## Dialog button heights

Normalized onto `GameConfig.DialogButtonMinHeight` (16f):

- **Buildings dialog** — Cancel and Build had no min-height at all.
- **Harvested Crops** — replaced a private duplicate of the constant, and added the min-height its stack sub-dialog's Sell/Close were missing.
- **Automation tab** — Choose Crops To Sell and the Gear Sell / Gear Purchase options dialogs (one shared `GearFilterOptionsDialog` class) had no min-height on their Select All / Deselect All / Close row. The Consumable sell/purchase dialogs already rendered at 16px via a hardcoded literal; pointed those at the constant too.
- **Refrigerator** — already correct; verified, not re-applied.

## Testing

`dotnet build PitHero.sln` clean; `dotnet test` 2043 passed / 0 failed / 6 skipped (baseline 0 failures; 4 of those tests are new). Placement, the reopen cycle and the stuck-highlight fixes were verified in game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBvPtUihLJHxNFVMQukx4A